### PR TITLE
Use `Namespace` for EOM amplitudes

### DIFF
--- a/ebcc/codegen/GCCSD.py
+++ b/ebcc/codegen/GCCSD.py
@@ -1019,7 +1019,7 @@ def hbar_matvec_ip(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, l1=No
     r1new -= einsum("i,ij->j", r1, f.oo)
     r2new += einsum("i,iajk->kja", r1, v.ovoo)
 
-    return r1new, r2new
+    return {"r1new": r1new, "r2new": r2new}
 
 def hbar_matvec_ea(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, l1=None, l2=None, r1=None, r2=None, **kwargs):
     r2 = -r2
@@ -1247,7 +1247,7 @@ def hbar_matvec_ea(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, l1=No
     r1new += einsum("a,ba->b", r1, f.vv)
     r2new += einsum("a,bcia->cbi", r1, v.vvov)
 
-    return r1new, r2new
+    return {"r1new": r1new, "r2new": r2new}
 
 def make_ee_mom_kets(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, l1=None, l2=None, **kwargs):
     delta_oo = np.eye(nocc)
@@ -1834,5 +1834,5 @@ def hbar_matvec_ee(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, l1=No
     ree2new += einsum("ia,jb->jiab", r1, x125)
     del x125
 
-    return ree1new, ree2new
+    return {"r1new": ree1new, "r2new": ree2new}
 

--- a/ebcc/codegen/UCCSD.py
+++ b/ebcc/codegen/UCCSD.py
@@ -4012,7 +4012,7 @@ def hbar_matvec_ip(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, l1=No
     r1new = Namespace(a=r1new_a, b=r1new_b)
     r2new = Namespace(aaa=r2new_aaa, aba=r2new_aba, bab=r2new_bab, bbb=r2new_bbb)
 
-    return r1new, r2new
+    return {"r1new": r1new, "r2new": r2new}
 
 def hbar_matvec_ea(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, l1=None, l2=None, r1=None, r2=None, **kwargs):
     x0 = np.zeros((nocc[0], nocc[1], nvir[1]), dtype=types[float])
@@ -4879,7 +4879,7 @@ def hbar_matvec_ea(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, l1=No
     r2new.bab *= -1
     r2new.bbb *= -1
 
-    return r1new, r2new
+    return {"r1new": r1new, "r2new": r2new}
 
 def make_ee_mom_kets(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, l1=None, l2=None, **kwargs):  # pragma: no cover
     delta_oo = Namespace()
@@ -7373,5 +7373,5 @@ def hbar_matvec_ee(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, l1=No
     ree1new = Namespace(aa=ree1new_aa, bb=ree1new_bb)
     ree2new = Namespace(aaaa=ree2new_aaaa, abab=ree2new_abab, baba=ree2new_baba, bbbb=ree2new_bbbb)
 
-    return ree1new, ree2new
+    return {"r1new": ree1new, "r2new": ree2new}
 

--- a/ebcc/eom/base.py
+++ b/ebcc/eom/base.py
@@ -121,7 +121,7 @@ class BaseEOM(ABC):
         return f"{self.excitation_type.upper()}-EOM-{self.spin_type}{self.ansatz.name}"
 
     @abstractmethod
-    def amplitudes_to_vector(self, *amplitudes: SpinArrayType) -> NDArray[float]:
+    def amplitudes_to_vector(self, amplitudes: Namespace[SpinArrayType]) -> NDArray[float]:
         """Construct a vector containing all of the amplitudes used in the given ansatz.
 
         Args:
@@ -133,7 +133,7 @@ class BaseEOM(ABC):
         pass
 
     @abstractmethod
-    def vector_to_amplitudes(self, vector: NDArray[float]) -> tuple[SpinArrayType, ...]:
+    def vector_to_amplitudes(self, vector: NDArray[float]) -> Namespace[SpinArrayType]:
         """Construct amplitudes from a vector.
 
         Args:
@@ -339,7 +339,7 @@ class BaseEOM(ABC):
             f"{ANSI.B}{'Root':>4s} {'Energy':>16s} {'Weight':>13s} {'Conv.':>8s}{ANSI.R}"
         )
         for n, (en, vn, cn) in enumerate(zip(e, v, converged)):
-            r1n = self.vector_to_amplitudes(vn)[0]
+            r1n = self.vector_to_amplitudes(vn)["r1"]
             qpwt = self._quasiparticle_weight(r1n)
             self.log.output(
                 f"{n:>4d} {en:>16.10f} {qpwt:>13.5g} {[ANSI.r, ANSI.g][bool(cn)]}{cn!r:>8s}{ANSI.R}"
@@ -398,7 +398,7 @@ class BaseIP_EOM(BaseEOM):
         """Get the type of excitation."""
         return "ip"
 
-    def amplitudes_to_vector(self, *amplitudes: SpinArrayType) -> NDArray[float]:
+    def amplitudes_to_vector(self, amplitudes: Namespace[SpinArrayType]) -> NDArray[float]:
         """Construct a vector containing all of the amplitudes used in the given ansatz.
 
         Args:
@@ -407,9 +407,9 @@ class BaseIP_EOM(BaseEOM):
         Returns:
             Cluster amplitudes as a vector.
         """
-        return self.ebcc.excitations_to_vector_ip(*amplitudes)
+        return self.ebcc.excitations_to_vector_ip(amplitudes)
 
-    def vector_to_amplitudes(self, vector: NDArray[float]) -> tuple[SpinArrayType, ...]:
+    def vector_to_amplitudes(self, vector: NDArray[float]) -> Namespace[SpinArrayType]:
         """Construct amplitudes from a vector.
 
         Args:
@@ -433,8 +433,8 @@ class BaseIP_EOM(BaseEOM):
             Resulting vector.
         """
         amplitudes = self.vector_to_amplitudes(vector)
-        result = self.ebcc.hbar_matvec_ip(*amplitudes, eris=eris)
-        return self.amplitudes_to_vector(*result)
+        result = self.ebcc.hbar_matvec_ip(amplitudes, eris=eris)
+        return self.amplitudes_to_vector(result)
 
 
 class BaseEA_EOM(BaseEOM):
@@ -445,7 +445,7 @@ class BaseEA_EOM(BaseEOM):
         """Get the type of excitation."""
         return "ea"
 
-    def amplitudes_to_vector(self, *amplitudes: SpinArrayType) -> NDArray[float]:
+    def amplitudes_to_vector(self, amplitudes: SpinArrayType) -> NDArray[float]:
         """Construct a vector containing all of the amplitudes used in the given ansatz.
 
         Args:
@@ -454,9 +454,9 @@ class BaseEA_EOM(BaseEOM):
         Returns:
             Cluster amplitudes as a vector.
         """
-        return self.ebcc.excitations_to_vector_ea(*amplitudes)
+        return self.ebcc.excitations_to_vector_ea(amplitudes)
 
-    def vector_to_amplitudes(self, vector: NDArray[float]) -> tuple[SpinArrayType, ...]:
+    def vector_to_amplitudes(self, vector: NDArray[float]) -> Namespace[SpinArrayType]:
         """Construct amplitudes from a vector.
 
         Args:
@@ -480,8 +480,8 @@ class BaseEA_EOM(BaseEOM):
             Resulting vector.
         """
         amplitudes = self.vector_to_amplitudes(vector)
-        result = self.ebcc.hbar_matvec_ea(*amplitudes, eris=eris)
-        return self.amplitudes_to_vector(*result)
+        result = self.ebcc.hbar_matvec_ea(amplitudes, eris=eris)
+        return self.amplitudes_to_vector(result)
 
 
 class BaseEE_EOM(BaseEOM):
@@ -492,7 +492,7 @@ class BaseEE_EOM(BaseEOM):
         """Get the type of excitation."""
         return "ee"
 
-    def amplitudes_to_vector(self, *amplitudes: SpinArrayType) -> NDArray[float]:
+    def amplitudes_to_vector(self, amplitudes: Namespace[SpinArrayType]) -> NDArray[float]:
         """Construct a vector containing all of the amplitudes used in the given ansatz.
 
         Args:
@@ -501,9 +501,9 @@ class BaseEE_EOM(BaseEOM):
         Returns:
             Cluster amplitudes as a vector.
         """
-        return self.ebcc.excitations_to_vector_ee(*amplitudes)
+        return self.ebcc.excitations_to_vector_ee(amplitudes)
 
-    def vector_to_amplitudes(self, vector: NDArray[float]) -> tuple[SpinArrayType, ...]:
+    def vector_to_amplitudes(self, vector: NDArray[float]) -> Namespace[SpinArrayType]:
         """Construct amplitudes from a vector.
 
         Args:
@@ -527,5 +527,5 @@ class BaseEE_EOM(BaseEOM):
             Resulting vector.
         """
         amplitudes = self.vector_to_amplitudes(vector)
-        result = self.ebcc.hbar_matvec_ee(*amplitudes, eris=eris)
-        return self.amplitudes_to_vector(*result)
+        result = self.ebcc.hbar_matvec_ee(amplitudes, eris=eris)
+        return self.amplitudes_to_vector(result)

--- a/ebcc/eom/geom.py
+++ b/ebcc/eom/geom.py
@@ -33,7 +33,7 @@ class IP_GEOM(GEOM, BaseIP_EOM):
     def _argsort_guesses(self, diag: NDArray[float]) -> NDArray[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
-            r1 = self.vector_to_amplitudes(diag)[0]
+            r1 = self.vector_to_amplitudes(diag)["r1"]
             arg = np.argsort(np.abs(diag[: r1.size]))
         else:
             arg = np.argsort(np.abs(diag))
@@ -53,16 +53,16 @@ class IP_GEOM(GEOM, BaseIP_EOM):
         Returns:
             Diagonal of the Hamiltonian.
         """
-        parts = []
+        parts: Namespace[SpinArrayType] = util.Namespace()
 
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
             key = key[:-1]
-            parts.append(self.ebcc.energy_sum(key))
+            parts[f"r{n}"] = self.ebcc.energy_sum(key)
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
             raise util.ModelNotImplemented
 
-        return self.amplitudes_to_vector(*parts)
+        return self.amplitudes_to_vector(parts)
 
     def bras(self, eris: Optional[ERIsInputType] = None) -> SpinArrayType:
         """Get the bra vectors.
@@ -73,9 +73,16 @@ class IP_GEOM(GEOM, BaseIP_EOM):
         Returns:
             Bra vectors.
         """
-        bras_raw = list(self.ebcc.make_ip_mom_bras(eris=eris))
+        bras_raw = util.Namespace(
+            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ip_mom_bras(eris=eris))}
+        )
         bras = np.array(
-            [self.amplitudes_to_vector(*[b[i] for b in bras_raw]) for i in range(self.nmo)]
+            [
+                self.amplitudes_to_vector(
+                    util.Namespace(**{key: b[i] for key, b in bras_raw.items()})
+                )
+                for i in range(self.nmo)
+            ]
         )
         return bras
 
@@ -88,9 +95,16 @@ class IP_GEOM(GEOM, BaseIP_EOM):
         Returns:
             Ket vectors.
         """
-        kets_raw = list(self.ebcc.make_ip_mom_kets(eris=eris))
+        kets_raw = util.Namespace(
+            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ip_mom_kets(eris=eris))}
+        )
         kets = np.array(
-            [self.amplitudes_to_vector(*[k[..., i] for k in kets_raw]) for i in range(self.nmo)]
+            [
+                self.amplitudes_to_vector(
+                    util.Namespace(**{key: k[..., i] for key, k in kets_raw.items()})
+                )
+                for i in range(self.nmo)
+            ]
         )
         return kets
 
@@ -144,7 +158,7 @@ class EA_GEOM(GEOM, BaseEA_EOM):
     def _argsort_guesses(self, diag: NDArray[float]) -> NDArray[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
-            r1 = self.vector_to_amplitudes(diag)[0]
+            r1 = self.vector_to_amplitudes(diag)["r1"]
             arg = np.argsort(np.abs(diag[: r1.size]))
         else:
             arg = np.argsort(np.abs(diag))
@@ -164,16 +178,16 @@ class EA_GEOM(GEOM, BaseEA_EOM):
         Returns:
             Diagonal of the Hamiltonian.
         """
-        parts = []
+        parts: Namespace[SpinArrayType] = util.Namespace()
 
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
             key = key[n:] + key[: n - 1]
-            parts.append(-self.ebcc.energy_sum(key))
+            parts[f"r{n}"] = -self.ebcc.energy_sum(key)
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
             raise util.ModelNotImplemented
 
-        return self.amplitudes_to_vector(*parts)
+        return self.amplitudes_to_vector(parts)
 
     def bras(self, eris: Optional[ERIsInputType] = None) -> SpinArrayType:
         """Get the bra vectors.
@@ -184,9 +198,16 @@ class EA_GEOM(GEOM, BaseEA_EOM):
         Returns:
             Bra vectors.
         """
-        bras_raw = list(self.ebcc.make_ea_mom_bras(eris=eris))
+        bras_raw = util.Namespace(
+            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ea_mom_bras(eris=eris))}
+        )
         bras = np.array(
-            [self.amplitudes_to_vector(*[b[i] for b in bras_raw]) for i in range(self.nmo)]
+            [
+                self.amplitudes_to_vector(
+                    util.Namespace(**{key: b[i] for key, b in bras_raw.items()})
+                )
+                for i in range(self.nmo)
+            ]
         )
         return bras
 
@@ -199,9 +220,16 @@ class EA_GEOM(GEOM, BaseEA_EOM):
         Returns:
             Ket vectors.
         """
-        kets_raw = list(self.ebcc.make_ea_mom_kets(eris=eris))
+        kets_raw = util.Namespace(
+            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ea_mom_kets(eris=eris))}
+        )
         kets = np.array(
-            [self.amplitudes_to_vector(*[k[..., i] for k in kets_raw]) for i in range(self.nmo)]
+            [
+                self.amplitudes_to_vector(
+                    util.Namespace(**{key: k[..., i] for key, k in kets_raw.items()})
+                )
+                for i in range(self.nmo)
+            ]
         )
         return kets
 
@@ -255,7 +283,7 @@ class EE_GEOM(GEOM, BaseEE_EOM):
     def _argsort_guesses(self, diag: NDArray[float]) -> NDArray[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
-            r1 = self.vector_to_amplitudes(diag)[0]
+            r1 = self.vector_to_amplitudes(diag)["r1"]
             arg = np.argsort(diag[: r1.size])
         else:
             arg = np.argsort(diag)
@@ -275,15 +303,15 @@ class EE_GEOM(GEOM, BaseEE_EOM):
         Returns:
             Diagonal of the Hamiltonian.
         """
-        parts = []
+        parts: Namespace[SpinArrayType] = util.Namespace()
 
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
-            parts.append(-self.ebcc.energy_sum(key))
+            parts[f"r{n}"] = -self.ebcc.energy_sum(key)
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
             raise util.ModelNotImplemented
 
-        return self.amplitudes_to_vector(*parts)
+        return self.amplitudes_to_vector(parts)
 
     def bras(self, eris: Optional[ERIsInputType] = None) -> SpinArrayType:
         """Get the bra vectors.
@@ -294,10 +322,17 @@ class EE_GEOM(GEOM, BaseEE_EOM):
         Returns:
             Bra vectors.
         """
-        bras_raw = list(self.ebcc.make_ee_mom_bras(eris=eris))
+        bras_raw = util.Namespace(
+            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ee_mom_bras(eris=eris))}
+        )
         bras = np.array(
             [
-                [self.amplitudes_to_vector(*[b[i, j] for b in bras_raw]) for j in range(self.nmo)]
+                [
+                    self.amplitudes_to_vector(
+                        util.Namespace(**{key: b[i, j] for key, b in bras_raw.items()})
+                    )
+                    for j in range(self.nmo)
+                ]
                 for i in range(self.nmo)
             ]
         )
@@ -312,11 +347,15 @@ class EE_GEOM(GEOM, BaseEE_EOM):
         Returns:
             Ket vectors.
         """
-        kets_raw = list(self.ebcc.make_ee_mom_kets(eris=eris))
+        kets_raw = util.Namespace(
+            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ee_mom_kets(eris=eris))}
+        )
         kets = np.array(
             [
                 [
-                    self.amplitudes_to_vector(*[k[..., i, j] for k in kets_raw])
+                    self.amplitudes_to_vector(
+                        util.Namespace(**{key: k[..., i, j] for key, k in kets_raw.items()})
+                    )
                     for j in range(self.nmo)
                 ]
                 for i in range(self.nmo)

--- a/ebcc/eom/geom.py
+++ b/ebcc/eom/geom.py
@@ -74,7 +74,7 @@ class IP_GEOM(GEOM, BaseIP_EOM):
             Bra vectors.
         """
         bras_raw = util.Namespace(
-            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ip_mom_bras(eris=eris))}
+            **{f"r{n + 1}": b for n, b in enumerate(self.ebcc.make_ip_mom_bras(eris=eris))}
         )
         bras = np.array(
             [
@@ -96,7 +96,7 @@ class IP_GEOM(GEOM, BaseIP_EOM):
             Ket vectors.
         """
         kets_raw = util.Namespace(
-            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ip_mom_kets(eris=eris))}
+            **{f"r{n + 1}": k for n, k in enumerate(self.ebcc.make_ip_mom_kets(eris=eris))}
         )
         kets = np.array(
             [
@@ -199,7 +199,7 @@ class EA_GEOM(GEOM, BaseEA_EOM):
             Bra vectors.
         """
         bras_raw = util.Namespace(
-            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ea_mom_bras(eris=eris))}
+            **{f"r{n + 1}": b for n, b in enumerate(self.ebcc.make_ea_mom_bras(eris=eris))}
         )
         bras = np.array(
             [
@@ -221,7 +221,7 @@ class EA_GEOM(GEOM, BaseEA_EOM):
             Ket vectors.
         """
         kets_raw = util.Namespace(
-            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ea_mom_kets(eris=eris))}
+            **{f"r{n + 1}": k for n, k in enumerate(self.ebcc.make_ea_mom_kets(eris=eris))}
         )
         kets = np.array(
             [
@@ -323,7 +323,7 @@ class EE_GEOM(GEOM, BaseEE_EOM):
             Bra vectors.
         """
         bras_raw = util.Namespace(
-            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ee_mom_bras(eris=eris))}
+            **{f"r{n + 1}": b for n, b in enumerate(self.ebcc.make_ee_mom_bras(eris=eris))}
         )
         bras = np.array(
             [
@@ -348,7 +348,7 @@ class EE_GEOM(GEOM, BaseEE_EOM):
             Ket vectors.
         """
         kets_raw = util.Namespace(
-            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ee_mom_kets(eris=eris))}
+            **{f"r{n + 1}": k for n, k in enumerate(self.ebcc.make_ee_mom_kets(eris=eris))}
         )
         kets = np.array(
             [

--- a/ebcc/eom/reom.py
+++ b/ebcc/eom/reom.py
@@ -74,7 +74,7 @@ class IP_REOM(REOM, BaseIP_EOM):
             Bra vectors.
         """
         bras_raw = util.Namespace(
-            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ip_mom_bras(eris=eris))}
+            **{f"r{n + 1}": b for n, b in enumerate(self.ebcc.make_ip_mom_bras(eris=eris))}
         )
         bras = np.array(
             [
@@ -96,7 +96,7 @@ class IP_REOM(REOM, BaseIP_EOM):
             Ket vectors.
         """
         kets_raw = util.Namespace(
-            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ip_mom_kets(eris=eris))}
+            **{f"r{n + 1}": k for n, k in enumerate(self.ebcc.make_ip_mom_kets(eris=eris))}
         )
         kets = np.array(
             [
@@ -199,7 +199,7 @@ class EA_REOM(REOM, BaseEA_EOM):
             Bra vectors.
         """
         bras_raw = util.Namespace(
-            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ea_mom_bras(eris=eris))}
+            **{f"r{n + 1}": b for n, b in enumerate(self.ebcc.make_ea_mom_bras(eris=eris))}
         )
         bras = np.array(
             [
@@ -221,7 +221,7 @@ class EA_REOM(REOM, BaseEA_EOM):
             Ket vectors.
         """
         kets_raw = util.Namespace(
-            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ea_mom_kets(eris=eris))}
+            **{f"r{n + 1}": k for n, k in enumerate(self.ebcc.make_ea_mom_kets(eris=eris))}
         )
         kets = np.array(
             [
@@ -323,7 +323,7 @@ class EE_REOM(REOM, BaseEE_EOM):
             Bra vectors.
         """
         bras_raw = util.Namespace(
-            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ee_mom_bras(eris=eris))}
+            **{f"r{n + 1}": b for n, b in enumerate(self.ebcc.make_ee_mom_bras(eris=eris))}
         )
         bras = np.array(
             [
@@ -348,7 +348,7 @@ class EE_REOM(REOM, BaseEE_EOM):
             Ket vectors.
         """
         kets_raw = util.Namespace(
-            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ee_mom_kets(eris=eris))}
+            **{f"r{n + 1}": k for n, k in enumerate(self.ebcc.make_ee_mom_kets(eris=eris))}
         )
         kets = np.array(
             [

--- a/ebcc/eom/reom.py
+++ b/ebcc/eom/reom.py
@@ -33,7 +33,7 @@ class IP_REOM(REOM, BaseIP_EOM):
     def _argsort_guesses(self, diag: NDArray[float]) -> NDArray[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
-            r1 = self.vector_to_amplitudes(diag)[0]
+            r1 = self.vector_to_amplitudes(diag)["r1"]
             arg = np.argsort(np.abs(diag[: r1.size]))
         else:
             arg = np.argsort(np.abs(diag))
@@ -53,16 +53,16 @@ class IP_REOM(REOM, BaseIP_EOM):
         Returns:
             Diagonal of the Hamiltonian.
         """
-        parts = []
+        parts: Namespace[SpinArrayType] = Namespace()
 
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
             key = key[:-1]
-            parts.append(self.ebcc.energy_sum(key))
+            parts[f"r{n}"] = self.ebcc.energy_sum(key)
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
             raise util.ModelNotImplemented
 
-        return self.amplitudes_to_vector(*parts)
+        return self.amplitudes_to_vector(parts)
 
     def bras(self, eris: Optional[ERIsInputType] = None) -> SpinArrayType:
         """Get the bra vectors.
@@ -73,9 +73,16 @@ class IP_REOM(REOM, BaseIP_EOM):
         Returns:
             Bra vectors.
         """
-        bras_raw = list(self.ebcc.make_ip_mom_bras(eris=eris))
+        bras_raw = util.Namespace(
+            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ip_mom_bras(eris=eris))}
+        )
         bras = np.array(
-            [self.amplitudes_to_vector(*[b[i] for b in bras_raw]) for i in range(self.nmo)]
+            [
+                self.amplitudes_to_vector(
+                    util.Namespace(**{key: b[i] for key, b in bras_raw.items()})
+                )
+                for i in range(self.nmo)
+            ]
         )
         return bras
 
@@ -88,9 +95,16 @@ class IP_REOM(REOM, BaseIP_EOM):
         Returns:
             Ket vectors.
         """
-        kets_raw = list(self.ebcc.make_ip_mom_kets(eris=eris))
+        kets_raw = util.Namespace(
+            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ip_mom_kets(eris=eris))}
+        )
         kets = np.array(
-            [self.amplitudes_to_vector(*[k[..., i] for k in kets_raw]) for i in range(self.nmo)]
+            [
+                self.amplitudes_to_vector(
+                    util.Namespace(**{key: k[..., i] for key, k in kets_raw.items()})
+                )
+                for i in range(self.nmo)
+            ]
         )
         return kets
 
@@ -144,7 +158,7 @@ class EA_REOM(REOM, BaseEA_EOM):
     def _argsort_guesses(self, diag: NDArray[float]) -> NDArray[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
-            r1 = self.vector_to_amplitudes(diag)[0]
+            r1 = self.vector_to_amplitudes(diag)["r1"]
             arg = np.argsort(np.abs(diag[: r1.size]))
         else:
             arg = np.argsort(np.abs(diag))
@@ -164,16 +178,16 @@ class EA_REOM(REOM, BaseEA_EOM):
         Returns:
             Diagonal of the Hamiltonian.
         """
-        parts = []
+        parts: Namespace[SpinArrayType] = Namespace()
 
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
             key = key[n:] + key[: n - 1]
-            parts.append(-self.ebcc.energy_sum(key))
+            parts[f"r{n}"] = self.ebcc.energy_sum(key)
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
             raise util.ModelNotImplemented
 
-        return self.amplitudes_to_vector(*parts)
+        return self.amplitudes_to_vector(parts)
 
     def bras(self, eris: Optional[ERIsInputType] = None) -> SpinArrayType:
         """Get the bra vectors.
@@ -184,9 +198,16 @@ class EA_REOM(REOM, BaseEA_EOM):
         Returns:
             Bra vectors.
         """
-        bras_raw = list(self.ebcc.make_ea_mom_bras(eris=eris))
+        bras_raw = util.Namespace(
+            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ea_mom_bras(eris=eris))}
+        )
         bras = np.array(
-            [self.amplitudes_to_vector(*[b[i] for b in bras_raw]) for i in range(self.nmo)]
+            [
+                self.amplitudes_to_vector(
+                    util.Namespace(**{key: b[i] for key, b in bras_raw.items()})
+                )
+                for i in range(self.nmo)
+            ]
         )
         return bras
 
@@ -199,9 +220,16 @@ class EA_REOM(REOM, BaseEA_EOM):
         Returns:
             Ket vectors.
         """
-        kets_raw = list(self.ebcc.make_ea_mom_kets(eris=eris))
+        kets_raw = util.Namespace(
+            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ea_mom_kets(eris=eris))}
+        )
         kets = np.array(
-            [self.amplitudes_to_vector(*[k[..., i] for k in kets_raw]) for i in range(self.nmo)]
+            [
+                self.amplitudes_to_vector(
+                    util.Namespace(**{key: k[..., i] for key, k in kets_raw.items()})
+                )
+                for i in range(self.nmo)
+            ]
         )
         return kets
 
@@ -255,7 +283,7 @@ class EE_REOM(REOM, BaseEE_EOM):
     def _argsort_guesses(self, diag: NDArray[float]) -> NDArray[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
-            r1 = self.vector_to_amplitudes(diag)[0]
+            r1 = self.vector_to_amplitudes(diag)["r1"]
             arg = np.argsort(diag[: r1.size])
         else:
             arg = np.argsort(diag)
@@ -275,15 +303,15 @@ class EE_REOM(REOM, BaseEE_EOM):
         Returns:
             Diagonal of the Hamiltonian.
         """
-        parts = []
+        parts: Namespace[SpinArrayType] = Namespace()
 
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
-            parts.append(-self.ebcc.energy_sum(key))
+            parts[f"r{n}"] = -self.ebcc.energy_sum(key)
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
             raise util.ModelNotImplemented
 
-        return self.amplitudes_to_vector(*parts)
+        return self.amplitudes_to_vector(parts)
 
     def bras(self, eris: Optional[ERIsInputType] = None) -> SpinArrayType:
         """Get the bra vectors.
@@ -294,10 +322,17 @@ class EE_REOM(REOM, BaseEE_EOM):
         Returns:
             Bra vectors.
         """
-        bras_raw = list(self.ebcc.make_ee_mom_bras(eris=eris))
+        bras_raw = util.Namespace(
+            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ee_mom_bras(eris=eris))}
+        )
         bras = np.array(
             [
-                [self.amplitudes_to_vector(*[b[i, j] for b in bras_raw]) for j in range(self.nmo)]
+                [
+                    self.amplitudes_to_vector(
+                        util.Namespace(**{key: b[i, j] for key, b in bras_raw.items()})
+                    )
+                    for j in range(self.nmo)
+                ]
                 for i in range(self.nmo)
             ]
         )
@@ -312,11 +347,15 @@ class EE_REOM(REOM, BaseEE_EOM):
         Returns:
             Ket vectors.
         """
-        kets_raw = list(self.ebcc.make_ee_mom_kets(eris=eris))
+        kets_raw = util.Namespace(
+            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ee_mom_kets(eris=eris))}
+        )
         kets = np.array(
             [
                 [
-                    self.amplitudes_to_vector(*[k[..., i, j] for k in kets_raw])
+                    self.amplitudes_to_vector(
+                        util.Namespace(**{key: k[..., i, j] for key, k in kets_raw.items()})
+                    )
                     for j in range(self.nmo)
                 ]
                 for i in range(self.nmo)

--- a/ebcc/eom/ueom.py
+++ b/ebcc/eom/ueom.py
@@ -76,7 +76,7 @@ class IP_UEOM(UEOM, BaseIP_EOM):
             Bra vectors.
         """
         bras_raw = util.Namespace(
-            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ip_mom_bras(eris=eris))}
+            **{f"r{n + 1}": b for n, b in enumerate(self.ebcc.make_ip_mom_bras(eris=eris))}
         )
         bras_tmp: Namespace[list[NDArray[float]]] = util.Namespace(a=[], b=[])
 
@@ -133,7 +133,7 @@ class IP_UEOM(UEOM, BaseIP_EOM):
             Ket vectors.
         """
         kets_raw = util.Namespace(
-            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ip_mom_kets(eris=eris))}
+            **{f"r{n + 1}": k for n, k in enumerate(self.ebcc.make_ip_mom_kets(eris=eris))}
         )
         kets_tmp: Namespace[list[NDArray[float]]] = util.Namespace(a=[], b=[])
 
@@ -279,7 +279,7 @@ class EA_UEOM(UEOM, BaseEA_EOM):
             Bra vectors.
         """
         bras_raw = util.Namespace(
-            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ea_mom_bras(eris=eris))}
+            **{f"r{n + 1}": b for n, b in enumerate(self.ebcc.make_ea_mom_bras(eris=eris))}
         )
         bras_tmp: Namespace[list[NDArray[float]]] = util.Namespace(a=[], b=[])
 
@@ -336,7 +336,7 @@ class EA_UEOM(UEOM, BaseEA_EOM):
             Ket vectors.
         """
         kets_raw = util.Namespace(
-            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ea_mom_kets(eris=eris))}
+            **{f"r{n + 1}": k for n, k in enumerate(self.ebcc.make_ea_mom_kets(eris=eris))}
         )
         kets_tmp: Namespace[list[NDArray[float]]] = util.Namespace(a=[], b=[])
 

