### PR TITLE
Disable 3.7 tests, add 3.10 and 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {python-version: "3.7", os: ubuntu-latest, documentation: True}
-          - {python-version: "3.8", os: ubuntu-latest, documentation: False}
+          - {python-version: "3.8", os: ubuntu-latest, documentation: True}
           - {python-version: "3.9", os: ubuntu-latest, documentation: False}
+          - {python-version: "3.10", os: ubuntu-latest, documentation: False}
+          - {python-version: "3.11", os: ubuntu-latest, documentation: False}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Disables 3.7 tests with EOL coming up, and adds 3.10 and 3.11 tests