### PR TITLE
Add `optimize=True` to `einsum` fallback

### DIFF
--- a/ebcc/util/einsumfunc.py
+++ b/ebcc/util/einsumfunc.py
@@ -37,7 +37,7 @@ def _fallback_einsum(*operands, **kwargs):
     out = kwargs.pop("out", None)
 
     # Perform the contraction
-    res = np.einsum(*operands, **kwargs)
+    res = np.einsum(*operands, **kwargs, optimize=True)
     res *= alpha
 
     # Scale the output


### PR DESCRIPTION
When `einsum` falls back to `numpy`, `optimize` is now set to `True`. This has performance benefits for large ansatzes with lots of smaller contractions (i.e. CCSDt).