--- a/ebcc/eom/ueom.py
+++ b/ebcc/eom/ueom.py
@@ -32,7 +32,7 @@ class IP_UEOM(UEOM, BaseIP_EOM):
     def _argsort_guesses(self, diag: NDArray[float]) -> NDArray[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
-            r1 = self.vector_to_amplitudes(diag)[0]
+            r1 = self.vector_to_amplitudes(diag)["r1"]
             arg = np.argsort(np.abs(diag[: r1.a.size + r1.b.size]))
         else:
             arg = np.argsort(np.abs(diag))
@@ -52,19 +52,19 @@ class IP_UEOM(UEOM, BaseIP_EOM):
         Returns:
             Diagonal of the Hamiltonian.
         """
-        parts = []
+        parts: Namespace[SpinArrayType] = util.Namespace()
 
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
             key = key[:-1]
             spin_part: SpinArrayType = util.Namespace()
             for comb in util.generate_spin_combinations(n, excited=True):
                 spin_part[comb] = self.ebcc.energy_sum(key, comb)
-            parts.append(spin_part)
+            parts[f"r{n}"] = spin_part
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
             raise util.ModelNotImplemented
 
-        return self.amplitudes_to_vector(*parts)
+        return self.amplitudes_to_vector(parts)
 
     def bras(self, eris: Optional[ERIsInputType] = None) -> SpinArrayType:
         """Get the bra vectors.
@@ -75,14 +75,15 @@ class IP_UEOM(UEOM, BaseIP_EOM):
         Returns:
             Bra vectors.
         """
-        bras_raw = list(self.ebcc.make_ip_mom_bras(eris=eris))
+        bras_raw = util.Namespace(
+            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ip_mom_bras(eris=eris))}
+        )
         bras_tmp: Namespace[list[NDArray[float]]] = util.Namespace(a=[], b=[])
 
         for i in range(self.nmo):
-            amps_a: list[SpinArrayType] = []
-            amps_b: list[SpinArrayType] = []
+            amps_a: Namespace[SpinArrayType] = util.Namespace()
+            amps_b: Namespace[SpinArrayType] = util.Namespace()
 
-            m = 0
             for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
                 amp_a: SpinArrayType = util.Namespace()
                 amp_b: SpinArrayType = util.Namespace()
@@ -93,20 +94,19 @@ class IP_UEOM(UEOM, BaseIP_EOM):
                     setattr(
                         amp_a,
                         spin,
-                        getattr(bras_raw[m], "a" + spin, {i: np.zeros(shape, dtype=types[float])})[
-                            i
-                        ],
+                        getattr(
+                            bras_raw[f"r{n}"], "a" + spin, {i: np.zeros(shape, dtype=types[float])}
+                        )[i],
                     )
                     setattr(
                         amp_b,
                         spin,
-                        getattr(bras_raw[m], "b" + spin, {i: np.zeros(shape, dtype=types[float])})[
-                            i
-                        ],
+                        getattr(
+                            bras_raw[f"r{n}"], "b" + spin, {i: np.zeros(shape, dtype=types[float])}
+                        )[i],
                     )
-                amps_a.append(amp_a)
-                amps_b.append(amp_b)
-                m += 1
+                amps_a[f"r{n}"] = amp_a
+                amps_b[f"r{n}"] = amp_b
 
             for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
                 raise util.ModelNotImplemented
@@ -114,8 +114,8 @@ class IP_UEOM(UEOM, BaseIP_EOM):
             for name, key, nf, nb in self.ansatz.coupling_cluster_ranks(spin_type=self.spin_type):
                 raise util.ModelNotImplemented
 
-            bras_tmp.a.append(self.amplitudes_to_vector(*amps_a))
-            bras_tmp.b.append(self.amplitudes_to_vector(*amps_b))
+            bras_tmp.a.append(self.amplitudes_to_vector(amps_a))
+            bras_tmp.b.append(self.amplitudes_to_vector(amps_b))
 
         bras: Namespace[NDArray[float]] = util.Namespace(
             a=np.array(bras_tmp.a), b=np.array(bras_tmp.b)
@@ -132,15 +132,16 @@ class IP_UEOM(UEOM, BaseIP_EOM):
         Returns:
             Ket vectors.
         """
-        kets_raw = list(self.ebcc.make_ip_mom_kets(eris=eris))
+        kets_raw = util.Namespace(
+            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ip_mom_kets(eris=eris))}
+        )
         kets_tmp: Namespace[list[NDArray[float]]] = util.Namespace(a=[], b=[])
 
         for i in range(self.nmo):
             j = (Ellipsis, i)
