### PR TITLE
Remove PyPI repository URL

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,6 +35,5 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://pypi.org/legacy/
           password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true


### PR DESCRIPTION
Doesn't need a URL