### PR TITLE
Fix `pyscf.tblis_einsum` import

### DIFF
--- a/ebcc/util.py
+++ b/ebcc/util.py
@@ -14,7 +14,7 @@ try:
     try:
         import tblis_einsum
     except ImportError:
-        from pyscf import tblis_einsum
+        from pyscf.tblis_einsum import tblis_einsum
     FOUND_TBLIS = True
 except ImportError:
     FOUND_TBLIS = False


### PR DESCRIPTION
Properly imports `tblis_einsum` when installed via `pyscf-tblis` (fixes #41)