-            amps_a: list[SpinArrayType] = []
-            amps_b: list[SpinArrayType] = []
+            amps_a: Namespace[SpinArrayType] = util.Namespace()
+            amps_b: Namespace[SpinArrayType] = util.Namespace()
 
-            m = 0
             for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
                 amp_a: SpinArrayType = util.Namespace()
                 amp_b: SpinArrayType = util.Namespace()
@@ -151,20 +152,19 @@ class IP_UEOM(UEOM, BaseIP_EOM):
                     setattr(
                         amp_a,
                         spin,
-                        getattr(kets_raw[m], spin + "a", {j: np.zeros(shape, dtype=types[float])})[
-                            j
-                        ],
+                        getattr(
+                            kets_raw[f"r{n}"], spin + "a", {j: np.zeros(shape, dtype=types[float])}
+                        )[j],
                     )
                     setattr(
                         amp_b,
                         spin,
-                        getattr(kets_raw[m], spin + "b", {j: np.zeros(shape, dtype=types[float])})[
-                            j
-                        ],
+                        getattr(
+                            kets_raw[f"r{n}"], spin + "b", {j: np.zeros(shape, dtype=types[float])}
+                        )[j],
                     )
-                amps_a.append(amp_a)
-                amps_b.append(amp_b)
-                m += 1
+                amps_a[f"r{n}"] = amp_a
+                amps_b[f"r{n}"] = amp_b
 
             for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
                 raise util.ModelNotImplemented
@@ -172,8 +172,8 @@ class IP_UEOM(UEOM, BaseIP_EOM):
             for name, key, nf, nb in self.ansatz.coupling_cluster_ranks(spin_type=self.spin_type):
                 raise util.ModelNotImplemented
 
-            kets_tmp.a.append(self.amplitudes_to_vector(*amps_a))
-            kets_tmp.b.append(self.amplitudes_to_vector(*amps_b))
+            kets_tmp.a.append(self.amplitudes_to_vector(amps_a))
+            kets_tmp.b.append(self.amplitudes_to_vector(amps_b))
 
         kets: Namespace[NDArray[float]] = util.Namespace(
             a=np.array(kets_tmp.a), b=np.array(kets_tmp.b)
@@ -235,7 +235,7 @@ class EA_UEOM(UEOM, BaseEA_EOM):
     def _argsort_guesses(self, diag: NDArray[float]) -> NDArray[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
-            r1 = self.vector_to_amplitudes(diag)[0]
+            r1 = self.vector_to_amplitudes(diag)["r1"]
             arg = np.argsort(np.abs(diag[: r1.a.size + r1.b.size]))
         else:
             arg = np.argsort(np.abs(diag))
@@ -255,19 +255,19 @@ class EA_UEOM(UEOM, BaseEA_EOM):
         Returns:
             Diagonal of the Hamiltonian.
         """
-        parts = []
+        parts: Namespace[SpinArrayType] = util.Namespace()
 
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
             key = key[n:] + key[: n - 1]
             spin_part: SpinArrayType = util.Namespace()
             for comb in util.generate_spin_combinations(n, excited=True):
                 spin_part[comb] = -self.ebcc.energy_sum(key, comb)
-            parts.append(spin_part)
+            parts[f"r{n}"] = spin_part
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
             raise util.ModelNotImplemented
 
-        return self.amplitudes_to_vector(*parts)
+        return self.amplitudes_to_vector(parts)
 
     def bras(self, eris: Optional[ERIsInputType] = None) -> SpinArrayType:
         """Get the bra vectors.
@@ -278,14 +278,15 @@ class EA_UEOM(UEOM, BaseEA_EOM):
         Returns:
             Bra vectors.
         """
-        bras_raw = list(self.ebcc.make_ea_mom_bras(eris=eris))
+        bras_raw = util.Namespace(
+            **{f"r{n+1}": b for n, b in enumerate(self.ebcc.make_ea_mom_bras(eris=eris))}
+        )
         bras_tmp: Namespace[list[NDArray[float]]] = util.Namespace(a=[], b=[])
 
         for i in range(self.nmo):
-            amps_a: list[SpinArrayType] = []
-            amps_b: list[SpinArrayType] = []
+            amps_a: Namespace[SpinArrayType] = util.Namespace()
+            amps_b: Namespace[SpinArrayType] = util.Namespace()
 
-            m = 0
             for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
                 amp_a: SpinArrayType = util.Namespace()
                 amp_b: SpinArrayType = util.Namespace()
@@ -296,20 +297,19 @@ class EA_UEOM(UEOM, BaseEA_EOM):
                     setattr(
                         amp_a,
                         spin,
-                        getattr(bras_raw[m], "a" + spin, {i: np.zeros(shape, dtype=types[float])})[
-                            i
-                        ],
+                        getattr(
+                            bras_raw[f"r{n}"], "a" + spin, {i: np.zeros(shape, dtype=types[float])}
+                        )[i],
                     )
                     setattr(
                         amp_b,
                         spin,
-                        getattr(bras_raw[m], "b" + spin, {i: np.zeros(shape, dtype=types[float])})[
-                            i
-                        ],
+                        getattr(
+                            bras_raw[f"r{n}"], "b" + spin, {i: np.zeros(shape, dtype=types[float])}
+                        )[i],
                     )
-                amps_a.append(amp_a)
-                amps_b.append(amp_b)
-                m += 1
+                amps_a[f"r{n}"] = amp_a
+                amps_b[f"r{n}"] = amp_b
 
             for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
                 raise util.ModelNotImplemented
@@ -317,8 +317,8 @@ class EA_UEOM(UEOM, BaseEA_EOM):
             for name, key, nf, nb in self.ansatz.coupling_cluster_ranks(spin_type=self.spin_type):
                 raise util.ModelNotImplemented
 
-            bras_tmp.a.append(self.amplitudes_to_vector(*amps_a))
-            bras_tmp.b.append(self.amplitudes_to_vector(*amps_b))
+            bras_tmp.a.append(self.amplitudes_to_vector(amps_a))
+            bras_tmp.b.append(self.amplitudes_to_vector(amps_b))
 
         bras: Namespace[NDArray[float]] = util.Namespace(
             a=np.array(bras_tmp.a), b=np.array(bras_tmp.b)
@@ -335,15 +335,16 @@ class EA_UEOM(UEOM, BaseEA_EOM):
         Returns:
             Ket vectors.
         """
-        kets_raw = list(self.ebcc.make_ea_mom_kets(eris=eris))
+        kets_raw = util.Namespace(
+            **{f"r{n+1}": k for n, k in enumerate(self.ebcc.make_ea_mom_kets(eris=eris))}
+        )
         kets_tmp: Namespace[list[NDArray[float]]] = util.Namespace(a=[], b=[])
 
         for i in range(self.nmo):
             j = (Ellipsis, i)
-            amps_a: list[SpinArrayType] = []
-            amps_b: list[SpinArrayType] = []
+            amps_a: Namespace[SpinArrayType] = util.Namespace()
+            amps_b: Namespace[SpinArrayType] = util.Namespace()
 
-            m = 0
             for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
                 amp_a: SpinArrayType = util.Namespace()
                 amp_b: SpinArrayType = util.Namespace()
@@ -354,20 +355,19 @@ class EA_UEOM(UEOM, BaseEA_EOM):
                     setattr(
                         amp_a,
                         spin,
-                        getattr(kets_raw[m], spin + "a", {j: np.zeros(shape, dtype=types[float])})[
-                            j
-                        ],
+                        getattr(
+                            kets_raw[f"r{n}"], spin + "a", {j: np.zeros(shape, dtype=types[float])}
+                        )[j],
                     )
                     setattr(
                         amp_b,
                         spin,
-                        getattr(kets_raw[m], spin + "b", {j: np.zeros(shape, dtype=types[float])})[
-                            j
-                        ],
+                        getattr(
+                            kets_raw[f"r{n}"], spin + "b", {j: np.zeros(shape, dtype=types[float])}
+                        )[j],
                     )
-                amps_a.append(amp_a)
-                amps_b.append(amp_b)
-                m += 1
+                amps_a[f"r{n}"] = amp_a
+                amps_b[f"r{n}"] = amp_b
 
             for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
                 raise util.ModelNotImplemented
@@ -375,8 +375,8 @@ class EA_UEOM(UEOM, BaseEA_EOM):
             for name, key, nf, nb in self.ansatz.coupling_cluster_ranks(spin_type=self.spin_type):
                 raise util.ModelNotImplemented
 
-            kets_tmp.a.append(self.amplitudes_to_vector(*amps_a))
-            kets_tmp.b.append(self.amplitudes_to_vector(*amps_b))
+            kets_tmp.a.append(self.amplitudes_to_vector(amps_a))
+            kets_tmp.b.append(self.amplitudes_to_vector(amps_b))
 
         kets: Namespace[NDArray[float]] = util.Namespace(
             a=np.array(kets_tmp.a), b=np.array(kets_tmp.b)
@@ -438,7 +438,7 @@ class EE_UEOM(UEOM, BaseEE_EOM):
     def _argsort_guesses(self, diag: NDArray[float]) -> NDArray[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
-            r1 = self.vector_to_amplitudes(diag)[0]
+            r1 = self.vector_to_amplitudes(diag)["r1"]
             arg = np.argsort(diag[: r1.aa.size + r1.bb.size])
         else:
             arg = np.argsort(diag)
@@ -458,18 +458,18 @@ class EE_UEOM(UEOM, BaseEE_EOM):
         Returns:
             Diagonal of the Hamiltonian.
         """
-        parts = []
+        parts: Namespace[SpinArrayType] = util.Namespace()
 
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
             spin_part: SpinArrayType = util.Namespace()
             for comb in util.generate_spin_combinations(n):
                 spin_part[comb] = self.ebcc.energy_sum(key, comb)
-            parts.append(spin_part)
+            parts[f"r{n}"] = spin_part
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
             raise util.ModelNotImplemented
 
-        return self.amplitudes_to_vector(*parts)
+        return self.amplitudes_to_vector(parts)
 
     def bras(self, eris: Optional[ERIsInputType] = None) -> SpinArrayType:
         """Get the bra vectors.


### PR DESCRIPTION
EOM amplitudes were hardcoded to use a tuple of `(r1, r2)`. This PR generalises the implementation w.r.t ansatzes.