### PR TITLE
Switchable numpy backends

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install ebcc
         run: |
           python -m pip install wheel
-          python -m pip install .[dev]
+          python -m pip install .[dev,numpy,jax,tensorflow]
       - name: Linting
         run: |
           python -m black ebcc/ --diff --check --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: python ${{ matrix.python-version }} on ${{matrix.os}}
+    name: python ${{ matrix.python-version }} on ${{ matrix.os }} with ${{ matrix.backend }} backend
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {python-version: "3.9", os: ubuntu-latest, documentation: True, coverage: True}
-          - {python-version: "3.10", os: ubuntu-latest, documentation: False, coverage: True}
-          - {python-version: "3.11", os: ubuntu-latest, documentation: False, coverage: True}
-          - {python-version: "3.12", os: ubuntu-latest, documentation: False, coverage: False}
+          - {python-version: "3.9", backend: "numpy", os: ubuntu-latest, documentation: True, coverage: True}
+          - {python-version: "3.10", backend: "numpy", os: ubuntu-latest, documentation: False, coverage: True}
+          - {python-version: "3.11", backend: "numpy", os: ubuntu-latest, documentation: False, coverage: True}
+          - {python-version: "3.12", backend: "numpy", os: ubuntu-latest, documentation: False, coverage: False}
+          - {python-version: "3.12", backend: "tensorflow", os: ubuntu-latest, documentation: False, coverage: False}
 
     steps:
       - uses: actions/checkout@v2
@@ -46,12 +47,12 @@ jobs:
       - name: Run unit tests with coverage
         run: |
           python -m pip install pytest pytest-cov
-          pytest --cov ebcc/
+          EBCC_BACKEND=${{ matrix.backend }} pytest --cov ebcc/
         if: matrix.coverage
       - name: Run unit tests
         run: |
           python -m pip install pytest
-          pytest
+          EBCC_BACKEND=${{ matrix.backend }} pytest
         if: ${{ ! matrix.coverage }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,11 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {python-version: "3.9", backend: "numpy", os: ubuntu-latest, documentation: True, coverage: True}
-          - {python-version: "3.10", backend: "numpy", os: ubuntu-latest, documentation: False, coverage: True}
-          - {python-version: "3.11", backend: "numpy", os: ubuntu-latest, documentation: False, coverage: True}
-          - {python-version: "3.12", backend: "numpy", os: ubuntu-latest, documentation: False, coverage: False}
-          - {python-version: "3.12", backend: "tensorflow", os: ubuntu-latest, documentation: False, coverage: False}
+          - {python-version: "3.9", backend: "numpy", os: ubuntu-latest, documentation: True, coverage: True, minimal: False}
+          - {python-version: "3.10", backend: "numpy", os: ubuntu-latest, documentation: False, coverage: True, minimal: False}
+          - {python-version: "3.11", backend: "numpy", os: ubuntu-latest, documentation: False, coverage: True, minimal: False}
+          - {python-version: "3.12", backend: "numpy", os: ubuntu-latest, documentation: False, coverage: False, minimal: False}
+          - {python-version: "3.12", backend: "tensorflow", os: ubuntu-latest, documentation: False, coverage: False, minimal: True}
 
     steps:
       - uses: actions/checkout@v2
@@ -44,16 +44,21 @@ jobs:
           python -m isort ebcc/ --diff --check-only --verbose
           python -m flake8 ebcc/ --verbose
           python -m mypy ebcc/ --verbose
+      - name: Run minimal unit tests
+        run: |
+          python -m pip install pytest
+          EBCC_BACKEND=${{ matrix.backend }} pytest tests/test_minimal.py
+        if: matrix.minimal
       - name: Run unit tests with coverage
         run: |
           python -m pip install pytest pytest-cov
           EBCC_BACKEND=${{ matrix.backend }} pytest --cov ebcc/
-        if: matrix.coverage
+        if: matrix.coverage && ! matrix.minimal
       - name: Run unit tests
         run: |
           python -m pip install pytest
           EBCC_BACKEND=${{ matrix.backend }} pytest
-        if: ${{ ! matrix.coverage }}
+        if: ! matrix.coverage && ! matrix.minimal
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,9 +52,14 @@ jobs:
         if: matrix.minimal
       - name: Run unit tests
         run: |
-          python -m pip install pytest ${{ 'pytest-cov' if matrix.coverage else '' }}
-          EBCC_BACKEND=${{ matrix.backend }} pytest ${{ '--cov ebcc/' if matrix.coverage else '' }}
+          python -m pip install pytest
+          EBCC_BACKEND=${{ matrix.backend }} pytest
         if: matrix.full
+      - name: Run unit tests with coverage
+        run: |
+          python -m pip install pytest pytest-cov
+          EBCC_BACKEND=${{ matrix.backend }} pytest --cov ebcc/
+        if: matrix.full && matrix.coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,17 +49,17 @@ jobs:
         run: |
           python -m pip install pytest
           EBCC_BACKEND=${{ matrix.backend }} pytest tests/test_minimal.py
-        if: matrix.minimal
+        if: ${{ matrix.minimal }}
       - name: Run unit tests with coverage
         run: |
           python -m pip install pytest pytest-cov
           EBCC_BACKEND=${{ matrix.backend }} pytest --cov ebcc/
-        if: matrix.coverage && ! matrix.minimal
+        if: $${{ matrix.coverage && ! matrix.minimal }}
       - name: Run unit tests
         run: |
           python -m pip install pytest
           EBCC_BACKEND=${{ matrix.backend }} pytest
-        if: ! matrix.coverage && ! matrix.minimal
+        if: ${{ ! matrix.coverage && ! matrix.minimal }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
         run: |
           python -m pip install pytest
           EBCC_BACKEND=${{ matrix.backend }} pytest
-        if: matrix.full
+        if: matrix.full && ! matrix.coverage
       - name: Run unit tests with coverage
         run: |
           python -m pip install pytest pytest-cov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,17 +49,12 @@ jobs:
         run: |
           python -m pip install pytest
           EBCC_BACKEND=${{ matrix.backend }} pytest tests/test_minimal.py
-        if: ${{ matrix.minimal }}
-      - name: Run unit tests with coverage
-        run: |
-          python -m pip install pytest pytest-cov
-          EBCC_BACKEND=${{ matrix.backend }} pytest --cov ebcc/
-        if: $${{ matrix.coverage && ! matrix.minimal }}
+        if: matrix.minimal
       - name: Run unit tests
         run: |
-          python -m pip install pytest
-          EBCC_BACKEND=${{ matrix.backend }} pytest
-        if: ${{ ! matrix.coverage && ! matrix.minimal }}
+          python -m pip install pytest ${{ 'pytest-cov' if matrix.coverage else '' }}
+          EBCC_BACKEND=${{ matrix.backend }} pytest ${{ '--cov ebcc/' if matrix.coverage else '' }}
+        if: ${{ ! matrix.minimal }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,11 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {python-version: "3.9", backend: "numpy", os: ubuntu-latest, documentation: True, coverage: True, minimal: False}
-          - {python-version: "3.10", backend: "numpy", os: ubuntu-latest, documentation: False, coverage: True, minimal: False}
-          - {python-version: "3.11", backend: "numpy", os: ubuntu-latest, documentation: False, coverage: True, minimal: False}
-          - {python-version: "3.12", backend: "numpy", os: ubuntu-latest, documentation: False, coverage: False, minimal: False}
+          - {python-version: "3.9",  backend: "numpy",      os: ubuntu-latest, documentation: True,  coverage: True,  minimal: False}
+          - {python-version: "3.10", backend: "numpy",      os: ubuntu-latest, documentation: False, coverage: True,  minimal: False}
+          - {python-version: "3.11", backend: "numpy",      os: ubuntu-latest, documentation: False, coverage: True,  minimal: False}
+          - {python-version: "3.12", backend: "numpy",      os: ubuntu-latest, documentation: False, coverage: False, minimal: False}
           - {python-version: "3.12", backend: "tensorflow", os: ubuntu-latest, documentation: False, coverage: False, minimal: True}
+          - {python-version: "3.12", backend: "jax",        os: ubuntu-latest, documentation: False, coverage: False, minimal: True}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {python-version: "3.9",  backend: "numpy",      os: ubuntu-latest, documentation: True,  coverage: True,  minimal: False}
-          - {python-version: "3.10", backend: "numpy",      os: ubuntu-latest, documentation: False, coverage: True,  minimal: False}
-          - {python-version: "3.11", backend: "numpy",      os: ubuntu-latest, documentation: False, coverage: True,  minimal: False}
-          - {python-version: "3.12", backend: "numpy",      os: ubuntu-latest, documentation: False, coverage: False, minimal: False}
-          - {python-version: "3.12", backend: "tensorflow", os: ubuntu-latest, documentation: False, coverage: False, minimal: True}
-          - {python-version: "3.12", backend: "jax",        os: ubuntu-latest, documentation: False, coverage: False, minimal: True}
+          - {python-version: "3.9",  backend: "numpy",      os: ubuntu-latest, documentation: True,  coverage: True,  minimal: True, full: True}
+          - {python-version: "3.10", backend: "numpy",      os: ubuntu-latest, documentation: False, coverage: True,  minimal: True, full: True}
+          - {python-version: "3.11", backend: "numpy",      os: ubuntu-latest, documentation: False, coverage: True,  minimal: True, full: True}
+          - {python-version: "3.12", backend: "numpy",      os: ubuntu-latest, documentation: False, coverage: False, minimal: True, full: True}
+          - {python-version: "3.12", backend: "tensorflow", os: ubuntu-latest, documentation: False, coverage: False, minimal: True, full: False}
+          - {python-version: "3.12", backend: "jax",        os: ubuntu-latest, documentation: False, coverage: False, minimal: True, full: False}
 
     steps:
       - uses: actions/checkout@v2
@@ -54,7 +54,7 @@ jobs:
         run: |
           python -m pip install pytest ${{ 'pytest-cov' if matrix.coverage else '' }}
           EBCC_BACKEND=${{ matrix.backend }} pytest ${{ '--cov ebcc/' if matrix.coverage else '' }}
-        if: ${{ ! matrix.minimal }}
+        if: matrix.full
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/ebcc/__init__.py
+++ b/ebcc/__init__.py
@@ -42,11 +42,19 @@ __version__ = "1.5.0"
 """List of supported ansatz types."""
 METHOD_TYPES = ["MP", "CC", "LCC", "QCI", "QCC", "DC"]
 
+import importlib
 import os
 import sys
 from typing import TYPE_CHECKING
 
-import numpy
+"""Backend to use for NumPy operations."""
+BACKEND = os.environ.get("EBCC_BACKEND", "numpy")
+
+if TYPE_CHECKING:
+    # Import NumPy directly for type-checking purposes
+    import numpy
+else:
+    numpy = importlib.import_module(f"ebcc.backend._{BACKEND}")
 
 from ebcc.core.logging import NullLogger, default_log, init_logging
 from ebcc.cc import GEBCC, REBCC, UEBCC

--- a/ebcc/__init__.py
+++ b/ebcc/__init__.py
@@ -48,7 +48,7 @@ import sys
 from typing import TYPE_CHECKING
 
 """Backend to use for NumPy operations."""
-BACKEND = os.environ.get("EBCC_BACKEND", "numpy")
+BACKEND: str = os.environ.get("EBCC_BACKEND", "numpy")
 
 if TYPE_CHECKING:
     # Import NumPy directly for type-checking purposes

--- a/ebcc/backend/__init__.py
+++ b/ebcc/backend/__init__.py
@@ -3,6 +3,7 @@
 Notes:
     Currently, the following backends are supported:
         - NumPy
+        - CuPy
         - TensorFlow
         - JAX
 
@@ -28,14 +29,16 @@ if TYPE_CHECKING:
 
     T = TypeVar("T", bound=generic)
 
-if BACKEND == "numpy":  # type: ignore
+if BACKEND == "numpy":
     import numpy as np
-elif BACKEND == "tensorflow":  # type: ignore
-    import tensorflow as tf  # type: ignore
-    import tensorflow.experimental.numpy as np  # type: ignore
-elif BACKEND == "jax":  # type: ignore
-    import jax  # type: ignore
-    import jax.numpy as np  # type: ignore
+elif BACKEND == "cupy":
+    import cupy as np  # type: ignore[no-redef]
+elif BACKEND == "tensorflow":
+    import tensorflow as tf
+    import tensorflow.experimental.numpy as np  # type: ignore[no-redef]
+elif BACKEND == "jax":
+    import jax
+    import jax.numpy as np  # type: ignore[no-redef]
 
 
 def __getattr__(name: str) -> ModuleType:
@@ -61,7 +64,7 @@ def _put(
     Notes:
         This function does not guarantee a copy of the array.
     """
-    if BACKEND == "numpy":
+    if BACKEND == "numpy" or BACKEND == "cupy":
         if isinstance(indices, tuple):
             indices_flat = np.ravel_multi_index(indices, array.shape)
             np.put(array, indices_flat, values)

--- a/ebcc/backend/__init__.py
+++ b/ebcc/backend/__init__.py
@@ -20,6 +20,8 @@ if BACKEND == "numpy":  # type: ignore
     import numpy as np
 elif BACKEND == "tensorflow":  # type: ignore
     import tensorflow as tf  # type: ignore
+elif BACKEND == "jax":  # type: ignore
+    import jax  # type: ignore
 
 
 def __getattr__(name: str) -> ModuleType:
@@ -45,7 +47,7 @@ def _put(
     Notes:
         This function does not guarantee a copy of the array.
     """
-    if BACKEND == "numpy":
+    if BACKEND == "numpy" or BACKEND == "jax":
         if isinstance(indices, tuple):
             indices_flat = np.ravel_multi_index(indices, array.shape)
             array.put(indices_flat, values)

--- a/ebcc/backend/__init__.py
+++ b/ebcc/backend/__init__.py
@@ -74,9 +74,9 @@ def _put(
     elif BACKEND == "jax":
         if isinstance(indices, tuple):
             indices_flat = np.ravel_multi_index(indices, array.shape)
-            array = np.put(array, indices_flat, values, inplace=True)  # type: ignore
+            array = np.put(array, indices_flat, values, inplace=False)  # type: ignore
         else:
-            array = np.put(array, indices, values, inplace=True)  # type: ignore
+            array = np.put(array, indices, values, inplace=False)  # type: ignore
         return array
     elif BACKEND == "tensorflow":
         if isinstance(indices, (tuple, list)):

--- a/ebcc/backend/__init__.py
+++ b/ebcc/backend/__init__.py
@@ -2,17 +2,64 @@
 
 from __future__ import annotations
 
+import importlib
 from typing import TYPE_CHECKING
 
-import importlib
+from ebcc import BACKEND
 
 if TYPE_CHECKING:
     from types import ModuleType
+    from typing import Union
+
+    from numpy import int64, float64
+    from numpy.typing import NDArray
+
+    T = float64
+
+if BACKEND == "numpy":  # type: ignore
+    import numpy as np
+elif BACKEND == "tensorflow":  # type: ignore
+    import tensorflow as tf  # type: ignore
 
 
 def __getattr__(name: str) -> ModuleType:
     """Get the backend module."""
-    if name.lower() == "numpy":
-        return importlib.import_module("ebcc.backend._numpy")
+    return importlib.import_module(f"ebcc.backend._{BACKEND.lower()}")
+
+
+def _put(
+    array: NDArray[T],
+    indices: Union[NDArray[int64], tuple[NDArray[int64], ...]],
+    values: NDArray[T],
+) -> NDArray[T]:
+    """Put values into an array at specified indices.
+
+    Args:
+        array: Array to put values into.
+        indices: Indices to put values at.
+        values: Values to put into the array.
+
+    Returns:
+        Array with values put at specified indices.
+
+    Notes:
+        This function does not guarantee a copy of the array.
+    """
+    if BACKEND == "numpy":
+        if isinstance(indices, tuple):
+            indices_flat = np.ravel_multi_index(indices, array.shape)
+            array.put(indices_flat, values)
+        else:
+            array.put(indices, values)
+        return array
+    elif BACKEND == "tensorflow":
+        if isinstance(indices, (tuple, list)):
+            indices_grid = tf.meshgrid(*indices, indexing="ij")
+            indices = tf.stack([tf.cast(idx, tf.int32).ravel() for idx in indices_grid], axis=1)
+        else:
+            indices = tf.cast(tf.convert_to_tensor(indices), tf.int32)
+            indices = tf.expand_dims(indices, axis=-1)
+        values = tf.convert_to_tensor(values, dtype=array.dtype)
+        return tf.tensor_scatter_nd_update(array, indices, values)  # type: ignore
     else:
-        raise ValueError(f"Unknown backend: {name}")
+        raise NotImplementedError(f"Backend {BACKEND} _put not implemented.")

--- a/ebcc/backend/__init__.py
+++ b/ebcc/backend/__init__.py
@@ -81,11 +81,11 @@ def _put(
     elif BACKEND == "tensorflow":
         if isinstance(indices, (tuple, list)):
             indices_grid = tf.meshgrid(*indices, indexing="ij")
-            indices = tf.stack([tf.cast(idx, tf.int32).ravel() for idx in indices_grid], axis=1)
+            indices = tf.stack([np.ravel(tf.cast(idx, tf.int32)) for idx in indices_grid], axis=1)
         else:
             indices = tf.cast(tf.convert_to_tensor(indices), tf.int32)
             indices = tf.expand_dims(indices, axis=-1)
-        values = tf.convert_to_tensor(values, dtype=array.dtype).ravel()
+        values = np.ravel(tf.convert_to_tensor(values, dtype=array.dtype))
         return tf.tensor_scatter_nd_update(array, indices, values)  # type: ignore
     else:
         raise NotImplementedError(f"Backend {BACKEND} _put not implemented.")

--- a/ebcc/backend/__init__.py
+++ b/ebcc/backend/__init__.py
@@ -59,7 +59,7 @@ def _put(
         else:
             indices = tf.cast(tf.convert_to_tensor(indices), tf.int32)
             indices = tf.expand_dims(indices, axis=-1)
-        values = tf.convert_to_tensor(values, dtype=array.dtype)
+        values = tf.convert_to_tensor(values, dtype=array.dtype).ravel()
         return tf.tensor_scatter_nd_update(array, indices, values)  # type: ignore
     else:
         raise NotImplementedError(f"Backend {BACKEND} _put not implemented.")

--- a/ebcc/backend/__init__.py
+++ b/ebcc/backend/__init__.py
@@ -9,12 +9,12 @@ from ebcc import BACKEND
 
 if TYPE_CHECKING:
     from types import ModuleType
-    from typing import Union
+    from typing import Union, TypeVar
 
-    from numpy import int64, float64
+    from numpy import int64, generic
     from numpy.typing import NDArray
 
-    T = float64
+    T = TypeVar("T", bound=generic)
 
 if BACKEND == "numpy":  # type: ignore
     import numpy as np

--- a/ebcc/backend/__init__.py
+++ b/ebcc/backend/__init__.py
@@ -94,9 +94,9 @@ def _put(
         # TODO MPI has to be manually managed here
         if isinstance(indices, tuple):
             indices_flat = np.ravel_multi_index(indices, array.shape)
-            array.write(indices_flat, values)
+            array.write(indices_flat, values)  # type: ignore
         else:
-            array.write(indices, values)
+            array.write(indices, values)  # type: ignore
         return array
     else:
         raise NotImplementedError(f"Backend {BACKEND} _put not implemented.")

--- a/ebcc/backend/__init__.py
+++ b/ebcc/backend/__init__.py
@@ -1,0 +1,18 @@
+"""Backend for NumPy operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import importlib
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def __getattr__(name: str) -> ModuleType:
+    """Get the backend module."""
+    if name.lower() == "numpy":
+        return importlib.import_module("ebcc.backend._numpy")
+    else:
+        raise ValueError(f"Unknown backend: {name}")

--- a/ebcc/backend/_ctf.py
+++ b/ebcc/backend/_ctf.py
@@ -2,12 +2,17 @@
 """Cyclops Tensor Framework backend."""
 
 import ctf
+import numpy
 import opt_einsum
 
 
 def __getattr__(name):
     """Get the attribute from CTF."""
     return getattr(ctf, name)
+
+
+bool_ = numpy.bool_
+asarray = ctf.astensor
 
 
 def astype(obj, dtype):

--- a/ebcc/backend/_ctf.py
+++ b/ebcc/backend/_ctf.py
@@ -19,6 +19,14 @@ def astype(obj, dtype):
     return obj.astype(dtype)
 
 
+def zeros_like(obj):
+    return ctf.zeros(obj.shape, dtype=obj.dtype)
+
+
+def ones_like(obj):
+    return ctf.ones(obj.shape, dtype=obj.dtype)
+
+
 def einsum(*args, optimize=True, **kwargs):
     """Evaluate an einsum expression."""
     # FIXME This shouldn't be called, except via `util.einsum`, which should have already

--- a/ebcc/backend/_ctf.py
+++ b/ebcc/backend/_ctf.py
@@ -1,0 +1,22 @@
+# type: ignore
+"""Cyclops Tensor Framework backend."""
+
+import ctf
+import opt_einsum
+
+
+def __getattr__(name):
+    """Get the attribute from CTF."""
+    return getattr(ctf, name)
+
+
+def astype(obj, dtype):
+    return obj.astype(dtype)
+
+
+def einsum_path(*args, **kwargs):
+    """Evaluate the lowest cost contraction order for an einsum expression."""
+    kwargs = dict(kwargs)
+    if kwargs.get("optimize", True) is True:
+        kwargs["optimize"] = "optimal"
+    return opt_einsum.contract_path(*args, **kwargs)

--- a/ebcc/backend/_ctf.py
+++ b/ebcc/backend/_ctf.py
@@ -4,7 +4,6 @@
 import ctf
 import numpy
 import opt_einsum
-import warnings
 
 
 def __getattr__(name):
@@ -16,17 +15,17 @@ class FakeLinalg:
     """Fake linalg module for CTF."""
 
     def __getattr__(self, name):
+        """Get the attribute from CTF's linalg module."""
         return getattr(ctf.linalg, name)
 
-    def eigh(self, a):
+    def eigh(self, a):  # noqa: D102
         # TODO Need to determine if SCALAPACK is available
         w, v = numpy.linalg.eigh(a.to_nparray())
         w = ctf.astensor(w)
         v = ctf.astensor(v)
         return w, v
 
-    #norm = ctf.norm
-    def norm(self, a, ord=None):
+    def norm(self, a, ord=None):  # noqa: D102
         return ctf.norm(a, ord=ord)
 
 
@@ -40,48 +39,49 @@ asarray = ctf.astensor
 
 _array = ctf.array
 
-def array(obj, **kwargs):
+
+def array(obj, **kwargs):  # noqa: D103
     if isinstance(obj, ctf.tensor):
         return obj
     return _array(numpy.asarray(obj), **kwargs)
 
 
-def astype(obj, dtype):
+def astype(obj, dtype):  # noqa: D103
     return obj.astype(dtype)
 
 
-def zeros_like(obj):
+def zeros_like(obj):  # noqa: D103
     return ctf.zeros(obj.shape).astype(obj.dtype)
 
 
-def ones_like(obj):
+def ones_like(obj):  # noqa: D103
     return ctf.ones(obj.shape).astype(obj.dtype)
 
 
-def arange(start, stop=None, step=1, dtype=None):
+def arange(start, stop=None, step=1, dtype=None):  # noqa: D103
     if stop is None:
         stop = start
         start = 0
     return ctf.arange(start, stop, step=step, dtype=dtype)
 
 
-def argmin(obj):
+def argmin(obj):  # noqa: D103
     return ctf.to_nparray(obj).argmin()
 
 
-def argmax(obj):
+def argmax(obj):  # noqa: D103
     return ctf.to_nparray(obj).argmax()
 
 
-def bitwise_and(a, b):
+def bitwise_and(a, b):  # noqa: D103
     return a * b
 
 
-def bitwise_not(a):
+def bitwise_not(a):  # noqa: D103
     return ones_like(a) - a
 
 
-def concatenate(arrays, axis=None):
+def concatenate(arrays, axis=None):  # noqa: D103
     if axis is None:
         axis = 0
     if axis < 0:
@@ -106,7 +106,7 @@ def concatenate(arrays, axis=None):
     return result
 
 
-def _block_recursive(arrays, max_depth, depth=0):
+def _block_recursive(arrays, max_depth, depth=0):  # noqa: D103
     if depth < max_depth:
         arrs = [_block_recursive(arr, max_depth, depth + 1) for arr in arrays]
         return concatenate(arrs, axis=-(max_depth - depth))
@@ -114,7 +114,7 @@ def _block_recursive(arrays, max_depth, depth=0):
         return arrays
 
 
-def block(arrays):
+def block(arrays):  # noqa: D103
     def _get_max_depth(arrays):
         if isinstance(arrays, list):
             return 1 + max([_get_max_depth(arr) for arr in arrays])

--- a/ebcc/backend/_ctf.py
+++ b/ebcc/backend/_ctf.py
@@ -19,6 +19,14 @@ def astype(obj, dtype):
     return obj.astype(dtype)
 
 
+def einsum(*args, optimize=True, **kwargs):
+    """Evaluate an einsum expression."""
+    # FIXME This shouldn't be called, except via `util.einsum`, which should have already
+    #       optimised the expression. We should check if this contraction has more than
+    #       two tensors and if so, raise an error.
+    return ctf.einsum(*args, **kwargs)
+
+
 def einsum_path(*args, **kwargs):
     """Evaluate the lowest cost contraction order for an einsum expression."""
     kwargs = dict(kwargs)

--- a/ebcc/backend/_cupy.py
+++ b/ebcc/backend/_cupy.py
@@ -1,0 +1,18 @@
+# type: ignore
+"""CuPy backend."""
+
+import cupy
+import opt_einsum
+
+
+def __getattr__(name):
+    """Get the attribute from CuPy."""
+    return getattr(cupy, name)
+
+
+def einsum_path(*args, **kwargs):
+    """Evaluate the lowest cost contraction order for an einsum expression."""
+    kwargs = dict(kwargs)
+    if kwargs.get("optimize", True) is True:
+        kwargs["optimize"] = "optimal"
+    return opt_einsum.contract_path(*args, **kwargs)

--- a/ebcc/backend/_jax.py
+++ b/ebcc/backend/_jax.py
@@ -13,18 +13,6 @@ def __getattr__(name):
     return getattr(jax.numpy, name)
 
 
-def _argsort(strings, **kwargs):
-    if not isinstance(strings, jax.numpy.ndarray):
-        return jax.numpy.asarray(
-            sorted(range(len(strings)), key=lambda i: strings[i]), dtype=jax.numpy.int32
-        )
-    return _jax_argsort(strings, **kwargs)
-
-
-_jax_argsort = jax.numpy.argsort
-jax.numpy.argsort = _argsort
-
-
 def _ix_(*args):
     args_ = []
     for arg in args:

--- a/ebcc/backend/_jax.py
+++ b/ebcc/backend/_jax.py
@@ -15,7 +15,8 @@ def __getattr__(name):
 
 _jax_ix_ = jax.numpy.ix_
 
-def ix_(*args):
+
+def ix_(*args):  # noqa: D103
     args_ = []
     for arg in args:
         if isinstance(arg, jax.numpy.ndarray) and arg.dtype == jax.numpy.bool_:

--- a/ebcc/backend/_jax.py
+++ b/ebcc/backend/_jax.py
@@ -13,17 +13,15 @@ def __getattr__(name):
     return getattr(jax.numpy, name)
 
 
-def _ix_(*args):
+_jax_ix_ = jax.numpy.ix_
+
+def ix_(*args):
     args_ = []
     for arg in args:
         if isinstance(arg, jax.numpy.ndarray) and arg.dtype == jax.numpy.bool_:
             arg = jax.numpy.where(arg)[0]
         args_.append(arg)
     return _jax_ix_(*args_)
-
-
-_jax_ix_ = jax.numpy.ix_
-jax.numpy.ix_ = _ix_
 
 
 def einsum_path(*args, **kwargs):

--- a/ebcc/backend/_jax.py
+++ b/ebcc/backend/_jax.py
@@ -25,7 +25,20 @@ _jax_argsort = jax.numpy.argsort
 jax.numpy.argsort = _argsort
 
 
-def einsum_path(*args, **kwargs):  # type: ignore
+def _ix_(*args):
+    args_ = []
+    for arg in args:
+        if isinstance(arg, jax.numpy.ndarray) and arg.dtype == jax.numpy.bool_:
+            arg = jax.numpy.where(arg)[0]
+        args_.append(arg)
+    return _jax_ix_(*args_)
+
+
+_jax_ix_ = jax.numpy.ix_
+jax.numpy.ix_ = _ix_
+
+
+def einsum_path(*args, **kwargs):
     """Evaluate the lowest cost contraction order for an einsum expression."""
     kwargs = dict(kwargs)
     if kwargs.get("optimize", True) is True:

--- a/ebcc/backend/_jax.py
+++ b/ebcc/backend/_jax.py
@@ -1,0 +1,33 @@
+# type: ignore
+"""JAX backend."""
+
+import jax
+import jax.numpy
+import opt_einsum
+
+jax.config.update("jax_enable_x64", True)
+
+
+def __getattr__(name):
+    """Get the attribute from the NumPy drop-in."""
+    return getattr(jax.numpy, name)
+
+
+def _argsort(strings, **kwargs):
+    if not isinstance(strings, jax.numpy.ndarray):
+        return jax.numpy.asarray(
+            sorted(range(len(strings)), key=lambda i: strings[i]), dtype=jax.numpy.int32
+        )
+    return _jax_argsort(strings, **kwargs)
+
+
+_jax_argsort = jax.numpy.argsort
+jax.numpy.argsort = _argsort
+
+
+def einsum_path(*args, **kwargs):  # type: ignore
+    """Evaluate the lowest cost contraction order for an einsum expression."""
+    kwargs = dict(kwargs)
+    if kwargs.get("optimize", True) is True:
+        kwargs["optimize"] = "optimal"
+    return opt_einsum.contract_path(*args, **kwargs)

--- a/ebcc/backend/_numpy.py
+++ b/ebcc/backend/_numpy.py
@@ -1,0 +1,10 @@
+"""NumPy backend."""
+
+from __future__ import annotations
+
+import numpy
+
+
+def __getattr__(name: str) -> object:
+    """Get the attribute from NumPy."""
+    return getattr(numpy, name)

--- a/ebcc/backend/_numpy.py
+++ b/ebcc/backend/_numpy.py
@@ -2,9 +2,32 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy
+
+if TYPE_CHECKING:
+    from numpy import generic
+    from numpy.typing import DType, NDArray
 
 
 def __getattr__(name: str) -> object:
     """Get the attribute from NumPy."""
     return getattr(numpy, name)
+
+
+def astype(obj: NDArray[generic], dtype: DType) -> NDArray[generic]:
+    """Cast the array to the specified type.
+
+    Args:
+        obj: The array to cast.
+        dtype: The type to cast the array to.
+
+    Returns:
+        The array cast to the specified type.
+
+    Note:
+        This function is part of the array API in NumPy 2.1.0, and this function is for backward
+        compatibility.
+    """
+    return obj.astype(dtype)

--- a/ebcc/backend/_numpy.py
+++ b/ebcc/backend/_numpy.py
@@ -8,7 +8,7 @@ import numpy
 
 if TYPE_CHECKING:
     from numpy import generic
-    from numpy.typing import DType, NDArray
+    from numpy.typing import NDArray
 
 
 def __getattr__(name: str) -> object:
@@ -16,7 +16,7 @@ def __getattr__(name: str) -> object:
     return getattr(numpy, name)
 
 
-def astype(obj: NDArray[generic], dtype: DType) -> NDArray[generic]:
+def astype(obj: NDArray[generic], dtype: type[generic]) -> NDArray[generic]:
     """Cast the array to the specified type.
 
     Args:

--- a/ebcc/backend/_tensorflow.py
+++ b/ebcc/backend/_tensorflow.py
@@ -15,6 +15,10 @@ def __getattr__(name):
     return getattr(tensorflow.experimental.numpy, name)
 
 
+def astype(obj, dtype):
+    return obj.astype(dtype)
+
+
 def _argsort(strings, **kwargs):
     if not isinstance(strings, tf.Tensor):
         return tf.convert_to_tensor(

--- a/ebcc/backend/_tensorflow.py
+++ b/ebcc/backend/_tensorflow.py
@@ -120,7 +120,7 @@ def _swapaxes(tensor, axis1, axis2):
 tf.Tensor.swapaxes = _swapaxes
 
 
-def einsum_path(*args, **kwargs):  # type: ignore
+def einsum_path(*args, **kwargs):
     """Evaluate the lowest cost contraction order for an einsum expression."""
     kwargs = dict(kwargs)
     if kwargs.get("optimize", True) is True:

--- a/ebcc/backend/_tensorflow.py
+++ b/ebcc/backend/_tensorflow.py
@@ -106,20 +106,6 @@ def _transpose(tensor, *axes):
 tf.Tensor.transpose = _transpose
 
 
-def _swapaxes(tensor, axis1, axis2):
-    # Get the current shape of the tensor
-    shape = tf.range(tf.rank(tensor))
-
-    # Swap the specified axes
-    perm = tf.tensor_scatter_nd_update(shape, [[axis1], [axis2]], [axis2, axis1])
-
-    # Transpose the tensor with the new permutation
-    return tf.transpose(tensor, perm)
-
-
-tf.Tensor.swapaxes = _swapaxes
-
-
 def einsum_path(*args, **kwargs):
     """Evaluate the lowest cost contraction order for an einsum expression."""
     kwargs = dict(kwargs)

--- a/ebcc/backend/_tensorflow.py
+++ b/ebcc/backend/_tensorflow.py
@@ -15,13 +15,6 @@ def __getattr__(name):
     return getattr(tensorflow.experimental.numpy, name)
 
 
-tf.Tensor.item = lambda self: self.numpy().item()
-tf.Tensor.copy = lambda self: tf.identity(self)
-tf.Tensor.real = property(lambda self: tensorflow.experimental.numpy.real(self))
-tf.Tensor.imag = property(lambda self: tensorflow.experimental.numpy.imag(self))
-tf.Tensor.conj = lambda self: tensorflow.experimental.numpy.conj(self)
-
-
 def _argsort(strings, **kwargs):
     if not isinstance(strings, tf.Tensor):
         return tf.convert_to_tensor(
@@ -92,18 +85,6 @@ def _indices(dimensions, dtype=tf.int32, sparse=False):
 
 
 tf.experimental.numpy.indices = _indices
-
-
-def _transpose(tensor, *axes):
-    # If axes are provided as separate arguments, convert them to a tuple
-    if len(axes) == 1 and isinstance(axes[0], (tuple, list)):
-        axes = axes[0]
-    if len(axes) == 0:
-        axes = tuple(reversed(range(tf.rank(tensor))))
-    return tf.transpose(tensor, perm=axes)
-
-
-tf.Tensor.transpose = _transpose
 
 
 def einsum_path(*args, **kwargs):

--- a/ebcc/backend/_tensorflow.py
+++ b/ebcc/backend/_tensorflow.py
@@ -36,8 +36,8 @@ tf.experimental.numpy.argsort = _argsort
 
 def _block_recursive(arrays, max_depth, depth=0):
     if depth < max_depth:
-        arrs = [_block_recursive(arr, max_depth, depth+1) for arr in arrays]
-        return tensorflow.experimental.numpy.concatenate(arrs, axis=-(max_depth-depth))
+        arrs = [_block_recursive(arr, max_depth, depth + 1) for arr in arrays]
+        return tensorflow.experimental.numpy.concatenate(arrs, axis=-(max_depth - depth))
     else:
         return arrays
 

--- a/ebcc/backend/_tensorflow.py
+++ b/ebcc/backend/_tensorflow.py
@@ -1,0 +1,21 @@
+"""TensorFlow backend."""
+
+from __future__ import annotations
+
+import opt_einsum
+import tensorflow
+import tensorflow.experimental.numpy
+tensorflow.experimental.numpy.experimental_enable_numpy_behavior()
+
+
+def __getattr__(name: str) -> object:
+    """Get the attribute from the NumPy drop-in."""
+    return getattr(tensorflow.experimental.numpy, name)
+
+
+def einsum_path(*args, **kwargs):  # type: ignore
+    """Evaluate the lowest cost contraction order for an einsum expression."""
+    kwargs = dict(kwargs)
+    if kwargs.get("optimize", True) is True:
+        kwargs["optimize"] = "optimal"
+    return opt_einsum.contract_path(*args, **kwargs)

--- a/ebcc/backend/_tensorflow.py
+++ b/ebcc/backend/_tensorflow.py
@@ -27,7 +27,7 @@ def _block_recursive(arrays, max_depth, depth=0):
         return arrays
 
 
-def _block(arrays):
+def block(arrays):
     def _get_max_depth(arrays):
         if isinstance(arrays, list):
             return 1 + max([_get_max_depth(arr) for arr in arrays])
@@ -36,10 +36,7 @@ def _block(arrays):
     return _block_recursive(arrays, _get_max_depth(arrays))
 
 
-tf.experimental.numpy.block = _block
-
-
-def _ravel_multi_index(multi_index, dims, mode="raise", order="C"):
+def ravel_multi_index(multi_index, dims, mode="raise", order="C"):
     if mode != "raise":
         raise NotImplementedError("Only 'raise' mode is implemented")
     if order != "C":
@@ -54,10 +51,7 @@ def _ravel_multi_index(multi_index, dims, mode="raise", order="C"):
     return flat_index
 
 
-tf.experimental.numpy.ravel_multi_index = _ravel_multi_index
-
-
-def _indices(dimensions, dtype=tf.int32, sparse=False):
+def indices(dimensions, dtype=tf.int32, sparse=False):
     # Generate a range of indices for each dimension
     ranges = [tf.range(dim, dtype=dtype) for dim in dimensions]
 
@@ -74,9 +68,6 @@ def _indices(dimensions, dtype=tf.int32, sparse=False):
         # Stack the grids together to form the final result
         indices = tf.stack(grids, axis=0)
         return indices
-
-
-tf.experimental.numpy.indices = _indices
 
 
 def einsum_path(*args, **kwargs):

--- a/ebcc/backend/_tensorflow.py
+++ b/ebcc/backend/_tensorflow.py
@@ -15,11 +15,11 @@ def __getattr__(name):
     return getattr(tensorflow.experimental.numpy, name)
 
 
-def astype(obj, dtype):
+def astype(obj, dtype):  # noqa: D103
     return obj.astype(dtype)
 
 
-def _block_recursive(arrays, max_depth, depth=0):
+def _block_recursive(arrays, max_depth, depth=0):  # noqa: D103
     if depth < max_depth:
         arrs = [_block_recursive(arr, max_depth, depth + 1) for arr in arrays]
         return tensorflow.experimental.numpy.concatenate(arrs, axis=-(max_depth - depth))
@@ -27,7 +27,7 @@ def _block_recursive(arrays, max_depth, depth=0):
         return arrays
 
 
-def block(arrays):
+def block(arrays):  # noqa: D103
     def _get_max_depth(arrays):
         if isinstance(arrays, list):
             return 1 + max([_get_max_depth(arr) for arr in arrays])
@@ -36,7 +36,7 @@ def block(arrays):
     return _block_recursive(arrays, _get_max_depth(arrays))
 
 
-def ravel_multi_index(multi_index, dims, mode="raise", order="C"):
+def ravel_multi_index(multi_index, dims, mode="raise", order="C"):  # noqa: D103
     if mode != "raise":
         raise NotImplementedError("Only 'raise' mode is implemented")
     if order != "C":
@@ -51,7 +51,7 @@ def ravel_multi_index(multi_index, dims, mode="raise", order="C"):
     return flat_index
 
 
-def indices(dimensions, dtype=tf.int32, sparse=False):
+def indices(dimensions, dtype=tf.int32, sparse=False):  # noqa: D103
     # Generate a range of indices for each dimension
     ranges = [tf.range(dim, dtype=dtype) for dim in dimensions]
 

--- a/ebcc/backend/_tensorflow.py
+++ b/ebcc/backend/_tensorflow.py
@@ -34,11 +34,21 @@ _tf_argsort = tf.experimental.numpy.argsort
 tf.experimental.numpy.argsort = _argsort
 
 
-def _block(arrays):
-    # FIXME Can't get this to work
-    import numpy
+def _block_recursive(arrays, max_depth, depth=0):
+    if depth < max_depth:
+        arrs = [_block_recursive(arr, max_depth, depth+1) for arr in arrays]
+        return tensorflow.experimental.numpy.concatenate(arrs, axis=-(max_depth-depth))
+    else:
+        return arrays
 
-    return tensorflow.experimental.numpy.asarray(numpy.block(arrays))
+
+def _block(arrays):
+    def _get_max_depth(arrays):
+        if isinstance(arrays, list):
+            return 1 + max([_get_max_depth(arr) for arr in arrays])
+        return 0
+
+    return _block_recursive(arrays, _get_max_depth(arrays))
 
 
 tf.experimental.numpy.block = _block

--- a/ebcc/backend/_tensorflow.py
+++ b/ebcc/backend/_tensorflow.py
@@ -19,18 +19,6 @@ def astype(obj, dtype):
     return obj.astype(dtype)
 
 
-def _argsort(strings, **kwargs):
-    if not isinstance(strings, tf.Tensor):
-        return tf.convert_to_tensor(
-            sorted(range(len(strings)), key=lambda i: strings[i]), dtype=tf.int32
-        )
-    return _tf_argsort(strings, **kwargs)
-
-
-_tf_argsort = tf.experimental.numpy.argsort
-tf.experimental.numpy.argsort = _argsort
-
-
 def _block_recursive(arrays, max_depth, depth=0):
     if depth < max_depth:
         arrs = [_block_recursive(arr, max_depth, depth + 1) for arr in arrays]

--- a/ebcc/backend/_tensorflow.py
+++ b/ebcc/backend/_tensorflow.py
@@ -1,16 +1,112 @@
+# type: ignore
 """TensorFlow backend."""
 
-from __future__ import annotations
-
 import opt_einsum
-import tensorflow
+import tensorflow as tf
 import tensorflow.experimental.numpy
 tensorflow.experimental.numpy.experimental_enable_numpy_behavior()
 
 
-def __getattr__(name: str) -> object:
+def __getattr__(name):
     """Get the attribute from the NumPy drop-in."""
     return getattr(tensorflow.experimental.numpy, name)
+
+
+tf.Tensor.item = lambda self: self.numpy().item()
+tf.Tensor.copy = lambda self: tf.identity(self)
+tf.Tensor.real = property(lambda self: tensorflow.experimental.numpy.real(self))
+tf.Tensor.imag = property(lambda self: tensorflow.experimental.numpy.imag(self))
+tf.Tensor.conj = lambda self: tensorflow.experimental.numpy.conj(self)
+
+
+def _argsort(strings, **kwargs):
+    if not isinstance(strings, tf.Tensor):
+        return tf.convert_to_tensor(sorted(range(len(strings)), key=lambda i: strings[i]), dtype=tf.int32)
+    return _tf_argsort(strings, **kwargs)
+
+
+_tf_argsort = tf.experimental.numpy.argsort
+tf.experimental.numpy.argsort = _argsort
+
+
+def _block(arrays):
+    if isinstance(arrays, list):
+        # Recursively process the nested list
+        if all(isinstance(arr, list) for arr in arrays):
+            # Concatenate along the first axis
+            return tf.concat([_block(arr) for arr in arrays], axis=0)
+        else:
+            # Concatenate along the second axis
+            return tf.concat([_block(arr) for arr in arrays], axis=1)
+    else:
+        # Return the tensor as is
+        return arrays
+
+
+tf.experimental.numpy.block = _block
+
+
+def _ravel_multi_index(multi_index, dims, mode='raise', order='C'):
+    if mode != 'raise':
+        raise NotImplementedError("Only 'raise' mode is implemented")
+    if order != 'C':
+        raise NotImplementedError("Only 'C' order is implemented")
+
+    # Calculate the strides for each dimension
+    strides = tf.math.cumprod([1] + list(dims[:-1]), exclusive=True, reverse=True)
+
+    # Compute the flat index
+    flat_index = tf.reduce_sum([idx * stride for idx, stride in zip(multi_index, strides)], axis=0)
+
+    return flat_index
+
+
+tf.experimental.numpy.ravel_multi_index = _ravel_multi_index
+
+
+def _indices(dimensions, dtype=tf.int32, sparse=False):
+    # Generate a range of indices for each dimension
+    ranges = [tf.range(dim, dtype=dtype) for dim in dimensions]
+
+    if sparse:
+        # Create sparse representation by reshaping ranges
+        grids = [tf.reshape(r, [-1 if i == j else 1 for j in range(len(dimensions))]) for i, r in enumerate(ranges)]
+        return grids
+    else:
+        # Create a dense meshgrid of indices for each dimension
+        grids = tf.meshgrid(*ranges, indexing='ij')
+        # Stack the grids together to form the final result
+        indices = tf.stack(grids, axis=0)
+        return indices
+
+
+tf.experimental.numpy.indices = _indices
+
+
+def _transpose(tensor, *axes):
+    # If axes are provided as separate arguments, convert them to a tuple
+    if len(axes) == 1 and isinstance(axes[0], (tuple, list)):
+        axes = axes[0]
+    if len(axes) == 0:
+        axes = tuple(reversed(range(tf.rank(tensor))))
+    return tf.transpose(tensor, perm=axes)
+
+
+tf.Tensor.transpose = _transpose
+
+
+def _swapaxes(tensor, axis1, axis2):
+    # Get the current shape of the tensor
+    shape = tf.range(tf.rank(tensor))
+
+    # Swap the specified axes
+    perm = tf.tensor_scatter_nd_update(shape, [[axis1], [axis2]], [axis2, axis1])
+
+    # Transpose the tensor with the new permutation
+    return tf.transpose(tensor, perm)
+
+
+tf.Tensor.swapaxes = _swapaxes
 
 
 def einsum_path(*args, **kwargs):  # type: ignore

--- a/ebcc/cc/base.py
+++ b/ebcc/cc/base.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, cast
 from ebcc import default_log, init_logging
 from ebcc import numpy as np
 from ebcc import util
+from ebcc.backend import ensure_scalar
 from ebcc.core.ansatz import Ansatz
 from ebcc.core.damping import DIIS
 from ebcc.core.dump import Dump
@@ -585,7 +586,7 @@ class BaseEBCC(ABC):
             eris=eris,
             amplitudes=amplitudes,
         )
-        res: float = np.ravel(func(**kwargs))[0].real
+        res: float = ensure_scalar(func(**kwargs)).real
         return astype(res, float)
 
     def energy_perturbative(
@@ -610,8 +611,8 @@ class BaseEBCC(ABC):
             amplitudes=amplitudes,
             lambdas=lambdas,
         )
-        res: float = np.ravel(func(**kwargs))[0].real
-        return astype(res, float)
+        res: float = ensure_scalar(func(**kwargs)).real
+        return res
 
     @abstractmethod
     def update_amps(
@@ -953,7 +954,7 @@ class BaseEBCC(ABC):
         """
         if self.options.shift:
             assert self.omega is not None
-            return cast(float, np.ravel(util.einsum("I,I->", self.omega, self.xi**2.0))[0])
+            return cast(float, ensure_scalar(util.einsum("I,I->", self.omega, self.xi**2.0)))
         return 0.0
 
     @property

--- a/ebcc/cc/base.py
+++ b/ebcc/cc/base.py
@@ -256,7 +256,7 @@ class BaseEBCC(ABC):
                 vector = self.amplitudes_to_vector(amplitudes)
                 vector = diis.update(vector)
                 amplitudes = self.vector_to_amplitudes(vector)
-                dt = np.max(np.abs(vector - self.amplitudes_to_vector(amplitudes_prev)))
+                dt = np.linalg.norm(np.abs(vector - self.amplitudes_to_vector(amplitudes_prev)), ord=np.inf)
 
                 # Update the energy and calculate change:
                 e_prev = e_cc
@@ -360,7 +360,7 @@ class BaseEBCC(ABC):
             vector = self.lambdas_to_vector(lambdas)
             vector = diis.update(vector)
             lambdas = self.vector_to_lambdas(vector)
-            dl = np.max(np.abs(vector - self.lambdas_to_vector(lambdas_prev)))
+            dl = np.linalg.norm(np.abs(vector - self.lambdas_to_vector(lambdas_prev)), ord=np.inf)
 
             # Log the iteration:
             converged = bool(dl < self.options.t_tol)
@@ -583,7 +583,7 @@ class BaseEBCC(ABC):
             eris=eris,
             amplitudes=amplitudes,
         )
-        res: float = np.ravel(np.real(func(**kwargs)))[0]
+        res: float = np.ravel(func(**kwargs))[0].real
         return astype(res, float)
 
     def energy_perturbative(
@@ -608,7 +608,7 @@ class BaseEBCC(ABC):
             amplitudes=amplitudes,
             lambdas=lambdas,
         )
-        res: float = np.ravel(np.real(func(**kwargs)))[0]
+        res: float = np.ravel(func(**kwargs))[0].real
         return astype(res, float)
 
     @abstractmethod
@@ -706,7 +706,7 @@ class BaseEBCC(ABC):
         dm: NDArray[T] = func(**kwargs)
 
         if hermitise:
-            dm = 0.5 * (dm + dm.T)
+            dm = (dm + np.transpose(dm)) * 0.5
 
         if unshifted and self.options.shift:
             xi = self.xi

--- a/ebcc/cc/base.py
+++ b/ebcc/cc/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from ebcc import default_log, init_logging
 from ebcc import numpy as np
@@ -256,7 +256,9 @@ class BaseEBCC(ABC):
                 vector = self.amplitudes_to_vector(amplitudes)
                 vector = diis.update(vector)
                 amplitudes = self.vector_to_amplitudes(vector)
-                dt = np.linalg.norm(np.abs(vector - self.amplitudes_to_vector(amplitudes_prev)), ord=np.inf)
+                dt = np.linalg.norm(
+                    np.abs(vector - self.amplitudes_to_vector(amplitudes_prev)), ord=np.inf
+                )
 
                 # Update the energy and calculate change:
                 e_prev = e_cc
@@ -951,7 +953,7 @@ class BaseEBCC(ABC):
         """
         if self.options.shift:
             assert self.omega is not None
-            return np.ravel(util.einsum("I,I->", self.omega, self.xi**2.0))[0]
+            return cast(float, np.ravel(util.einsum("I,I->", self.omega, self.xi**2.0))[0])
         return 0.0
 
     @property

--- a/ebcc/cc/base.py
+++ b/ebcc/cc/base.py
@@ -129,10 +129,10 @@ class BaseEBCC(ABC):
         self.log = default_log if log is None else log
         self.mf = self._convert_mf(mf)
         self._mo_coeff: Optional[NDArray[T]] = (
-            np.astype(mo_coeff, types[float]) if mo_coeff is not None else None
+            np.asarray(mo_coeff, dtype=types[float]) if mo_coeff is not None else None
         )
         self._mo_occ: Optional[NDArray[T]] = (
-            np.astype(mo_occ, types[float]) if mo_occ is not None else None
+            np.asarray(mo_occ, dtype=types[float]) if mo_occ is not None else None
         )
 
         # Ansatz:
@@ -157,9 +157,9 @@ class BaseEBCC(ABC):
             raise ValueError(
                 "Fermionic and bosonic coupling ranks must both be zero, or both non-zero."
             )
-        self.omega = np.astype(omega, types[float]) if omega is not None else None
-        self.bare_g = np.astype(g, types[float]) if g is not None else None
-        self.bare_G = np.astype(G, types[float]) if G is not None else None
+        self.omega = np.asarray(omega, dtype=types[float]) if omega is not None else None
+        self.bare_g = np.asarray(g, dtype=types[float]) if g is not None else None
+        self.bare_G = np.asarray(G, dtype=types[float]) if G is not None else None
         if self.boson_ansatz != "":
             self.g = self.get_g()
             self.G = self.get_mean_field_G()
@@ -964,7 +964,7 @@ class BaseEBCC(ABC):
             Molecular orbital coefficients.
         """
         if self._mo_coeff is None:
-            return np.astype(self.mf.mo_coeff, types[float])  # type: ignore
+            return np.asarray(self.mf.mo_coeff, dtype=types[float])
         return self._mo_coeff
 
     @property
@@ -975,7 +975,7 @@ class BaseEBCC(ABC):
             Molecular orbital occupation numbers.
         """
         if self._mo_occ is None:
-            return np.astype(self.mf.mo_occ, types[float])  # type: ignore
+            return np.asarray(self.mf.mo_occ, dtype=types[float])
         return self._mo_occ
 
     @property

--- a/ebcc/cc/base.py
+++ b/ebcc/cc/base.py
@@ -129,10 +129,10 @@ class BaseEBCC(ABC):
         self.log = default_log if log is None else log
         self.mf = self._convert_mf(mf)
         self._mo_coeff: Optional[NDArray[T]] = (
-            mo_coeff.astype(types[float]) if mo_coeff is not None else None
+            np.astype(mo_coeff, types[float]) if mo_coeff is not None else None
         )
         self._mo_occ: Optional[NDArray[T]] = (
-            mo_occ.astype(types[float]) if mo_occ is not None else None
+            np.astype(mo_occ, types[float]) if mo_occ is not None else None
         )
 
         # Ansatz:
@@ -157,9 +157,9 @@ class BaseEBCC(ABC):
             raise ValueError(
                 "Fermionic and bosonic coupling ranks must both be zero, or both non-zero."
             )
-        self.omega = omega.astype(types[float]) if omega is not None else None
-        self.bare_g = g.astype(types[float]) if g is not None else None
-        self.bare_G = G.astype(types[float]) if G is not None else None
+        self.omega = np.astype(omega, types[float]) if omega is not None else None
+        self.bare_g = np.astype(g, types[float]) if g is not None else None
+        self.bare_G = np.astype(G, types[float]) if G is not None else None
         if self.boson_ansatz != "":
             self.g = self.get_g()
             self.G = self.get_mean_field_G()
@@ -583,7 +583,7 @@ class BaseEBCC(ABC):
             eris=eris,
             amplitudes=amplitudes,
         )
-        res: float = func(**kwargs).real.item()
+        res: float = np.ravel(np.real(func(**kwargs)))[0]
         return astype(res, float)
 
     def energy_perturbative(
@@ -608,7 +608,7 @@ class BaseEBCC(ABC):
             amplitudes=amplitudes,
             lambdas=lambdas,
         )
-        res: float = func(**kwargs).real.item()
+        res: float = np.ravel(np.real(func(**kwargs)))[0]
         return astype(res, float)
 
     @abstractmethod
@@ -951,7 +951,7 @@ class BaseEBCC(ABC):
         """
         if self.options.shift:
             assert self.omega is not None
-            return util.einsum("I,I->", self.omega, self.xi**2.0).item()
+            return np.ravel(util.einsum("I,I->", self.omega, self.xi**2.0))[0]
         return 0.0
 
     @property
@@ -962,7 +962,7 @@ class BaseEBCC(ABC):
             Molecular orbital coefficients.
         """
         if self._mo_coeff is None:
-            return self.mf.mo_coeff.astype(types[float])  # type: ignore
+            return np.astype(self.mf.mo_coeff, types[float])  # type: ignore
         return self._mo_coeff
 
     @property
@@ -973,7 +973,7 @@ class BaseEBCC(ABC):
             Molecular orbital occupation numbers.
         """
         if self._mo_occ is None:
-            return self.mf.mo_occ.astype(types[float])  # type: ignore
+            return np.astype(self.mf.mo_occ, types[float])  # type: ignore
         return self._mo_occ
 
     @property

--- a/ebcc/cc/gebcc.py
+++ b/ebcc/cc/gebcc.py
@@ -122,14 +122,14 @@ class GEBCC(BaseEBCC):
         sb = np.where(orbspin == 1)[0]
 
         occupied = np.zeros((nocc + nvir,), dtype=bool)
-        occupied = _put(occupied, sa, ucc.space[0]._occupied.copy())
-        occupied = _put(occupied, sb, ucc.space[1]._occupied.copy())
+        occupied = _put(occupied, sa, np.copy(ucc.space[0]._occupied))
+        occupied = _put(occupied, sb, np.copy(ucc.space[1]._occupied))
         frozen = np.zeros((nocc + nvir,), dtype=bool)
-        frozen = _put(frozen, sa, ucc.space[0]._frozen.copy())
-        frozen = _put(frozen, sb, ucc.space[1]._frozen.copy())
+        frozen = _put(frozen, sa, np.copy(ucc.space[0]._frozen))
+        frozen = _put(frozen, sb, np.copy(ucc.space[1]._frozen))
         active = np.zeros((nocc + nvir,), dtype=bool)
-        active = _put(active, sa, ucc.space[0]._active.copy())
-        active = _put(active, sb, ucc.space[1]._active.copy())
+        active = _put(active, sa, np.copy(ucc.space[0]._active))
+        active = _put(active, sb, np.copy(ucc.space[1]._active))
         space = Space(occupied, frozen, active)
 
         slices = util.Namespace(
@@ -144,8 +144,8 @@ class GEBCC(BaseEBCC):
             else:
                 bare_g_a, bare_g_b = ucc.bare_g
             g = np.zeros((ucc.nbos, ucc.nmo * 2, ucc.nmo * 2), dtype=types[float])
-            g = _put(g, np.ix_(np.arange(ucc.nbos), sa, sa), bare_g_a.copy())
-            g = _put(g, np.ix_(np.arange(ucc.nbos), sb, sb), bare_g_b.copy())
+            g = _put(g, np.ix_(np.arange(ucc.nbos), sa, sa), np.copy(bare_g_a))
+            g = _put(g, np.ix_(np.arange(ucc.nbos), sb, sb), np.copy(bare_g_b))
 
         gcc = cls(
             ucc.mf,
@@ -182,7 +182,7 @@ class GEBCC(BaseEBCC):
                             mask = np.ix_(*[slices[s][k] for s, k in zip(combn, key)])
                             transpose = tuple(lperm) + tuple(p + n for p in uperm)
                             amp = (
-                                getattr(ucc.amplitudes[name], comb).transpose(transpose)
+                                np.transpose(getattr(ucc.amplitudes[name], comb), transpose)
                                 * lsign
                                 * usign
                             )
@@ -192,12 +192,12 @@ class GEBCC(BaseEBCC):
                                     amplitudes[name] = _put(
                                         amplitudes[name],
                                         mask,
-                                        amplitudes[name][mask] + amp.transpose(transpose) * sign,
+                                        amplitudes[name][mask] + np.transpose(amp, transpose) * sign,
                                     )
                             done.add(combn)
 
             for name, key, n in ucc.ansatz.bosonic_cluster_ranks(spin_type=ucc.spin_type):
-                amplitudes[name] = ucc.amplitudes[name].copy()  # type: ignore
+                amplitudes[name] = np.copy(ucc.amplitudes[name])  # type: ignore
 
             for name, key, nf, nb in ucc.ansatz.coupling_cluster_ranks(spin_type=ucc.spin_type):
                 shape = (nbos,) * nb + tuple(space.size(k) for k in key[nb:])
@@ -220,7 +220,7 @@ class GEBCC(BaseEBCC):
                                 + tuple(p + nb + nf for p in uperm)
                             )
                             amp = (
-                                getattr(ucc.amplitudes[name], comb).transpose(transpose)
+                                np.transpose(getattr(ucc.amplitudes[name], comb), transpose)
                                 * lsign
                                 * usign
                             )
@@ -234,7 +234,7 @@ class GEBCC(BaseEBCC):
                                     amplitudes[name] = _put(
                                         amplitudes[name],
                                         mask,
-                                        amplitudes[name][mask] + amp.transpose(transpose) * sign,
+                                        amplitudes[name][mask] + np.transpose(amp, transpose) * sign,
                                     )
                             done.add(combn)
 
@@ -258,7 +258,7 @@ class GEBCC(BaseEBCC):
                             mask = np.ix_(*[slices[s][k] for s, k in zip(combn, key[n:] + key[:n])])
                             transpose = tuple(lperm) + tuple(p + n for p in uperm)
                             amp = (
-                                getattr(ucc.lambdas[lname], comb).transpose(transpose)
+                                np.transpose(getattr(ucc.lambdas[lname], comb), transpose)
                                 * lsign
                                 * usign
                             )
@@ -268,13 +268,13 @@ class GEBCC(BaseEBCC):
                                     lambdas[lname] = _put(
                                         lambdas[lname],
                                         mask,
-                                        lambdas[lname][mask] + amp.transpose(transpose) * sign,
+                                        lambdas[lname][mask] + np.transpose(amp, transpose) * sign,
                                     )
                             done.add(combn)
 
             for name, key, n in ucc.ansatz.bosonic_cluster_ranks(spin_type=ucc.spin_type):
                 lname = "l" + name
-                lambdas[lname] = ucc.lambdas[lname].copy()  # type: ignore
+                lambdas[lname] = np.copy(ucc.lambdas[lname])  # type: ignore
 
             for name, key, nf, nb in ucc.ansatz.coupling_cluster_ranks(spin_type=ucc.spin_type):
                 lname = "l" + name
@@ -303,7 +303,7 @@ class GEBCC(BaseEBCC):
                                 + tuple(p + nb + nf for p in uperm)
                             )
                             amp = (
-                                getattr(ucc.lambdas[lname], comb).transpose(transpose)
+                                np.transpose(getattr(ucc.lambdas[lname], comb), transpose)
                                 * lsign
                                 * usign
                             )
@@ -317,7 +317,7 @@ class GEBCC(BaseEBCC):
                                     lambdas[lname] = _put(
                                         lambdas[lname],
                                         mask,
-                                        lambdas[lname][mask] + amp.transpose(transpose) * sign,
+                                        lambdas[lname][mask] + np.transpose(amp, transpose) * sign,
                                     )
                             done.add(combn)
 
@@ -441,7 +441,7 @@ class GEBCC(BaseEBCC):
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
             lname = name.replace("t", "l")
             perm = list(range(n, 2 * n)) + list(range(n))
-            lambdas[lname] = amplitudes[name].transpose(perm)
+            lambdas[lname] = np.transpose(amplitudes[name], perm)
 
         # Build LS amplitudes:
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
@@ -454,7 +454,7 @@ class GEBCC(BaseEBCC):
                 raise util.ModelNotImplemented
             lname = "l" + name
             perm = list(range(nb)) + [nb + 1, nb]
-            lambdas[lname] = amplitudes[name].transpose(perm)
+            lambdas[lname] = np.transpose(amplitudes[name], perm)
 
         return lambdas
 
@@ -622,8 +622,8 @@ class GEBCC(BaseEBCC):
         dm: SpinArrayType = func(**kwargs)
 
         if hermitise:
-            dm = 0.5 * (dm.transpose(0, 1, 2, 3) + dm.transpose(2, 3, 0, 1))
-            dm = 0.5 * (dm.transpose(0, 1, 2, 3) + dm.transpose(1, 0, 3, 2))
+            dm = 0.5 * (np.transpose(dm, (0, 1, 2, 3)) + np.transpose(dm, (2, 3, 0, 1)))
+            dm = 0.5 * (np.transpose(dm, (0, 1, 2, 3)) + np.transpose(dm, (1, 0, 3, 2)))
 
         return dm
 
@@ -667,8 +667,8 @@ class GEBCC(BaseEBCC):
         if hermitise:
             dm_eb = np.array(
                 [
-                    0.5 * (dm_eb[0] + dm_eb[1].transpose(0, 2, 1)),
-                    0.5 * (dm_eb[1] + dm_eb[0].transpose(0, 2, 1)),
+                    0.5 * (dm_eb[0] + np.transpose(dm_eb[1], (0, 2, 1))),
+                    0.5 * (dm_eb[1] + np.transpose(dm_eb[0], (0, 2, 1))),
                 ]
             )
 
@@ -734,13 +734,13 @@ class GEBCC(BaseEBCC):
         vectors = []
 
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
-            vectors.append(amplitudes[name].ravel())
+            vectors.append(np.ravel(amplitudes[name]))
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
-            vectors.append(amplitudes[name].ravel())
+            vectors.append(np.ravel(amplitudes[name]))
 
         for name, key, nf, nb in self.ansatz.coupling_cluster_ranks(spin_type=self.spin_type):
-            vectors.append(amplitudes[name].ravel())
+            vectors.append(np.ravel(amplitudes[name]))
 
         return np.concatenate(vectors)
 
@@ -759,19 +759,19 @@ class GEBCC(BaseEBCC):
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
             shape = tuple(self.space.size(k) for k in key)
             size = util.prod(shape)
-            amplitudes[name] = vector[i0 : i0 + size].reshape(shape)
+            amplitudes[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
             shape = (self.nbos,) * n
             size = util.prod(shape)
-            amplitudes[name] = vector[i0 : i0 + size].reshape(shape)
+            amplitudes[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         for name, key, nf, nb in self.ansatz.coupling_cluster_ranks(spin_type=self.spin_type):
             shape = (self.nbos,) * nb + tuple(self.space.size(k) for k in key[nb:])
             size = util.prod(shape)
-            amplitudes[name] = vector[i0 : i0 + size].reshape(shape)
+            amplitudes[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         return amplitudes
@@ -790,15 +790,15 @@ class GEBCC(BaseEBCC):
         for name, key, n in self.ansatz.fermionic_cluster_ranks(
             spin_type=self.spin_type, which="l"
         ):
-            vectors.append(lambdas[name].ravel())
+            vectors.append(np.ravel(lambdas[name]))
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="l"):
-            vectors.append(lambdas[name].ravel())
+            vectors.append(np.ravel(lambdas[name]))
 
         for name, key, nf, nb in self.ansatz.coupling_cluster_ranks(
             spin_type=self.spin_type, which="l"
         ):
-            vectors.append(lambdas[name].ravel())
+            vectors.append(np.ravel(lambdas[name]))
 
         return np.concatenate(vectors)
 
@@ -819,13 +819,13 @@ class GEBCC(BaseEBCC):
         ):
             shape = tuple(self.space.size(k) for k in key)
             size = util.prod(shape)
-            lambdas[name] = vector[i0 : i0 + size].reshape(shape)
+            lambdas[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="l"):
             shape = (self.nbos,) * n
             size = util.prod(shape)
-            lambdas[name] = vector[i0 : i0 + size].reshape(shape)
+            lambdas[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         for name, key, nf, nb in self.ansatz.coupling_cluster_ranks(
@@ -833,7 +833,7 @@ class GEBCC(BaseEBCC):
         ):
             shape = (self.nbos,) * nb + tuple(self.space.size(k) for k in key[nb:])
             size = util.prod(shape)
-            lambdas[name] = vector[i0 : i0 + size].reshape(shape)
+            lambdas[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         return lambdas

--- a/ebcc/cc/gebcc.py
+++ b/ebcc/cc/gebcc.py
@@ -121,13 +121,13 @@ class GEBCC(BaseEBCC):
         sa = np.where(orbspin == 0)[0]
         sb = np.where(orbspin == 1)[0]
 
-        occupied = np.zeros((nocc + nvir,), dtype=bool)
+        occupied = np.zeros((nocc + nvir,), dtype=np.bool_)
         occupied = _put(occupied, sa, np.copy(ucc.space[0]._occupied))
         occupied = _put(occupied, sb, np.copy(ucc.space[1]._occupied))
-        frozen = np.zeros((nocc + nvir,), dtype=bool)
+        frozen = np.zeros((nocc + nvir,), dtype=np.bool_)
         frozen = _put(frozen, sa, np.copy(ucc.space[0]._frozen))
         frozen = _put(frozen, sb, np.copy(ucc.space[1]._frozen))
-        active = np.zeros((nocc + nvir,), dtype=bool)
+        active = np.zeros((nocc + nvir,), dtype=np.bool_)
         active = _put(active, sa, np.copy(ucc.space[0]._active))
         active = _put(active, sb, np.copy(ucc.space[1]._active))
         space = Space(occupied, frozen, active)
@@ -349,8 +349,8 @@ class GEBCC(BaseEBCC):
         """
         space = Space(
             self.mo_occ > 0,
-            np.zeros(self.mo_occ.shape, dtype=bool),
-            np.zeros(self.mo_occ.shape, dtype=bool),
+            np.zeros(self.mo_occ.shape, dtype=np.bool_),
+            np.zeros(self.mo_occ.shape, dtype=np.bool_),
         )
         return space
 

--- a/ebcc/cc/gebcc.py
+++ b/ebcc/cc/gebcc.py
@@ -591,7 +591,7 @@ class GEBCC(BaseEBCC):
         dm: SpinArrayType = func(**kwargs)
 
         if hermitise:
-            dm = 0.5 * (dm + dm.T)
+            dm = (dm + np.transpose(dm)) * 0.5
 
         return dm
 
@@ -622,8 +622,8 @@ class GEBCC(BaseEBCC):
         dm: SpinArrayType = func(**kwargs)
 
         if hermitise:
-            dm = 0.5 * (np.transpose(dm, (0, 1, 2, 3)) + np.transpose(dm, (2, 3, 0, 1)))
-            dm = 0.5 * (np.transpose(dm, (0, 1, 2, 3)) + np.transpose(dm, (1, 0, 3, 2)))
+            dm = (np.transpose(dm, (0, 1, 2, 3)) + np.transpose(dm, (2, 3, 0, 1))) * 0.5
+            dm = (np.transpose(dm, (0, 1, 2, 3)) + np.transpose(dm, (1, 0, 3, 2))) * 0.5
 
         return dm
 
@@ -667,8 +667,8 @@ class GEBCC(BaseEBCC):
         if hermitise:
             dm_eb = np.array(
                 [
-                    0.5 * (dm_eb[0] + np.transpose(dm_eb[1], (0, 2, 1))),
-                    0.5 * (dm_eb[1] + np.transpose(dm_eb[0], (0, 2, 1))),
+                    (dm_eb[0] + np.transpose(dm_eb[1], (0, 2, 1))) * 0.5,
+                    (dm_eb[1] + np.transpose(dm_eb[0], (0, 2, 1))) * 0.5,
                 ]
             )
 
@@ -713,9 +713,9 @@ class GEBCC(BaseEBCC):
             factor = 1 if signs_dict[key] == "+" else -1
             if key == "b":
                 assert self.omega is not None
-                energies.append(factor * self.omega)
+                energies.append(self.omega * types[float](factor))
             else:
-                energies.append(factor * np.diag(self.fock[key + key]))
+                energies.append(np.diag(self.fock[key + key]) * types[float](factor))
 
         subscript = ",".join([next_char() for k in subscript])
         energy_sum = util.dirsum(subscript, *energies)

--- a/ebcc/cc/gebcc.py
+++ b/ebcc/cc/gebcc.py
@@ -192,7 +192,8 @@ class GEBCC(BaseEBCC):
                                     amplitudes[name] = _put(
                                         amplitudes[name],
                                         mask,
-                                        amplitudes[name][mask] + np.transpose(amp, transpose) * sign,
+                                        amplitudes[name][mask]
+                                        + np.transpose(amp, transpose) * sign,
                                     )
                             done.add(combn)
 
@@ -234,7 +235,8 @@ class GEBCC(BaseEBCC):
                                     amplitudes[name] = _put(
                                         amplitudes[name],
                                         mask,
-                                        amplitudes[name][mask] + np.transpose(amp, transpose) * sign,
+                                        amplitudes[name][mask]
+                                        + np.transpose(amp, transpose) * sign,
                                     )
                             done.add(combn)
 

--- a/ebcc/cc/gebcc.py
+++ b/ebcc/cc/gebcc.py
@@ -114,7 +114,7 @@ class GEBCC(BaseEBCC):
         Returns:
             GEBCC object.
         """
-        orbspin = scf.addons.get_ghf_orbspin(ucc.mf.mo_energy, ucc.mf.mo_occ, False)
+        orbspin = np.asarray(scf.addons.get_ghf_orbspin(ucc.mf.mo_energy, ucc.mf.mo_occ, False))
         nocc = ucc.space[0].nocc + ucc.space[1].nocc
         nvir = ucc.space[0].nvir + ucc.space[1].nvir
         nbos = ucc.nbos

--- a/ebcc/cc/gebcc.py
+++ b/ebcc/cc/gebcc.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from pyscf import scf
 
-from ebcc import BACKEND
 from ebcc import numpy as np
 from ebcc import util
 from ebcc.backend import _put

--- a/ebcc/cc/rebcc.py
+++ b/ebcc/cc/rebcc.py
@@ -105,8 +105,8 @@ class REBCC(BaseEBCC):
         """
         space = Space(
             self.mo_occ > 0,
-            np.zeros(self.mo_occ.shape, dtype=bool),
-            np.zeros(self.mo_occ.shape, dtype=bool),
+            np.zeros(self.mo_occ.shape, dtype=np.bool_),
+            np.zeros(self.mo_occ.shape, dtype=np.bool_),
         )
         return space
 

--- a/ebcc/cc/rebcc.py
+++ b/ebcc/cc/rebcc.py
@@ -153,7 +153,7 @@ class REBCC(BaseEBCC):
                 amplitudes[name] = self.fock[key] / self.energy_sum(key)
             elif n == 2:
                 key_t = key[0] + key[2] + key[1] + key[3]
-                amplitudes[name] = eris[key_t].transpose(0, 2, 1, 3) / self.energy_sum(key)
+                amplitudes[name] = np.transpose(eris[key_t], (0, 2, 1, 3)) / self.energy_sum(key)
             else:
                 shape = tuple(self.space.size(k) for k in key)
                 amplitudes[name] = np.zeros(shape, dtype=types[float])
@@ -201,7 +201,7 @@ class REBCC(BaseEBCC):
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
             lname = name.replace("t", "l")
             perm = list(range(n, 2 * n)) + list(range(n))
-            lambdas[lname] = amplitudes[name].transpose(perm)
+            lambdas[lname] = np.transpose(amplitudes[name], perm)
 
         # Build LS amplitudes:
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
@@ -214,7 +214,7 @@ class REBCC(BaseEBCC):
                 raise util.ModelNotImplemented
             lname = "l" + name
             perm = list(range(nb)) + [nb + 1, nb]
-            lambdas[lname] = amplitudes[name].transpose(perm)
+            lambdas[lname] = np.transpose(amplitudes[name], perm)
 
         return lambdas
 
@@ -382,8 +382,8 @@ class REBCC(BaseEBCC):
         dm: NDArray[T] = func(**kwargs)
 
         if hermitise:
-            dm = 0.5 * (dm.transpose(0, 1, 2, 3) + dm.transpose(2, 3, 0, 1))
-            dm = 0.5 * (dm.transpose(0, 1, 2, 3) + dm.transpose(1, 0, 3, 2))
+            dm = 0.5 * (np.transpose(dm, (0, 1, 2, 3)) + np.transpose(dm, (2, 3, 0, 1)))
+            dm = 0.5 * (np.transpose(dm, (0, 1, 2, 3)) + np.transpose(dm, (1, 0, 3, 2)))
 
         return dm
 
@@ -427,8 +427,8 @@ class REBCC(BaseEBCC):
         if hermitise:
             dm_eb = np.array(
                 [
-                    0.5 * (dm_eb[0] + dm_eb[1].transpose(0, 2, 1)),
-                    0.5 * (dm_eb[1] + dm_eb[0].transpose(0, 2, 1)),
+                    0.5 * (dm_eb[0] + np.transpose(dm_eb[1], (0, 2, 1))),
+                    0.5 * (dm_eb[1] + np.transpose(dm_eb[0], (0, 2, 1))),
                 ]
             )
 
@@ -494,13 +494,13 @@ class REBCC(BaseEBCC):
         vectors = []
 
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
-            vectors.append(amplitudes[name].ravel())
+            vectors.append(np.ravel(amplitudes[name]))
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
-            vectors.append(amplitudes[name].ravel())
+            vectors.append(np.ravel(amplitudes[name]))
 
         for name, key, nf, nb in self.ansatz.coupling_cluster_ranks(spin_type=self.spin_type):
-            vectors.append(amplitudes[name].ravel())
+            vectors.append(np.ravel(amplitudes[name]))
 
         return np.concatenate(vectors)
 
@@ -519,19 +519,19 @@ class REBCC(BaseEBCC):
         for name, key, n in self.ansatz.fermionic_cluster_ranks(spin_type=self.spin_type):
             shape = tuple(self.space.size(k) for k in key)
             size = util.prod(shape)
-            amplitudes[name] = vector[i0 : i0 + size].reshape(shape)
+            amplitudes[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type):
             shape = (self.nbos,) * n
             size = util.prod(shape)
-            amplitudes[name] = vector[i0 : i0 + size].reshape(shape)
+            amplitudes[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         for name, key, nf, nb in self.ansatz.coupling_cluster_ranks(spin_type=self.spin_type):
             shape = (self.nbos,) * nb + tuple(self.space.size(k) for k in key[nb:])
             size = util.prod(shape)
-            amplitudes[name] = vector[i0 : i0 + size].reshape(shape)
+            amplitudes[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         return amplitudes
@@ -550,15 +550,15 @@ class REBCC(BaseEBCC):
         for name, key, n in self.ansatz.fermionic_cluster_ranks(
             spin_type=self.spin_type, which="l"
         ):
-            vectors.append(lambdas[name].ravel())
+            vectors.append(np.ravel(lambdas[name]))
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="l"):
-            vectors.append(lambdas[name].ravel())
+            vectors.append(np.ravel(lambdas[name]))
 
         for name, key, nf, nb in self.ansatz.coupling_cluster_ranks(
             spin_type=self.spin_type, which="l"
         ):
-            vectors.append(lambdas[name].ravel())
+            vectors.append(np.ravel(lambdas[name]))
 
         return np.concatenate(vectors)
 
@@ -579,13 +579,13 @@ class REBCC(BaseEBCC):
         ):
             shape = tuple(self.space.size(k) for k in key)
             size = util.prod(shape)
-            lambdas[name] = vector[i0 : i0 + size].reshape(shape)
+            lambdas[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="l"):
             shape = (self.nbos,) * n
             size = util.prod(shape)
-            lambdas[name] = vector[i0 : i0 + size].reshape(shape)
+            lambdas[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         for name, key, nf, nb in self.ansatz.coupling_cluster_ranks(
@@ -593,7 +593,7 @@ class REBCC(BaseEBCC):
         ):
             shape = (self.nbos,) * nb + tuple(self.space.size(k) for k in key[nb:])
             size = util.prod(shape)
-            lambdas[name] = vector[i0 : i0 + size].reshape(shape)
+            lambdas[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         return lambdas

--- a/ebcc/cc/rebcc.py
+++ b/ebcc/cc/rebcc.py
@@ -153,7 +153,7 @@ class REBCC(BaseEBCC):
                 amplitudes[name] = self.fock[key] / self.energy_sum(key)
             elif n == 2:
                 key_t = key[0] + key[2] + key[1] + key[3]
-                amplitudes[name] = eris[key_t].swapaxes(1, 2) / self.energy_sum(key)
+                amplitudes[name] = eris[key_t].transpose(0, 2, 1, 3) / self.energy_sum(key)
             else:
                 shape = tuple(self.space.size(k) for k in key)
                 amplitudes[name] = np.zeros(shape, dtype=types[float])

--- a/ebcc/cc/rebcc.py
+++ b/ebcc/cc/rebcc.py
@@ -425,8 +425,12 @@ class REBCC(BaseEBCC):
         dm_eb: NDArray[T] = func(**kwargs)
 
         if hermitise:
-            dm_eb[0] = 0.5 * (dm_eb[0] + dm_eb[1].transpose(0, 2, 1))
-            dm_eb[1] = dm_eb[0].transpose(0, 2, 1).copy()
+            dm_eb = np.array(
+                [
+                    0.5 * (dm_eb[0] + dm_eb[1].transpose(0, 2, 1)),
+                    0.5 * (dm_eb[1] + dm_eb[0].transpose(0, 2, 1)),
+                ]
+            )
 
         if unshifted and self.options.shift:
             rdm1_f = self.make_rdm1_f(hermitise=hermitise)
@@ -619,7 +623,7 @@ class REBCC(BaseEBCC):
         Returns:
             Mean-field Fock matrix.
         """
-        fock_ao: NDArray[T] = self.mf.get_fock().astype(types[float])
+        fock_ao: NDArray[T] = np.asarray(self.mf.get_fock(), dtype=types[float])
         fock = util.einsum("pq,pi,qj->ij", fock_ao, self.mo_coeff, self.mo_coeff)
         return fock
 

--- a/ebcc/cc/rebcc.py
+++ b/ebcc/cc/rebcc.py
@@ -351,7 +351,7 @@ class REBCC(BaseEBCC):
         dm: NDArray[T] = func(**kwargs)
 
         if hermitise:
-            dm = 0.5 * (dm + dm.T)
+            dm = (dm + np.transpose(dm)) * 0.5
 
         return dm
 
@@ -382,8 +382,8 @@ class REBCC(BaseEBCC):
         dm: NDArray[T] = func(**kwargs)
 
         if hermitise:
-            dm = 0.5 * (np.transpose(dm, (0, 1, 2, 3)) + np.transpose(dm, (2, 3, 0, 1)))
-            dm = 0.5 * (np.transpose(dm, (0, 1, 2, 3)) + np.transpose(dm, (1, 0, 3, 2)))
+            dm = (np.transpose(dm, (0, 1, 2, 3)) + np.transpose(dm, (2, 3, 0, 1))) * 0.5
+            dm = (np.transpose(dm, (0, 1, 2, 3)) + np.transpose(dm, (1, 0, 3, 2))) * 0.5
 
         return dm
 
@@ -427,8 +427,8 @@ class REBCC(BaseEBCC):
         if hermitise:
             dm_eb = np.array(
                 [
-                    0.5 * (dm_eb[0] + np.transpose(dm_eb[1], (0, 2, 1))),
-                    0.5 * (dm_eb[1] + np.transpose(dm_eb[0], (0, 2, 1))),
+                    (dm_eb[0] + np.transpose(dm_eb[1], (0, 2, 1))) * 0.5,
+                    (dm_eb[1] + np.transpose(dm_eb[0], (0, 2, 1))) * 0.5,
                 ]
             )
 
@@ -473,9 +473,9 @@ class REBCC(BaseEBCC):
             factor = 1 if signs_dict[key] == "+" else -1
             if key == "b":
                 assert self.omega is not None
-                energies.append(factor * self.omega)
+                energies.append(self.omega * types[float](factor))
             else:
-                energies.append(factor * np.diag(self.fock[key + key]))
+                energies.append(np.diag(self.fock[key + key]) * types[float](factor))
 
         subscript = ",".join([next_char() for k in subscript])
         energy_sum = util.dirsum(subscript, *energies)

--- a/ebcc/cc/uebcc.py
+++ b/ebcc/cc/uebcc.py
@@ -892,7 +892,8 @@ class UEBCC(BaseEBCC):
             Number of occupied molecular orbitals for each spin.
         """
         return cast(
-            tuple[int, int], tuple(np.sum(np.astype((mo_occ > 0), int)) for mo_occ in self.mo_occ)
+            tuple[int, int],
+            tuple(np.sum(np.asarray(mo_occ > 0, dtype=int)) for mo_occ in self.mo_occ),
         )
 
     @property

--- a/ebcc/cc/uebcc.py
+++ b/ebcc/cc/uebcc.py
@@ -186,13 +186,13 @@ class UEBCC(BaseEBCC):
         space = (
             Space(
                 self.mo_occ[0] > 0,
-                np.zeros(self.mo_occ[0].shape, dtype=bool),
-                np.zeros(self.mo_occ[0].shape, dtype=bool),
+                np.zeros(self.mo_occ[0].shape, dtype=np.bool_),
+                np.zeros(self.mo_occ[0].shape, dtype=np.bool_),
             ),
             Space(
                 self.mo_occ[1] > 0,
-                np.zeros(self.mo_occ[1].shape, dtype=bool),
-                np.zeros(self.mo_occ[1].shape, dtype=bool),
+                np.zeros(self.mo_occ[1].shape, dtype=np.bool_),
+                np.zeros(self.mo_occ[1].shape, dtype=np.bool_),
             ),
         )
         return space

--- a/ebcc/cc/uebcc.py
+++ b/ebcc/cc/uebcc.py
@@ -243,7 +243,9 @@ class UEBCC(BaseEBCC):
                 elif n == 2:
                     comb_t = comb[0] + comb[2] + comb[1] + comb[3]
                     key_t = key[0] + key[2] + key[1] + key[3]
-                    tn[comb] = np.transpose(eris[comb_t][key_t], (0, 2, 1, 3)) / self.energy_sum(key, comb)
+                    tn[comb] = np.transpose(eris[comb_t][key_t], (0, 2, 1, 3)) / self.energy_sum(
+                        key, comb
+                    )
                     if comb in ("aaaa", "bbbb"):
                         # TODO generalise:
                         tn[comb] = (tn[comb] - np.transpose(tn[comb], (1, 0, 2, 3))) * 0.5

--- a/ebcc/cc/uebcc.py
+++ b/ebcc/cc/uebcc.py
@@ -243,10 +243,10 @@ class UEBCC(BaseEBCC):
                 elif n == 2:
                     comb_t = comb[0] + comb[2] + comb[1] + comb[3]
                     key_t = key[0] + key[2] + key[1] + key[3]
-                    tn[comb] = eris[comb_t][key_t].swapaxes(1, 2) / self.energy_sum(key, comb)
+                    tn[comb] = eris[comb_t][key_t].transpose(0, 2, 1, 3) / self.energy_sum(key, comb)
                     if comb in ("aaaa", "bbbb"):
                         # TODO generalise:
-                        tn[comb] = 0.5 * (tn[comb] - tn[comb].swapaxes(0, 1))
+                        tn[comb] = 0.5 * (tn[comb] - tn[comb].transpose(1, 0, 2, 3))
                 else:
                     shape = tuple(self.space["ab".index(s)].size(k) for s, k in zip(comb, key))
                     tn[comb] = np.zeros(shape, dtype=types[float])

--- a/ebcc/cc/uebcc.py
+++ b/ebcc/cc/uebcc.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from ebcc import BACKEND
 from ebcc import numpy as np
 from ebcc import util
 from ebcc.cc.base import BaseEBCC

--- a/ebcc/cc/uebcc.py
+++ b/ebcc/cc/uebcc.py
@@ -111,11 +111,6 @@ class UEBCC(BaseEBCC):
         Returns:
             UEBCC object.
         """
-        if BACKEND != "numpy":
-            raise NotImplementedError(
-                "Spin conversion routines currently not implemented for immutable backends."
-            )
-
         ucc = cls(
             rcc.mf,
             log=rcc.log,

--- a/ebcc/codegen/GCC2.py
+++ b/ebcc/codegen/GCC2.py
@@ -37,7 +37,7 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp0 = t2.copy()
+    tmp0 = np.copy(t2)
     tmp0 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
     e_cc = einsum(f.ov, (0, 1), t1, (0, 1), ())
     e_cc += einsum(v.oovv, (0, 1, 2, 3), tmp0, (0, 1, 2, 3), ()) * 0.25
@@ -77,19 +77,19 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp13 = einsum(t2, (0, 1, 2, 3), tmp4, (1, 4), (4, 0, 2, 3))
     tmp16 = einsum(t1, (0, 1), tmp15, (2, 0, 3, 4), (2, 3, 4, 1)) * -1
     del tmp15
-    tmp23 = v.oooo.copy()
+    tmp23 = np.copy(v.oooo)
     tmp23 += einsum(t1, (0, 1), tmp0, (2, 3, 4, 1), (4, 3, 0, 2)) * -1
     tmp11 = einsum(t1, (0, 1), tmp10, (2, 3, 4, 1), (2, 0, 3, 4)) * -1
     del tmp10
     tmp21 = einsum(v.ovov, (0, 1, 2, 3), t1, (4, 3), (4, 0, 2, 1))
     tmp19 = einsum(t2, (0, 1, 2, 3), f.ov, (4, 3), (4, 0, 1, 2))
-    tmp5 = t2.copy()
+    tmp5 = np.copy(t2)
     tmp5 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
-    tmp17 = tmp13.transpose((0, 1, 3, 2)).copy() * -1
+    tmp17 = np.copy(np.transpose(tmp13, (0, 1, 3, 2))) * -1
     del tmp13
-    tmp17 += tmp16.transpose((0, 1, 3, 2))
+    tmp17 += np.transpose(tmp16, (0, 1, 3, 2))
     del tmp16
-    tmp24 = v.ooov.copy() * -1
+    tmp24 = np.copy(v.ooov) * -1
     tmp24 += einsum(tmp23, (0, 1, 2, 3), t1, (0, 4), (2, 3, 1, 4)) * -1
     del tmp23
     tmp18 = einsum(f.oo, (0, 1), t2, (2, 1, 3, 4), (0, 2, 3, 4))
@@ -102,45 +102,45 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp19
     tmp9 = einsum(v.ovvv, (0, 1, 2, 3), t1, (4, 1), (4, 0, 2, 3))
     tmp8 = einsum(f.vv, (0, 1), t2, (2, 3, 4, 1), (2, 3, 0, 4))
-    tmp3 = f.ov.copy()
+    tmp3 = np.copy(f.ov)
     tmp3 += einsum(t1, (0, 1), v.oovv, (2, 0, 3, 1), (2, 3))
-    tmp6 = f.oo.copy()
+    tmp6 = np.copy(f.oo)
     tmp6 += tmp4
     del tmp4
     tmp6 += einsum(v.ooov, (0, 1, 2, 3), t1, (1, 3), (0, 2))
     tmp6 += einsum(tmp5, (0, 1, 2, 3), v.oovv, (4, 0, 2, 3), (4, 1)) * -0.5
     del tmp5
-    tmp1 = v.ovoo.transpose((0, 2, 3, 1)).copy() * -1
-    tmp1 += tmp0.transpose((0, 2, 1, 3)) * -1
+    tmp1 = np.copy(np.transpose(v.ovoo, (0, 2, 3, 1))) * -1
+    tmp1 += np.transpose(tmp0, (0, 2, 1, 3)) * -1
     del tmp0
-    tmp2 = t2.copy() * 0.5
+    tmp2 = np.copy(t2) * 0.5
     tmp2 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     t2new = einsum(t1, (0, 1), tmp7, (2, 3, 4, 1), (0, 2, 4, 3)) * -1
     del tmp7
     t2new += v.oovv
     t2new += einsum(t1, (0, 1), v.ooov, (2, 3, 0, 4), (2, 3, 4, 1))
-    t2new += tmp8.transpose((1, 0, 2, 3))
-    t2new += tmp8.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp8, (1, 0, 2, 3))
+    t2new += np.transpose(tmp8, (1, 0, 3, 2)) * -1
     del tmp8
-    t2new += tmp9.transpose((0, 1, 3, 2))
-    t2new += tmp9.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp9, (0, 1, 3, 2))
+    t2new += np.transpose(tmp9, (1, 0, 3, 2)) * -1
     del tmp9
     t2new += tmp12 * -1
-    t2new += tmp12.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp12, (0, 1, 3, 2))
     del tmp12
     t2new += tmp17
-    t2new += tmp17.transpose((1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp17, (1, 0, 2, 3)) * -1
     del tmp17
-    t2new += tmp18.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp18.transpose((1, 0, 3, 2))
+    t2new += np.transpose(tmp18, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp18, (1, 0, 3, 2))
     del tmp18
     t2new += tmp20
-    t2new += tmp20.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp20, (0, 1, 3, 2)) * -1
     del tmp20
     t2new += tmp22
-    t2new += tmp22.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp22.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp22.transpose((1, 0, 3, 2))
+    t2new += np.transpose(tmp22, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp22, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp22, (1, 0, 3, 2))
     del tmp22
     t2new += einsum(t1, (0, 1), tmp24, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp24
@@ -187,14 +187,14 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
 
     tmp5 = einsum(v.oovv, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
     tmp4 = einsum(t1, (0, 1), v.ovvv, (2, 3, 4, 1), (0, 2, 3, 4))
-    tmp10 = v.ooov.copy()
-    tmp10 += tmp5.transpose((2, 1, 0, 3)) * 0.5
+    tmp10 = np.copy(v.ooov)
+    tmp10 += np.transpose(tmp5, (2, 1, 0, 3)) * 0.5
     tmp1 = einsum(t1, (0, 1), l2, (2, 1, 3, 4), (3, 4, 0, 2))
     tmp7 = einsum(t1, (0, 1), v.oovv, (2, 0, 3, 1), (2, 3))
-    tmp6 = v.ovoo.transpose((0, 2, 3, 1)).copy() * -1
-    tmp6 += tmp5.transpose((0, 2, 1, 3)) * -1
+    tmp6 = np.copy(np.transpose(v.ovoo, (0, 2, 3, 1))) * -1
+    tmp6 += np.transpose(tmp5, (0, 2, 1, 3)) * -1
     tmp23 = einsum(v.ovvv, (0, 1, 2, 3), t1, (0, 3), (1, 2))
-    tmp34 = v.ovov.transpose((0, 2, 3, 1)).copy() * -1
+    tmp34 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -1
     tmp34 += tmp4
     tmp18 = einsum(t1, (0, 1), l1, (1, 2), (2, 0))
     tmp25 = einsum(t1, (0, 1), v.ooov, (2, 0, 3, 1), (2, 3))
@@ -219,61 +219,61 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp41
     tmp30 = einsum(f.oo, (0, 1), l2, (2, 3, 4, 1), (0, 4, 2, 3))
     tmp31 = einsum(v.ovvv, (0, 1, 2, 3), l1, (1, 4), (4, 0, 2, 3))
-    tmp20 = tmp18.copy() * 2
+    tmp20 = np.copy(tmp18) * 2
     tmp20 += tmp19
-    tmp12 = v.oooo.copy() * -0.5
+    tmp12 = np.copy(v.oooo) * -0.5
     tmp12 += einsum(t2, (0, 1, 2, 3), v.oovv, (4, 5, 2, 3), (4, 5, 0, 1)) * -0.25
-    tmp12 += tmp11.transpose((1, 0, 3, 2)) * -1
-    tmp9 = v.ovov.transpose((0, 2, 1, 3)).copy()
-    tmp9 += tmp4.transpose((0, 1, 3, 2)) * -0.5
-    tmp8 = f.ov.copy()
+    tmp12 += np.transpose(tmp11, (1, 0, 3, 2)) * -1
+    tmp9 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3)))
+    tmp9 += np.transpose(tmp4, (0, 1, 3, 2)) * -0.5
+    tmp8 = np.copy(f.ov)
     tmp8 += tmp7
-    tmp15 = tmp0.transpose((1, 0, 3, 2)).copy() * -0.5
-    tmp15 += tmp2.transpose((0, 1, 3, 2))
+    tmp15 = np.copy(np.transpose(tmp0, (1, 0, 3, 2))) * -0.5
+    tmp15 += np.transpose(tmp2, (0, 1, 3, 2))
     tmp48 = einsum(tmp1, (0, 1, 2, 3), tmp5, (0, 4, 2, 5), (1, 4, 3, 5)) * -1
     del tmp5
     tmp47 = einsum(l2, (0, 1, 2, 3), tmp46, (3, 4), (2, 4, 0, 1))
     del tmp46
-    tmp49 = v.oooo.copy() * 0.5
-    tmp49 += tmp11.transpose((2, 3, 1, 0)) * -1
+    tmp49 = np.copy(v.oooo) * 0.5
+    tmp49 += np.transpose(tmp11, (2, 3, 1, 0)) * -1
     del tmp11
-    tmp29 = tmp27.transpose((1, 0, 2, 3)).copy() * -1
+    tmp29 = np.copy(np.transpose(tmp27, (1, 0, 2, 3))) * -1
     del tmp27
     tmp29 += tmp28
     del tmp28
-    tmp40 = tmp37.copy() * -1
+    tmp40 = np.copy(tmp37) * -1
     del tmp37
     tmp40 += tmp38
     del tmp38
-    tmp40 += tmp39.transpose((1, 0, 3, 2))
+    tmp40 += np.transpose(tmp39, (1, 0, 3, 2))
     del tmp39
     tmp36 = einsum(tmp7, (0, 1), l1, (2, 3), (3, 0, 2, 1))
     del tmp7
     tmp36 += tmp33
     del tmp33
-    tmp36 += tmp35.transpose((1, 0, 3, 2))
+    tmp36 += np.transpose(tmp35, (1, 0, 3, 2))
     del tmp35
-    tmp45 = tmp42.transpose((0, 1, 3, 2)).copy() * -1
+    tmp45 = np.copy(np.transpose(tmp42, (0, 1, 3, 2))) * -1
     del tmp42
-    tmp45 += tmp43.transpose((0, 1, 3, 2)) * -1
+    tmp45 += np.transpose(tmp43, (0, 1, 3, 2)) * -1
     del tmp43
-    tmp45 += tmp44.transpose((0, 1, 3, 2))
+    tmp45 += np.transpose(tmp44, (0, 1, 3, 2))
     del tmp44
-    tmp32 = tmp30.transpose((0, 1, 3, 2)).copy() * -1
+    tmp32 = np.copy(np.transpose(tmp30, (0, 1, 3, 2))) * -1
     del tmp30
-    tmp32 += tmp31.transpose((0, 1, 3, 2))
+    tmp32 += np.transpose(tmp31, (0, 1, 3, 2))
     del tmp31
-    tmp14 = v.ovvv.copy()
+    tmp14 = np.copy(v.ovvv)
     tmp14 += einsum(v.vvvv, (0, 1, 2, 3), t1, (4, 1), (4, 0, 2, 3)) * -1
-    tmp22 = tmp18.copy()
+    tmp22 = np.copy(tmp18)
     del tmp18
     tmp22 += tmp19 * 0.5
     del tmp19
-    tmp21 = t1.copy() * -1
+    tmp21 = np.copy(t1) * -1
     tmp21 += einsum(t2, (0, 1, 2, 3), l1, (3, 1), (0, 2)) * -1
     tmp21 += einsum(t2, (0, 1, 2, 3), tmp1, (1, 0, 4, 3), (4, 2)) * 0.5
     tmp21 += einsum(tmp20, (0, 1), t1, (0, 2), (1, 2)) * 0.5
-    tmp13 = v.ovoo.transpose((0, 2, 3, 1)).copy() * -0.5
+    tmp13 = np.copy(np.transpose(v.ovoo, (0, 2, 3, 1))) * -0.5
     tmp13 += einsum(t2, (0, 1, 2, 3), v.ovvv, (4, 5, 2, 3), (4, 0, 1, 5)) * -0.25
     tmp13 += einsum(tmp6, (0, 1, 2, 3), t2, (4, 1, 5, 3), (2, 4, 0, 5))
     del tmp6
@@ -288,47 +288,47 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp15
     tmp17 = einsum(t1, (0, 1), l1, (2, 0), (2, 1))
     tmp17 += einsum(t2, (0, 1, 2, 3), l2, (4, 3, 0, 1), (4, 2)) * 0.5
-    tmp24 = f.vv.copy()
+    tmp24 = np.copy(f.vv)
     tmp24 += tmp23 * -1
     del tmp23
     tmp3 = einsum(l2, (0, 1, 2, 3), t2, (4, 3, 5, 1), (2, 4, 0, 5))
-    tmp26 = f.oo.copy() * 2
-    tmp26 += tmp25.transpose((1, 0)) * 2
+    tmp26 = np.copy(f.oo) * 2
+    tmp26 += np.transpose(tmp25, (1, 0)) * 2
     del tmp25
     tmp26 += einsum(t2, (0, 1, 2, 3), v.oovv, (4, 1, 2, 3), (0, 4))
     tmp26 += einsum(tmp8, (0, 1), t1, (2, 1), (2, 0)) * 2
     l2new = einsum(l2, (0, 1, 2, 3), v.vvvv, (4, 5, 0, 1), (4, 5, 2, 3)) * 0.5
     l2new += einsum(tmp1, (0, 1, 2, 3), v.ovvv, (2, 3, 4, 5), (4, 5, 0, 1))
-    l2new += v.oovv.transpose((2, 3, 0, 1))
+    l2new += np.transpose(v.oovv, (2, 3, 0, 1))
     l2new += einsum(v.oovv, (0, 1, 2, 3), tmp2, (4, 5, 1, 0), (2, 3, 5, 4)) * 0.5
-    l2new += tmp29.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp29.transpose((3, 2, 0, 1))
+    l2new += np.transpose(tmp29, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp29, (3, 2, 0, 1))
     del tmp29
-    l2new += tmp32.transpose((2, 3, 0, 1))
-    l2new += tmp32.transpose((2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp32, (2, 3, 0, 1))
+    l2new += np.transpose(tmp32, (2, 3, 1, 0)) * -1
     del tmp32
-    l2new += tmp36.transpose((2, 3, 0, 1))
-    l2new += tmp36.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp36.transpose((2, 3, 1, 0)) * -1
-    l2new += tmp36.transpose((3, 2, 1, 0))
+    l2new += np.transpose(tmp36, (2, 3, 0, 1))
+    l2new += np.transpose(tmp36, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp36, (2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp36, (3, 2, 1, 0))
     del tmp36
-    l2new += tmp40.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp40.transpose((3, 2, 0, 1))
+    l2new += np.transpose(tmp40, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp40, (3, 2, 0, 1))
     del tmp40
     l2new += einsum(l1, (0, 1), f.ov, (2, 3), (3, 0, 2, 1))
     l2new += einsum(l1, (0, 1), f.ov, (2, 3), (0, 3, 2, 1)) * -1
     l2new += einsum(l1, (0, 1), f.ov, (2, 3), (3, 0, 1, 2)) * -1
     l2new += einsum(f.ov, (0, 1), l1, (2, 3), (2, 1, 3, 0))
-    l2new += tmp45.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp45.transpose((3, 2, 1, 0))
+    l2new += np.transpose(tmp45, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp45, (3, 2, 1, 0))
     del tmp45
-    l2new += tmp47.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp47.transpose((2, 3, 1, 0))
+    l2new += np.transpose(tmp47, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp47, (2, 3, 1, 0))
     del tmp47
-    l2new += tmp48.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp48.transpose((3, 2, 0, 1))
-    l2new += tmp48.transpose((2, 3, 1, 0))
-    l2new += tmp48.transpose((3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp48, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp48, (3, 2, 0, 1))
+    l2new += np.transpose(tmp48, (2, 3, 1, 0))
+    l2new += np.transpose(tmp48, (3, 2, 1, 0)) * -1
     del tmp48
     l2new += einsum(tmp49, (0, 1, 2, 3), l2, (4, 5, 0, 1), (4, 5, 2, 3))
     del tmp49
@@ -337,7 +337,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l1new += einsum(v.ooov, (0, 1, 2, 3), tmp2, (4, 2, 0, 1), (3, 4)) * -0.5
     del tmp2
     l1new += einsum(v.ovov, (0, 1, 2, 3), tmp1, (4, 2, 0, 1), (3, 4)) * -1
-    l1new += f.ov.transpose((1, 0))
+    l1new += np.transpose(f.ov, (1, 0))
     l1new += einsum(v.ovov, (0, 1, 2, 3), l1, (1, 2), (3, 0)) * -1
     l1new += einsum(tmp3, (0, 1, 2, 3), v.ovvv, (1, 2, 4, 3), (4, 0)) * -1
     del tmp3
@@ -392,23 +392,23 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     )
     tmp0 = einsum(t1, (0, 1), l1, (1, 2), (2, 0))
     tmp1 = einsum(l2, (0, 1, 2, 3), t2, (4, 3, 0, 1), (2, 4))
-    tmp3 = tmp0.copy()
+    tmp3 = np.copy(tmp0)
     tmp3 += tmp1 * 0.5
     tmp2 = einsum(t1, (0, 1), l2, (2, 1, 3, 4), (3, 4, 0, 2))
     rdm1.vv = einsum(t1, (0, 1), l1, (2, 0), (2, 1))
     rdm1.vv += einsum(t2, (0, 1, 2, 3), l2, (4, 3, 0, 1), (4, 2)) * 0.5
-    rdm1.vo = l1.copy()
+    rdm1.vo = np.copy(l1)
     rdm1.ov = einsum(tmp2, (0, 1, 2, 3), t2, (1, 0, 4, 3), (2, 4)) * -0.5
     del tmp2
     rdm1.ov += einsum(t2, (0, 1, 2, 3), l1, (3, 1), (0, 2))
     rdm1.ov += t1
     rdm1.ov += einsum(t1, (0, 1), tmp3, (0, 2), (2, 1)) * -1
     del tmp3
-    rdm1.oo = tmp0.transpose((1, 0)).copy() * -1
+    rdm1.oo = np.copy(np.transpose(tmp0, (1, 0))) * -1
     del tmp0
     rdm1.oo += delta.oo
     del delta
-    rdm1.oo += tmp1.transpose((1, 0)) * -0.5
+    rdm1.oo += np.transpose(tmp1, (1, 0)) * -0.5
     del tmp1
     rdm1 = np.block([[rdm1.oo, rdm1.ov], [rdm1.vo, rdm1.vv]])
 
@@ -450,16 +450,16 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp10 = einsum(t2, (0, 1, 2, 3), l1, (3, 1), (0, 2))
     tmp11 = einsum(t1, (0, 1), tmp3, (0, 2), (2, 1))
     tmp5 = einsum(l1, (0, 1), t2, (2, 3, 4, 0), (1, 2, 3, 4))
-    tmp14 = tmp3.copy() * 2
+    tmp14 = np.copy(tmp3) * 2
     tmp14 += tmp4
     tmp30 = einsum(t1, (0, 1), l1, (2, 0), (2, 1))
     tmp25 = einsum(t2, (0, 1, 2, 3), l2, (4, 3, 0, 1), (4, 2))
     tmp29 = einsum(t1, (0, 1), tmp1, (2, 0, 3, 4), (2, 3, 4, 1))
     tmp36 = einsum(t1, (0, 1), tmp21, (0, 2, 3, 4), (2, 3, 1, 4))
-    tmp13 = tmp0.transpose((1, 0, 3, 2)).copy() * -0.5
-    tmp13 += tmp2.transpose((0, 1, 3, 2))
+    tmp13 = np.copy(np.transpose(tmp0, (1, 0, 3, 2))) * -0.5
+    tmp13 += np.transpose(tmp2, (0, 1, 3, 2))
     tmp18 = einsum(t1, (0, 1), tmp6, (0, 2, 3, 4), (2, 3, 1, 4))
-    tmp12 = tmp10.copy()
+    tmp12 = np.copy(tmp10)
     tmp12 += tmp11 * -1
     del tmp11
     tmp20 = einsum(t1, (0, 1), tmp5, (0, 2, 3, 4), (2, 3, 1, 4))
@@ -469,33 +469,33 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp15 = einsum(t1, (0, 1), tmp14, (0, 2), (2, 1)) * 0.5
     del tmp14
     tmp38 = einsum(t1, (0, 1), l2, (2, 3, 4, 0), (4, 2, 3, 1))
-    tmp31 = tmp30.copy()
+    tmp31 = np.copy(tmp30)
     tmp31 += tmp25 * 0.5
     tmp35 = einsum(l1, (0, 1), t2, (2, 1, 3, 4), (2, 0, 3, 4))
     tmp34 = einsum(t1, (0, 1), tmp29, (0, 2, 3, 4), (2, 3, 4, 1)) * -1
     tmp33 = einsum(t2, (0, 1, 2, 3), tmp1, (1, 0, 4, 5), (4, 5, 2, 3)) * -1
-    tmp37 = tmp36.copy()
+    tmp37 = np.copy(tmp36)
     tmp37 += einsum(tmp25, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * -0.5
-    tmp32 = tmp30.copy() * 2
+    tmp32 = np.copy(tmp30) * 2
     tmp32 += tmp25
     tmp28 = einsum(tmp13, (0, 1, 2, 3), t1, (0, 4), (1, 3, 2, 4)) * -2
     tmp24 = einsum(t2, (0, 1, 2, 3), tmp3, (1, 4), (4, 0, 2, 3))
     tmp27 = einsum(t2, (0, 1, 2, 3), tmp4, (1, 4), (0, 4, 2, 3))
-    tmp19 = tmp18.copy()
+    tmp19 = np.copy(tmp18)
     del tmp18
     tmp19 += einsum(tmp12, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * -1
     tmp26 = einsum(t2, (0, 1, 2, 3), tmp25, (3, 4), (0, 1, 2, 4))
     del tmp25
-    tmp23 = tmp20.copy()
+    tmp23 = np.copy(tmp20)
     del tmp20
     tmp23 += tmp22
     del tmp22
-    tmp9 = tmp7.copy()
+    tmp9 = np.copy(tmp7)
     tmp9 += tmp8
     del tmp8
-    tmp17 = tmp0.transpose((1, 0, 3, 2)).copy() * -1
-    tmp17 += tmp2.transpose((0, 1, 3, 2)) * 2
-    tmp16 = tmp10.copy() * -1
+    tmp17 = np.copy(np.transpose(tmp0, (1, 0, 3, 2))) * -1
+    tmp17 += np.transpose(tmp2, (0, 1, 3, 2)) * 2
+    tmp16 = np.copy(tmp10) * -1
     del tmp10
     tmp16 += tmp7 * 0.5
     del tmp7
@@ -503,69 +503,69 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp15
     rdm2.vvvv = einsum(t2, (0, 1, 2, 3), l2, (4, 5, 0, 1), (4, 5, 2, 3)) * 0.5
     rdm2.vvvv += einsum(tmp38, (0, 1, 2, 3), t1, (0, 4), (1, 2, 4, 3))
-    rdm2.vvvo = tmp38.transpose((2, 1, 3, 0)).copy()
-    rdm2.vvov = tmp38.transpose((2, 1, 0, 3)).copy() * -1
+    rdm2.vvvo = np.copy(np.transpose(tmp38, (2, 1, 3, 0)))
+    rdm2.vvov = np.copy(np.transpose(tmp38, (2, 1, 0, 3))) * -1
     del tmp38
-    rdm2.vovv = tmp33.transpose((1, 0, 3, 2)).copy() * 0.5
-    rdm2.vovv += tmp34.transpose((1, 0, 3, 2))
-    rdm2.vovv += tmp35.transpose((1, 0, 3, 2))
-    rdm2.vovv += tmp36.transpose((1, 0, 2, 3))
-    rdm2.vovv += tmp36.transpose((1, 0, 3, 2)) * -1
+    rdm2.vovv = np.copy(np.transpose(tmp33, (1, 0, 3, 2))) * 0.5
+    rdm2.vovv += np.transpose(tmp34, (1, 0, 3, 2))
+    rdm2.vovv += np.transpose(tmp35, (1, 0, 3, 2))
+    rdm2.vovv += np.transpose(tmp36, (1, 0, 2, 3))
+    rdm2.vovv += np.transpose(tmp36, (1, 0, 3, 2)) * -1
     del tmp36
     rdm2.vovv += einsum(t1, (0, 1), tmp31, (2, 3), (2, 0, 1, 3)) * -1
     rdm2.vovv += einsum(t1, (0, 1), tmp31, (2, 3), (2, 0, 3, 1))
-    rdm2.ovvv = tmp33.transpose((0, 1, 3, 2)).copy() * -0.5
+    rdm2.ovvv = np.copy(np.transpose(tmp33, (0, 1, 3, 2))) * -0.5
     del tmp33
-    rdm2.ovvv += tmp34.transpose((0, 1, 3, 2)) * -1
+    rdm2.ovvv += np.transpose(tmp34, (0, 1, 3, 2)) * -1
     del tmp34
-    rdm2.ovvv += tmp35.transpose((0, 1, 3, 2)) * -1
+    rdm2.ovvv += np.transpose(tmp35, (0, 1, 3, 2)) * -1
     del tmp35
     rdm2.ovvv += tmp37 * -1
-    rdm2.ovvv += tmp37.transpose((0, 1, 3, 2))
+    rdm2.ovvv += np.transpose(tmp37, (0, 1, 3, 2))
     del tmp37
     rdm2.ovvv += einsum(tmp30, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     rdm2.ovvv += einsum(tmp30, (0, 1), t1, (2, 3), (2, 0, 1, 3)) * -1
     del tmp30
-    rdm2.vvoo = l2.copy()
-    rdm2.vovo = tmp21.transpose((2, 1, 3, 0)).copy() * -1
-    rdm2.vovo += tmp29.transpose((2, 1, 3, 0))
+    rdm2.vvoo = np.copy(l2)
+    rdm2.vovo = np.copy(np.transpose(tmp21, (2, 1, 3, 0))) * -1
+    rdm2.vovo += np.transpose(tmp29, (2, 1, 3, 0))
     rdm2.vovo += einsum(l1, (0, 1), t1, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.vovo += einsum(delta.oo, (0, 1), tmp32, (2, 3), (2, 0, 3, 1)) * 0.5
-    rdm2.voov = tmp21.transpose((2, 1, 0, 3)).copy()
-    rdm2.voov += tmp29.transpose((2, 1, 0, 3)) * -1
+    rdm2.voov = np.copy(np.transpose(tmp21, (2, 1, 0, 3)))
+    rdm2.voov += np.transpose(tmp29, (2, 1, 0, 3)) * -1
     rdm2.voov += einsum(l1, (0, 1), t1, (2, 3), (0, 2, 1, 3))
     rdm2.voov += einsum(delta.oo, (0, 1), tmp31, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.ovvo = tmp21.transpose((1, 2, 3, 0)).copy()
-    rdm2.ovvo += tmp29.transpose((1, 2, 3, 0)) * -1
+    rdm2.ovvo = np.copy(np.transpose(tmp21, (1, 2, 3, 0)))
+    rdm2.ovvo += np.transpose(tmp29, (1, 2, 3, 0)) * -1
     rdm2.ovvo += einsum(l1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     rdm2.ovvo += einsum(delta.oo, (0, 1), tmp32, (2, 3), (0, 2, 3, 1)) * -0.5
     del tmp32
-    rdm2.ovov = tmp21.transpose((1, 2, 0, 3)).copy() * -1
+    rdm2.ovov = np.copy(np.transpose(tmp21, (1, 2, 0, 3))) * -1
     del tmp21
-    rdm2.ovov += tmp29.transpose((1, 2, 0, 3))
+    rdm2.ovov += np.transpose(tmp29, (1, 2, 0, 3))
     del tmp29
     rdm2.ovov += einsum(l1, (0, 1), t1, (2, 3), (2, 0, 1, 3)) * -1
     rdm2.ovov += einsum(delta.oo, (0, 1), tmp31, (2, 3), (0, 2, 1, 3))
     del tmp31
-    rdm2.oovv = t2.copy()
+    rdm2.oovv = np.copy(t2)
     rdm2.oovv += tmp19 * -1
-    rdm2.oovv += tmp19.transpose((0, 1, 3, 2))
-    rdm2.oovv += tmp19.transpose((1, 0, 2, 3))
-    rdm2.oovv += tmp19.transpose((1, 0, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp19, (0, 1, 3, 2))
+    rdm2.oovv += np.transpose(tmp19, (1, 0, 2, 3))
+    rdm2.oovv += np.transpose(tmp19, (1, 0, 3, 2)) * -1
     del tmp19
     rdm2.oovv += tmp23
-    rdm2.oovv += tmp23.transpose((0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp23, (0, 1, 3, 2)) * -1
     del tmp23
-    rdm2.oovv += tmp24.transpose((0, 1, 3, 2)) * -1
-    rdm2.oovv += tmp24.transpose((1, 0, 3, 2))
+    rdm2.oovv += np.transpose(tmp24, (0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp24, (1, 0, 3, 2))
     del tmp24
     rdm2.oovv += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 1, 3)) * -1
     rdm2.oovv += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     rdm2.oovv += tmp26 * -0.5
-    rdm2.oovv += tmp26.transpose((0, 1, 3, 2)) * 0.5
+    rdm2.oovv += np.transpose(tmp26, (0, 1, 3, 2)) * 0.5
     del tmp26
-    rdm2.oovv += tmp27.transpose((0, 1, 3, 2)) * 0.5
-    rdm2.oovv += tmp27.transpose((1, 0, 3, 2)) * -0.5
+    rdm2.oovv += np.transpose(tmp27, (0, 1, 3, 2)) * 0.5
+    rdm2.oovv += np.transpose(tmp27, (1, 0, 3, 2)) * -0.5
     del tmp27
     rdm2.oovv += einsum(tmp9, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * -0.5
     rdm2.oovv += einsum(t1, (0, 1), tmp9, (2, 3), (0, 2, 3, 1)) * 0.5
@@ -574,18 +574,18 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oovv += einsum(t2, (0, 1, 2, 3), tmp13, (0, 1, 4, 5), (5, 4, 2, 3)) * 0.5
     rdm2.oovv += einsum(tmp28, (0, 1, 2, 3), t1, (0, 4), (1, 2, 4, 3)) * 0.5
     del tmp28
-    rdm2.vooo = tmp1.transpose((3, 2, 1, 0)).copy()
+    rdm2.vooo = np.copy(np.transpose(tmp1, (3, 2, 1, 0)))
     rdm2.vooo += einsum(l1, (0, 1), delta.oo, (2, 3), (0, 2, 1, 3))
     rdm2.vooo += einsum(delta.oo, (0, 1), l1, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.ovoo = tmp1.transpose((2, 3, 1, 0)).copy() * -1
+    rdm2.ovoo = np.copy(np.transpose(tmp1, (2, 3, 1, 0))) * -1
     del tmp1
     rdm2.ovoo += einsum(l1, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * -1
     rdm2.ovoo += einsum(delta.oo, (0, 1), l1, (2, 3), (0, 2, 1, 3))
-    rdm2.oovo = tmp5.transpose((2, 1, 3, 0)).copy()
+    rdm2.oovo = np.copy(np.transpose(tmp5, (2, 1, 3, 0)))
     rdm2.oovo += einsum(tmp3, (0, 1), t1, (2, 3), (2, 1, 3, 0)) * -1
     rdm2.oovo += einsum(t1, (0, 1), tmp3, (2, 3), (3, 0, 1, 2))
-    rdm2.oovo += tmp6.transpose((1, 2, 3, 0))
-    rdm2.oovo += tmp6.transpose((2, 1, 3, 0)) * -1
+    rdm2.oovo += np.transpose(tmp6, (1, 2, 3, 0))
+    rdm2.oovo += np.transpose(tmp6, (2, 1, 3, 0)) * -1
     rdm2.oovo += einsum(tmp4, (0, 1), t1, (2, 3), (2, 1, 3, 0)) * -0.5
     rdm2.oovo += einsum(t1, (0, 1), tmp4, (2, 3), (3, 0, 1, 2)) * 0.5
     rdm2.oovo += einsum(delta.oo, (0, 1), t1, (2, 3), (2, 0, 3, 1))
@@ -595,12 +595,12 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp16
     rdm2.oovo += einsum(t1, (0, 1), tmp17, (0, 2, 3, 4), (4, 3, 1, 2)) * 0.5
     del tmp17
-    rdm2.ooov = tmp5.transpose((2, 1, 0, 3)).copy() * -1
+    rdm2.ooov = np.copy(np.transpose(tmp5, (2, 1, 0, 3))) * -1
     del tmp5
     rdm2.ooov += einsum(tmp3, (0, 1), t1, (2, 3), (2, 1, 0, 3))
     rdm2.ooov += einsum(t1, (0, 1), tmp3, (2, 3), (3, 0, 2, 1)) * -1
-    rdm2.ooov += tmp6.transpose((1, 2, 0, 3)) * -1
-    rdm2.ooov += tmp6.transpose((2, 1, 0, 3))
+    rdm2.ooov += np.transpose(tmp6, (1, 2, 0, 3)) * -1
+    rdm2.ooov += np.transpose(tmp6, (2, 1, 0, 3))
     del tmp6
     rdm2.ooov += einsum(tmp4, (0, 1), t1, (2, 3), (2, 1, 0, 3)) * 0.5
     rdm2.ooov += einsum(t1, (0, 1), tmp4, (2, 3), (3, 0, 2, 1)) * -0.5
@@ -614,9 +614,9 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp12
     rdm2.ooov += einsum(t1, (0, 1), tmp13, (0, 2, 3, 4), (4, 3, 2, 1)) * -1
     del tmp13
-    rdm2.oooo = tmp0.transpose((3, 2, 1, 0)).copy() * 0.5
+    rdm2.oooo = np.copy(np.transpose(tmp0, (3, 2, 1, 0))) * 0.5
     del tmp0
-    rdm2.oooo += tmp2.transpose((2, 3, 1, 0)) * -1
+    rdm2.oooo += np.transpose(tmp2, (2, 3, 1, 0)) * -1
     del tmp2
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp3, (2, 3), (3, 0, 2, 1)) * -1
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp3, (2, 3), (0, 3, 2, 1))
@@ -631,7 +631,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp4, (2, 3), (0, 3, 1, 2)) * -0.5
     del tmp4, delta
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.transpose(0, 2, 1, 3)
+    rdm2 = np.transpose(rdm2, (0, 2, 1, 3))
 
     return rdm2
 
@@ -721,7 +721,7 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     """
 
     ints = kwargs["ints"]
-    tmp5 = f.oo.copy()
+    tmp5 = np.copy(f.oo)
     tmp5 += ints.tmp0
     tmp6 = einsum(r2, (0, 1, 2), tmp5, (1, 3), (0, 3, 2)) * -1
     del tmp5
@@ -732,15 +732,15 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp23
     tmp8 = einsum(ints.tmp4, (0, 1), r2, (2, 1, 3), (0, 2, 3))
     tmp3 = einsum(v.oovv, (0, 1, 2, 3), r2, (0, 1, 3), (2,))
-    tmp13 = ints.tmp22.transpose((1, 0)).copy() * 0.5
+    tmp13 = np.copy(np.transpose(ints.tmp22, (1, 0))) * 0.5
     del ints.tmp22
     tmp13 += f.vv * -1
     tmp13 += einsum(t1, (0, 1), f.ov, (0, 2), (2, 1))
-    tmp7 = tmp4.copy()
+    tmp7 = np.copy(tmp4)
     del tmp4
-    tmp7 += tmp6.transpose((1, 0, 2)) * -1
+    tmp7 += np.transpose(tmp6, (1, 0, 2)) * -1
     del tmp6
-    tmp15 = ints.tmp13.copy()
+    tmp15 = np.copy(ints.tmp13)
     del ints.tmp13
     tmp15 += ints.tmp15 * 0.5
     del ints.tmp15
@@ -753,42 +753,42 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp11
     tmp15 += ints.tmp8 * -1
     del ints.tmp8
-    tmp12 = ints.tmp21.copy() * -0.5
+    tmp12 = np.copy(ints.tmp21) * -0.5
     del ints.tmp21
     tmp12 += v.oooo * -1
-    tmp14 = ints.tmp19.transpose((2, 0, 1, 3)).copy() * 0.5
+    tmp14 = np.copy(np.transpose(ints.tmp19, (2, 0, 1, 3))) * 0.5
     del ints.tmp19
-    tmp14 += v.ovoo.transpose((0, 2, 3, 1))
+    tmp14 += np.transpose(v.ovoo, (0, 2, 3, 1))
     tmp14 += ints.tmp12 * -1
     del ints.tmp12
-    tmp11 = tmp8.copy() * -0.5
+    tmp11 = np.copy(tmp8) * -0.5
     del tmp8
     tmp11 += tmp9
     del tmp9
     tmp11 += tmp10
     del tmp10
-    tmp1 = f.ov.copy()
+    tmp1 = np.copy(f.ov)
     tmp1 += ints.tmp2
     del ints.tmp2
-    tmp0 = ints.tmp3.copy()
+    tmp0 = np.copy(ints.tmp3)
     del ints.tmp3
-    tmp0 += v.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp2 = f.oo.copy() * 2
+    tmp0 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
+    tmp2 = np.copy(f.oo) * 2
     tmp2 += ints.tmp0 * 2
     del ints.tmp0
     tmp2 += ints.tmp1 * 2
     del ints.tmp1
-    tmp2 += ints.tmp4.transpose((1, 0))
+    tmp2 += np.transpose(ints.tmp4, (1, 0))
     del ints.tmp4
-    tmp2 += ints.tmp5.transpose((1, 0)) * 2
+    tmp2 += np.transpose(ints.tmp5, (1, 0)) * 2
     del ints.tmp5
     r2new = einsum(t2, (0, 1, 2, 3), tmp3, (3,), (0, 1, 2)) * 0.5
     del tmp3
     r2new += tmp7
-    r2new += tmp7.transpose((1, 0, 2)) * -1
+    r2new += np.transpose(tmp7, (1, 0, 2)) * -1
     del tmp7
     r2new += tmp11 * -1
-    r2new += tmp11.transpose((1, 0, 2))
+    r2new += np.transpose(tmp11, (1, 0, 2))
     del tmp11
     r2new += einsum(tmp12, (0, 1, 2, 3), r2, (3, 2, 4), (0, 1, 4)) * 0.5
     del tmp12
@@ -886,8 +886,8 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     """
 
     ints = kwargs["ints"]
-    tmp10 = f.vv.copy() * 2
-    tmp10 += ints.tmp4.transpose((1, 0)) * -1
+    tmp10 = np.copy(f.vv) * 2
+    tmp10 += np.transpose(ints.tmp4, (1, 0)) * -1
     tmp8 = einsum(r2, (0, 1, 2), f.ov, (3, 1), (3, 2, 0))
     tmp11 = einsum(tmp10, (0, 1), r2, (2, 0, 3), (3, 2, 1)) * -0.5
     del tmp10
@@ -897,31 +897,31 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp8
     tmp7 = einsum(v.ovov, (0, 1, 2, 3), r2, (4, 1, 2), (0, 4, 3))
     tmp2 = einsum(v.oovv, (0, 1, 2, 3), r2, (2, 3, 1), (0,))
-    tmp0 = f.ov.copy()
+    tmp0 = np.copy(f.ov)
     tmp0 += ints.tmp2
     del ints.tmp2
-    tmp13 = ints.tmp16.copy() * 0.5
+    tmp13 = np.copy(ints.tmp16) * 0.5
     del ints.tmp16
-    tmp13 += v.ovvv.transpose((0, 2, 3, 1))
+    tmp13 += np.transpose(v.ovvv, (0, 2, 3, 1))
     tmp5 = einsum(r1, (0,), ints.tmp18, (1, 2, 3, 0), (1, 2, 3))
     del ints.tmp18
     tmp4 = einsum(r2, (0, 1, 2), v.oovv, (3, 4, 0, 1), (2, 3, 4))
-    tmp12 = tmp6.copy()
+    tmp12 = np.copy(tmp6)
     del tmp6
     tmp12 += tmp7
     del tmp7
     tmp12 += tmp9
     del tmp9
-    tmp12 += tmp11.transpose((0, 2, 1)) * -1
+    tmp12 += np.transpose(tmp11, (0, 2, 1)) * -1
     del tmp11
-    tmp14 = f.oo.copy()
-    tmp14 += ints.tmp20.transpose((1, 0)) * 0.5
+    tmp14 = np.copy(f.oo)
+    tmp14 += np.transpose(ints.tmp20, (1, 0)) * 0.5
     del ints.tmp20
     tmp14 += ints.tmp9
     del ints.tmp9
     tmp15 = einsum(r1, (0,), f.ov, (1, 0), (1,)) * 2
     tmp15 += tmp2
-    tmp16 = ints.tmp13.copy()
+    tmp16 = np.copy(ints.tmp13)
     del ints.tmp13
     tmp16 += ints.tmp15 * 0.5
     del ints.tmp15
@@ -934,22 +934,22 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp12
     tmp16 += ints.tmp8 * -1
     del ints.tmp8
-    tmp3 = tmp2.copy() * 0.5
+    tmp3 = np.copy(tmp2) * 0.5
     del tmp2
     tmp3 += einsum(r1, (0,), tmp0, (1, 0), (1,))
-    tmp1 = ints.tmp1.transpose((1, 0)).copy()
+    tmp1 = np.copy(np.transpose(ints.tmp1, (1, 0)))
     del ints.tmp1
-    tmp1 += ints.tmp4.transpose((1, 0)) * 0.5
+    tmp1 += np.transpose(ints.tmp4, (1, 0)) * 0.5
     del ints.tmp4
     tmp1 += f.vv * -1
     r2new = einsum(r2, (0, 1, 2), v.vvvv, (3, 4, 0, 1), (3, 4, 2)) * 0.5
     r2new += einsum(t2, (0, 1, 2, 3), tmp4, (4, 1, 0), (2, 3, 4)) * -0.25
     del tmp4
-    r2new += tmp5.transpose((1, 2, 0))
-    r2new += tmp5.transpose((2, 1, 0)) * -1
+    r2new += np.transpose(tmp5, (1, 2, 0))
+    r2new += np.transpose(tmp5, (2, 1, 0)) * -1
     del tmp5
-    r2new += tmp12.transpose((1, 2, 0)) * -1
-    r2new += tmp12.transpose((2, 1, 0))
+    r2new += np.transpose(tmp12, (1, 2, 0)) * -1
+    r2new += np.transpose(tmp12, (2, 1, 0))
     del tmp12
     r2new += einsum(r1, (0,), tmp13, (1, 2, 3, 0), (3, 2, 1))
     del tmp13
@@ -1067,12 +1067,12 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp27 = einsum(r1, (0, 1), f.ov, (2, 1), (2, 0))
     tmp6 = einsum(v.oovv, (0, 1, 2, 3), r2, (4, 1, 2, 3), (4, 0))
     tmp15 = einsum(v.ooov, (0, 1, 2, 3), r1, (1, 3), (0, 2))
-    tmp28 = tmp27.transpose((1, 0)).copy()
+    tmp28 = np.copy(np.transpose(tmp27, (1, 0)))
     del tmp27
     tmp28 += tmp6 * 0.5
-    tmp25 = f.oo.copy()
+    tmp25 = np.copy(f.oo)
     tmp25 += ints.tmp0
-    tmp25 += ints.tmp9.transpose((1, 0)) * 0.5
+    tmp25 += np.transpose(ints.tmp9, (1, 0)) * 0.5
     tmp34 = einsum(f.ov, (0, 1), r2, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp36 = einsum(v.oovv, (0, 1, 2, 3), r2, (0, 1, 4, 3), (4, 2))
     tmp16 = einsum(tmp15, (0, 1), t2, (2, 0, 3, 4), (2, 1, 3, 4)) * -1
@@ -1103,17 +1103,17 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp19 = einsum(f.vv, (0, 1), r2, (2, 3, 4, 1), (2, 3, 0, 4))
     tmp18 = einsum(v.ooov, (0, 1, 2, 3), r1, (2, 4), (0, 1, 4, 3))
     tmp31 = einsum(r1, (0, 1), v.ovvv, (0, 2, 3, 1), (2, 3))
-    tmp1 = ints.tmp7.copy()
+    tmp1 = np.copy(ints.tmp7)
     del ints.tmp7
-    tmp1 += v.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp2 = f.ov.copy()
+    tmp1 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
+    tmp2 = np.copy(f.ov)
     tmp2 += ints.tmp6
     del ints.tmp6
-    tmp17 = tmp14.transpose((0, 1, 3, 2)).copy() * -1
+    tmp17 = np.copy(np.transpose(tmp14, (0, 1, 3, 2))) * -1
     del tmp14
-    tmp17 += tmp16.transpose((0, 1, 3, 2))
+    tmp17 += np.transpose(tmp16, (0, 1, 3, 2))
     del tmp16
-    tmp13 = tmp9.copy()
+    tmp13 = np.copy(tmp9)
     del tmp9
     tmp13 += tmp10
     del tmp10
@@ -1121,7 +1121,7 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp11
     tmp13 += tmp12 * -1
     del tmp12
-    tmp40 = ints.tmp17.copy()
+    tmp40 = np.copy(ints.tmp17)
     del ints.tmp17
     tmp40 += ints.tmp26
     del ints.tmp26
@@ -1134,50 +1134,50 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp18
     tmp40 += ints.tmp22 * -1
     del ints.tmp22
-    tmp23 = tmp21.copy() * 0.5
+    tmp23 = np.copy(tmp21) * 0.5
     del tmp21
-    tmp23 += tmp22.transpose((1, 0, 2, 3)) * -0.5
+    tmp23 += np.transpose(tmp22, (1, 0, 2, 3)) * -0.5
     del tmp22
-    tmp30 = tmp24.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp30 = np.copy(np.transpose(tmp24, (0, 1, 3, 2))) * -0.5
     del tmp24
-    tmp30 += tmp26.transpose((0, 1, 3, 2))
+    tmp30 += np.transpose(tmp26, (0, 1, 3, 2))
     del tmp26
-    tmp30 += tmp29.transpose((0, 1, 3, 2))
+    tmp30 += np.transpose(tmp29, (0, 1, 3, 2))
     del tmp29
-    tmp38 = tmp33.copy()
+    tmp38 = np.copy(tmp33)
     del tmp33
     tmp38 += tmp35
     del tmp35
     tmp38 += tmp37 * 0.5
     del tmp37
-    tmp20 = tmp18.transpose((1, 0, 2, 3)).copy() * -1
+    tmp20 = np.copy(np.transpose(tmp18, (1, 0, 2, 3))) * -1
     del tmp18
-    tmp20 += tmp19.transpose((1, 0, 2, 3)) * -1
+    tmp20 += np.transpose(tmp19, (1, 0, 2, 3)) * -1
     del tmp19
     tmp32 = einsum(t2, (0, 1, 2, 3), tmp31, (4, 3), (0, 1, 2, 4)) * -1
     del tmp31
-    tmp39 = ints.tmp44.copy() * -0.5
+    tmp39 = np.copy(ints.tmp44) * -0.5
     del ints.tmp44
     tmp39 += v.oooo * -1
     tmp8 = einsum(v.oovv, (0, 1, 2, 3), r2, (4, 5, 2, 3), (4, 5, 0, 1))
-    tmp3 = ints.tmp5.copy()
+    tmp3 = np.copy(ints.tmp5)
     del ints.tmp5
-    tmp3 += v.ovov.transpose((0, 2, 3, 1)) * -1
-    tmp5 = f.oo.copy()
+    tmp3 += np.transpose(v.ovov, (0, 2, 3, 1)) * -1
+    tmp5 = np.copy(f.oo)
     tmp5 += ints.tmp0
     del ints.tmp0
-    tmp5 += ints.tmp12.transpose((1, 0))
+    tmp5 += np.transpose(ints.tmp12, (1, 0))
     del ints.tmp12
     tmp5 += ints.tmp2
     del ints.tmp2
-    tmp5 += ints.tmp9.transpose((1, 0)) * 0.5
+    tmp5 += np.transpose(ints.tmp9, (1, 0)) * 0.5
     del ints.tmp9
-    tmp4 = ints.tmp10.transpose((1, 0)).copy() * 0.5
+    tmp4 = np.copy(np.transpose(ints.tmp10, (1, 0))) * 0.5
     del ints.tmp10
-    tmp4 += ints.tmp4.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp4, (1, 0))
     del ints.tmp4
     tmp4 += f.vv * -1
-    tmp7 = tmp6.transpose((1, 0)).copy() * 0.5
+    tmp7 = np.copy(np.transpose(tmp6, (1, 0))) * 0.5
     del tmp6
     tmp7 += einsum(tmp1, (0, 1, 2, 3), r1, (1, 3), (2, 0))
     tmp7 += einsum(r1, (0, 1), tmp2, (2, 1), (2, 0))
@@ -1186,27 +1186,27 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r2new += einsum(t2, (0, 1, 2, 3), tmp8, (4, 5, 1, 0), (5, 4, 2, 3)) * 0.25
     del tmp8
     r2new += tmp13 * -1
-    r2new += tmp13.transpose((0, 1, 3, 2))
-    r2new += tmp13.transpose((1, 0, 2, 3))
-    r2new += tmp13.transpose((1, 0, 3, 2)) * -1
+    r2new += np.transpose(tmp13, (0, 1, 3, 2))
+    r2new += np.transpose(tmp13, (1, 0, 2, 3))
+    r2new += np.transpose(tmp13, (1, 0, 3, 2)) * -1
     del tmp13
     r2new += tmp17 * -1
-    r2new += tmp17.transpose((1, 0, 2, 3))
+    r2new += np.transpose(tmp17, (1, 0, 2, 3))
     del tmp17
     r2new += tmp20 * -1
-    r2new += tmp20.transpose((0, 1, 3, 2))
+    r2new += np.transpose(tmp20, (0, 1, 3, 2))
     del tmp20
-    r2new += tmp23.transpose((1, 0, 2, 3)) * -1
-    r2new += tmp23.transpose((1, 0, 3, 2))
+    r2new += np.transpose(tmp23, (1, 0, 2, 3)) * -1
+    r2new += np.transpose(tmp23, (1, 0, 3, 2))
     del tmp23
     r2new += tmp30
-    r2new += tmp30.transpose((1, 0, 2, 3)) * -1
+    r2new += np.transpose(tmp30, (1, 0, 2, 3)) * -1
     del tmp30
     r2new += tmp32
-    r2new += tmp32.transpose((0, 1, 3, 2)) * -1
+    r2new += np.transpose(tmp32, (0, 1, 3, 2)) * -1
     del tmp32
     r2new += tmp38 * -1
-    r2new += tmp38.transpose((0, 1, 3, 2))
+    r2new += np.transpose(tmp38, (0, 1, 3, 2))
     del tmp38
     r2new += einsum(tmp39, (0, 1, 2, 3), r2, (2, 3, 4, 5), (0, 1, 4, 5)) * -0.5
     del tmp39
@@ -1361,8 +1361,8 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp41
     tmp6 = einsum(v.ovov, (0, 1, 2, 3), r2, (4, 2, 1), (4, 0, 3))
     tmp4 = einsum(ints.tmp10, (0, 1), r2, (2, 0, 3), (1, 2, 3))
-    tmp8 = f.oo.copy()
-    tmp8 += ints.tmp0.transpose((1, 0))
+    tmp8 = np.copy(f.oo)
+    tmp8 += np.transpose(ints.tmp0, (1, 0))
     tmp3 = einsum(r2, (0, 1, 2), t2, (0, 1, 3, 2), (3,))
     tmp7 = einsum(r1, (0,), f.ov, (1, 2), (1, 0, 2))
     tmp7 += tmp4 * -0.5
@@ -1371,16 +1371,16 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp5
     tmp7 += tmp6
     del tmp6
-    tmp11 = ints.tmp40.copy() * 0.5
+    tmp11 = np.copy(ints.tmp40) * 0.5
     del ints.tmp40
     tmp11 += f.vv * -1
     tmp11 += einsum(f.ov, (0, 1), t1, (0, 2), (2, 1))
-    tmp10 = ints.tmp22.copy() * -0.5
+    tmp10 = np.copy(ints.tmp22) * -0.5
     del ints.tmp22
     tmp10 += v.oooo * -1
     tmp9 = einsum(tmp8, (0, 1), r2, (2, 0, 3), (1, 2, 3)) * -1
     del tmp8
-    tmp1 = ints.tmp11.copy()
+    tmp1 = np.copy(ints.tmp11)
     del ints.tmp11
     tmp1 += ints.tmp13
     del ints.tmp13
@@ -1407,46 +1407,46 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp2
     tmp1 += ints.tmp3 * -2
     del ints.tmp3
-    tmp0 = ints.tmp12.copy()
+    tmp0 = np.copy(ints.tmp12)
     del ints.tmp12
-    tmp0 += ints.tmp23.transpose((0, 2, 1, 3)) * 0.25
+    tmp0 += np.transpose(ints.tmp23, (0, 2, 1, 3)) * 0.25
     del ints.tmp23
-    tmp0 += ints.tmp34.transpose((0, 2, 1, 3)) * 0.5
+    tmp0 += np.transpose(ints.tmp34, (0, 2, 1, 3)) * 0.5
     del ints.tmp34
-    tmp0 += ints.tmp4.transpose((1, 0, 2, 3)) * 0.5
+    tmp0 += np.transpose(ints.tmp4, (1, 0, 2, 3)) * 0.5
     del ints.tmp4
-    tmp0 += ints.tmp7.transpose((0, 2, 1, 3)) * 0.5
+    tmp0 += np.transpose(ints.tmp7, (0, 2, 1, 3)) * 0.5
     del ints.tmp7
     tmp0 += ints.tmp9
     del ints.tmp9
-    tmp0 += ints.tmp14.transpose((0, 2, 1, 3)) * -0.25
+    tmp0 += np.transpose(ints.tmp14, (0, 2, 1, 3)) * -0.25
     del ints.tmp14
-    tmp0 += ints.tmp17.transpose((0, 2, 1, 3)) * -0.5
+    tmp0 += np.transpose(ints.tmp17, (0, 2, 1, 3)) * -0.5
     del ints.tmp17
-    tmp0 += ints.tmp20.transpose((0, 2, 1, 3)) * -1
+    tmp0 += np.transpose(ints.tmp20, (0, 2, 1, 3)) * -1
     del ints.tmp20
     tmp0 += ints.tmp27 * -1
     del ints.tmp27
-    tmp0 += ints.tmp31.transpose((0, 2, 1, 3)) * -0.5
+    tmp0 += np.transpose(ints.tmp31, (0, 2, 1, 3)) * -0.5
     del ints.tmp31
-    tmp0 += v.ooov.transpose((0, 2, 1, 3)) * -0.5
-    tmp2 = f.oo.copy() * 2
-    tmp2 += ints.tmp0.transpose((1, 0)) * 2
+    tmp0 += np.transpose(v.ooov, (0, 2, 1, 3)) * -0.5
+    tmp2 = np.copy(f.oo) * 2
+    tmp2 += np.transpose(ints.tmp0, (1, 0)) * 2
     del ints.tmp0
     tmp2 += ints.tmp10
     del ints.tmp10
     tmp2 += ints.tmp24 * 2
     del ints.tmp24
-    tmp2 += ints.tmp6.transpose((1, 0)) * 2
+    tmp2 += np.transpose(ints.tmp6, (1, 0)) * 2
     del ints.tmp6
     r2new = einsum(v.oovv, (0, 1, 2, 3), tmp3, (3,), (0, 1, 2)) * 0.5
     del tmp3
     r2new += einsum(r1, (0,), v.ooov, (1, 2, 0, 3), (1, 2, 3)) * -1
     r2new += tmp7 * -1
-    r2new += tmp7.transpose((1, 0, 2))
+    r2new += np.transpose(tmp7, (1, 0, 2))
     del tmp7
     r2new += tmp9 * -1
-    r2new += tmp9.transpose((1, 0, 2))
+    r2new += np.transpose(tmp9, (1, 0, 2))
     del tmp9
     r2new += einsum(r2, (0, 1, 2), tmp10, (1, 0, 3, 4), (3, 4, 2)) * 0.5
     del tmp10
@@ -1566,9 +1566,9 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
 
     ints = kwargs["ints"]
     tmp13 = einsum(t1, (0, 1), f.ov, (0, 2), (2, 1))
-    tmp14 = ints.tmp11.copy()
+    tmp14 = np.copy(ints.tmp11)
     tmp14 += f.vv * -2
-    tmp14 += tmp13.transpose((1, 0)) * 2
+    tmp14 += np.transpose(tmp13, (1, 0)) * 2
     del tmp13
     tmp12 = einsum(v.ovov, (0, 1, 2, 3), r2, (4, 1, 2), (0, 4, 3))
     tmp11 = einsum(r2, (0, 1, 2), ints.tmp23, (2, 3, 1, 4), (3, 4, 0))
@@ -1576,10 +1576,10 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp14
     tmp1 = einsum(t1, (0, 1), r2, (2, 1, 3), (3, 0, 2))
     tmp7 = einsum(r2, (0, 1, 2), t2, (3, 2, 0, 1), (3,))
-    tmp17 = f.oo.copy()
+    tmp17 = np.copy(f.oo)
     tmp17 += ints.tmp21 * 0.5
     del ints.tmp21
-    tmp17 += ints.tmp5.transpose((1, 0))
+    tmp17 += np.transpose(ints.tmp5, (1, 0))
     del ints.tmp5
     tmp16 = einsum(r1, (0,), f.ov, (1, 2), (1, 2, 0))
     tmp16 += tmp11
@@ -1590,7 +1590,7 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp15
     tmp10 = einsum(r2, (0, 1, 2), t2, (3, 4, 0, 1), (2, 3, 4))
     tmp3 = einsum(tmp1, (0, 1, 2), t1, (3, 2), (0, 1, 3)) * -1
-    tmp5 = ints.tmp12.copy() * 0.5
+    tmp5 = np.copy(ints.tmp12) * 0.5
     del ints.tmp12
     tmp5 += ints.tmp14 * 0.5
     del ints.tmp14
@@ -1617,15 +1617,15 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp2
     tmp5 += ints.tmp3 * -1
     del ints.tmp3
-    tmp6 = ints.tmp11.copy() * 0.5
+    tmp6 = np.copy(ints.tmp11) * 0.5
     del ints.tmp11
     tmp6 += ints.tmp7
     del ints.tmp7
     tmp6 += f.vv * -1
-    tmp4 = ints.tmp18.copy()
+    tmp4 = np.copy(ints.tmp18)
     del ints.tmp18
-    tmp4 += v.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp0 = ints.tmp10.copy() * 0.5
+    tmp4 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
+    tmp0 = np.copy(ints.tmp10) * 0.5
     del ints.tmp10
     tmp0 += ints.tmp15
     del ints.tmp15
@@ -1633,25 +1633,25 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp20
     tmp0 += ints.tmp13 * -0.25
     del ints.tmp13
-    tmp0 += v.ovvv.transpose((0, 2, 3, 1)) * -0.5
-    tmp9 = f.ov.copy()
+    tmp0 += np.transpose(v.ovvv, (0, 2, 3, 1)) * -0.5
+    tmp9 = np.copy(f.ov)
     tmp9 += ints.tmp16
     del ints.tmp16
     tmp8 = einsum(r1, (0,), t1, (1, 0), (1,))
     tmp8 += tmp7 * 0.5
-    tmp2 = ints.tmp23.copy()
+    tmp2 = np.copy(ints.tmp23)
     del ints.tmp23
     tmp2 += ints.tmp28
     del ints.tmp28
-    tmp2 += v.ovov.transpose((0, 2, 3, 1)) * -1
+    tmp2 += np.transpose(v.ovov, (0, 2, 3, 1)) * -1
     r2new = einsum(r1, (0,), v.ovvv, (1, 0, 2, 3), (2, 3, 1)) * -1
     r2new += einsum(r2, (0, 1, 2), v.vvvv, (3, 4, 0, 1), (3, 4, 2)) * 0.5
     r2new += einsum(v.oovv, (0, 1, 2, 3), tmp10, (4, 1, 0), (2, 3, 4)) * -0.25
     del tmp10
     r2new += einsum(tmp7, (0,), v.oovv, (1, 0, 2, 3), (2, 3, 1)) * 0.5
     del tmp7
-    r2new += tmp16.transpose((1, 2, 0)) * -1
-    r2new += tmp16.transpose((2, 1, 0))
+    r2new += np.transpose(tmp16, (1, 2, 0)) * -1
+    r2new += np.transpose(tmp16, (2, 1, 0))
     del tmp16
     r2new += einsum(r2, (0, 1, 2), tmp17, (2, 3), (0, 1, 3)) * -1
     del tmp17
@@ -1805,8 +1805,8 @@ def hbar_lmatvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp0 = einsum(r2, (0, 1, 2, 3), t2, (0, 1, 4, 3), (2, 4))
     tmp4 = einsum(r2, (0, 1, 2, 3), t1, (4, 3), (0, 1, 4, 2))
     tmp10 = einsum(t2, (0, 1, 2, 3), r2, (4, 1, 2, 3), (4, 0))
-    tmp26 = f.oo.copy()
-    tmp26 += ints.tmp0.transpose((1, 0))
+    tmp26 = np.copy(f.oo)
+    tmp26 += np.transpose(ints.tmp0, (1, 0))
     tmp26 += ints.tmp16 * 0.5
     tmp30 = einsum(tmp0, (0, 1), v.oovv, (2, 3, 4, 1), (2, 3, 0, 4)) * -1
     tmp29 = einsum(tmp4, (0, 1, 2, 3), f.ov, (2, 4), (0, 1, 4, 3))
@@ -1820,40 +1820,40 @@ def hbar_lmatvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp9 = einsum(t1, (0, 1), r1, (2, 1), (2, 0))
     tmp17 = einsum(v.ovvv, (0, 1, 2, 3), r1, (4, 1), (4, 0, 2, 3))
     tmp16 = einsum(t2, (0, 1, 2, 3), r2, (4, 5, 2, 3), (4, 5, 0, 1))
-    tmp31 = tmp29.copy()
+    tmp31 = np.copy(tmp29)
     del tmp29
     tmp31 += tmp30 * -0.5
     del tmp30
     tmp21 = einsum(ints.tmp17, (0, 1), r2, (2, 3, 4, 0), (2, 3, 1, 4))
-    tmp20 = tmp18.transpose((1, 0, 2, 3)).copy() * -1
+    tmp20 = np.copy(np.transpose(tmp18, (1, 0, 2, 3))) * -1
     del tmp18
-    tmp20 += tmp19.transpose((1, 0, 2, 3)) * -1
+    tmp20 += np.transpose(tmp19, (1, 0, 2, 3)) * -1
     del tmp19
-    tmp32 = ints.tmp34.copy() * -0.5
+    tmp32 = np.copy(ints.tmp34) * -0.5
     del ints.tmp34
     tmp32 += v.oooo * -1
-    tmp28 = tmp25.transpose((0, 1, 3, 2)).copy() * 0.5
+    tmp28 = np.copy(np.transpose(tmp25, (0, 1, 3, 2))) * 0.5
     del tmp25
-    tmp28 += tmp27.transpose((0, 1, 3, 2))
+    tmp28 += np.transpose(tmp27, (0, 1, 3, 2))
     del tmp27
     tmp24 = einsum(r1, (0, 1), f.ov, (2, 3), (2, 0, 3, 1))
     tmp24 += tmp22
     del tmp22
     tmp24 += tmp23 * -1
     del tmp23
-    tmp3 = ints.tmp10.copy()
+    tmp3 = np.copy(ints.tmp10)
     tmp3 += ints.tmp36
     del ints.tmp36
-    tmp3 += v.ovov.transpose((0, 2, 3, 1)) * -1
-    tmp13 = ints.tmp17.copy() * 0.5
+    tmp3 += np.transpose(v.ovov, (0, 2, 3, 1)) * -1
+    tmp13 = np.copy(ints.tmp17) * 0.5
     del ints.tmp17
     tmp13 += ints.tmp9
     del ints.tmp9
     tmp13 += f.vv * -1
-    tmp5 = ints.tmp29.copy()
+    tmp5 = np.copy(ints.tmp29)
     del ints.tmp29
-    tmp5 += v.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp7 = ints.tmp12.copy() * 2
+    tmp5 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
+    tmp7 = np.copy(ints.tmp12) * 2
     del ints.tmp12
     tmp7 += ints.tmp19
     del ints.tmp19
@@ -1881,13 +1881,13 @@ def hbar_lmatvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp7 += ints.tmp4 * -2
     del ints.tmp4
     tmp6 = einsum(t1, (0, 1), tmp4, (2, 3, 4, 1), (2, 3, 0, 4))
-    tmp15 = f.ov.copy()
+    tmp15 = np.copy(f.ov)
     tmp15 += ints.tmp26
     del ints.tmp26
-    tmp12 = ints.tmp10.copy()
+    tmp12 = np.copy(ints.tmp10)
     del ints.tmp10
-    tmp12 += v.ovov.transpose((0, 2, 3, 1)) * -1
-    tmp1 = ints.tmp15.copy() * 0.5
+    tmp12 += np.transpose(v.ovov, (0, 2, 3, 1)) * -1
+    tmp1 = np.copy(ints.tmp15) * 0.5
     del ints.tmp15
     tmp1 += ints.tmp24
     del ints.tmp24
@@ -1895,33 +1895,33 @@ def hbar_lmatvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp32
     tmp1 += ints.tmp21 * -0.25
     del ints.tmp21
-    tmp1 += v.ovvv.transpose((0, 2, 3, 1)) * -0.5
-    tmp14 = f.oo.copy()
-    tmp14 += ints.tmp0.transpose((1, 0))
+    tmp1 += np.transpose(v.ovvv, (0, 2, 3, 1)) * -0.5
+    tmp14 = np.copy(f.oo)
+    tmp14 += np.transpose(ints.tmp0, (1, 0))
     del ints.tmp0
     tmp14 += ints.tmp16 * 0.5
     del ints.tmp16
     tmp14 += ints.tmp38
     del ints.tmp38
-    tmp14 += ints.tmp8.transpose((1, 0))
+    tmp14 += np.transpose(ints.tmp8, (1, 0))
     del ints.tmp8
-    tmp11 = tmp9.copy()
+    tmp11 = np.copy(tmp9)
     del tmp9
     tmp11 += tmp10 * 0.5
     del tmp10
     tmp8 = einsum(r1, (0, 1), t2, (2, 0, 3, 1), (2, 3))
     tmp8 += einsum(t2, (0, 1, 2, 3), tmp4, (1, 0, 4, 3), (4, 2)) * -0.5
-    tmp2 = ints.tmp11.copy() * 0.5
+    tmp2 = np.copy(ints.tmp11) * 0.5
     del ints.tmp11
-    tmp2 += ints.tmp13.transpose((0, 2, 1, 3))
+    tmp2 += np.transpose(ints.tmp13, (0, 2, 1, 3))
     del ints.tmp13
-    tmp2 += ints.tmp20.transpose((0, 2, 1, 3))
+    tmp2 += np.transpose(ints.tmp20, (0, 2, 1, 3))
     del ints.tmp20
     tmp2 += ints.tmp35 * 0.25
     del ints.tmp35
     tmp2 += ints.tmp47 * 0.5
     del ints.tmp47
-    tmp2 += ints.tmp5.transpose((1, 2, 0, 3)) * 0.5
+    tmp2 += np.transpose(ints.tmp5, (1, 2, 0, 3)) * 0.5
     del ints.tmp5
     tmp2 += ints.tmp23 * -0.25
     del ints.tmp23
@@ -1929,7 +1929,7 @@ def hbar_lmatvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp28
     tmp2 += ints.tmp31 * -1
     del ints.tmp31
-    tmp2 += ints.tmp41.transpose((0, 2, 1, 3)) * -1
+    tmp2 += np.transpose(ints.tmp41, (0, 2, 1, 3)) * -1
     del ints.tmp41
     tmp2 += ints.tmp44 * -0.5
     del ints.tmp44
@@ -1937,25 +1937,25 @@ def hbar_lmatvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     r2new = einsum(r2, (0, 1, 2, 3), v.vvvv, (4, 5, 2, 3), (0, 1, 4, 5)) * 0.5
     r2new += einsum(tmp16, (0, 1, 2, 3), v.oovv, (3, 2, 4, 5), (1, 0, 4, 5)) * 0.25
     del tmp16
-    r2new += tmp17.transpose((0, 1, 3, 2))
-    r2new += tmp17.transpose((1, 0, 3, 2)) * -1
+    r2new += np.transpose(tmp17, (0, 1, 3, 2))
+    r2new += np.transpose(tmp17, (1, 0, 3, 2)) * -1
     del tmp17
     r2new += tmp20 * -1
-    r2new += tmp20.transpose((0, 1, 3, 2))
+    r2new += np.transpose(tmp20, (0, 1, 3, 2))
     del tmp20
-    r2new += tmp21.transpose((1, 0, 2, 3)) * -0.5
-    r2new += tmp21.transpose((1, 0, 3, 2)) * 0.5
+    r2new += np.transpose(tmp21, (1, 0, 2, 3)) * -0.5
+    r2new += np.transpose(tmp21, (1, 0, 3, 2)) * 0.5
     del tmp21
     r2new += tmp24
-    r2new += tmp24.transpose((0, 1, 3, 2)) * -1
-    r2new += tmp24.transpose((1, 0, 2, 3)) * -1
-    r2new += tmp24.transpose((1, 0, 3, 2))
+    r2new += np.transpose(tmp24, (0, 1, 3, 2)) * -1
+    r2new += np.transpose(tmp24, (1, 0, 2, 3)) * -1
+    r2new += np.transpose(tmp24, (1, 0, 3, 2))
     del tmp24
     r2new += tmp28
-    r2new += tmp28.transpose((1, 0, 2, 3)) * -1
+    r2new += np.transpose(tmp28, (1, 0, 2, 3)) * -1
     del tmp28
     r2new += tmp31
-    r2new += tmp31.transpose((0, 1, 3, 2)) * -1
+    r2new += np.transpose(tmp31, (0, 1, 3, 2)) * -1
     del tmp31
     r2new += einsum(tmp32, (0, 1, 2, 3), r2, (0, 1, 4, 5), (2, 3, 4, 5)) * -0.5
     del tmp32

--- a/ebcc/codegen/GCC2.py
+++ b/ebcc/codegen/GCC2.py
@@ -631,7 +631,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp4, (2, 3), (0, 3, 1, 2)) * -0.5
     del tmp4, delta
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.swapaxes(1, 2)
+    rdm2 = rdm2.tranpose(0, 2, 1, 3)
 
     return rdm2
 

--- a/ebcc/codegen/GCC2.py
+++ b/ebcc/codegen/GCC2.py
@@ -631,7 +631,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp4, (2, 3), (0, 3, 1, 2)) * -0.5
     del tmp4, delta
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.tranpose(0, 2, 1, 3)
+    rdm2 = rdm2.transpose(0, 2, 1, 3)
 
     return rdm2
 

--- a/ebcc/codegen/GCC3.py
+++ b/ebcc/codegen/GCC3.py
@@ -37,7 +37,7 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp0 = t2.copy()
+    tmp0 = np.copy(t2)
     tmp0 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
     e_cc = einsum(tmp0, (0, 1, 2, 3), v.oovv, (0, 1, 2, 3), ()) * 0.25
     del tmp0
@@ -93,7 +93,7 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp51 = einsum(t1, (0, 1), tmp49, (2, 3, 4, 1), (2, 0, 3, 4)) * -1
     tmp60 = einsum(t1, (0, 1), tmp59, (2, 3, 4, 0, 5, 6), (2, 3, 4, 5, 1, 6))
     del tmp59
-    tmp69 = tmp17.transpose((2, 1, 0, 3)).copy() * -1
+    tmp69 = np.copy(np.transpose(tmp17, (2, 1, 0, 3))) * -1
     tmp69 += tmp68
     del tmp68
     tmp40 = einsum(t1, (0, 1), v.ovvv, (0, 2, 3, 1), (2, 3))
@@ -102,19 +102,19 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp6 = einsum(v.ooov, (0, 1, 2, 3), t1, (1, 3), (0, 2))
     tmp37 = einsum(t1, (0, 1), tmp3, (2, 1), (0, 2))
     tmp15 = einsum(v.oovv, (0, 1, 2, 3), t2, (0, 1, 4, 3), (4, 2))
-    tmp20 = tmp17.transpose((0, 2, 1, 3)).copy()
+    tmp20 = np.copy(np.transpose(tmp17, (0, 2, 1, 3)))
     del tmp17
-    tmp20 += tmp18.transpose((2, 1, 0, 3)) * -0.5
+    tmp20 += np.transpose(tmp18, (2, 1, 0, 3)) * -0.5
     del tmp18
-    tmp20 += tmp19.transpose((2, 1, 0, 3)) * 0.5
+    tmp20 += np.transpose(tmp19, (2, 1, 0, 3)) * 0.5
     del tmp19
     tmp9 = einsum(v.ooov, (0, 1, 2, 3), t2, (4, 1, 5, 3), (4, 0, 2, 5))
-    tmp11 = t2.copy()
+    tmp11 = np.copy(t2)
     tmp11 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 1, 3)) * -1
     tmp26 = einsum(t2, (0, 1, 2, 3), v.oovv, (4, 1, 2, 3), (0, 4))
-    tmp7 = t2.copy()
+    tmp7 = np.copy(t2)
     tmp7 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
-    tmp82 = f.vv.copy()
+    tmp82 = np.copy(f.vv)
     tmp82 += tmp81 * -1
     del tmp81
     tmp64 = einsum(tmp49, (0, 1, 2, 3), t2, (4, 5, 6, 3), (0, 4, 5, 1, 6, 2)) * -1
@@ -124,7 +124,7 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp55 = einsum(t2, (0, 1, 2, 3), tmp54, (4, 5, 1, 6), (0, 4, 5, 6, 2, 3)) * -1
     del tmp54
     tmp77 = einsum(t1, (0, 1), tmp28, (2, 0, 3, 4), (2, 3, 4, 1)) * -1
-    tmp79 = f.oo.copy()
+    tmp79 = np.copy(f.oo)
     tmp79 += tmp5
     tmp72 = einsum(v.ooov, (0, 1, 2, 3), t2, (4, 2, 5, 6), (4, 0, 1, 5, 6, 3))
     tmp75 = einsum(t1, (0, 1), tmp74, (2, 3, 4, 0, 5, 6), (2, 3, 4, 5, 1, 6)) * -1
@@ -167,251 +167,251 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp28
     tmp83 = einsum(t3, (0, 1, 2, 3, 4, 5), tmp82, (5, 6), (0, 1, 2, 6, 3, 4))
     del tmp82
-    t3new = tmp83.transpose((1, 2, 0, 4, 5, 3)).copy()
-    t3new += tmp83.transpose((1, 2, 0, 4, 3, 5)) * -1
-    t3new += tmp83.transpose((1, 2, 0, 3, 4, 5))
+    t3new = np.copy(np.transpose(tmp83, (1, 2, 0, 4, 5, 3)))
+    t3new += np.transpose(tmp83, (1, 2, 0, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp83, (1, 2, 0, 3, 4, 5))
     del tmp83
     tmp65 = einsum(t1, (0, 1), tmp64, (2, 3, 4, 0, 5, 6), (2, 3, 4, 1, 5, 6))
     del tmp64
-    t3new += tmp65.transpose((1, 2, 0, 5, 4, 3))
-    t3new += tmp65.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new += tmp65.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new += tmp65.transpose((1, 2, 0, 4, 3, 5))
-    t3new += tmp65.transpose((1, 2, 0, 3, 5, 4))
-    t3new += tmp65.transpose((1, 2, 0, 3, 4, 5)) * -1
-    t3new += tmp65.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new += tmp65.transpose((1, 0, 2, 4, 5, 3))
-    t3new += tmp65.transpose((1, 0, 2, 5, 3, 4))
-    t3new += tmp65.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new += tmp65.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new += tmp65.transpose((1, 0, 2, 3, 4, 5))
-    t3new += tmp65.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new += tmp65.transpose((0, 2, 1, 4, 5, 3))
-    t3new += tmp65.transpose((0, 2, 1, 5, 3, 4))
-    t3new += tmp65.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new += tmp65.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new += tmp65.transpose((0, 2, 1, 3, 4, 5))
+    t3new += np.transpose(tmp65, (1, 2, 0, 5, 4, 3))
+    t3new += np.transpose(tmp65, (1, 2, 0, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp65, (1, 2, 0, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp65, (1, 2, 0, 4, 3, 5))
+    t3new += np.transpose(tmp65, (1, 2, 0, 3, 5, 4))
+    t3new += np.transpose(tmp65, (1, 2, 0, 3, 4, 5)) * -1
+    t3new += np.transpose(tmp65, (1, 0, 2, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp65, (1, 0, 2, 4, 5, 3))
+    t3new += np.transpose(tmp65, (1, 0, 2, 5, 3, 4))
+    t3new += np.transpose(tmp65, (1, 0, 2, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp65, (1, 0, 2, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp65, (1, 0, 2, 3, 4, 5))
+    t3new += np.transpose(tmp65, (0, 2, 1, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp65, (0, 2, 1, 4, 5, 3))
+    t3new += np.transpose(tmp65, (0, 2, 1, 5, 3, 4))
+    t3new += np.transpose(tmp65, (0, 2, 1, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp65, (0, 2, 1, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp65, (0, 2, 1, 3, 4, 5))
     del tmp65
     tmp87 = einsum(t1, (0, 1), tmp86, (2, 3, 0, 4, 5, 6), (2, 3, 4, 1, 5, 6))
     del tmp86
-    t3new += tmp87.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new += tmp87.transpose((2, 1, 0, 4, 5, 3))
-    t3new += tmp87.transpose((2, 1, 0, 5, 3, 4))
-    t3new += tmp87.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new += tmp87.transpose((2, 1, 0, 3, 5, 4)) * -1
-    t3new += tmp87.transpose((2, 1, 0, 3, 4, 5))
-    t3new += tmp87.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new += tmp87.transpose((0, 2, 1, 4, 5, 3))
-    t3new += tmp87.transpose((0, 2, 1, 5, 3, 4))
-    t3new += tmp87.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new += tmp87.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new += tmp87.transpose((0, 2, 1, 3, 4, 5))
-    t3new += tmp87.transpose((0, 1, 2, 5, 4, 3))
-    t3new += tmp87.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new += tmp87.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new += tmp87.transpose((0, 1, 2, 4, 3, 5))
-    t3new += tmp87.transpose((0, 1, 2, 3, 5, 4))
+    t3new += np.transpose(tmp87, (2, 1, 0, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp87, (2, 1, 0, 4, 5, 3))
+    t3new += np.transpose(tmp87, (2, 1, 0, 5, 3, 4))
+    t3new += np.transpose(tmp87, (2, 1, 0, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp87, (2, 1, 0, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp87, (2, 1, 0, 3, 4, 5))
+    t3new += np.transpose(tmp87, (0, 2, 1, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp87, (0, 2, 1, 4, 5, 3))
+    t3new += np.transpose(tmp87, (0, 2, 1, 5, 3, 4))
+    t3new += np.transpose(tmp87, (0, 2, 1, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp87, (0, 2, 1, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp87, (0, 2, 1, 3, 4, 5))
+    t3new += np.transpose(tmp87, (0, 1, 2, 5, 4, 3))
+    t3new += np.transpose(tmp87, (0, 1, 2, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp87, (0, 1, 2, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp87, (0, 1, 2, 4, 3, 5))
+    t3new += np.transpose(tmp87, (0, 1, 2, 3, 5, 4))
     t3new += tmp87 * -1
     del tmp87
-    tmp58 = tmp55.transpose((0, 2, 1, 3, 5, 4)).copy()
+    tmp58 = np.copy(np.transpose(tmp55, (0, 2, 1, 3, 5, 4)))
     del tmp55
-    tmp58 += tmp57.transpose((0, 2, 1, 3, 5, 4))
+    tmp58 += np.transpose(tmp57, (0, 2, 1, 3, 5, 4))
     del tmp57
-    t3new += tmp58.transpose((2, 1, 0, 4, 5, 3))
-    t3new += tmp58.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new += tmp58.transpose((2, 1, 0, 3, 4, 5))
-    t3new += tmp58.transpose((2, 0, 1, 4, 5, 3)) * -1
-    t3new += tmp58.transpose((2, 0, 1, 4, 3, 5))
-    t3new += tmp58.transpose((2, 0, 1, 3, 4, 5)) * -1
-    t3new += tmp58.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new += tmp58.transpose((0, 1, 2, 4, 3, 5))
+    t3new += np.transpose(tmp58, (2, 1, 0, 4, 5, 3))
+    t3new += np.transpose(tmp58, (2, 1, 0, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp58, (2, 1, 0, 3, 4, 5))
+    t3new += np.transpose(tmp58, (2, 0, 1, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp58, (2, 0, 1, 4, 3, 5))
+    t3new += np.transpose(tmp58, (2, 0, 1, 3, 4, 5)) * -1
+    t3new += np.transpose(tmp58, (0, 1, 2, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp58, (0, 1, 2, 4, 3, 5))
     t3new += tmp58 * -1
     del tmp58
     tmp78 = einsum(t2, (0, 1, 2, 3), tmp77, (4, 1, 5, 6), (4, 0, 5, 6, 2, 3)) * -1
     del tmp77
-    t3new += tmp78.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new += tmp78.transpose((2, 1, 0, 5, 3, 4))
-    t3new += tmp78.transpose((2, 1, 0, 3, 5, 4)) * -1
-    t3new += tmp78.transpose((1, 2, 0, 5, 4, 3))
-    t3new += tmp78.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new += tmp78.transpose((1, 2, 0, 3, 5, 4))
-    t3new += tmp78.transpose((2, 0, 1, 5, 4, 3))
-    t3new += tmp78.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new += tmp78.transpose((2, 0, 1, 3, 5, 4))
-    t3new += tmp78.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new += tmp78.transpose((1, 0, 2, 5, 3, 4))
-    t3new += tmp78.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new += tmp78.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new += tmp78.transpose((0, 2, 1, 5, 3, 4))
-    t3new += tmp78.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new += tmp78.transpose((0, 1, 2, 5, 4, 3))
-    t3new += tmp78.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new += tmp78.transpose((0, 1, 2, 3, 5, 4))
+    t3new += np.transpose(tmp78, (2, 1, 0, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp78, (2, 1, 0, 5, 3, 4))
+    t3new += np.transpose(tmp78, (2, 1, 0, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp78, (1, 2, 0, 5, 4, 3))
+    t3new += np.transpose(tmp78, (1, 2, 0, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp78, (1, 2, 0, 3, 5, 4))
+    t3new += np.transpose(tmp78, (2, 0, 1, 5, 4, 3))
+    t3new += np.transpose(tmp78, (2, 0, 1, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp78, (2, 0, 1, 3, 5, 4))
+    t3new += np.transpose(tmp78, (1, 0, 2, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp78, (1, 0, 2, 5, 3, 4))
+    t3new += np.transpose(tmp78, (1, 0, 2, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp78, (0, 2, 1, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp78, (0, 2, 1, 5, 3, 4))
+    t3new += np.transpose(tmp78, (0, 2, 1, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp78, (0, 1, 2, 5, 4, 3))
+    t3new += np.transpose(tmp78, (0, 1, 2, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp78, (0, 1, 2, 3, 5, 4))
     del tmp78
     tmp80 = einsum(t3, (0, 1, 2, 3, 4, 5), tmp79, (2, 6), (6, 0, 1, 3, 4, 5))
     del tmp79
-    t3new += tmp80.transpose((2, 1, 0, 3, 4, 5))
-    t3new += tmp80.transpose((2, 0, 1, 3, 4, 5)) * -1
+    t3new += np.transpose(tmp80, (2, 1, 0, 3, 4, 5))
+    t3new += np.transpose(tmp80, (2, 0, 1, 3, 4, 5)) * -1
     t3new += tmp80 * -1
     del tmp80
-    tmp76 = tmp72.transpose((0, 2, 1, 4, 3, 5)).copy()
+    tmp76 = np.copy(np.transpose(tmp72, (0, 2, 1, 4, 3, 5)))
     del tmp72
-    tmp76 += tmp75.transpose((0, 2, 1, 4, 3, 5))
+    tmp76 += np.transpose(tmp75, (0, 2, 1, 4, 3, 5))
     del tmp75
-    t3new += tmp76.transpose((2, 1, 0, 5, 3, 4))
-    t3new += tmp76.transpose((2, 1, 0, 3, 5, 4)) * -1
-    t3new += tmp76.transpose((2, 1, 0, 3, 4, 5))
-    t3new += tmp76.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new += tmp76.transpose((2, 0, 1, 3, 5, 4))
-    t3new += tmp76.transpose((2, 0, 1, 3, 4, 5)) * -1
-    t3new += tmp76.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new += tmp76.transpose((0, 1, 2, 3, 5, 4))
+    t3new += np.transpose(tmp76, (2, 1, 0, 5, 3, 4))
+    t3new += np.transpose(tmp76, (2, 1, 0, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp76, (2, 1, 0, 3, 4, 5))
+    t3new += np.transpose(tmp76, (2, 0, 1, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp76, (2, 0, 1, 3, 5, 4))
+    t3new += np.transpose(tmp76, (2, 0, 1, 3, 4, 5)) * -1
+    t3new += np.transpose(tmp76, (0, 1, 2, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp76, (0, 1, 2, 3, 5, 4))
     t3new += tmp76 * -1
     del tmp76
     tmp85 = einsum(tmp84, (0, 1, 2, 3), t2, (4, 1, 5, 6), (0, 4, 2, 5, 6, 3))
     del tmp84
-    t3new += tmp85.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new += tmp85.transpose((2, 1, 0, 4, 5, 3))
-    t3new += tmp85.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new += tmp85.transpose((1, 2, 0, 5, 4, 3))
-    t3new += tmp85.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new += tmp85.transpose((1, 2, 0, 4, 3, 5))
-    t3new += tmp85.transpose((2, 0, 1, 5, 4, 3))
-    t3new += tmp85.transpose((2, 0, 1, 4, 5, 3)) * -1
-    t3new += tmp85.transpose((2, 0, 1, 4, 3, 5))
-    t3new += tmp85.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new += tmp85.transpose((1, 0, 2, 4, 5, 3))
-    t3new += tmp85.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new += tmp85.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new += tmp85.transpose((0, 2, 1, 4, 5, 3))
-    t3new += tmp85.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new += tmp85.transpose((0, 1, 2, 5, 4, 3))
-    t3new += tmp85.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new += tmp85.transpose((0, 1, 2, 4, 3, 5))
+    t3new += np.transpose(tmp85, (2, 1, 0, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp85, (2, 1, 0, 4, 5, 3))
+    t3new += np.transpose(tmp85, (2, 1, 0, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp85, (1, 2, 0, 5, 4, 3))
+    t3new += np.transpose(tmp85, (1, 2, 0, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp85, (1, 2, 0, 4, 3, 5))
+    t3new += np.transpose(tmp85, (2, 0, 1, 5, 4, 3))
+    t3new += np.transpose(tmp85, (2, 0, 1, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp85, (2, 0, 1, 4, 3, 5))
+    t3new += np.transpose(tmp85, (1, 0, 2, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp85, (1, 0, 2, 4, 5, 3))
+    t3new += np.transpose(tmp85, (1, 0, 2, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp85, (0, 2, 1, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp85, (0, 2, 1, 4, 5, 3))
+    t3new += np.transpose(tmp85, (0, 2, 1, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp85, (0, 1, 2, 5, 4, 3))
+    t3new += np.transpose(tmp85, (0, 1, 2, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp85, (0, 1, 2, 4, 3, 5))
     del tmp85
-    tmp63 = tmp61.transpose((0, 1, 2, 4, 3, 5)).copy() * -1
+    tmp63 = np.copy(np.transpose(tmp61, (0, 1, 2, 4, 3, 5))) * -1
     del tmp61
-    tmp63 += tmp62.transpose((0, 1, 2, 4, 3, 5)) * -1
+    tmp63 += np.transpose(tmp62, (0, 1, 2, 4, 3, 5)) * -1
     del tmp62
-    t3new += tmp63.transpose((2, 1, 0, 5, 3, 4))
-    t3new += tmp63.transpose((2, 1, 0, 3, 5, 4)) * -1
-    t3new += tmp63.transpose((2, 1, 0, 3, 4, 5))
-    t3new += tmp63.transpose((0, 2, 1, 5, 3, 4))
-    t3new += tmp63.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new += tmp63.transpose((0, 2, 1, 3, 4, 5))
-    t3new += tmp63.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new += tmp63.transpose((0, 1, 2, 3, 5, 4))
+    t3new += np.transpose(tmp63, (2, 1, 0, 5, 3, 4))
+    t3new += np.transpose(tmp63, (2, 1, 0, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp63, (2, 1, 0, 3, 4, 5))
+    t3new += np.transpose(tmp63, (0, 2, 1, 5, 3, 4))
+    t3new += np.transpose(tmp63, (0, 2, 1, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp63, (0, 2, 1, 3, 4, 5))
+    t3new += np.transpose(tmp63, (0, 1, 2, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp63, (0, 1, 2, 3, 5, 4))
     t3new += tmp63 * -1
     del tmp63
-    tmp71 = tmp66.transpose((0, 1, 2, 3, 5, 4)).copy() * -1
+    tmp71 = np.copy(np.transpose(tmp66, (0, 1, 2, 3, 5, 4))) * -1
     del tmp66
-    tmp71 += tmp70.transpose((0, 1, 2, 3, 5, 4)) * -1
+    tmp71 += np.transpose(tmp70, (0, 1, 2, 3, 5, 4)) * -1
     del tmp70
-    t3new += tmp71.transpose((2, 1, 0, 4, 5, 3))
-    t3new += tmp71.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new += tmp71.transpose((2, 1, 0, 3, 4, 5))
-    t3new += tmp71.transpose((0, 2, 1, 4, 5, 3))
-    t3new += tmp71.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new += tmp71.transpose((0, 2, 1, 3, 4, 5))
-    t3new += tmp71.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new += tmp71.transpose((0, 1, 2, 4, 3, 5))
+    t3new += np.transpose(tmp71, (2, 1, 0, 4, 5, 3))
+    t3new += np.transpose(tmp71, (2, 1, 0, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp71, (2, 1, 0, 3, 4, 5))
+    t3new += np.transpose(tmp71, (0, 2, 1, 4, 5, 3))
+    t3new += np.transpose(tmp71, (0, 2, 1, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp71, (0, 2, 1, 3, 4, 5))
+    t3new += np.transpose(tmp71, (0, 1, 2, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp71, (0, 1, 2, 4, 3, 5))
     t3new += tmp71 * -1
     del tmp71
-    tmp46 = tmp41.copy()
+    tmp46 = np.copy(tmp41)
     del tmp41
     tmp46 += tmp43
     del tmp43
     tmp46 += tmp45 * -1
     del tmp45
-    t2new = tmp46.transpose((0, 1, 3, 2)).copy() * -1
+    t2new = np.copy(np.transpose(tmp46, (0, 1, 3, 2))) * -1
     t2new += tmp46
     del tmp46
-    tmp33 = tmp31.transpose((1, 0, 2, 3)).copy() * -1
+    tmp33 = np.copy(np.transpose(tmp31, (1, 0, 2, 3))) * -1
     del tmp31
-    tmp33 += tmp32.transpose((1, 0, 2, 3)) * -1
+    tmp33 += np.transpose(tmp32, (1, 0, 2, 3)) * -1
     del tmp32
-    t2new += tmp33.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp33, (0, 1, 3, 2))
     t2new += tmp33 * -1
     del tmp33
-    tmp53 = v.oooo.copy()
+    tmp53 = np.copy(v.oooo)
     tmp53 += einsum(tmp7, (0, 1, 2, 3), v.oovv, (4, 5, 2, 3), (4, 5, 1, 0)) * -0.5
     t2new += einsum(tmp7, (0, 1, 2, 3), tmp53, (0, 1, 4, 5), (4, 5, 3, 2)) * -0.5
     del tmp53
-    tmp39 = tmp35.transpose((0, 1, 3, 2)).copy() * -1
+    tmp39 = np.copy(np.transpose(tmp35, (0, 1, 3, 2))) * -1
     del tmp35
-    tmp39 += tmp36.transpose((0, 1, 3, 2))
+    tmp39 += np.transpose(tmp36, (0, 1, 3, 2))
     del tmp36
-    tmp39 += tmp38.transpose((0, 1, 3, 2)) * -1
+    tmp39 += np.transpose(tmp38, (0, 1, 3, 2)) * -1
     del tmp38
-    t2new += tmp39.transpose((1, 0, 2, 3))
+    t2new += np.transpose(tmp39, (1, 0, 2, 3))
     t2new += tmp39 * -1
     del tmp39
     tmp50 = einsum(tmp49, (0, 1, 2, 3), t2, (4, 1, 5, 3), (0, 4, 5, 2)) * -1
     del tmp49
-    t2new += tmp50.transpose((1, 0, 3, 2))
-    t2new += tmp50.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp50.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp50, (1, 0, 3, 2))
+    t2new += np.transpose(tmp50, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp50, (0, 1, 3, 2)) * -1
     t2new += tmp50
     del tmp50
-    tmp2 = t2.copy() * 0.5
+    tmp2 = np.copy(t2) * 0.5
     tmp2 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     t2new += einsum(v.vvvv, (0, 1, 2, 3), tmp2, (4, 5, 2, 3), (5, 4, 0, 1)) * -1
     t1new = einsum(v.ovvv, (0, 1, 2, 3), tmp2, (0, 4, 2, 3), (4, 1))
     del tmp2
-    tmp4 = f.ov.copy()
+    tmp4 = np.copy(f.ov)
     tmp4 += tmp3
     del tmp3
     t2new += einsum(t3, (0, 1, 2, 3, 4, 5), tmp4, (2, 5), (0, 1, 3, 4))
     t1new += einsum(t2, (0, 1, 2, 3), tmp4, (1, 3), (0, 2))
     del tmp4
-    tmp22 = tmp14.copy() * 0.5
+    tmp22 = np.copy(tmp14) * 0.5
     del tmp14
     tmp22 += tmp16 * 0.5
     del tmp16
-    tmp22 += tmp21.transpose((1, 0, 3, 2)) * -1
+    tmp22 += np.transpose(tmp21, (1, 0, 3, 2)) * -1
     del tmp21
-    t2new += tmp22.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp22, (0, 1, 3, 2))
     t2new += tmp22 * -1
     del tmp22
     tmp52 = einsum(tmp51, (0, 1, 2, 3), t1, (2, 4), (1, 0, 4, 3)) * -1
     del tmp51
-    t2new += tmp52.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp52, (0, 1, 3, 2))
     t2new += tmp52 * -1
     del tmp52
     tmp48 = einsum(tmp47, (0, 1, 2, 3), t1, (2, 4), (0, 1, 4, 3))
     del tmp47
-    t2new += tmp48.transpose((1, 0, 3, 2)) * -1
-    t2new += tmp48.transpose((1, 0, 2, 3))
-    t2new += tmp48.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp48, (1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp48, (1, 0, 2, 3))
+    t2new += np.transpose(tmp48, (0, 1, 3, 2))
     t2new += tmp48 * -1
     del tmp48
     tmp34 = einsum(t2, (0, 1, 2, 3), f.oo, (4, 1), (4, 0, 2, 3))
-    t2new += tmp34.transpose((1, 0, 3, 2))
-    t2new += tmp34.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp34, (1, 0, 3, 2))
+    t2new += np.transpose(tmp34, (0, 1, 3, 2)) * -1
     del tmp34
-    tmp13 = tmp10.copy()
+    tmp13 = np.copy(tmp10)
     del tmp10
     tmp13 += tmp12 * -1
     del tmp12
-    t2new += tmp13.transpose((1, 0, 3, 2))
-    t2new += tmp13.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp13.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp13, (1, 0, 3, 2))
+    t2new += np.transpose(tmp13, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp13, (0, 1, 3, 2)) * -1
     t2new += tmp13
     del tmp13
-    tmp30 = tmp23.transpose((0, 1, 3, 2)).copy()
+    tmp30 = np.copy(np.transpose(tmp23, (0, 1, 3, 2)))
     del tmp23
-    tmp30 += tmp24.transpose((0, 1, 3, 2)) * -0.5
+    tmp30 += np.transpose(tmp24, (0, 1, 3, 2)) * -0.5
     del tmp24
-    tmp30 += tmp25.transpose((0, 1, 3, 2)) * 0.5
+    tmp30 += np.transpose(tmp25, (0, 1, 3, 2)) * 0.5
     del tmp25
-    tmp30 += tmp27.transpose((0, 1, 3, 2)) * -0.5
+    tmp30 += np.transpose(tmp27, (0, 1, 3, 2)) * -0.5
     del tmp27
-    tmp30 += tmp29.transpose((0, 1, 3, 2)) * -1
+    tmp30 += np.transpose(tmp29, (0, 1, 3, 2)) * -1
     del tmp29
-    t2new += tmp30.transpose((1, 0, 2, 3))
+    t2new += np.transpose(tmp30, (1, 0, 2, 3))
     t2new += tmp30 * -1
     del tmp30
-    tmp8 = f.oo.copy()
+    tmp8 = np.copy(f.oo)
     tmp8 += tmp5
     del tmp5
     tmp8 += tmp6
@@ -420,8 +420,8 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp7
     t1new += einsum(t1, (0, 1), tmp8, (0, 2), (2, 1)) * -1
     del tmp8
-    tmp1 = v.ovoo.transpose((0, 2, 3, 1)).copy() * -1
-    tmp1 += tmp0.transpose((0, 2, 1, 3)) * -1
+    tmp1 = np.copy(np.transpose(v.ovoo, (0, 2, 3, 1))) * -1
+    tmp1 += np.transpose(tmp0, (0, 2, 1, 3)) * -1
     del tmp0
     t1new += einsum(t2, (0, 1, 2, 3), tmp1, (4, 0, 1, 3), (4, 2)) * 0.5
     del tmp1

--- a/ebcc/codegen/GCCD.py
+++ b/ebcc/codegen/GCCD.py
@@ -67,30 +67,30 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp1 = einsum(t2, (0, 1, 2, 3), tmp0, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp0
     tmp8 = einsum(f.vv, (0, 1), t2, (2, 3, 4, 1), (2, 3, 0, 4))
-    tmp9 = v.oooo.copy()
+    tmp9 = np.copy(v.oooo)
     tmp9 += einsum(t2, (0, 1, 2, 3), v.oovv, (4, 5, 2, 3), (4, 5, 0, 1)) * 0.5
     tmp6 = einsum(f.oo, (0, 1), t2, (2, 1, 3, 4), (0, 2, 3, 4))
     t2new = einsum(v.vvvv, (0, 1, 2, 3), t2, (4, 5, 2, 3), (4, 5, 0, 1)) * 0.5
     t2new += v.oovv
     t2new += tmp1
-    t2new += tmp1.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp1, (0, 1, 3, 2)) * -1
     del tmp1
     t2new += tmp3 * -0.5
-    t2new += tmp3.transpose((0, 1, 3, 2)) * 0.5
+    t2new += np.transpose(tmp3, (0, 1, 3, 2)) * 0.5
     del tmp3
-    t2new += tmp5.transpose((0, 1, 3, 2)) * 0.5
-    t2new += tmp5.transpose((1, 0, 3, 2)) * -0.5
+    t2new += np.transpose(tmp5, (0, 1, 3, 2)) * 0.5
+    t2new += np.transpose(tmp5, (1, 0, 3, 2)) * -0.5
     del tmp5
-    t2new += tmp6.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp6.transpose((1, 0, 3, 2))
+    t2new += np.transpose(tmp6, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp6, (1, 0, 3, 2))
     del tmp6
     t2new += tmp7 * -1
-    t2new += tmp7.transpose((0, 1, 3, 2))
-    t2new += tmp7.transpose((1, 0, 2, 3))
-    t2new += tmp7.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp7, (0, 1, 3, 2))
+    t2new += np.transpose(tmp7, (1, 0, 2, 3))
+    t2new += np.transpose(tmp7, (1, 0, 3, 2)) * -1
     del tmp7
-    t2new += tmp8.transpose((1, 0, 2, 3))
-    t2new += tmp8.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp8, (1, 0, 2, 3))
+    t2new += np.transpose(tmp8, (1, 0, 3, 2)) * -1
     del tmp8
     t2new += einsum(tmp9, (0, 1, 2, 3), t2, (0, 1, 4, 5), (2, 3, 4, 5)) * 0.5
     del tmp9
@@ -123,7 +123,7 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp9 = einsum(v.oovv, (0, 1, 2, 3), t2, (0, 1, 4, 3), (4, 2))
     tmp6 = einsum(t2, (0, 1, 2, 3), l2, (2, 3, 4, 1), (4, 0))
     tmp4 = einsum(t2, (0, 1, 2, 3), v.oovv, (4, 1, 2, 3), (0, 4))
-    tmp2 = v.ovov.transpose((0, 2, 3, 1)).copy() * -1
+    tmp2 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -1
     tmp2 += tmp1
     del tmp1
     tmp12 = einsum(v.oovv, (0, 1, 2, 3), tmp11, (4, 3), (0, 1, 4, 2)) * -1
@@ -139,36 +139,36 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp3 = einsum(tmp2, (0, 1, 2, 3), l2, (4, 2, 5, 0), (5, 1, 4, 3))
     del tmp2
     tmp15 = einsum(l2, (0, 1, 2, 3), f.vv, (4, 1), (2, 3, 4, 0))
-    tmp13 = tmp10.copy() * 0.5
+    tmp13 = np.copy(tmp10) * 0.5
     del tmp10
     tmp13 += tmp12 * 0.5
     del tmp12
-    tmp8 = tmp5.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp8 = np.copy(np.transpose(tmp5, (0, 1, 3, 2))) * -0.5
     del tmp5
-    tmp8 += tmp7.transpose((0, 1, 3, 2)) * -0.5
+    tmp8 += np.transpose(tmp7, (0, 1, 3, 2)) * -0.5
     del tmp7
-    tmp16 = v.oooo.copy() * 2
+    tmp16 = np.copy(v.oooo) * 2
     tmp16 += einsum(v.oovv, (0, 1, 2, 3), t2, (4, 5, 2, 3), (4, 5, 0, 1))
     l2new = einsum(v.oovv, (0, 1, 2, 3), tmp0, (4, 5, 1, 0), (2, 3, 4, 5)) * -0.25
     del tmp0
     l2new += einsum(l2, (0, 1, 2, 3), v.vvvv, (4, 5, 0, 1), (4, 5, 2, 3)) * 0.5
-    l2new += v.oovv.transpose((2, 3, 0, 1))
-    l2new += tmp3.transpose((2, 3, 0, 1))
-    l2new += tmp3.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp3.transpose((2, 3, 1, 0)) * -1
-    l2new += tmp3.transpose((3, 2, 1, 0))
+    l2new += np.transpose(v.oovv, (2, 3, 0, 1))
+    l2new += np.transpose(tmp3, (2, 3, 0, 1))
+    l2new += np.transpose(tmp3, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp3, (2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp3, (3, 2, 1, 0))
     del tmp3
-    l2new += tmp8.transpose((3, 2, 0, 1))
-    l2new += tmp8.transpose((3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp8, (3, 2, 0, 1))
+    l2new += np.transpose(tmp8, (3, 2, 1, 0)) * -1
     del tmp8
-    l2new += tmp13.transpose((2, 3, 1, 0))
-    l2new += tmp13.transpose((3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp13, (2, 3, 1, 0))
+    l2new += np.transpose(tmp13, (3, 2, 1, 0)) * -1
     del tmp13
-    l2new += tmp14.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp14.transpose((3, 2, 1, 0))
+    l2new += np.transpose(tmp14, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp14, (3, 2, 1, 0))
     del tmp14
-    l2new += tmp15.transpose((2, 3, 1, 0))
-    l2new += tmp15.transpose((3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp15, (2, 3, 1, 0))
+    l2new += np.transpose(tmp15, (3, 2, 1, 0)) * -1
     del tmp15
     l2new += einsum(tmp16, (0, 1, 2, 3), l2, (4, 5, 0, 1), (4, 5, 2, 3)) * 0.25
     del tmp16
@@ -198,7 +198,7 @@ def make_rdm1_f(l2=None, t2=None, **kwargs):
         vv=np.eye(t2.shape[-1]),
     )
     rdm1.vv = einsum(t2, (0, 1, 2, 3), l2, (4, 3, 0, 1), (4, 2)) * 0.5
-    rdm1.oo = delta.oo.copy()
+    rdm1.oo = np.copy(delta.oo)
     del delta
     rdm1.oo += einsum(l2, (0, 1, 2, 3), t2, (4, 3, 0, 1), (4, 2)) * -0.5
     rdm1.ov = np.zeros((t2.shape[0], t2.shape[-1]))
@@ -237,29 +237,29 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     tmp3 = einsum(t2, (0, 1, 2, 3), tmp2, (1, 4, 3, 5), (4, 0, 5, 2))
     tmp6 = einsum(tmp1, (0, 1), t2, (2, 0, 3, 4), (2, 1, 3, 4))
     rdm2.vvvv = einsum(l2, (0, 1, 2, 3), t2, (2, 3, 4, 5), (0, 1, 4, 5)) * 0.5
-    rdm2.vvoo = l2.copy()
+    rdm2.vvoo = np.copy(l2)
     rdm2.vovo = einsum(tmp4, (0, 1), delta.oo, (2, 3), (0, 2, 1, 3)) * 0.5
-    rdm2.vovo += tmp2.transpose((2, 1, 3, 0)) * -1
+    rdm2.vovo += np.transpose(tmp2, (2, 1, 3, 0)) * -1
     rdm2.voov = einsum(tmp4, (0, 1), delta.oo, (2, 3), (0, 2, 3, 1)) * -0.5
-    rdm2.voov += tmp2.transpose((2, 1, 0, 3))
+    rdm2.voov += np.transpose(tmp2, (2, 1, 0, 3))
     rdm2.ovvo = einsum(tmp4, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * -0.5
-    rdm2.ovvo += tmp2.transpose((1, 2, 3, 0))
+    rdm2.ovvo += np.transpose(tmp2, (1, 2, 3, 0))
     rdm2.ovov = einsum(tmp4, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1)) * 0.5
     del tmp4
-    rdm2.ovov += tmp2.transpose((1, 2, 0, 3)) * -1
+    rdm2.ovov += np.transpose(tmp2, (1, 2, 0, 3)) * -1
     del tmp2
     rdm2.oovv = einsum(t2, (0, 1, 2, 3), tmp0, (1, 0, 4, 5), (5, 4, 2, 3)) * 0.25
     rdm2.oovv += t2
     rdm2.oovv += tmp3
-    rdm2.oovv += tmp3.transpose((0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp3, (0, 1, 3, 2)) * -1
     del tmp3
     rdm2.oovv += tmp5 * -0.5
-    rdm2.oovv += tmp5.transpose((0, 1, 3, 2)) * 0.5
+    rdm2.oovv += np.transpose(tmp5, (0, 1, 3, 2)) * 0.5
     del tmp5
-    rdm2.oovv += tmp6.transpose((0, 1, 3, 2)) * 0.5
-    rdm2.oovv += tmp6.transpose((1, 0, 3, 2)) * -0.5
+    rdm2.oovv += np.transpose(tmp6, (0, 1, 3, 2)) * 0.5
+    rdm2.oovv += np.transpose(tmp6, (1, 0, 3, 2)) * -0.5
     del tmp6
-    rdm2.oooo = tmp0.transpose((3, 2, 1, 0)).copy() * 0.5
+    rdm2.oooo = np.copy(np.transpose(tmp0, (3, 2, 1, 0))) * 0.5
     del tmp0
     rdm2.oooo += einsum(delta.oo, (0, 1), delta.oo, (2, 3), (0, 2, 1, 3))
     rdm2.oooo += einsum(delta.oo, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * -1
@@ -277,7 +277,7 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.vvov = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[0], t2.shape[-1]))
     rdm2.vvvo = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[0]))
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.transpose(0, 2, 1, 3)
+    rdm2 = np.transpose(rdm2, (0, 2, 1, 3))
 
     return rdm2
 
@@ -354,45 +354,45 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp6 = einsum(f.oo, (0, 1), r2, (2, 1, 3), (0, 2, 3))
     tmp7 = einsum(ints.tmp6, (0, 1, 2, 3), r1, (1,), (0, 2, 3))
     del ints.tmp6
-    tmp10 = f.vv.copy()
-    tmp10 += ints.tmp12.transpose((1, 0)) * -0.5
+    tmp10 = np.copy(f.vv)
+    tmp10 += np.transpose(ints.tmp12, (1, 0)) * -0.5
     del ints.tmp12
-    tmp5 = tmp2.copy() * -0.5
+    tmp5 = np.copy(tmp2) * -0.5
     del tmp2
     tmp5 += tmp3
     del tmp3
     tmp5 += tmp4
     del tmp4
     tmp1 = einsum(r2, (0, 1, 2), v.oovv, (0, 1, 3, 2), (3,))
-    tmp11 = ints.tmp9.transpose((2, 0, 1, 3)).copy() * 0.5
+    tmp11 = np.copy(np.transpose(ints.tmp9, (2, 0, 1, 3))) * 0.5
     del ints.tmp9
-    tmp11 += v.ovoo.transpose((0, 2, 3, 1))
+    tmp11 += np.transpose(v.ovoo, (0, 2, 3, 1))
     tmp11 += ints.tmp3 * -1
     del ints.tmp3
-    tmp8 = tmp6.copy()
+    tmp8 = np.copy(tmp6)
     del tmp6
     tmp8 += tmp7
     del tmp7
-    tmp9 = ints.tmp11.copy() * -0.5
+    tmp9 = np.copy(ints.tmp11) * -0.5
     del ints.tmp11
     tmp9 += v.oooo * -1
-    tmp12 = f.ov.copy()
+    tmp12 = np.copy(f.ov)
     tmp12 += ints.tmp2
     del ints.tmp2
     tmp12 += ints.tmp5 * -0.5
     del ints.tmp5
     tmp12 += ints.tmp8 * -0.5
     del ints.tmp8
-    tmp0 = f.oo.copy() * 2
-    tmp0 += ints.tmp0.transpose((1, 0))
+    tmp0 = np.copy(f.oo) * 2
+    tmp0 += np.transpose(ints.tmp0, (1, 0))
     del ints.tmp0
     r2new = einsum(tmp1, (0,), t2, (1, 2, 3, 0), (1, 2, 3)) * 0.5
     del tmp1
     r2new += tmp5 * -1
-    r2new += tmp5.transpose((1, 0, 2))
+    r2new += np.transpose(tmp5, (1, 0, 2))
     del tmp5
     r2new += tmp8
-    r2new += tmp8.transpose((1, 0, 2)) * -1
+    r2new += np.transpose(tmp8, (1, 0, 2)) * -1
     del tmp8
     r2new += einsum(r2, (0, 1, 2), tmp9, (3, 4, 1, 0), (3, 4, 2)) * 0.5
     del tmp9
@@ -472,8 +472,8 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     """
 
     ints = kwargs["ints"]
-    tmp4 = f.vv.copy() * 2
-    tmp4 += ints.tmp0.transpose((1, 0)) * -1
+    tmp4 = np.copy(f.vv) * 2
+    tmp4 += np.transpose(ints.tmp0, (1, 0)) * -1
     tmp2 = einsum(ints.tmp12, (0, 1, 2, 3), r2, (4, 3, 1), (0, 2, 4))
     del ints.tmp12
     tmp5 = einsum(tmp4, (0, 1), r2, (2, 0, 3), (3, 2, 1)) * -0.5
@@ -481,11 +481,11 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp3 = einsum(v.ovov, (0, 1, 2, 3), r2, (4, 1, 2), (0, 4, 3))
     tmp7 = einsum(r1, (0,), ints.tmp8, (1, 2, 3, 0), (1, 2, 3))
     del ints.tmp8
-    tmp10 = f.oo.copy()
-    tmp10 += ints.tmp10.transpose((1, 0)) * 0.5
+    tmp10 = np.copy(f.oo)
+    tmp10 += np.transpose(ints.tmp10, (1, 0)) * 0.5
     del ints.tmp10
     tmp1 = einsum(r2, (0, 1, 2), v.oovv, (3, 4, 0, 1), (2, 3, 4))
-    tmp11 = f.ov.copy()
+    tmp11 = np.copy(f.ov)
     tmp11 += ints.tmp2
     del ints.tmp2
     tmp11 += ints.tmp5 * -0.5
@@ -494,26 +494,26 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp7
     tmp9 = einsum(r1, (0,), f.ov, (1, 0), (1,))
     tmp9 += einsum(r2, (0, 1, 2), v.oovv, (3, 2, 0, 1), (3,)) * 0.5
-    tmp8 = ints.tmp6.copy() * 0.5
+    tmp8 = np.copy(ints.tmp6) * 0.5
     del ints.tmp6
-    tmp8 += v.ovvv.transpose((0, 2, 3, 1))
-    tmp6 = tmp2.copy()
+    tmp8 += np.transpose(v.ovvv, (0, 2, 3, 1))
+    tmp6 = np.copy(tmp2)
     del tmp2
     tmp6 += tmp3
     del tmp3
-    tmp6 += tmp5.transpose((0, 2, 1)) * -1
+    tmp6 += np.transpose(tmp5, (0, 2, 1)) * -1
     del tmp5
-    tmp0 = f.vv.copy()
-    tmp0 += ints.tmp0.transpose((1, 0)) * -0.5
+    tmp0 = np.copy(f.vv)
+    tmp0 += np.transpose(ints.tmp0, (1, 0)) * -0.5
     del ints.tmp0
     r2new = einsum(tmp1, (0, 1, 2), t2, (2, 1, 3, 4), (3, 4, 0)) * -0.25
     del tmp1
     r2new += einsum(v.vvvv, (0, 1, 2, 3), r2, (2, 3, 4), (0, 1, 4)) * 0.5
-    r2new += tmp6.transpose((1, 2, 0)) * -1
-    r2new += tmp6.transpose((2, 1, 0))
+    r2new += np.transpose(tmp6, (1, 2, 0)) * -1
+    r2new += np.transpose(tmp6, (2, 1, 0))
     del tmp6
-    r2new += tmp7.transpose((1, 2, 0))
-    r2new += tmp7.transpose((2, 1, 0)) * -1
+    r2new += np.transpose(tmp7, (1, 2, 0))
+    r2new += np.transpose(tmp7, (2, 1, 0)) * -1
     del tmp7
     r2new += einsum(tmp8, (0, 1, 2, 3), r1, (3,), (2, 1, 0))
     del tmp8
@@ -603,9 +603,9 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     ints = kwargs["ints"]
     tmp7 = einsum(r1, (0, 1), f.ov, (2, 1), (2, 0))
     tmp8 = einsum(r2, (0, 1, 2, 3), v.oovv, (4, 1, 2, 3), (0, 4))
-    tmp5 = f.oo.copy() * 2
-    tmp5 += ints.tmp0.transpose((1, 0))
-    tmp9 = tmp7.transpose((1, 0)).copy()
+    tmp5 = np.copy(f.oo) * 2
+    tmp5 += np.transpose(ints.tmp0, (1, 0))
+    tmp9 = np.copy(np.transpose(tmp7, (1, 0)))
     del tmp7
     tmp9 += tmp8 * 0.5
     del tmp8
@@ -637,28 +637,28 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp16 = einsum(r1, (0, 1), v.ovvv, (2, 1, 3, 4), (0, 2, 3, 4))
     tmp18 = einsum(tmp17, (0, 1), t2, (2, 0, 3, 4), (2, 1, 3, 4)) * -1
     del tmp17
-    tmp34 = f.ov.copy()
+    tmp34 = np.copy(f.ov)
     tmp34 += ints.tmp5
     tmp34 += ints.tmp13 * -0.5
     tmp34 += ints.tmp20 * -0.5
     tmp21 = einsum(tmp20, (0, 1), t2, (2, 3, 4, 1), (2, 3, 4, 0)) * -1
     del tmp20
     tmp3 = einsum(v.oovv, (0, 1, 2, 3), r2, (4, 5, 2, 3), (4, 5, 0, 1))
-    tmp32 = tmp30.copy() * 0.5
+    tmp32 = np.copy(tmp30) * 0.5
     del tmp30
-    tmp32 += tmp31.transpose((1, 0, 2, 3)) * -0.5
+    tmp32 += np.transpose(tmp31, (1, 0, 2, 3)) * -0.5
     del tmp31
-    tmp29 = tmp27.transpose((1, 0, 2, 3)).copy() * -1
+    tmp29 = np.copy(np.transpose(tmp27, (1, 0, 2, 3))) * -1
     del tmp27
-    tmp29 += tmp28.transpose((1, 0, 2, 3)) * -1
+    tmp29 += np.transpose(tmp28, (1, 0, 2, 3)) * -1
     del tmp28
-    tmp11 = tmp4.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp11 = np.copy(np.transpose(tmp4, (0, 1, 3, 2))) * -0.5
     del tmp4
-    tmp11 += tmp6.transpose((1, 0, 3, 2))
+    tmp11 += np.transpose(tmp6, (1, 0, 3, 2))
     del tmp6
-    tmp11 += tmp10.transpose((1, 0, 3, 2))
+    tmp11 += np.transpose(tmp10, (1, 0, 3, 2))
     del tmp10
-    tmp26 = tmp22.copy()
+    tmp26 = np.copy(tmp22)
     del tmp22
     tmp26 += tmp23
     del tmp23
@@ -666,56 +666,56 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp24
     tmp26 += tmp25 * -1
     del tmp25
-    tmp15 = tmp12.copy()
+    tmp15 = np.copy(tmp12)
     del tmp12
     tmp15 += tmp14 * 0.5
     del tmp14
-    tmp33 = ints.tmp28.copy() * -1
+    tmp33 = np.copy(ints.tmp28) * -1
     del ints.tmp28
     tmp33 += v.oooo * -2
-    tmp19 = tmp16.transpose((0, 1, 3, 2)).copy() * -1
+    tmp19 = np.copy(np.transpose(tmp16, (0, 1, 3, 2))) * -1
     del tmp16
-    tmp19 += tmp18.transpose((0, 1, 3, 2))
+    tmp19 += np.transpose(tmp18, (0, 1, 3, 2))
     del tmp18
-    tmp35 = f.ov.copy() * 2
+    tmp35 = np.copy(f.ov) * 2
     tmp35 += ints.tmp5 * 2
     del ints.tmp5
     tmp35 += ints.tmp13 * -1
     del ints.tmp13
     tmp35 += ints.tmp20 * -1
     del ints.tmp20
-    tmp2 = f.oo.copy()
-    tmp2 += ints.tmp0.transpose((1, 0)) * 0.5
+    tmp2 = np.copy(f.oo)
+    tmp2 += np.transpose(ints.tmp0, (1, 0)) * 0.5
     del ints.tmp0
     tmp0 = einsum(v.oovv, (0, 1, 2, 3), r1, (1, 3), (0, 2))
-    tmp1 = f.vv.copy()
-    tmp1 += ints.tmp1.transpose((1, 0)) * -0.5
+    tmp1 = np.copy(f.vv)
+    tmp1 += np.transpose(ints.tmp1, (1, 0)) * -0.5
     del ints.tmp1
     r2new = einsum(t2, (0, 1, 2, 3), tmp3, (4, 5, 1, 0), (5, 4, 2, 3)) * 0.25
     del tmp3
     r2new += einsum(v.vvvv, (0, 1, 2, 3), r2, (4, 5, 2, 3), (4, 5, 0, 1)) * 0.5
     r2new += tmp11
-    r2new += tmp11.transpose((1, 0, 2, 3)) * -1
+    r2new += np.transpose(tmp11, (1, 0, 2, 3)) * -1
     del tmp11
     r2new += tmp15 * -1
-    r2new += tmp15.transpose((0, 1, 3, 2))
+    r2new += np.transpose(tmp15, (0, 1, 3, 2))
     del tmp15
     r2new += tmp19 * -1
-    r2new += tmp19.transpose((1, 0, 2, 3))
+    r2new += np.transpose(tmp19, (1, 0, 2, 3))
     del tmp19
     r2new += tmp21
-    r2new += tmp21.transpose((0, 1, 3, 2)) * -1
+    r2new += np.transpose(tmp21, (0, 1, 3, 2)) * -1
     del tmp21
     r2new += tmp26 * -1
-    r2new += tmp26.transpose((0, 1, 3, 2))
-    r2new += tmp26.transpose((1, 0, 2, 3))
-    r2new += tmp26.transpose((1, 0, 3, 2)) * -1
+    r2new += np.transpose(tmp26, (0, 1, 3, 2))
+    r2new += np.transpose(tmp26, (1, 0, 2, 3))
+    r2new += np.transpose(tmp26, (1, 0, 3, 2)) * -1
     del tmp26
     r2new += tmp29 * -1
-    r2new += tmp29.transpose((0, 1, 3, 2))
+    r2new += np.transpose(tmp29, (0, 1, 3, 2))
     del tmp29
-    r2new += tmp32.transpose((1, 0, 2, 3)) * -1
-    r2new += tmp32.transpose((1, 0, 3, 2))
+    r2new += np.transpose(tmp32, (1, 0, 2, 3)) * -1
+    r2new += np.transpose(tmp32, (1, 0, 3, 2))
     del tmp32
     r2new += einsum(r2, (0, 1, 2, 3), tmp33, (4, 5, 1, 0), (4, 5, 2, 3)) * 0.25
     del tmp33
@@ -815,25 +815,25 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp5
     tmp7 += tmp6
     del tmp6
-    tmp10 = f.vv.copy()
+    tmp10 = np.copy(f.vv)
     tmp10 += ints.tmp11 * -0.5
     del ints.tmp11
     tmp3 = einsum(r2, (0, 1, 2), t2, (0, 1, 3, 2), (3,))
     tmp8 = einsum(f.oo, (0, 1), r2, (2, 1, 3), (0, 2, 3))
-    tmp9 = ints.tmp10.copy() * -0.5
+    tmp9 = np.copy(ints.tmp10) * -0.5
     del ints.tmp10
     tmp9 += v.oooo * -1
-    tmp2 = f.oo.copy() * 2
+    tmp2 = np.copy(f.oo) * 2
     tmp2 += ints.tmp2
     del ints.tmp2
-    tmp0 = ints.tmp1.copy() * 0.5
+    tmp0 = np.copy(ints.tmp1) * 0.5
     del ints.tmp1
-    tmp0 += ints.tmp4.transpose((1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp4, (1, 0, 2, 3))
     del ints.tmp4
-    tmp0 += ints.tmp6.transpose((2, 0, 1, 3)) * -0.25
+    tmp0 += np.transpose(ints.tmp6, (2, 0, 1, 3)) * -0.25
     del ints.tmp6
-    tmp0 += v.ovoo.transpose((0, 2, 3, 1)) * -0.5
-    tmp1 = f.ov.copy()
+    tmp0 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -0.5
+    tmp1 = np.copy(f.ov)
     tmp1 += ints.tmp0
     del ints.tmp0
     tmp1 += ints.tmp3 * -0.5
@@ -844,10 +844,10 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     r2new += einsum(v.oovv, (0, 1, 2, 3), tmp3, (3,), (0, 1, 2)) * 0.5
     del tmp3
     r2new += tmp7 * -1
-    r2new += tmp7.transpose((1, 0, 2))
+    r2new += np.transpose(tmp7, (1, 0, 2))
     del tmp7
     r2new += tmp8
-    r2new += tmp8.transpose((1, 0, 2)) * -1
+    r2new += np.transpose(tmp8, (1, 0, 2)) * -1
     del tmp8
     r2new += einsum(r2, (0, 1, 2), tmp9, (1, 0, 3, 4), (3, 4, 2)) * 0.5
     del tmp9
@@ -924,14 +924,14 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     """
 
     ints = kwargs["ints"]
-    tmp7 = f.vv.copy() * 2
+    tmp7 = np.copy(f.vv) * 2
     tmp7 += ints.tmp2 * -1
     tmp5 = einsum(r2, (0, 1, 2), ints.tmp11, (2, 3, 1, 4), (3, 4, 0))
     del ints.tmp11
     tmp8 = einsum(tmp7, (0, 1), r2, (2, 0, 3), (3, 2, 1)) * -0.5
     del tmp7
     tmp6 = einsum(v.ovov, (0, 1, 2, 3), r2, (4, 1, 2), (0, 4, 3))
-    tmp10 = f.oo.copy()
+    tmp10 = np.copy(f.oo)
     tmp10 += ints.tmp9 * 0.5
     del ints.tmp9
     tmp0 = einsum(r2, (0, 1, 2), t2, (3, 2, 0, 1), (3,))
@@ -940,22 +940,22 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp5
     tmp9 += tmp6
     del tmp6
-    tmp9 += tmp8.transpose((0, 2, 1)) * -1
+    tmp9 += np.transpose(tmp8, (0, 2, 1)) * -1
     del tmp8
     tmp4 = einsum(r2, (0, 1, 2), t2, (3, 4, 0, 1), (2, 3, 4))
-    tmp2 = f.ov.copy()
+    tmp2 = np.copy(f.ov)
     tmp2 += ints.tmp0
     del ints.tmp0
     tmp2 += ints.tmp3 * -0.5
     del ints.tmp3
     tmp2 += ints.tmp5 * -0.5
     del ints.tmp5
-    tmp3 = f.vv.copy()
+    tmp3 = np.copy(f.vv)
     tmp3 += ints.tmp2 * -0.5
     del ints.tmp2
-    tmp1 = ints.tmp4.copy() * 0.25
+    tmp1 = np.copy(ints.tmp4) * 0.25
     del ints.tmp4
-    tmp1 += v.ovvv.transpose((0, 2, 3, 1)) * 0.5
+    tmp1 += np.transpose(v.ovvv, (0, 2, 3, 1)) * 0.5
     tmp1 += ints.tmp6 * -1
     del ints.tmp6
     r2new = einsum(v.oovv, (0, 1, 2, 3), tmp4, (4, 1, 0), (2, 3, 4)) * -0.25
@@ -963,8 +963,8 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     r2new += einsum(v.oovv, (0, 1, 2, 3), tmp0, (1,), (2, 3, 0)) * 0.5
     r2new += einsum(v.vvvv, (0, 1, 2, 3), r2, (2, 3, 4), (0, 1, 4)) * 0.5
     r2new += einsum(v.ovvv, (0, 1, 2, 3), r1, (1,), (2, 3, 0)) * -1
-    r2new += tmp9.transpose((1, 2, 0)) * -1
-    r2new += tmp9.transpose((2, 1, 0))
+    r2new += np.transpose(tmp9, (1, 2, 0)) * -1
+    r2new += np.transpose(tmp9, (2, 1, 0))
     del tmp9
     r2new += einsum(tmp10, (0, 1), r2, (2, 3, 0), (2, 3, 1)) * -1
     del tmp10
@@ -1050,7 +1050,7 @@ def hbar_lmatvec_ee(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
 
     ints = kwargs["ints"]
     tmp2 = einsum(t2, (0, 1, 2, 3), r2, (4, 1, 2, 3), (4, 0))
-    tmp7 = f.oo.copy() * 2
+    tmp7 = np.copy(f.oo) * 2
     tmp7 += ints.tmp3
     del ints.tmp3
     tmp16 = einsum(r1, (0, 1), v.ooov, (2, 3, 0, 4), (2, 3, 1, 4))
@@ -1061,17 +1061,17 @@ def hbar_lmatvec_ee(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp13 = einsum(ints.tmp21, (0, 1, 2, 3), r2, (4, 0, 5, 2), (1, 4, 3, 5))
     del ints.tmp21
     tmp0 = einsum(r2, (0, 1, 2, 3), t2, (0, 1, 4, 3), (2, 4))
-    tmp21 = ints.tmp19.copy() * -1
+    tmp21 = np.copy(ints.tmp19) * -1
     del ints.tmp19
     tmp21 += v.oooo * -2
     tmp20 = einsum(r2, (0, 1, 2, 3), ints.tmp4, (3, 4), (0, 1, 4, 2))
-    tmp18 = tmp16.transpose((1, 0, 2, 3)).copy() * -1
+    tmp18 = np.copy(np.transpose(tmp16, (1, 0, 2, 3))) * -1
     del tmp16
-    tmp18 += tmp17.transpose((1, 0, 2, 3)) * -1
+    tmp18 += np.transpose(tmp17, (1, 0, 2, 3)) * -1
     del tmp17
-    tmp11 = tmp9.transpose((0, 1, 3, 2)).copy() * 0.5
+    tmp11 = np.copy(np.transpose(tmp9, (0, 1, 3, 2))) * 0.5
     del tmp9
-    tmp11 += tmp10.transpose((1, 0, 3, 2))
+    tmp11 += np.transpose(tmp10, (1, 0, 3, 2))
     del tmp10
     tmp15 = einsum(f.ov, (0, 1), r1, (2, 3), (0, 2, 1, 3))
     tmp15 += tmp13
@@ -1081,25 +1081,25 @@ def hbar_lmatvec_ee(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp8 = einsum(t2, (0, 1, 2, 3), r2, (4, 5, 2, 3), (4, 5, 0, 1))
     tmp19 = einsum(r1, (0, 1), v.ovvv, (2, 1, 3, 4), (0, 2, 3, 4))
     tmp12 = einsum(v.oovv, (0, 1, 2, 3), tmp0, (4, 3), (0, 1, 4, 2)) * -1
-    tmp5 = f.ov.copy()
+    tmp5 = np.copy(f.ov)
     tmp5 += ints.tmp0
     del ints.tmp0
     tmp5 += ints.tmp6 * -0.5
     del ints.tmp6
     tmp5 += ints.tmp9 * -0.5
     del ints.tmp9
-    tmp3 = ints.tmp8.copy() * 0.25
+    tmp3 = np.copy(ints.tmp8) * 0.25
     del ints.tmp8
-    tmp3 += v.ovvv.transpose((0, 2, 3, 1)) * 0.5
+    tmp3 += np.transpose(v.ovvv, (0, 2, 3, 1)) * 0.5
     tmp3 += ints.tmp11 * -1
     del ints.tmp11
     tmp1 = einsum(t2, (0, 1, 2, 3), r1, (1, 3), (0, 2))
-    tmp6 = f.vv.copy()
+    tmp6 = np.copy(f.vv)
     tmp6 += ints.tmp4 * -0.5
     del ints.tmp4
-    tmp4 = ints.tmp1.transpose((1, 2, 0, 3)).copy()
+    tmp4 = np.copy(np.transpose(ints.tmp1, (1, 2, 0, 3)))
     del ints.tmp1
-    tmp4 += ints.tmp7.transpose((0, 2, 1, 3)) * 2
+    tmp4 += np.transpose(ints.tmp7, (0, 2, 1, 3)) * 2
     del ints.tmp7
     tmp4 += ints.tmp10 * -0.5
     del ints.tmp10
@@ -1108,24 +1108,24 @@ def hbar_lmatvec_ee(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp8
     r2new += einsum(v.vvvv, (0, 1, 2, 3), r2, (4, 5, 2, 3), (4, 5, 0, 1)) * 0.5
     r2new += tmp11
-    r2new += tmp11.transpose((1, 0, 2, 3)) * -1
+    r2new += np.transpose(tmp11, (1, 0, 2, 3)) * -1
     del tmp11
     r2new += tmp12 * -0.5
-    r2new += tmp12.transpose((0, 1, 3, 2)) * 0.5
+    r2new += np.transpose(tmp12, (0, 1, 3, 2)) * 0.5
     del tmp12
     r2new += tmp15
-    r2new += tmp15.transpose((0, 1, 3, 2)) * -1
-    r2new += tmp15.transpose((1, 0, 2, 3)) * -1
-    r2new += tmp15.transpose((1, 0, 3, 2))
+    r2new += np.transpose(tmp15, (0, 1, 3, 2)) * -1
+    r2new += np.transpose(tmp15, (1, 0, 2, 3)) * -1
+    r2new += np.transpose(tmp15, (1, 0, 3, 2))
     del tmp15
     r2new += tmp18 * -1
-    r2new += tmp18.transpose((0, 1, 3, 2))
+    r2new += np.transpose(tmp18, (0, 1, 3, 2))
     del tmp18
-    r2new += tmp19.transpose((0, 1, 3, 2))
-    r2new += tmp19.transpose((1, 0, 3, 2)) * -1
+    r2new += np.transpose(tmp19, (0, 1, 3, 2))
+    r2new += np.transpose(tmp19, (1, 0, 3, 2)) * -1
     del tmp19
-    r2new += tmp20.transpose((1, 0, 2, 3)) * -0.5
-    r2new += tmp20.transpose((1, 0, 3, 2)) * 0.5
+    r2new += np.transpose(tmp20, (1, 0, 2, 3)) * -0.5
+    r2new += np.transpose(tmp20, (1, 0, 3, 2)) * 0.5
     del tmp20
     r2new += einsum(r2, (0, 1, 2, 3), tmp21, (1, 0, 4, 5), (4, 5, 2, 3)) * 0.25
     del tmp21

--- a/ebcc/codegen/GCCD.py
+++ b/ebcc/codegen/GCCD.py
@@ -277,7 +277,7 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.vvov = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[0], t2.shape[-1]))
     rdm2.vvvo = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[0]))
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.swapaxes(1, 2)
+    rdm2 = rdm2.transpose(0, 2, 1, 3)
 
     return rdm2
 

--- a/ebcc/codegen/GCCSD.py
+++ b/ebcc/codegen/GCCSD.py
@@ -725,7 +725,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp4, (2, 3), (0, 3, 1, 2)) * -1
     del tmp4, delta
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.swapaxes(1, 2)
+    rdm2 = rdm2.transpose(0, 2, 1, 3)
 
     return rdm2
 

--- a/ebcc/codegen/GCCSD.py
+++ b/ebcc/codegen/GCCSD.py
@@ -37,7 +37,7 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp0 = t2.copy()
+    tmp0 = np.copy(t2)
     tmp0 += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 2
     e_cc = einsum(t1, (0, 1), f.ov, (0, 1), ())
     e_cc += einsum(v.oovv, (0, 1, 2, 3), tmp0, (0, 1, 2, 3), ()) * 0.25
@@ -72,19 +72,19 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp20 = einsum(t2, (0, 1, 2, 3), f.ov, (4, 3), (4, 0, 1, 2))
     tmp3 = einsum(t1, (0, 1), v.oovv, (2, 0, 3, 1), (2, 3))
     tmp18 = einsum(v.oovv, (0, 1, 2, 3), t2, (0, 1, 4, 3), (4, 2))
-    tmp22 = tmp20.transpose((0, 2, 1, 3)).copy() * -1
+    tmp22 = np.copy(np.transpose(tmp20, (0, 2, 1, 3))) * -1
     del tmp20
-    tmp22 += tmp21.transpose((2, 1, 0, 3)) * 0.5
+    tmp22 += np.transpose(tmp21, (2, 1, 0, 3)) * 0.5
     del tmp21
     tmp11 = einsum(v.ovvv, (0, 1, 2, 3), t1, (0, 3), (1, 2))
     tmp13 = einsum(t2, (0, 1, 2, 3), v.oovv, (4, 1, 5, 3), (0, 4, 2, 5))
     tmp15 = einsum(tmp3, (0, 1), t2, (2, 3, 4, 1), (2, 3, 0, 4)) * -1
-    tmp42 = t2.copy()
+    tmp42 = np.copy(t2)
     tmp42 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 1, 3)) * -1
     tmp40 = einsum(t2, (0, 1, 2, 3), v.ooov, (4, 1, 5, 3), (0, 4, 5, 2))
     tmp5 = einsum(f.ov, (0, 1), t1, (2, 1), (0, 2))
     tmp28 = einsum(v.oovv, (0, 1, 2, 3), t2, (4, 1, 2, 3), (4, 0))
-    tmp7 = t2.copy()
+    tmp7 = np.copy(t2)
     tmp7 += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 2
     tmp30 = einsum(t1, (0, 1), v.ooov, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp0 = einsum(v.oovv, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
@@ -118,100 +118,100 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp36 = einsum(t2, (0, 1, 2, 3), tmp6, (1, 4), (0, 4, 2, 3)) * -1
     tmp38 = einsum(t2, (0, 1, 2, 3), tmp37, (4, 1), (4, 0, 2, 3)) * -1
     del tmp37
-    tmp24 = tmp19.copy() * 0.5
+    tmp24 = np.copy(tmp19) * 0.5
     del tmp19
-    tmp24 += tmp23.transpose((1, 0, 3, 2))
+    tmp24 += np.transpose(tmp23, (1, 0, 3, 2))
     del tmp23
-    tmp2 = t2.copy() * 0.5
+    tmp2 = np.copy(t2) * 0.5
     tmp2 += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3))
-    tmp17 = tmp12.copy()
+    tmp17 = np.copy(tmp12)
     del tmp12
     tmp17 += tmp14
     del tmp14
     tmp17 += tmp16 * -1
     del tmp16
-    tmp49 = v.oooo.copy()
+    tmp49 = np.copy(v.oooo)
     tmp49 += einsum(v.oovv, (0, 1, 2, 3), tmp7, (4, 5, 2, 3), (0, 1, 5, 4)) * -0.5
-    tmp44 = tmp41.copy()
+    tmp44 = np.copy(tmp41)
     del tmp41
     tmp44 += tmp43 * -1
     del tmp43
-    tmp32 = tmp27.transpose((0, 1, 3, 2)).copy()
+    tmp32 = np.copy(np.transpose(tmp27, (0, 1, 3, 2)))
     del tmp27
-    tmp32 += tmp29.transpose((0, 1, 3, 2)) * -0.5
+    tmp32 += np.transpose(tmp29, (0, 1, 3, 2)) * -0.5
     del tmp29
-    tmp32 += tmp31.transpose((0, 1, 3, 2)) * -1
+    tmp32 += np.transpose(tmp31, (0, 1, 3, 2)) * -1
     del tmp31
     tmp10 = einsum(tmp9, (0, 1, 2, 3), t2, (4, 1, 5, 3), (0, 4, 5, 2)) * -1
     del tmp9
     tmp34 = einsum(t1, (0, 1), tmp33, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp33
-    tmp47 = tmp45.transpose((1, 0, 2, 3)).copy() * -1
+    tmp47 = np.copy(np.transpose(tmp45, (1, 0, 2, 3))) * -1
     del tmp45
-    tmp47 += tmp46.transpose((1, 0, 2, 3)) * -1
+    tmp47 += np.transpose(tmp46, (1, 0, 2, 3)) * -1
     del tmp46
     tmp26 = einsum(t1, (0, 1), tmp25, (2, 3, 0, 4), (3, 2, 1, 4)) * -1
     del tmp25
-    tmp39 = tmp35.transpose((0, 1, 3, 2)).copy() * -1
+    tmp39 = np.copy(np.transpose(tmp35, (0, 1, 3, 2))) * -1
     del tmp35
-    tmp39 += tmp36.transpose((0, 1, 3, 2))
+    tmp39 += np.transpose(tmp36, (0, 1, 3, 2))
     del tmp36
-    tmp39 += tmp38.transpose((0, 1, 3, 2)) * -1
+    tmp39 += np.transpose(tmp38, (0, 1, 3, 2)) * -1
     del tmp38
     tmp48 = einsum(t2, (0, 1, 2, 3), f.oo, (4, 1), (4, 0, 2, 3))
-    tmp8 = f.oo.copy()
+    tmp8 = np.copy(f.oo)
     tmp8 += tmp5
     del tmp5
     tmp8 += tmp6
     del tmp6
     tmp8 += einsum(v.oovv, (0, 1, 2, 3), tmp7, (1, 4, 2, 3), (0, 4)) * -0.5
-    tmp1 = v.ovoo.transpose((0, 2, 3, 1)).copy() * -1
-    tmp1 += tmp0.transpose((0, 2, 1, 3)) * -1
+    tmp1 = np.copy(np.transpose(v.ovoo, (0, 2, 3, 1))) * -1
+    tmp1 += np.transpose(tmp0, (0, 2, 1, 3)) * -1
     del tmp0
-    tmp4 = f.ov.copy()
+    tmp4 = np.copy(f.ov)
     tmp4 += tmp3
     del tmp3
-    t2new = v.oovv.copy()
+    t2new = np.copy(v.oovv)
     t2new += tmp10
-    t2new += tmp10.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp10.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp10.transpose((1, 0, 3, 2))
+    t2new += np.transpose(tmp10, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp10, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp10, (1, 0, 3, 2))
     del tmp10
     t2new += tmp17
-    t2new += tmp17.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp17, (0, 1, 3, 2)) * -1
     del tmp17
     t2new += tmp24 * -1
-    t2new += tmp24.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp24, (0, 1, 3, 2))
     del tmp24
     t2new += tmp26 * -1
-    t2new += tmp26.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp26, (0, 1, 3, 2))
     del tmp26
     t2new += tmp32 * -1
-    t2new += tmp32.transpose((1, 0, 2, 3))
+    t2new += np.transpose(tmp32, (1, 0, 2, 3))
     del tmp32
     t2new += tmp34 * -1
-    t2new += tmp34.transpose((0, 1, 3, 2))
-    t2new += tmp34.transpose((1, 0, 2, 3))
-    t2new += tmp34.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp34, (0, 1, 3, 2))
+    t2new += np.transpose(tmp34, (1, 0, 2, 3))
+    t2new += np.transpose(tmp34, (1, 0, 3, 2)) * -1
     del tmp34
     t2new += tmp39 * -1
-    t2new += tmp39.transpose((1, 0, 2, 3))
+    t2new += np.transpose(tmp39, (1, 0, 2, 3))
     del tmp39
     t2new += tmp44
-    t2new += tmp44.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp44.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp44.transpose((1, 0, 3, 2))
+    t2new += np.transpose(tmp44, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp44, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp44, (1, 0, 3, 2))
     del tmp44
     t2new += tmp47 * -1
-    t2new += tmp47.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp47, (0, 1, 3, 2))
     del tmp47
-    t2new += tmp48.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp48.transpose((1, 0, 3, 2))
+    t2new += np.transpose(tmp48, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp48, (1, 0, 3, 2))
     del tmp48
     t2new += einsum(tmp7, (0, 1, 2, 3), tmp49, (0, 1, 4, 5), (4, 5, 3, 2)) * -0.5
     del tmp7, tmp49
     t2new += einsum(tmp2, (0, 1, 2, 3), v.vvvv, (4, 5, 2, 3), (1, 0, 4, 5)) * -1
-    t1new = f.ov.copy()
+    t1new = np.copy(f.ov)
     t1new += einsum(t1, (0, 1), v.ovov, (2, 1, 0, 3), (2, 3)) * -1
     t1new += einsum(f.vv, (0, 1), t1, (2, 1), (2, 0))
     t1new += einsum(t2, (0, 1, 2, 3), tmp1, (4, 0, 1, 3), (4, 2)) * 0.5
@@ -262,25 +262,25 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp1 = einsum(t1, (0, 1), v.ovvv, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp2 = einsum(l2, (0, 1, 2, 3), t1, (4, 1), (2, 3, 4, 0))
     tmp17 = einsum(t2, (0, 1, 2, 3), l2, (4, 3, 0, 1), (4, 2))
-    tmp6 = v.ovoo.transpose((0, 2, 3, 1)).copy() * -1
-    tmp6 += tmp5.transpose((0, 2, 1, 3)) * -1
-    tmp35 = tmp23.copy()
+    tmp6 = np.copy(np.transpose(v.ovoo, (0, 2, 3, 1))) * -1
+    tmp6 += np.transpose(tmp5, (0, 2, 1, 3)) * -1
+    tmp35 = np.copy(tmp23)
     tmp35 += tmp34 * 0.5
     del tmp34
-    tmp45 = tmp19.copy()
+    tmp45 = np.copy(tmp19)
     tmp45 += tmp20 * 0.5
     tmp43 = einsum(f.ov, (0, 1), t1, (2, 1), (0, 2))
-    tmp47 = tmp25.copy() * 2
-    tmp47 += tmp26.transpose((1, 0))
+    tmp47 = np.copy(tmp25) * 2
+    tmp47 += np.transpose(tmp26, (1, 0))
     tmp39 = einsum(v.oovv, (0, 1, 2, 3), t2, (4, 1, 5, 3), (4, 0, 5, 2))
-    tmp29 = v.ovov.transpose((0, 2, 3, 1)).copy() * -1
+    tmp29 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -1
     tmp29 += tmp1
     tmp7 = einsum(t1, (0, 1), v.oovv, (2, 0, 3, 1), (2, 3))
     tmp4 = einsum(t1, (0, 1), tmp2, (2, 3, 4, 1), (3, 2, 4, 0))
     tmp3 = einsum(l2, (0, 1, 2, 3), t2, (4, 5, 0, 1), (2, 3, 4, 5))
     tmp10 = einsum(v.oovv, (0, 1, 2, 3), t2, (4, 5, 2, 3), (4, 5, 0, 1))
-    tmp11 = v.ooov.copy()
-    tmp11 += tmp5.transpose((2, 1, 0, 3)) * 0.5
+    tmp11 = np.copy(v.ooov)
+    tmp11 += np.transpose(tmp5, (2, 1, 0, 3)) * 0.5
     tmp32 = einsum(f.ov, (0, 1), tmp2, (2, 3, 0, 4), (2, 3, 1, 4))
     tmp33 = einsum(v.oovv, (0, 1, 2, 3), tmp17, (4, 3), (0, 1, 4, 2)) * -1
     tmp37 = einsum(tmp6, (0, 1, 2, 3), l1, (4, 0), (1, 2, 3, 4))
@@ -304,34 +304,34 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp50 = einsum(t1, (0, 1), tmp7, (2, 1), (0, 2))
     tmp56 = einsum(v.ovvv, (0, 1, 2, 3), l1, (1, 4), (4, 0, 2, 3))
     tmp55 = einsum(l2, (0, 1, 2, 3), f.oo, (4, 3), (4, 2, 0, 1))
-    tmp8 = f.ov.copy()
+    tmp8 = np.copy(f.ov)
     tmp8 += tmp7
-    tmp21 = tmp19.copy() * 2
+    tmp21 = np.copy(tmp19) * 2
     del tmp19
     tmp21 += tmp20
     del tmp20
-    tmp15 = tmp3.transpose((1, 0, 3, 2)).copy() * -0.5
-    tmp15 += tmp4.transpose((0, 1, 3, 2))
-    tmp9 = v.ovov.transpose((0, 2, 1, 3)).copy()
-    tmp9 += tmp1.transpose((0, 1, 3, 2)) * -0.5
-    tmp12 = v.oooo.copy() * -0.5
-    tmp12 += tmp10.transpose((3, 2, 1, 0)) * -0.25
+    tmp15 = np.copy(np.transpose(tmp3, (1, 0, 3, 2))) * -0.5
+    tmp15 += np.transpose(tmp4, (0, 1, 3, 2))
+    tmp9 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3)))
+    tmp9 += np.transpose(tmp1, (0, 1, 3, 2)) * -0.5
+    tmp12 = np.copy(v.oooo) * -0.5
+    tmp12 += np.transpose(tmp10, (3, 2, 1, 0)) * -0.25
     tmp12 += einsum(t1, (0, 1), tmp11, (2, 3, 4, 1), (3, 2, 0, 4)) * -1
-    tmp38 = tmp32.copy() * -1
+    tmp38 = np.copy(tmp32) * -1
     del tmp32
     tmp38 += tmp33 * 0.5
     del tmp33
-    tmp38 += tmp36.transpose((1, 0, 3, 2))
+    tmp38 += np.transpose(tmp36, (1, 0, 3, 2))
     del tmp36
-    tmp38 += tmp37.transpose((1, 0, 3, 2))
+    tmp38 += np.transpose(tmp37, (1, 0, 3, 2))
     del tmp37
-    tmp49 = tmp44.transpose((0, 1, 3, 2)).copy()
+    tmp49 = np.copy(np.transpose(tmp44, (0, 1, 3, 2)))
     del tmp44
-    tmp49 += tmp46.transpose((0, 1, 3, 2)) * -1
+    tmp49 += np.transpose(tmp46, (0, 1, 3, 2)) * -1
     del tmp46
-    tmp49 += tmp48.transpose((1, 0, 3, 2))
+    tmp49 += np.transpose(tmp48, (1, 0, 3, 2))
     del tmp48
-    tmp42 = tmp40.copy()
+    tmp42 = np.copy(tmp40)
     del tmp40
     tmp42 += tmp41 * -1
     del tmp41
@@ -339,30 +339,30 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp7
     tmp31 += tmp28
     del tmp28
-    tmp31 += tmp30.transpose((1, 0, 3, 2))
+    tmp31 += np.transpose(tmp30, (1, 0, 3, 2))
     del tmp30
-    tmp54 = tmp52.transpose((1, 0, 2, 3)).copy() * -1
+    tmp54 = np.copy(np.transpose(tmp52, (1, 0, 2, 3))) * -1
     del tmp52
     tmp54 += tmp53
     del tmp53
     tmp51 = einsum(tmp50, (0, 1), l2, (2, 3, 4, 0), (4, 1, 2, 3))
     del tmp50
-    tmp57 = tmp55.transpose((0, 1, 3, 2)).copy() * -1
+    tmp57 = np.copy(np.transpose(tmp55, (0, 1, 3, 2))) * -1
     del tmp55
-    tmp57 += tmp56.transpose((0, 1, 3, 2))
+    tmp57 += np.transpose(tmp56, (0, 1, 3, 2))
     del tmp56
-    tmp58 = v.oooo.copy()
-    tmp58 += tmp10.transpose((1, 0, 3, 2)) * 0.5
+    tmp58 = np.copy(v.oooo)
+    tmp58 += np.transpose(tmp10, (1, 0, 3, 2)) * 0.5
     del tmp10
     tmp58 += einsum(tmp11, (0, 1, 2, 3), t1, (4, 3), (2, 4, 1, 0)) * -2
     del tmp11
-    tmp59 = tmp3.transpose((1, 0, 3, 2)).copy() * -1
-    tmp59 += tmp4.transpose((0, 1, 3, 2)) * 2
-    tmp24 = f.vv.copy()
+    tmp59 = np.copy(np.transpose(tmp3, (1, 0, 3, 2))) * -1
+    tmp59 += np.transpose(tmp4, (0, 1, 3, 2)) * 2
+    tmp24 = np.copy(f.vv)
     tmp24 += tmp23 * -1
     del tmp23
-    tmp27 = f.oo.copy()
-    tmp27 += tmp25.transpose((1, 0))
+    tmp27 = np.copy(f.oo)
+    tmp27 += np.transpose(tmp25, (1, 0))
     del tmp25
     tmp27 += tmp26 * 0.5
     del tmp26
@@ -371,17 +371,17 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp18 += tmp17 * 0.5
     del tmp17
     tmp0 = einsum(l2, (0, 1, 2, 3), t2, (4, 3, 5, 1), (2, 4, 0, 5))
-    tmp22 = t1.copy() * -2
+    tmp22 = np.copy(t1) * -2
     tmp22 += einsum(l1, (0, 1), t2, (2, 1, 3, 0), (2, 3)) * -2
     tmp22 += einsum(t2, (0, 1, 2, 3), tmp2, (1, 0, 4, 3), (4, 2))
     tmp22 += einsum(t1, (0, 1), tmp21, (0, 2), (2, 1))
-    tmp14 = v.ovvv.copy()
+    tmp14 = np.copy(v.ovvv)
     tmp14 += einsum(v.vvvv, (0, 1, 2, 3), t1, (4, 1), (4, 0, 2, 3)) * -1
     tmp16 = einsum(t2, (0, 1, 2, 3), l1, (3, 4), (4, 0, 1, 2))
     tmp16 += einsum(t2, (0, 1, 2, 3), tmp2, (4, 1, 5, 3), (4, 0, 5, 2)) * -2
     tmp16 += einsum(tmp15, (0, 1, 2, 3), t1, (0, 4), (1, 3, 2, 4)) * -1
     del tmp15
-    tmp13 = v.ovoo.transpose((0, 2, 3, 1)).copy() * -1
+    tmp13 = np.copy(np.transpose(v.ovoo, (0, 2, 3, 1))) * -1
     tmp13 += einsum(v.ovvv, (0, 1, 2, 3), t2, (4, 5, 2, 3), (0, 4, 5, 1)) * -0.5
     tmp13 += einsum(t2, (0, 1, 2, 3), tmp6, (4, 1, 5, 3), (5, 0, 4, 2)) * 2
     del tmp6
@@ -391,36 +391,36 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp13 += einsum(t1, (0, 1), tmp12, (0, 2, 3, 4), (2, 4, 3, 1)) * -2
     del tmp12
     l2new = einsum(v.ovvv, (0, 1, 2, 3), tmp2, (4, 5, 0, 1), (2, 3, 4, 5))
-    l2new += v.oovv.transpose((2, 3, 0, 1))
+    l2new += np.transpose(v.oovv, (2, 3, 0, 1))
     l2new += einsum(l2, (0, 1, 2, 3), v.vvvv, (4, 5, 0, 1), (4, 5, 2, 3)) * 0.5
-    l2new += tmp31.transpose((2, 3, 0, 1))
-    l2new += tmp31.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp31.transpose((2, 3, 1, 0)) * -1
-    l2new += tmp31.transpose((3, 2, 1, 0))
+    l2new += np.transpose(tmp31, (2, 3, 0, 1))
+    l2new += np.transpose(tmp31, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp31, (2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp31, (3, 2, 1, 0))
     del tmp31
-    l2new += tmp38.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp38.transpose((3, 2, 0, 1))
+    l2new += np.transpose(tmp38, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp38, (3, 2, 0, 1))
     del tmp38
-    l2new += tmp42.transpose((2, 3, 0, 1))
-    l2new += tmp42.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp42.transpose((2, 3, 1, 0)) * -1
-    l2new += tmp42.transpose((3, 2, 1, 0))
+    l2new += np.transpose(tmp42, (2, 3, 0, 1))
+    l2new += np.transpose(tmp42, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp42, (2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp42, (3, 2, 1, 0))
     del tmp42
-    l2new += tmp49.transpose((3, 2, 0, 1))
-    l2new += tmp49.transpose((3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp49, (3, 2, 0, 1))
+    l2new += np.transpose(tmp49, (3, 2, 1, 0)) * -1
     del tmp49
-    l2new += tmp51.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp51.transpose((2, 3, 1, 0))
+    l2new += np.transpose(tmp51, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp51, (2, 3, 1, 0))
     del tmp51
-    l2new += tmp54.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp54.transpose((3, 2, 0, 1))
+    l2new += np.transpose(tmp54, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp54, (3, 2, 0, 1))
     del tmp54
     l2new += einsum(l1, (0, 1), f.ov, (2, 3), (3, 0, 2, 1))
     l2new += einsum(l1, (0, 1), f.ov, (2, 3), (0, 3, 2, 1)) * -1
     l2new += einsum(f.ov, (0, 1), l1, (2, 3), (1, 2, 3, 0)) * -1
     l2new += einsum(l1, (0, 1), f.ov, (2, 3), (0, 3, 1, 2))
-    l2new += tmp57.transpose((2, 3, 0, 1))
-    l2new += tmp57.transpose((2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp57, (2, 3, 0, 1))
+    l2new += np.transpose(tmp57, (2, 3, 1, 0)) * -1
     del tmp57
     l2new += einsum(tmp58, (0, 1, 2, 3), l2, (4, 5, 0, 1), (4, 5, 2, 3)) * 0.5
     del tmp58
@@ -437,7 +437,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp3
     l1new += einsum(tmp4, (0, 1, 2, 3), v.ooov, (2, 3, 1, 4), (4, 0)) * -0.5
     del tmp4
-    l1new += f.ov.transpose((1, 0))
+    l1new += np.transpose(f.ov, (1, 0))
     l1new += einsum(l2, (0, 1, 2, 3), tmp13, (4, 2, 3, 1), (0, 4)) * 0.5
     del tmp13
     l1new += einsum(l2, (0, 1, 2, 3), tmp14, (3, 4, 0, 1), (4, 2)) * -0.5
@@ -487,22 +487,22 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp1 = einsum(l2, (0, 1, 2, 3), t2, (4, 3, 0, 1), (2, 4))
     tmp0 = einsum(t1, (0, 1), l1, (1, 2), (2, 0))
     tmp2 = einsum(l2, (0, 1, 2, 3), t1, (4, 1), (2, 3, 4, 0))
-    tmp3 = tmp0.copy()
+    tmp3 = np.copy(tmp0)
     tmp3 += tmp1 * 0.5
     rdm1.vv = einsum(t1, (0, 1), l1, (2, 0), (2, 1))
     rdm1.vv += einsum(t2, (0, 1, 2, 3), l2, (4, 3, 0, 1), (4, 2)) * 0.5
-    rdm1.vo = l1.copy()
-    rdm1.ov = t1.copy()
+    rdm1.vo = np.copy(l1)
+    rdm1.ov = np.copy(t1)
     rdm1.ov += einsum(t2, (0, 1, 2, 3), tmp2, (1, 0, 4, 3), (4, 2)) * -0.5
     del tmp2
     rdm1.ov += einsum(l1, (0, 1), t2, (2, 1, 3, 0), (2, 3))
     rdm1.ov += einsum(tmp3, (0, 1), t1, (0, 2), (1, 2)) * -1
     del tmp3
-    rdm1.oo = delta.oo.copy()
+    rdm1.oo = np.copy(delta.oo)
     del delta
-    rdm1.oo += tmp0.transpose((1, 0)) * -1
+    rdm1.oo += np.transpose(tmp0, (1, 0)) * -1
     del tmp0
-    rdm1.oo += tmp1.transpose((1, 0)) * -0.5
+    rdm1.oo += np.transpose(tmp1, (1, 0)) * -0.5
     del tmp1
     rdm1 = np.block([[rdm1.oo, rdm1.ov], [rdm1.vo, rdm1.vv]])
 
@@ -544,52 +544,52 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp5 = einsum(t2, (0, 1, 2, 3), l1, (3, 4), (4, 0, 1, 2))
     tmp2 = einsum(t1, (0, 1), tmp1, (2, 3, 4, 1), (2, 3, 0, 4))
     tmp0 = einsum(l2, (0, 1, 2, 3), t2, (4, 5, 0, 1), (2, 3, 4, 5))
-    tmp14 = tmp4.copy() * 2
+    tmp14 = np.copy(tmp4) * 2
     tmp14 += tmp3
     tmp25 = einsum(t2, (0, 1, 2, 3), l2, (4, 3, 0, 1), (4, 2))
     tmp30 = einsum(t1, (0, 1), l1, (2, 0), (2, 1))
     tmp29 = einsum(tmp1, (0, 1, 2, 3), t1, (1, 4), (0, 2, 3, 4))
     tmp36 = einsum(t1, (0, 1), tmp21, (0, 2, 3, 4), (2, 3, 1, 4))
-    tmp9 = tmp7.copy()
+    tmp9 = np.copy(tmp7)
     tmp9 += tmp8 * -1
     del tmp8
     tmp18 = einsum(t1, (0, 1), tmp6, (0, 2, 3, 4), (2, 3, 1, 4))
     tmp20 = einsum(t1, (0, 1), tmp5, (0, 2, 3, 4), (2, 3, 1, 4))
     tmp22 = einsum(t2, (0, 1, 2, 3), tmp21, (1, 4, 3, 5), (0, 4, 2, 5))
-    tmp13 = tmp0.transpose((1, 0, 3, 2)).copy() * -0.5
-    tmp13 += tmp2.transpose((0, 1, 3, 2))
+    tmp13 = np.copy(np.transpose(tmp0, (1, 0, 3, 2))) * -0.5
+    tmp13 += np.transpose(tmp2, (0, 1, 3, 2))
     tmp10 = einsum(t2, (0, 1, 2, 3), tmp1, (1, 0, 4, 3), (4, 2))
     tmp11 = einsum(tmp3, (0, 1), t1, (0, 2), (1, 2))
     tmp15 = einsum(tmp14, (0, 1), t1, (0, 2), (1, 2)) * 0.5
     del tmp14
     tmp38 = einsum(l2, (0, 1, 2, 3), t1, (3, 4), (2, 0, 1, 4))
-    tmp32 = tmp30.copy()
+    tmp32 = np.copy(tmp30)
     tmp32 += tmp25 * 0.5
     tmp34 = einsum(tmp1, (0, 1, 2, 3), t2, (1, 0, 4, 5), (2, 3, 4, 5)) * -1
     tmp35 = einsum(tmp29, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4)) * -1
     tmp33 = einsum(l1, (0, 1), t2, (2, 1, 3, 4), (2, 0, 3, 4))
-    tmp37 = tmp36.copy()
+    tmp37 = np.copy(tmp36)
     tmp37 += einsum(tmp25, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * -0.5
-    tmp31 = tmp30.copy() * 2
+    tmp31 = np.copy(tmp30) * 2
     tmp31 += tmp25
     tmp27 = einsum(t2, (0, 1, 2, 3), tmp3, (1, 4), (0, 4, 2, 3))
     tmp24 = einsum(t2, (0, 1, 2, 3), tmp4, (1, 4), (4, 0, 2, 3))
-    tmp19 = tmp18.copy()
+    tmp19 = np.copy(tmp18)
     del tmp18
     tmp19 += einsum(t1, (0, 1), tmp9, (2, 3), (0, 2, 1, 3)) * -1
-    tmp23 = tmp20.copy()
+    tmp23 = np.copy(tmp20)
     del tmp20
     tmp23 += tmp22
     del tmp22
     tmp28 = einsum(t1, (0, 1), tmp13, (0, 2, 3, 4), (2, 4, 3, 1)) * -2
     tmp26 = einsum(tmp25, (0, 1), t2, (2, 3, 4, 0), (2, 3, 4, 1))
     del tmp25
-    tmp12 = tmp10.copy()
+    tmp12 = np.copy(tmp10)
     tmp12 += tmp11
     del tmp11
-    tmp17 = tmp0.transpose((1, 0, 3, 2)).copy() * -1
-    tmp17 += tmp2.transpose((0, 1, 3, 2)) * 2
-    tmp16 = tmp7.copy() * -1
+    tmp17 = np.copy(np.transpose(tmp0, (1, 0, 3, 2))) * -1
+    tmp17 += np.transpose(tmp2, (0, 1, 3, 2)) * 2
+    tmp16 = np.copy(tmp7) * -1
     del tmp7
     tmp16 += tmp10 * 0.5
     del tmp10
@@ -597,69 +597,69 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp15
     rdm2.vvvv = einsum(t2, (0, 1, 2, 3), l2, (4, 5, 0, 1), (4, 5, 2, 3)) * 0.5
     rdm2.vvvv += einsum(tmp38, (0, 1, 2, 3), t1, (0, 4), (1, 2, 4, 3))
-    rdm2.vvvo = tmp38.transpose((2, 1, 3, 0)).copy()
-    rdm2.vvov = tmp38.transpose((2, 1, 0, 3)).copy() * -1
+    rdm2.vvvo = np.copy(np.transpose(tmp38, (2, 1, 3, 0)))
+    rdm2.vvov = np.copy(np.transpose(tmp38, (2, 1, 0, 3))) * -1
     del tmp38
-    rdm2.vovv = tmp33.transpose((1, 0, 3, 2)).copy()
-    rdm2.vovv += tmp34.transpose((1, 0, 3, 2)) * 0.5
-    rdm2.vovv += tmp35.transpose((1, 0, 3, 2))
+    rdm2.vovv = np.copy(np.transpose(tmp33, (1, 0, 3, 2)))
+    rdm2.vovv += np.transpose(tmp34, (1, 0, 3, 2)) * 0.5
+    rdm2.vovv += np.transpose(tmp35, (1, 0, 3, 2))
     rdm2.vovv += einsum(tmp32, (0, 1), t1, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.vovv += einsum(t1, (0, 1), tmp32, (2, 3), (2, 0, 3, 1))
-    rdm2.vovv += tmp36.transpose((1, 0, 2, 3))
-    rdm2.vovv += tmp36.transpose((1, 0, 3, 2)) * -1
+    rdm2.vovv += np.transpose(tmp36, (1, 0, 2, 3))
+    rdm2.vovv += np.transpose(tmp36, (1, 0, 3, 2)) * -1
     del tmp36
-    rdm2.ovvv = tmp33.transpose((0, 1, 3, 2)).copy() * -1
+    rdm2.ovvv = np.copy(np.transpose(tmp33, (0, 1, 3, 2))) * -1
     del tmp33
-    rdm2.ovvv += tmp34.transpose((0, 1, 3, 2)) * -0.5
+    rdm2.ovvv += np.transpose(tmp34, (0, 1, 3, 2)) * -0.5
     del tmp34
-    rdm2.ovvv += tmp35.transpose((0, 1, 3, 2)) * -1
+    rdm2.ovvv += np.transpose(tmp35, (0, 1, 3, 2)) * -1
     del tmp35
     rdm2.ovvv += einsum(tmp30, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     rdm2.ovvv += einsum(t1, (0, 1), tmp30, (2, 3), (0, 2, 3, 1)) * -1
     del tmp30
     rdm2.ovvv += tmp37 * -1
-    rdm2.ovvv += tmp37.transpose((0, 1, 3, 2))
+    rdm2.ovvv += np.transpose(tmp37, (0, 1, 3, 2))
     del tmp37
-    rdm2.vvoo = l2.copy()
-    rdm2.vovo = tmp21.transpose((2, 1, 3, 0)).copy() * -1
-    rdm2.vovo += tmp29.transpose((2, 1, 3, 0))
+    rdm2.vvoo = np.copy(l2)
+    rdm2.vovo = np.copy(np.transpose(tmp21, (2, 1, 3, 0))) * -1
+    rdm2.vovo += np.transpose(tmp29, (2, 1, 3, 0))
     rdm2.vovo += einsum(l1, (0, 1), t1, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.vovo += einsum(tmp32, (0, 1), delta.oo, (2, 3), (0, 2, 1, 3))
-    rdm2.voov = tmp21.transpose((2, 1, 0, 3)).copy()
-    rdm2.voov += tmp29.transpose((2, 1, 0, 3)) * -1
+    rdm2.voov = np.copy(np.transpose(tmp21, (2, 1, 0, 3)))
+    rdm2.voov += np.transpose(tmp29, (2, 1, 0, 3)) * -1
     rdm2.voov += einsum(l1, (0, 1), t1, (2, 3), (0, 2, 1, 3))
     rdm2.voov += einsum(tmp31, (0, 1), delta.oo, (2, 3), (0, 2, 3, 1)) * -0.5
-    rdm2.ovvo = tmp21.transpose((1, 2, 3, 0)).copy()
-    rdm2.ovvo += tmp29.transpose((1, 2, 3, 0)) * -1
+    rdm2.ovvo = np.copy(np.transpose(tmp21, (1, 2, 3, 0)))
+    rdm2.ovvo += np.transpose(tmp29, (1, 2, 3, 0)) * -1
     rdm2.ovvo += einsum(l1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     rdm2.ovvo += einsum(tmp32, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * -1
     del tmp32
-    rdm2.ovov = tmp21.transpose((1, 2, 0, 3)).copy() * -1
+    rdm2.ovov = np.copy(np.transpose(tmp21, (1, 2, 0, 3))) * -1
     del tmp21
-    rdm2.ovov += tmp29.transpose((1, 2, 0, 3))
+    rdm2.ovov += np.transpose(tmp29, (1, 2, 0, 3))
     del tmp29
     rdm2.ovov += einsum(l1, (0, 1), t1, (2, 3), (2, 0, 1, 3)) * -1
     rdm2.ovov += einsum(tmp31, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1)) * 0.5
     del tmp31
-    rdm2.oovv = t2.copy()
+    rdm2.oovv = np.copy(t2)
     rdm2.oovv += tmp19 * -1
-    rdm2.oovv += tmp19.transpose((0, 1, 3, 2))
-    rdm2.oovv += tmp19.transpose((1, 0, 2, 3))
-    rdm2.oovv += tmp19.transpose((1, 0, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp19, (0, 1, 3, 2))
+    rdm2.oovv += np.transpose(tmp19, (1, 0, 2, 3))
+    rdm2.oovv += np.transpose(tmp19, (1, 0, 3, 2)) * -1
     del tmp19
     rdm2.oovv += tmp23
-    rdm2.oovv += tmp23.transpose((0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp23, (0, 1, 3, 2)) * -1
     del tmp23
-    rdm2.oovv += tmp24.transpose((0, 1, 3, 2)) * -1
-    rdm2.oovv += tmp24.transpose((1, 0, 3, 2))
+    rdm2.oovv += np.transpose(tmp24, (0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp24, (1, 0, 3, 2))
     del tmp24
     rdm2.oovv += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 1, 3)) * -1
     rdm2.oovv += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3))
     rdm2.oovv += tmp26 * -0.5
-    rdm2.oovv += tmp26.transpose((0, 1, 3, 2)) * 0.5
+    rdm2.oovv += np.transpose(tmp26, (0, 1, 3, 2)) * 0.5
     del tmp26
-    rdm2.oovv += tmp27.transpose((0, 1, 3, 2)) * 0.5
-    rdm2.oovv += tmp27.transpose((1, 0, 3, 2)) * -0.5
+    rdm2.oovv += np.transpose(tmp27, (0, 1, 3, 2)) * 0.5
+    rdm2.oovv += np.transpose(tmp27, (1, 0, 3, 2)) * -0.5
     del tmp27
     rdm2.oovv += einsum(t1, (0, 1), tmp12, (2, 3), (0, 2, 1, 3)) * -0.5
     rdm2.oovv += einsum(tmp12, (0, 1), t1, (2, 3), (2, 0, 1, 3)) * 0.5
@@ -668,16 +668,16 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oovv += einsum(tmp13, (0, 1, 2, 3), t2, (0, 1, 4, 5), (3, 2, 4, 5)) * 0.5
     rdm2.oovv += einsum(t1, (0, 1), tmp28, (0, 2, 3, 4), (2, 3, 1, 4)) * 0.5
     del tmp28
-    rdm2.vooo = tmp1.transpose((3, 2, 1, 0)).copy()
+    rdm2.vooo = np.copy(np.transpose(tmp1, (3, 2, 1, 0)))
     rdm2.vooo += einsum(delta.oo, (0, 1), l1, (2, 3), (2, 0, 3, 1))
     rdm2.vooo += einsum(l1, (0, 1), delta.oo, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.ovoo = tmp1.transpose((2, 3, 1, 0)).copy() * -1
+    rdm2.ovoo = np.copy(np.transpose(tmp1, (2, 3, 1, 0))) * -1
     del tmp1
     rdm2.ovoo += einsum(delta.oo, (0, 1), l1, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.ovoo += einsum(l1, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1))
-    rdm2.oovo = tmp5.transpose((2, 1, 3, 0)).copy()
-    rdm2.oovo += tmp6.transpose((1, 2, 3, 0))
-    rdm2.oovo += tmp6.transpose((2, 1, 3, 0)) * -1
+    rdm2.oovo = np.copy(np.transpose(tmp5, (2, 1, 3, 0)))
+    rdm2.oovo += np.transpose(tmp6, (1, 2, 3, 0))
+    rdm2.oovo += np.transpose(tmp6, (2, 1, 3, 0)) * -1
     rdm2.oovo += einsum(t1, (0, 1), tmp3, (2, 3), (0, 3, 1, 2)) * -0.5
     rdm2.oovo += einsum(t1, (0, 1), tmp3, (2, 3), (3, 0, 1, 2)) * 0.5
     rdm2.oovo += einsum(delta.oo, (0, 1), tmp16, (2, 3), (2, 0, 3, 1)) * -1
@@ -689,10 +689,10 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oovo += einsum(t1, (0, 1), tmp4, (2, 3), (3, 0, 1, 2))
     rdm2.oovo += einsum(t1, (0, 1), tmp17, (0, 2, 3, 4), (4, 3, 1, 2)) * 0.5
     del tmp17
-    rdm2.ooov = tmp5.transpose((2, 1, 0, 3)).copy() * -1
+    rdm2.ooov = np.copy(np.transpose(tmp5, (2, 1, 0, 3))) * -1
     del tmp5
-    rdm2.ooov += tmp6.transpose((1, 2, 0, 3)) * -1
-    rdm2.ooov += tmp6.transpose((2, 1, 0, 3))
+    rdm2.ooov += np.transpose(tmp6, (1, 2, 0, 3)) * -1
+    rdm2.ooov += np.transpose(tmp6, (2, 1, 0, 3))
     del tmp6
     rdm2.ooov += einsum(t1, (0, 1), tmp3, (2, 3), (0, 3, 2, 1)) * 0.5
     rdm2.ooov += einsum(t1, (0, 1), tmp3, (2, 3), (3, 0, 2, 1)) * -0.5
@@ -708,9 +708,9 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.ooov += einsum(t1, (0, 1), tmp4, (2, 3), (3, 0, 2, 1)) * -1
     rdm2.ooov += einsum(tmp13, (0, 1, 2, 3), t1, (0, 4), (3, 2, 1, 4)) * -1
     del tmp13
-    rdm2.oooo = tmp0.transpose((3, 2, 1, 0)).copy() * 0.5
+    rdm2.oooo = np.copy(np.transpose(tmp0, (3, 2, 1, 0))) * 0.5
     del tmp0
-    rdm2.oooo += tmp2.transpose((2, 3, 1, 0)) * -1
+    rdm2.oooo += np.transpose(tmp2, (2, 3, 1, 0)) * -1
     del tmp2
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp3, (2, 3), (3, 0, 2, 1)) * -0.5
     rdm2.oooo += einsum(tmp3, (0, 1), delta.oo, (2, 3), (2, 1, 0, 3)) * 0.5
@@ -725,7 +725,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp4, (2, 3), (0, 3, 1, 2)) * -1
     del tmp4, delta
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.transpose(0, 2, 1, 3)
+    rdm2 = np.transpose(rdm2, (0, 2, 1, 3))
 
     return rdm2
 
@@ -855,20 +855,20 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     ints = kwargs["ints"]
     tmp10 = einsum(v.ooov, (0, 1, 2, 3), r2, (4, 1, 3), (4, 0, 2))
     tmp9 = einsum(r2, (0, 1, 2), ints.tmp3, (3, 1, 4, 2), (3, 4, 0))
-    tmp7 = ints.tmp25.copy()
+    tmp7 = np.copy(ints.tmp25)
     tmp7 += ints.tmp35
-    tmp13 = ints.tmp41.copy()
-    tmp13 += ints.tmp46.transpose((0, 2, 1, 3))
-    tmp11 = tmp9.copy()
+    tmp13 = np.copy(ints.tmp41)
+    tmp13 += np.transpose(ints.tmp46, (0, 2, 1, 3))
+    tmp11 = np.copy(tmp9)
     del tmp9
     tmp11 += tmp10 * -1
     del tmp10
-    tmp18 = ints.tmp17.copy()
+    tmp18 = np.copy(ints.tmp17)
     tmp18 += ints.tmp28
-    tmp16 = f.oo.copy()
+    tmp16 = np.copy(f.oo)
     tmp16 += ints.tmp0
     tmp16 += ints.tmp1
-    tmp16 += ints.tmp5.transpose((1, 0))
+    tmp16 += np.transpose(ints.tmp5, (1, 0))
     tmp8 = einsum(tmp7, (0, 1, 2, 3), r2, (4, 1, 3), (0, 4, 2)) * -1
     del tmp7
     tmp4 = einsum(r2, (0, 1, 2), ints.tmp4, (3, 1), (3, 0, 2))
@@ -878,21 +878,21 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp6 = einsum(r2, (0, 1, 2), v.ovov, (3, 2, 1, 4), (0, 3, 4))
     tmp12 = einsum(t1, (0, 1), tmp11, (2, 0, 3), (2, 3, 1))
     del tmp11
-    tmp22 = f.ov.copy()
+    tmp22 = np.copy(f.ov)
     tmp22 += ints.tmp2
     tmp19 = einsum(r1, (0,), tmp18, (1, 0, 2, 3), (1, 2, 3))
     del tmp18
     tmp17 = einsum(tmp16, (0, 1), r2, (2, 0, 3), (1, 2, 3)) * -1
     del tmp16
-    tmp24 = ints.tmp12.copy()
-    tmp24 += ints.tmp15.transpose((2, 0, 1, 3))
-    tmp24 += ints.tmp44.transpose((2, 0, 1, 3)) * 0.5
-    tmp24 += ints.tmp49.transpose((2, 1, 0, 3))
-    tmp24 += ints.tmp31.transpose((2, 0, 1, 3)) * -0.5
-    tmp24 += ints.tmp39.transpose((2, 0, 1, 3)) * -1
-    tmp24 += ints.tmp56.transpose((2, 1, 0, 3)) * -1
-    tmp24 += v.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp15 = tmp4.copy() * -0.5
+    tmp24 = np.copy(ints.tmp12)
+    tmp24 += np.transpose(ints.tmp15, (2, 0, 1, 3))
+    tmp24 += np.transpose(ints.tmp44, (2, 0, 1, 3)) * 0.5
+    tmp24 += np.transpose(ints.tmp49, (2, 1, 0, 3))
+    tmp24 += np.transpose(ints.tmp31, (2, 0, 1, 3)) * -0.5
+    tmp24 += np.transpose(ints.tmp39, (2, 0, 1, 3)) * -1
+    tmp24 += np.transpose(ints.tmp56, (2, 1, 0, 3)) * -1
+    tmp24 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
+    tmp15 = np.copy(tmp4) * -0.5
     del tmp4
     tmp15 += tmp5 * 0.5
     del tmp5
@@ -905,19 +905,19 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp15 += tmp14
     del tmp14
     tmp3 = einsum(r2, (0, 1, 2), v.oovv, (0, 1, 3, 2), (3,))
-    tmp23 = ints.tmp24.transpose((1, 0)).copy()
-    tmp23 += ints.tmp34.transpose((1, 0)) * 0.5
+    tmp23 = np.copy(np.transpose(ints.tmp24, (1, 0)))
+    tmp23 += np.transpose(ints.tmp34, (1, 0)) * 0.5
     tmp23 += f.vv * -1
     tmp23 += einsum(t1, (0, 1), tmp22, (0, 2), (2, 1))
     del tmp22
-    tmp21 = ints.tmp33.copy() * 0.5
+    tmp21 = np.copy(ints.tmp33) * 0.5
     tmp21 += ints.tmp52
     tmp21 += v.oooo
-    tmp20 = tmp17.copy() * -1
+    tmp20 = np.copy(tmp17) * -1
     del tmp17
     tmp20 += tmp19
     del tmp19
-    tmp25 = ints.tmp13.copy()
+    tmp25 = np.copy(ints.tmp13)
     tmp25 += ints.tmp16
     tmp25 += ints.tmp27 * 0.5
     tmp25 += ints.tmp30 * 0.5
@@ -931,22 +931,22 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp25 += ints.tmp11 * -1
     tmp25 += ints.tmp38 * -1
     tmp25 += ints.tmp8 * -1
-    tmp2 = f.oo.copy() * 2
+    tmp2 = np.copy(f.oo) * 2
     tmp2 += ints.tmp0 * 2
     tmp2 += ints.tmp1 * 2
-    tmp2 += ints.tmp4.transpose((1, 0))
-    tmp2 += ints.tmp5.transpose((1, 0)) * 2
-    tmp0 = ints.tmp3.copy()
-    tmp0 += v.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp1 = f.ov.copy()
+    tmp2 += np.transpose(ints.tmp4, (1, 0))
+    tmp2 += np.transpose(ints.tmp5, (1, 0)) * 2
+    tmp0 = np.copy(ints.tmp3)
+    tmp0 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
+    tmp1 = np.copy(f.ov)
     tmp1 += ints.tmp2
     r2new = einsum(tmp3, (0,), t2, (1, 2, 3, 0), (1, 2, 3)) * 0.5
     del tmp3
     r2new += tmp15 * -1
-    r2new += tmp15.transpose((1, 0, 2))
+    r2new += np.transpose(tmp15, (1, 0, 2))
     del tmp15
     r2new += tmp20
-    r2new += tmp20.transpose((1, 0, 2)) * -1
+    r2new += np.transpose(tmp20, (1, 0, 2)) * -1
     del tmp20
     r2new += einsum(r2, (0, 1, 2), tmp21, (3, 4, 0, 1), (3, 4, 2)) * 0.5
     del tmp21
@@ -1070,22 +1070,22 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     """
 
     ints = kwargs["ints"]
-    tmp13 = ints.tmp38.copy()
-    tmp13 += v.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp0 = f.ov.copy()
+    tmp13 = np.copy(ints.tmp38)
+    tmp13 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
+    tmp0 = np.copy(f.ov)
     tmp0 += ints.tmp2
     tmp14 = einsum(r2, (0, 1, 2), tmp13, (3, 2, 4, 1), (3, 4, 0)) * -1
     tmp15 = einsum(r2, (0, 1, 2), tmp0, (3, 1), (2, 3, 0)) * -1
-    tmp8 = r2.transpose((2, 0, 1)).copy()
+    tmp8 = np.copy(np.transpose(r2, (2, 0, 1)))
     tmp8 += einsum(r1, (0,), t1, (1, 2), (1, 0, 2))
-    tmp16 = tmp14.transpose((1, 0, 2)).copy() * -1
+    tmp16 = np.copy(np.transpose(tmp14, (1, 0, 2))) * -1
     del tmp14
-    tmp16 += tmp15.transpose((1, 0, 2)) * -1
+    tmp16 += np.transpose(tmp15, (1, 0, 2)) * -1
     del tmp15
-    tmp9 = ints.tmp23.copy()
+    tmp9 = np.copy(ints.tmp23)
     tmp9 += ints.tmp34
-    tmp11 = f.vv.copy() * 2
-    tmp11 += ints.tmp4.transpose((1, 0)) * -1
+    tmp11 = np.copy(f.vv) * 2
+    tmp11 += np.transpose(ints.tmp4, (1, 0)) * -1
     tmp6 = einsum(v.ovvv, (0, 1, 2, 3), r2, (2, 3, 4), (4, 0, 1))
     tmp5 = einsum(r2, (0, 1, 2), v.oovv, (3, 4, 0, 1), (2, 3, 4))
     tmp18 = einsum(v.ovov, (0, 1, 2, 3), tmp8, (2, 1, 4), (0, 4, 3))
@@ -1101,10 +1101,10 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp20 = einsum(ints.tmp1, (0, 1), r2, (2, 1, 3), (3, 0, 2))
     tmp2 = einsum(r2, (0, 1, 2), v.oovv, (3, 2, 0, 1), (3,))
     tmp3 = einsum(tmp0, (0, 1), r1, (1,), (0,))
-    tmp25 = tmp5.transpose((0, 2, 1)).copy() * -0.5
+    tmp25 = np.copy(np.transpose(tmp5, (0, 2, 1))) * -0.5
     tmp25 += einsum(r1, (0,), tmp13, (1, 2, 3, 0), (1, 2, 3))
     del tmp13
-    tmp27 = ints.tmp13.copy()
+    tmp27 = np.copy(ints.tmp13)
     tmp27 += ints.tmp15
     tmp27 += ints.tmp27 * 0.5
     tmp27 += ints.tmp29 * 0.5
@@ -1118,12 +1118,12 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp27 += ints.tmp12 * -1
     tmp27 += ints.tmp37 * -1
     tmp27 += ints.tmp8 * -1
-    tmp24 = f.oo.copy()
+    tmp24 = np.copy(f.oo)
     tmp24 += ints.tmp19
-    tmp24 += ints.tmp32.transpose((1, 0)) * 0.5
-    tmp24 += ints.tmp50.transpose((1, 0))
+    tmp24 += np.transpose(ints.tmp32, (1, 0)) * 0.5
+    tmp24 += np.transpose(ints.tmp50, (1, 0))
     tmp24 += ints.tmp9
-    tmp19 = tmp7.copy() * 0.5
+    tmp19 = np.copy(tmp7) * 0.5
     del tmp7
     tmp19 += tmp10 * -1
     del tmp10
@@ -1133,31 +1133,31 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp17
     tmp19 += tmp18 * -1
     del tmp18
-    tmp22 = tmp20.copy()
+    tmp22 = np.copy(tmp20)
     del tmp20
     tmp22 += tmp21
     del tmp21
-    tmp23 = ints.tmp18.copy()
+    tmp23 = np.copy(ints.tmp18)
     tmp23 += ints.tmp40 * 0.5
     tmp23 += ints.tmp28 * -0.5
-    tmp23 += v.ovvv.transpose((0, 2, 3, 1)) * -1
-    tmp4 = tmp2.copy() * 0.5
+    tmp23 += np.transpose(v.ovvv, (0, 2, 3, 1)) * -1
+    tmp4 = np.copy(tmp2) * 0.5
     del tmp2
     tmp4 += tmp3
     del tmp3
     tmp26 = einsum(t1, (0, 1), tmp25, (2, 3, 0), (2, 3, 1)) * 2
     del tmp25
-    tmp1 = ints.tmp1.transpose((1, 0)).copy()
-    tmp1 += ints.tmp4.transpose((1, 0)) * 0.5
+    tmp1 = np.copy(np.transpose(ints.tmp1, (1, 0)))
+    tmp1 += np.transpose(ints.tmp4, (1, 0)) * 0.5
     tmp1 += f.vv * -1
     r2new = einsum(tmp5, (0, 1, 2), t2, (2, 1, 3, 4), (3, 4, 0)) * -0.25
     del tmp5
     r2new += einsum(v.vvvv, (0, 1, 2, 3), r2, (2, 3, 4), (0, 1, 4)) * 0.5
-    r2new += tmp19.transpose((1, 2, 0)) * -1
-    r2new += tmp19.transpose((2, 1, 0))
+    r2new += np.transpose(tmp19, (1, 2, 0)) * -1
+    r2new += np.transpose(tmp19, (2, 1, 0))
     del tmp19
-    r2new += tmp22.transpose((1, 2, 0))
-    r2new += tmp22.transpose((2, 1, 0)) * -1
+    r2new += np.transpose(tmp22, (1, 2, 0))
+    r2new += np.transpose(tmp22, (2, 1, 0)) * -1
     del tmp22
     r2new += einsum(tmp23, (0, 1, 2, 3), r1, (3,), (2, 1, 0)) * -1
     del tmp23
@@ -1311,10 +1311,10 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     """
 
     ints = kwargs["ints"]
-    tmp2 = f.ov.copy()
+    tmp2 = np.copy(f.ov)
     tmp2 += ints.tmp6
     tmp0 = einsum(v.oovv, (0, 1, 2, 3), r1, (1, 3), (0, 2))
-    tmp39 = ints.tmp5.copy()
+    tmp39 = np.copy(ints.tmp5)
     tmp39 += ints.tmp64
     tmp25 = einsum(v.ooov, (0, 1, 2, 3), r1, (4, 3), (4, 0, 1, 2))
     tmp6 = einsum(r1, (0, 1), tmp2, (2, 1), (2, 0))
@@ -1325,28 +1325,28 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp43 = einsum(tmp39, (0, 1, 2, 3), r1, (4, 3), (0, 1, 4, 2))
     tmp42 = einsum(ints.tmp7, (0, 1, 2, 3), r2, (4, 1, 5, 3), (0, 2, 4, 5))
     tmp41 = einsum(r2, (0, 1, 2, 3), v.ooov, (4, 1, 5, 3), (0, 4, 5, 2))
-    tmp57 = ints.tmp23.copy()
-    tmp57 += ints.tmp30.transpose((2, 0, 1, 3))
-    tmp62 = ints.tmp55.copy()
+    tmp57 = np.copy(ints.tmp23)
+    tmp57 += np.transpose(ints.tmp30, (2, 0, 1, 3))
+    tmp62 = np.copy(ints.tmp55)
     tmp62 += ints.tmp71 * 2
     tmp62 += ints.tmp81 * -1
-    tmp60 = ints.tmp10.copy() * 0.5
+    tmp60 = np.copy(ints.tmp10) * 0.5
     tmp60 += ints.tmp4
     tmp26 = einsum(tmp25, (0, 1, 2, 3), t1, (2, 4), (0, 1, 3, 4))
     del tmp25
     tmp23 = einsum(v.ooov, (0, 1, 2, 3), r1, (1, 3), (0, 2))
-    tmp8 = f.oo.copy()
+    tmp8 = np.copy(f.oo)
     tmp8 += ints.tmp0
-    tmp8 += ints.tmp12.transpose((1, 0))
+    tmp8 += np.transpose(ints.tmp12, (1, 0))
     tmp8 += ints.tmp2
-    tmp8 += ints.tmp9.transpose((1, 0)) * 0.5
-    tmp28 = ints.tmp51.copy()
+    tmp8 += np.transpose(ints.tmp9, (1, 0)) * 0.5
+    tmp28 = np.copy(ints.tmp51)
     tmp28 += ints.tmp77 * -1
-    tmp32 = tmp31.copy()
+    tmp32 = np.copy(tmp31)
     del tmp31
     tmp32 += tmp5 * 0.5
-    tmp32 += tmp6.transpose((1, 0))
-    tmp20 = tmp18.transpose((1, 0, 2, 3)).copy()
+    tmp32 += np.transpose(tmp6, (1, 0))
+    tmp20 = np.copy(np.transpose(tmp18, (1, 0, 2, 3)))
     del tmp18
     tmp20 += tmp19 * -2
     del tmp19
@@ -1354,14 +1354,14 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp14 = einsum(v.oovv, (0, 1, 2, 3), r2, (0, 1, 4, 3), (4, 2))
     tmp49 = einsum(r1, (0, 1), ints.tmp7, (2, 3, 4, 1), (2, 3, 4, 0))
     tmp10 = einsum(v.ovvv, (0, 1, 2, 3), r1, (0, 3), (1, 2))
-    tmp44 = tmp41.copy()
+    tmp44 = np.copy(tmp41)
     del tmp41
     tmp44 += tmp42 * -1
     del tmp42
     tmp44 += tmp43
     del tmp43
     tmp37 = einsum(r1, (0, 1), v.ovov, (2, 3, 4, 1), (0, 2, 4, 3))
-    tmp46 = ints.tmp33.copy()
+    tmp46 = np.copy(ints.tmp33)
     tmp46 += ints.tmp49
     tmp58 = einsum(tmp57, (0, 1, 2, 3), r1, (0, 4), (1, 2, 3, 4))
     del tmp57
@@ -1387,8 +1387,8 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp16
     tmp15 = einsum(t2, (0, 1, 2, 3), tmp14, (4, 3), (0, 1, 4, 2)) * -1
     del tmp14
-    tmp65 = ints.tmp75.copy()
-    tmp65 += ints.tmp88.transpose((0, 2, 1, 3))
+    tmp65 = np.copy(ints.tmp75)
+    tmp65 += np.transpose(ints.tmp88, (0, 2, 1, 3))
     tmp52 = einsum(ints.tmp37, (0, 1, 2, 3), r1, (4, 3), (0, 4, 1, 2))
     tmp53 = einsum(v.ovvv, (0, 1, 2, 3), r1, (4, 1), (4, 0, 2, 3))
     tmp50 = einsum(t1, (0, 1), tmp49, (2, 3, 0, 4), (2, 3, 4, 1))
@@ -1406,20 +1406,20 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp35 = einsum(r1, (0, 1), ints.tmp57, (2, 3, 4, 1), (2, 0, 3, 4))
     tmp40 = einsum(r2, (0, 1, 2, 3), tmp39, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp39
-    tmp1 = ints.tmp7.copy()
-    tmp1 += v.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp67 = ints.tmp101.copy()
+    tmp1 = np.copy(ints.tmp7)
+    tmp1 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
+    tmp67 = np.copy(ints.tmp101)
     tmp67 += ints.tmp62 * 0.5
     tmp67 += v.oooo
-    tmp67 += ints.tmp40.transpose((0, 3, 1, 2)) * -1
-    tmp67 += ints.tmp40.transpose((3, 0, 1, 2))
-    tmp59 = tmp55.transpose((1, 0, 2, 3)).copy() * -1
+    tmp67 += np.transpose(ints.tmp40, (0, 3, 1, 2)) * -1
+    tmp67 += np.transpose(ints.tmp40, (3, 0, 1, 2))
+    tmp59 = np.copy(np.transpose(tmp55, (1, 0, 2, 3))) * -1
     del tmp55
-    tmp59 += tmp56.transpose((1, 0, 2, 3)) * -1
+    tmp59 += np.transpose(tmp56, (1, 0, 2, 3)) * -1
     del tmp56
     tmp59 += tmp58
     del tmp58
-    tmp71 = ints.tmp105.copy() * 2
+    tmp71 = np.copy(ints.tmp105) * 2
     tmp71 += ints.tmp17 * 2
     tmp71 += ints.tmp26 * 2
     tmp71 += ints.tmp32 * 2
@@ -1433,41 +1433,41 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp71 += ints.tmp18 * -2
     tmp71 += ints.tmp22 * -2
     tmp71 += ints.tmp70 * -2
-    tmp64 = tmp61.transpose((1, 0, 2, 3)).copy() * -1
+    tmp64 = np.copy(np.transpose(tmp61, (1, 0, 2, 3))) * -1
     del tmp61
     tmp64 += tmp63 * -1
     del tmp63
-    tmp34 = tmp24.transpose((0, 1, 3, 2)).copy() * -1
+    tmp34 = np.copy(np.transpose(tmp24, (0, 1, 3, 2))) * -1
     del tmp24
-    tmp34 += tmp27.transpose((0, 1, 3, 2))
+    tmp34 += np.transpose(tmp27, (0, 1, 3, 2))
     del tmp27
-    tmp34 += tmp29.transpose((0, 1, 3, 2)) * -1
+    tmp34 += np.transpose(tmp29, (0, 1, 3, 2)) * -1
     del tmp29
-    tmp34 += tmp30.transpose((0, 1, 3, 2))
+    tmp34 += np.transpose(tmp30, (0, 1, 3, 2))
     del tmp30
-    tmp34 += tmp33.transpose((0, 1, 3, 2))
+    tmp34 += np.transpose(tmp33, (0, 1, 3, 2))
     del tmp33
-    tmp22 = tmp13.copy()
+    tmp22 = np.copy(tmp13)
     del tmp13
     tmp22 += tmp15 * 0.5
     del tmp15
-    tmp22 += tmp17.transpose((1, 0, 2, 3)) * -1
+    tmp22 += np.transpose(tmp17, (1, 0, 2, 3)) * -1
     del tmp17
-    tmp22 += tmp21.transpose((1, 0, 3, 2))
+    tmp22 += np.transpose(tmp21, (1, 0, 3, 2))
     del tmp21
     tmp66 = einsum(tmp65, (0, 1, 2, 3), r1, (2, 4), (0, 1, 3, 4))
     del tmp65
-    tmp54 = tmp52.copy()
+    tmp54 = np.copy(tmp52)
     del tmp52
-    tmp54 += tmp53.transpose((0, 1, 3, 2)) * -1
+    tmp54 += np.transpose(tmp53, (0, 1, 3, 2)) * -1
     del tmp53
     tmp51 = einsum(t1, (0, 1), tmp50, (2, 0, 3, 4), (2, 3, 1, 4))
     del tmp50
-    tmp12 = tmp9.copy()
+    tmp12 = np.copy(tmp9)
     del tmp9
     tmp12 += tmp11
     del tmp11
-    tmp70 = ints.tmp105.copy()
+    tmp70 = np.copy(ints.tmp105)
     tmp70 += ints.tmp17
     tmp70 += ints.tmp26
     tmp70 += ints.tmp32
@@ -1482,7 +1482,7 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp70 += ints.tmp22 * -1
     tmp70 += ints.tmp70 * -1
     tmp68 = einsum(v.oovv, (0, 1, 2, 3), r2, (4, 5, 2, 3), (4, 5, 0, 1))
-    tmp48 = tmp35.copy()
+    tmp48 = np.copy(tmp35)
     del tmp35
     tmp48 += tmp36
     del tmp36
@@ -1494,49 +1494,49 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp45
     tmp48 += tmp47
     del tmp47
-    tmp69 = t2.copy()
+    tmp69 = np.copy(t2)
     tmp69 += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 2
-    tmp3 = ints.tmp5.copy()
-    tmp3 += v.ovov.transpose((0, 2, 3, 1)) * -1
-    tmp4 = ints.tmp10.transpose((1, 0)).copy() * 0.5
-    tmp4 += ints.tmp4.transpose((1, 0))
+    tmp3 = np.copy(ints.tmp5)
+    tmp3 += np.transpose(v.ovov, (0, 2, 3, 1)) * -1
+    tmp4 = np.copy(np.transpose(ints.tmp10, (1, 0))) * 0.5
+    tmp4 += np.transpose(ints.tmp4, (1, 0))
     tmp4 += f.vv * -1
-    tmp7 = tmp5.transpose((1, 0)).copy() * 0.5
+    tmp7 = np.copy(np.transpose(tmp5, (1, 0))) * 0.5
     del tmp5
     tmp7 += einsum(tmp1, (0, 1, 2, 3), r1, (1, 3), (2, 0))
     tmp7 += tmp6
     del tmp6
     r2new = einsum(r2, (0, 1, 2, 3), v.vvvv, (4, 5, 2, 3), (0, 1, 4, 5)) * 0.5
     r2new += tmp12
-    r2new += tmp12.transpose((0, 1, 3, 2)) * -1
+    r2new += np.transpose(tmp12, (0, 1, 3, 2)) * -1
     del tmp12
     r2new += tmp22 * -1
-    r2new += tmp22.transpose((0, 1, 3, 2))
+    r2new += np.transpose(tmp22, (0, 1, 3, 2))
     del tmp22
     r2new += tmp34
-    r2new += tmp34.transpose((1, 0, 2, 3)) * -1
+    r2new += np.transpose(tmp34, (1, 0, 2, 3)) * -1
     del tmp34
     r2new += tmp48 * -1
-    r2new += tmp48.transpose((0, 1, 3, 2))
-    r2new += tmp48.transpose((1, 0, 2, 3))
-    r2new += tmp48.transpose((1, 0, 3, 2)) * -1
+    r2new += np.transpose(tmp48, (0, 1, 3, 2))
+    r2new += np.transpose(tmp48, (1, 0, 2, 3))
+    r2new += np.transpose(tmp48, (1, 0, 3, 2)) * -1
     del tmp48
     r2new += tmp51 * -1
-    r2new += tmp51.transpose((1, 0, 2, 3))
+    r2new += np.transpose(tmp51, (1, 0, 2, 3))
     del tmp51
-    r2new += tmp54.transpose((0, 1, 3, 2))
-    r2new += tmp54.transpose((1, 0, 3, 2)) * -1
+    r2new += np.transpose(tmp54, (0, 1, 3, 2))
+    r2new += np.transpose(tmp54, (1, 0, 3, 2)) * -1
     del tmp54
-    r2new += tmp59.transpose((1, 0, 2, 3))
-    r2new += tmp59.transpose((1, 0, 3, 2)) * -1
+    r2new += np.transpose(tmp59, (1, 0, 2, 3))
+    r2new += np.transpose(tmp59, (1, 0, 3, 2)) * -1
     del tmp59
-    r2new += tmp64.transpose((1, 0, 2, 3))
-    r2new += tmp64.transpose((1, 0, 3, 2)) * -1
+    r2new += np.transpose(tmp64, (1, 0, 2, 3))
+    r2new += np.transpose(tmp64, (1, 0, 3, 2)) * -1
     del tmp64
     r2new += tmp66
-    r2new += tmp66.transpose((0, 1, 3, 2)) * -1
-    r2new += tmp66.transpose((1, 0, 2, 3)) * -1
-    r2new += tmp66.transpose((1, 0, 3, 2))
+    r2new += np.transpose(tmp66, (0, 1, 3, 2)) * -1
+    r2new += np.transpose(tmp66, (1, 0, 2, 3)) * -1
+    r2new += np.transpose(tmp66, (1, 0, 3, 2))
     del tmp66
     r2new += einsum(r2, (0, 1, 2, 3), tmp67, (4, 5, 0, 1), (4, 5, 2, 3)) * 0.5
     del tmp67
@@ -1690,13 +1690,13 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     """
 
     ints = kwargs["ints"]
-    tmp9 = ints.tmp30.copy()
+    tmp9 = np.copy(ints.tmp30)
     tmp9 += ints.tmp44
     tmp6 = einsum(t1, (0, 1), r2, (2, 3, 1), (2, 3, 0))
-    tmp13 = f.oo.copy()
-    tmp13 += ints.tmp0.transpose((1, 0))
+    tmp13 = np.copy(f.oo)
+    tmp13 += np.transpose(ints.tmp0, (1, 0))
     tmp13 += ints.tmp24
-    tmp13 += ints.tmp6.transpose((1, 0))
+    tmp13 += np.transpose(ints.tmp6, (1, 0))
     tmp10 = einsum(tmp9, (0, 1, 2, 3), r2, (4, 0, 2), (1, 4, 3)) * -1
     del tmp9
     tmp8 = einsum(v.ooov, (0, 1, 2, 3), tmp6, (4, 2, 1), (4, 0, 3))
@@ -1704,18 +1704,18 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp5 = einsum(r2, (0, 1, 2), v.ovov, (3, 2, 1, 4), (0, 3, 4))
     tmp7 = einsum(tmp6, (0, 1, 2), ints.tmp18, (1, 3, 2, 4), (3, 0, 4))
     del tmp6
-    tmp11 = f.ov.copy()
+    tmp11 = np.copy(f.ov)
     tmp11 += ints.tmp15
-    tmp17 = ints.tmp18.copy()
-    tmp17 += v.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp15 = ints.tmp22.copy()
+    tmp17 = np.copy(ints.tmp18)
+    tmp17 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
+    tmp15 = np.copy(ints.tmp22)
     tmp15 += ints.tmp33 * 2
     tmp15 += v.oooo * 2
-    tmp15 += ints.tmp26.transpose((0, 3, 1, 2)) * -4
+    tmp15 += np.transpose(ints.tmp26, (0, 3, 1, 2)) * -4
     tmp3 = einsum(r2, (0, 1, 2), t2, (0, 1, 3, 2), (3,))
     tmp14 = einsum(r2, (0, 1, 2), tmp13, (1, 3), (3, 0, 2)) * -1
     del tmp13
-    tmp12 = tmp4.copy() * -0.5
+    tmp12 = np.copy(tmp4) * -0.5
     del tmp4
     tmp12 += tmp5
     del tmp5
@@ -1726,29 +1726,29 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp12 += tmp10 * -1
     del tmp10
     tmp12 += einsum(r1, (0,), tmp11, (1, 2), (1, 0, 2))
-    tmp16 = ints.tmp28.copy()
+    tmp16 = np.copy(ints.tmp28)
     tmp16 += ints.tmp43 * 0.5
     tmp16 += f.vv * -1
     tmp16 += einsum(t1, (0, 1), tmp11, (0, 2), (1, 2))
     del tmp11
-    tmp2 = f.oo.copy() * 2
-    tmp2 += ints.tmp0.transpose((1, 0)) * 2
+    tmp2 = np.copy(f.oo) * 2
+    tmp2 += np.transpose(ints.tmp0, (1, 0)) * 2
     tmp2 += ints.tmp10
     tmp2 += ints.tmp24 * 2
-    tmp2 += ints.tmp6.transpose((1, 0)) * 2
-    tmp0 = ints.tmp12.copy()
-    tmp0 += ints.tmp23.transpose((0, 2, 1, 3)) * 0.25
-    tmp0 += ints.tmp34.transpose((0, 2, 1, 3)) * 0.5
-    tmp0 += ints.tmp4.transpose((1, 0, 2, 3)) * 0.5
-    tmp0 += ints.tmp7.transpose((0, 2, 1, 3)) * 0.5
+    tmp2 += np.transpose(ints.tmp6, (1, 0)) * 2
+    tmp0 = np.copy(ints.tmp12)
+    tmp0 += np.transpose(ints.tmp23, (0, 2, 1, 3)) * 0.25
+    tmp0 += np.transpose(ints.tmp34, (0, 2, 1, 3)) * 0.5
+    tmp0 += np.transpose(ints.tmp4, (1, 0, 2, 3)) * 0.5
+    tmp0 += np.transpose(ints.tmp7, (0, 2, 1, 3)) * 0.5
     tmp0 += ints.tmp9
-    tmp0 += ints.tmp14.transpose((0, 2, 1, 3)) * -0.25
-    tmp0 += ints.tmp17.transpose((0, 2, 1, 3)) * -0.5
-    tmp0 += ints.tmp20.transpose((0, 2, 1, 3)) * -1
+    tmp0 += np.transpose(ints.tmp14, (0, 2, 1, 3)) * -0.25
+    tmp0 += np.transpose(ints.tmp17, (0, 2, 1, 3)) * -0.5
+    tmp0 += np.transpose(ints.tmp20, (0, 2, 1, 3)) * -1
     tmp0 += ints.tmp27 * -1
-    tmp0 += ints.tmp31.transpose((0, 2, 1, 3)) * -0.5
-    tmp0 += v.ooov.transpose((0, 2, 1, 3)) * -0.5
-    tmp1 = ints.tmp11.copy()
+    tmp0 += np.transpose(ints.tmp31, (0, 2, 1, 3)) * -0.5
+    tmp0 += np.transpose(v.ooov, (0, 2, 1, 3)) * -0.5
+    tmp1 = np.copy(ints.tmp11)
     tmp1 += ints.tmp13
     tmp1 += ints.tmp19
     tmp1 += ints.tmp1 * 2
@@ -1765,10 +1765,10 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     r2new = einsum(tmp3, (0,), v.oovv, (1, 2, 3, 0), (1, 2, 3)) * 0.5
     del tmp3
     r2new += tmp12 * -1
-    r2new += tmp12.transpose((1, 0, 2))
+    r2new += np.transpose(tmp12, (1, 0, 2))
     del tmp12
     r2new += tmp14 * -1
-    r2new += tmp14.transpose((1, 0, 2))
+    r2new += np.transpose(tmp14, (1, 0, 2))
     del tmp14
     r2new += einsum(r2, (0, 1, 2), tmp15, (0, 1, 3, 4), (3, 4, 2)) * 0.25
     del tmp15
@@ -1889,23 +1889,23 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     """
 
     ints = kwargs["ints"]
-    tmp10 = f.ov.copy()
+    tmp10 = np.copy(f.ov)
     tmp10 += ints.tmp16
     tmp17 = einsum(t1, (0, 1), v.ooov, (2, 0, 3, 4), (2, 3, 1, 4))
     tmp11 = einsum(ints.tmp18, (0, 1, 2, 3), t1, (2, 4), (0, 1, 3, 4))
     tmp14 = einsum(tmp10, (0, 1), t1, (0, 2), (1, 2)) * 2
-    tmp18 = v.ovov.transpose((0, 2, 1, 3)).copy()
-    tmp18 += tmp17.transpose((1, 0, 3, 2)) * -1
+    tmp18 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3)))
+    tmp18 += np.transpose(tmp17, (1, 0, 3, 2)) * -1
     del tmp17
-    tmp12 = ints.tmp23.copy()
+    tmp12 = np.copy(ints.tmp23)
     tmp12 += ints.tmp28
-    tmp12 += tmp11.transpose((0, 1, 3, 2)) * -1
+    tmp12 += np.transpose(tmp11, (0, 1, 3, 2)) * -1
     del tmp11
-    tmp15 = ints.tmp11.copy()
+    tmp15 = np.copy(ints.tmp11)
     tmp15 += f.vv * -2
-    tmp15 += tmp14.transpose((1, 0))
+    tmp15 += np.transpose(tmp14, (1, 0))
     del tmp14
-    tmp22 = t2.copy()
+    tmp22 = np.copy(t2)
     tmp22 += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 2
     tmp7 = einsum(t1, (0, 1), r1, (1,), (0,))
     tmp8 = einsum(r2, (0, 1, 2), t2, (3, 2, 0, 1), (3,))
@@ -1916,37 +1916,37 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp16 = einsum(r2, (0, 1, 2), tmp15, (1, 3), (2, 3, 0)) * -0.5
     del tmp15
     tmp1 = einsum(t1, (0, 1), r2, (2, 1, 3), (3, 0, 2))
-    tmp24 = f.oo.copy()
+    tmp24 = np.copy(f.oo)
     tmp24 += ints.tmp21 * 0.5
-    tmp24 += ints.tmp24.transpose((1, 0))
+    tmp24 += np.transpose(ints.tmp24, (1, 0))
     tmp24 += ints.tmp29
-    tmp24 += ints.tmp5.transpose((1, 0))
+    tmp24 += np.transpose(ints.tmp5, (1, 0))
     tmp23 = einsum(tmp22, (0, 1, 2, 3), r2, (2, 3, 4), (4, 1, 0)) * -1
     del tmp22
-    tmp9 = tmp7.copy() * 2
+    tmp9 = np.copy(tmp7) * 2
     del tmp7
     tmp9 += tmp8
     del tmp8
     tmp21 = einsum(r2, (0, 1, 2), ints.tmp7, (1, 3), (2, 3, 0))
-    tmp20 = tmp13.copy() * -1
+    tmp20 = np.copy(tmp13) * -1
     del tmp13
     tmp20 += tmp16
     del tmp16
-    tmp20 += tmp19.transpose((0, 2, 1)) * -1
+    tmp20 += np.transpose(tmp19, (0, 2, 1)) * -1
     del tmp19
     tmp20 += einsum(tmp10, (0, 1), r1, (2,), (0, 1, 2))
-    tmp2 = ints.tmp23.copy()
+    tmp2 = np.copy(ints.tmp23)
     tmp2 += ints.tmp28
-    tmp2 += v.ovov.transpose((0, 2, 3, 1)) * -1
-    tmp0 = ints.tmp10.copy() * 0.5
+    tmp2 += np.transpose(v.ovov, (0, 2, 3, 1)) * -1
+    tmp0 = np.copy(ints.tmp10) * 0.5
     tmp0 += ints.tmp15
     tmp0 += ints.tmp20 * 0.25
     tmp0 += ints.tmp13 * -0.25
-    tmp0 += v.ovvv.transpose((0, 2, 3, 1)) * -0.5
+    tmp0 += np.transpose(v.ovvv, (0, 2, 3, 1)) * -0.5
     tmp3 = einsum(t1, (0, 1), tmp1, (2, 3, 1), (2, 3, 0)) * -1
-    tmp4 = ints.tmp18.copy()
-    tmp4 += v.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp5 = ints.tmp12.copy()
+    tmp4 = np.copy(ints.tmp18)
+    tmp4 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
+    tmp5 = np.copy(ints.tmp12)
     tmp5 += ints.tmp14
     tmp5 += ints.tmp19
     tmp5 += ints.tmp1 * 2
@@ -1960,17 +1960,17 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp5 += ints.tmp17 * -2
     tmp5 += ints.tmp2 * -2
     tmp5 += ints.tmp3 * -2
-    tmp6 = ints.tmp11.copy() * 0.5
+    tmp6 = np.copy(ints.tmp11) * 0.5
     tmp6 += ints.tmp7
     tmp6 += f.vv * -1
     r2new = einsum(v.ovvv, (0, 1, 2, 3), r1, (1,), (2, 3, 0)) * -1
     r2new += einsum(tmp1, (0, 1, 2), v.ovvv, (1, 2, 3, 4), (3, 4, 0))
     r2new += einsum(v.vvvv, (0, 1, 2, 3), r2, (2, 3, 4), (0, 1, 4)) * 0.5
-    r2new += tmp20.transpose((1, 2, 0)) * -1
-    r2new += tmp20.transpose((2, 1, 0))
+    r2new += np.transpose(tmp20, (1, 2, 0)) * -1
+    r2new += np.transpose(tmp20, (2, 1, 0))
     del tmp20
-    r2new += tmp21.transpose((1, 2, 0))
-    r2new += tmp21.transpose((2, 1, 0)) * -1
+    r2new += np.transpose(tmp21, (1, 2, 0))
+    r2new += np.transpose(tmp21, (2, 1, 0)) * -1
     del tmp21
     r2new += einsum(tmp23, (0, 1, 2), v.oovv, (1, 2, 3, 4), (3, 4, 0)) * 0.25
     del tmp23
@@ -2126,18 +2126,18 @@ def hbar_lmatvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     ints = kwargs["ints"]
     tmp2 = einsum(r2, (0, 1, 2, 3), t2, (4, 1, 2, 3), (0, 4))
     tmp0 = einsum(t1, (0, 1), r1, (2, 1), (2, 0))
-    tmp14 = f.oo.copy()
-    tmp14 += ints.tmp0.transpose((1, 0))
+    tmp14 = np.copy(f.oo)
+    tmp14 += np.transpose(ints.tmp0, (1, 0))
     tmp14 += ints.tmp16 * 0.5
     tmp14 += ints.tmp38
-    tmp14 += ints.tmp8.transpose((1, 0))
-    tmp12 = tmp0.copy() * 2
+    tmp14 += np.transpose(ints.tmp8, (1, 0))
+    tmp12 = np.copy(tmp0) * 2
     tmp12 += tmp2
     tmp5 = einsum(t1, (0, 1), r2, (2, 3, 4, 1), (2, 3, 0, 4))
-    tmp16 = f.ov.copy()
+    tmp16 = np.copy(f.ov)
     tmp16 += ints.tmp26
     tmp1 = einsum(t2, (0, 1, 2, 3), r2, (0, 1, 4, 3), (4, 2))
-    tmp26 = ints.tmp10.copy()
+    tmp26 = np.copy(ints.tmp10)
     tmp26 += ints.tmp36
     tmp17 = einsum(tmp14, (0, 1), r2, (2, 0, 3, 4), (1, 2, 3, 4)) * -1
     tmp18 = einsum(tmp12, (0, 1), v.oovv, (2, 1, 3, 4), (2, 0, 3, 4)) * -0.5
@@ -2148,25 +2148,25 @@ def hbar_lmatvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp24 = einsum(v.ooov, (0, 1, 2, 3), tmp5, (4, 2, 1, 5), (4, 0, 5, 3))
     tmp23 = einsum(v.ovov, (0, 1, 2, 3), r2, (4, 2, 5, 1), (4, 0, 5, 3))
     tmp25 = einsum(ints.tmp29, (0, 1, 2, 3), tmp5, (4, 0, 2, 5), (1, 4, 3, 5))
-    tmp34 = ints.tmp17.copy() * 0.5
+    tmp34 = np.copy(ints.tmp17) * 0.5
     tmp34 += ints.tmp9
     tmp32 = einsum(r2, (0, 1, 2, 3), f.vv, (4, 3), (0, 1, 4, 2))
     tmp31 = einsum(r1, (0, 1), v.ooov, (2, 3, 0, 4), (2, 3, 1, 4))
     tmp30 = einsum(ints.tmp29, (0, 1, 2, 3), r1, (0, 4), (1, 2, 3, 4))
     tmp7 = einsum(t1, (0, 1), tmp5, (2, 3, 4, 1), (2, 3, 0, 4))
-    tmp36 = ints.tmp40.transpose((0, 3, 1, 2)).copy()
+    tmp36 = np.copy(np.transpose(ints.tmp40, (0, 3, 1, 2)))
     tmp36 += ints.tmp34 * -0.25
     tmp36 += ints.tmp46 * -0.5
     tmp36 += v.oooo * -0.5
-    tmp19 = tmp17.transpose((0, 1, 3, 2)).copy()
+    tmp19 = np.copy(np.transpose(tmp17, (0, 1, 3, 2)))
     del tmp17
-    tmp19 += tmp18.transpose((1, 0, 3, 2))
+    tmp19 += np.transpose(tmp18, (1, 0, 3, 2))
     del tmp18
-    tmp22 = tmp20.copy() * -0.5
+    tmp22 = np.copy(tmp20) * -0.5
     del tmp20
-    tmp22 += tmp21.transpose((1, 0, 3, 2)) * -1
+    tmp22 += np.transpose(tmp21, (1, 0, 3, 2)) * -1
     del tmp21
-    tmp28 = tmp23.copy() * -1
+    tmp28 = np.copy(tmp23) * -1
     del tmp23
     tmp28 += tmp24
     del tmp24
@@ -2178,36 +2178,36 @@ def hbar_lmatvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp35 = einsum(r2, (0, 1, 2, 3), tmp34, (3, 4), (0, 1, 4, 2)) * -1
     del tmp34
     tmp29 = einsum(v.ovvv, (0, 1, 2, 3), r1, (4, 1), (4, 0, 2, 3))
-    tmp33 = tmp30.copy() * -1
+    tmp33 = np.copy(tmp30) * -1
     del tmp30
-    tmp33 += tmp31.transpose((1, 0, 2, 3))
+    tmp33 += np.transpose(tmp31, (1, 0, 2, 3))
     del tmp31
-    tmp33 += tmp32.transpose((1, 0, 2, 3))
+    tmp33 += np.transpose(tmp32, (1, 0, 2, 3))
     del tmp32
     tmp37 = einsum(t2, (0, 1, 2, 3), r2, (4, 5, 2, 3), (4, 5, 0, 1)) * -0.5
-    tmp37 += tmp7.transpose((0, 1, 3, 2))
-    tmp3 = ints.tmp15.copy() * 0.5
+    tmp37 += np.transpose(tmp7, (0, 1, 3, 2))
+    tmp3 = np.copy(ints.tmp15) * 0.5
     tmp3 += ints.tmp24
     tmp3 += ints.tmp32 * 0.25
     tmp3 += ints.tmp21 * -0.25
-    tmp3 += v.ovvv.transpose((0, 2, 3, 1)) * -0.5
-    tmp4 = ints.tmp11.copy()
-    tmp4 += ints.tmp13.transpose((0, 2, 1, 3)) * 2
-    tmp4 += ints.tmp20.transpose((0, 2, 1, 3)) * 2
+    tmp3 += np.transpose(v.ovvv, (0, 2, 3, 1)) * -0.5
+    tmp4 = np.copy(ints.tmp11)
+    tmp4 += np.transpose(ints.tmp13, (0, 2, 1, 3)) * 2
+    tmp4 += np.transpose(ints.tmp20, (0, 2, 1, 3)) * 2
     tmp4 += ints.tmp35 * 0.5
     tmp4 += ints.tmp47
-    tmp4 += ints.tmp5.transpose((1, 2, 0, 3))
+    tmp4 += np.transpose(ints.tmp5, (1, 2, 0, 3))
     tmp4 += ints.tmp23 * -0.5
     tmp4 += ints.tmp28 * -1
     tmp4 += ints.tmp31 * -2
-    tmp4 += ints.tmp41.transpose((0, 2, 1, 3)) * -2
+    tmp4 += np.transpose(ints.tmp41, (0, 2, 1, 3)) * -2
     tmp4 += ints.tmp44 * -1
     tmp4 += v.ooov * -1
-    tmp15 = tmp0.copy()
+    tmp15 = np.copy(tmp0)
     tmp15 += tmp2 * 0.5
     tmp10 = einsum(t2, (0, 1, 2, 3), r1, (1, 3), (0, 2)) * 2
     tmp10 += einsum(t2, (0, 1, 2, 3), tmp5, (1, 0, 4, 3), (4, 2)) * -1
-    tmp9 = ints.tmp12.copy()
+    tmp9 = np.copy(ints.tmp12)
     tmp9 += ints.tmp19 * 0.5
     tmp9 += ints.tmp22 * 0.5
     tmp9 += ints.tmp2
@@ -2221,37 +2221,37 @@ def hbar_lmatvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp9 += ints.tmp27 * -1
     tmp9 += ints.tmp3 * -1
     tmp9 += ints.tmp4 * -1
-    tmp13 = ints.tmp17.copy() * 0.5
+    tmp13 = np.copy(ints.tmp17) * 0.5
     tmp13 += ints.tmp9
     tmp13 += f.vv * -1
-    tmp6 = ints.tmp10.copy()
+    tmp6 = np.copy(ints.tmp10)
     tmp6 += ints.tmp36
-    tmp6 += v.ovov.transpose((0, 2, 3, 1)) * -1
-    tmp11 = ints.tmp10.copy()
-    tmp11 += v.ovov.transpose((0, 2, 3, 1)) * -1
-    tmp8 = ints.tmp29.copy()
-    tmp8 += v.ovoo.transpose((0, 2, 3, 1)) * -1
+    tmp6 += np.transpose(v.ovov, (0, 2, 3, 1)) * -1
+    tmp11 = np.copy(ints.tmp10)
+    tmp11 += np.transpose(v.ovov, (0, 2, 3, 1)) * -1
+    tmp8 = np.copy(ints.tmp29)
+    tmp8 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
     r2new = einsum(v.ovvv, (0, 1, 2, 3), tmp5, (4, 5, 0, 1), (5, 4, 2, 3)) * -1
     r2new += einsum(r2, (0, 1, 2, 3), v.vvvv, (4, 5, 2, 3), (0, 1, 4, 5)) * 0.5
     r2new += tmp19
-    r2new += tmp19.transpose((1, 0, 2, 3)) * -1
+    r2new += np.transpose(tmp19, (1, 0, 2, 3)) * -1
     del tmp19
     r2new += tmp22
-    r2new += tmp22.transpose((0, 1, 3, 2)) * -1
+    r2new += np.transpose(tmp22, (0, 1, 3, 2)) * -1
     del tmp22
     r2new += tmp28
-    r2new += tmp28.transpose((0, 1, 3, 2)) * -1
-    r2new += tmp28.transpose((1, 0, 2, 3)) * -1
-    r2new += tmp28.transpose((1, 0, 3, 2))
+    r2new += np.transpose(tmp28, (0, 1, 3, 2)) * -1
+    r2new += np.transpose(tmp28, (1, 0, 2, 3)) * -1
+    r2new += np.transpose(tmp28, (1, 0, 3, 2))
     del tmp28
-    r2new += tmp29.transpose((0, 1, 3, 2))
-    r2new += tmp29.transpose((1, 0, 3, 2)) * -1
+    r2new += np.transpose(tmp29, (0, 1, 3, 2))
+    r2new += np.transpose(tmp29, (1, 0, 3, 2)) * -1
     del tmp29
-    r2new += tmp33.transpose((1, 0, 2, 3)) * -1
-    r2new += tmp33.transpose((1, 0, 3, 2))
+    r2new += np.transpose(tmp33, (1, 0, 2, 3)) * -1
+    r2new += np.transpose(tmp33, (1, 0, 3, 2))
     del tmp33
-    r2new += tmp35.transpose((1, 0, 2, 3))
-    r2new += tmp35.transpose((1, 0, 3, 2)) * -1
+    r2new += np.transpose(tmp35, (1, 0, 2, 3))
+    r2new += np.transpose(tmp35, (1, 0, 3, 2)) * -1
     del tmp35
     r2new += einsum(r2, (0, 1, 2, 3), tmp36, (0, 1, 4, 5), (4, 5, 2, 3)) * -1
     del tmp36

--- a/ebcc/codegen/GCCSDT.py
+++ b/ebcc/codegen/GCCSDT.py
@@ -1686,7 +1686,7 @@ def make_rdm2_f(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, t3=None,
 
     rdm2_f = pack_2e(rdm2_f_oooo, rdm2_f_ooov, rdm2_f_oovo, rdm2_f_ovoo, rdm2_f_vooo, rdm2_f_oovv, rdm2_f_ovov, rdm2_f_ovvo, rdm2_f_voov, rdm2_f_vovo, rdm2_f_vvoo, rdm2_f_ovvv, rdm2_f_vovv, rdm2_f_vvov, rdm2_f_vvvo, rdm2_f_vvvv)
 
-    rdm2_f = rdm2_f.transpose(0, 2, 1, 3)
+    rdm2_f = np.transpose(rdm2_f, (0, 2, 1, 3))
 
     return rdm2_f
 

--- a/ebcc/codegen/GCCSDT.py
+++ b/ebcc/codegen/GCCSDT.py
@@ -1686,7 +1686,7 @@ def make_rdm2_f(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, t3=None,
 
     rdm2_f = pack_2e(rdm2_f_oooo, rdm2_f_ooov, rdm2_f_oovo, rdm2_f_ovoo, rdm2_f_vooo, rdm2_f_oovv, rdm2_f_ovov, rdm2_f_ovvo, rdm2_f_voov, rdm2_f_vovo, rdm2_f_vvoo, rdm2_f_ovvv, rdm2_f_vovv, rdm2_f_vvov, rdm2_f_vvvo, rdm2_f_vvvv)
 
-    rdm2_f = rdm2_f.swapaxes(1, 2)
+    rdm2_f = rdm2_f.transpose(0, 2, 1, 3)
 
     return rdm2_f
 

--- a/ebcc/codegen/GCCSD_SD_1_1.py
+++ b/ebcc/codegen/GCCSD_SD_1_1.py
@@ -25,10 +25,10 @@ def energy(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=No
 def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # T1, T2, S1, S2 and U11 amplitudes
@@ -390,10 +390,10 @@ def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # L1, L2, LS1 , LS2 and LU11 amplitudes
@@ -989,10 +989,10 @@ def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)
@@ -1045,10 +1045,10 @@ def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)
@@ -1411,17 +1411,17 @@ def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 
     rdm2_f = pack_2e(rdm2_f_oooo, rdm2_f_ooov, rdm2_f_oovo, rdm2_f_ovoo, rdm2_f_vooo, rdm2_f_oovv, rdm2_f_ovov, rdm2_f_ovvo, rdm2_f_voov, rdm2_f_vovo, rdm2_f_vvoo, rdm2_f_ovvv, rdm2_f_vovv, rdm2_f_vvov, rdm2_f_vvvo, rdm2_f_vvvv)
 
-    rdm2_f = rdm2_f.transpose(0, 2, 1, 3)
+    rdm2_f = np.transpose(rdm2_f, (0, 2, 1, 3))
 
     return rdm2_f
 
 def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # Single boson DM
@@ -1439,10 +1439,10 @@ def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None,
 def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # Boson 1RDM
@@ -1456,10 +1456,10 @@ def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_eb_coup_rdm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)

--- a/ebcc/codegen/GCCSD_SD_1_2.py
+++ b/ebcc/codegen/GCCSD_SD_1_2.py
@@ -25,10 +25,10 @@ def energy(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=No
 def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, u12=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # T1, T2, S1, S2, U11 and U12 amplitudes
@@ -525,10 +525,10 @@ def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, u12=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, lu12=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # L1, L2, LS1, LS2, LU11 and LU12 amplitudes
@@ -1326,10 +1326,10 @@ def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, u12=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, lu12=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)
@@ -1394,10 +1394,10 @@ def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, u12=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, lu12=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)
@@ -1887,17 +1887,17 @@ def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 
     rdm2_f = pack_2e(rdm2_f_oooo, rdm2_f_ooov, rdm2_f_oovo, rdm2_f_ovoo, rdm2_f_vooo, rdm2_f_oovv, rdm2_f_ovov, rdm2_f_ovvo, rdm2_f_voov, rdm2_f_vovo, rdm2_f_vvoo, rdm2_f_ovvv, rdm2_f_vovv, rdm2_f_vvov, rdm2_f_vvvo, rdm2_f_vvvv)
 
-    rdm2_f = rdm2_f.transpose(0, 2, 1, 3)
+    rdm2_f = np.transpose(rdm2_f, (0, 2, 1, 3))
 
     return rdm2_f
 
 def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, u12=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, lu12=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # Single boson DM
@@ -1916,10 +1916,10 @@ def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None,
 def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, u12=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, lu12=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # Boson 1RDM
@@ -1934,10 +1934,10 @@ def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_eb_coup_rdm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, u12=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, lu12=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)

--- a/ebcc/codegen/GCCSD_S_1_1.py
+++ b/ebcc/codegen/GCCSD_S_1_1.py
@@ -25,10 +25,10 @@ def energy(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=No
 def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, u11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # T1, T2, S1 and U11 amplitudes
@@ -362,10 +362,10 @@ def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, u11=None, l1=None, l2=None, ls1=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # L1, L2, LS1 and LU11 amplitudes
@@ -925,10 +925,10 @@ def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, u11=None, l1=None, l2=None, ls1=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)
@@ -981,10 +981,10 @@ def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, u11=None, l1=None, l2=None, ls1=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)
@@ -1334,17 +1334,17 @@ def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 
     rdm2_f = pack_2e(rdm2_f_oooo, rdm2_f_ooov, rdm2_f_oovo, rdm2_f_ovoo, rdm2_f_vooo, rdm2_f_oovv, rdm2_f_ovov, rdm2_f_ovvo, rdm2_f_voov, rdm2_f_vovo, rdm2_f_vvoo, rdm2_f_ovvv, rdm2_f_vovv, rdm2_f_vvov, rdm2_f_vvvo, rdm2_f_vvvv)
 
-    rdm2_f = rdm2_f.transpose(0, 2, 1, 3)
+    rdm2_f = np.transpose(rdm2_f, (0, 2, 1, 3))
 
     return rdm2_f
 
 def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, u11=None, l1=None, l2=None, ls1=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # Single boson DM
@@ -1361,10 +1361,10 @@ def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None,
 def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, u11=None, l1=None, l2=None, ls1=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # Boson 1RDM
@@ -1377,10 +1377,10 @@ def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_eb_coup_rdm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, u11=None, l1=None, l2=None, ls1=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)

--- a/ebcc/codegen/GCCSDtp.py
+++ b/ebcc/codegen/GCCSDtp.py
@@ -21,8 +21,8 @@ def update_amps(f=None, v=None, space=None, t1=None, t2=None, t3=None, **kwargs)
     nvir = space.ncvir
     naocc = space.naocc
     navir = space.navir
-    so = np.ones((nocc,), dtype=bool)
-    sv = np.ones((nvir,), dtype=bool)
+    so = np.ones((nocc,), dtype=np.bool_)
+    sv = np.ones((nvir,), dtype=np.bool_)
     sO = space.active[space.correlated][space.occupied[space.correlated]]
     sV = space.active[space.correlated][space.virtual[space.correlated]]
 

--- a/ebcc/codegen/GMP2.py
+++ b/ebcc/codegen/GMP2.py
@@ -103,7 +103,7 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.vvvo = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[0]))
     rdm2.vvvv = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[-1]))
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.tranpose(0, 2, 1, 3)
+    rdm2 = rdm2.transpose(0, 2, 1, 3)
     rdm1 = make_rdm1_f(t2=t2, l2=l2)
     delta = np.diag(np.concatenate([np.ones(t2.shape[0]), np.zeros(t2.shape[-1])]))
     rdm1 -= delta

--- a/ebcc/codegen/GMP2.py
+++ b/ebcc/codegen/GMP2.py
@@ -103,7 +103,7 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.vvvo = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[0]))
     rdm2.vvvv = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[-1]))
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.swapaxes(1, 2)
+    rdm2 = rdm2.tranpose(0, 2, 1, 3)
     rdm1 = make_rdm1_f(t2=t2, l2=l2)
     delta = np.diag(np.concatenate([np.ones(t2.shape[0]), np.zeros(t2.shape[-1])]))
     rdm1 -= delta

--- a/ebcc/codegen/GMP2.py
+++ b/ebcc/codegen/GMP2.py
@@ -59,7 +59,7 @@ def make_rdm1_f(l2=None, t2=None, **kwargs):
         vv=np.eye(t2.shape[-1]),
     )
     rdm1.vv = einsum(t2, (0, 1, 2, 3), l2, (4, 3, 0, 1), (4, 2)) * 0.5
-    rdm1.oo = delta.oo.copy()
+    rdm1.oo = np.copy(delta.oo)
     del delta
     rdm1.oo += einsum(l2, (0, 1, 2, 3), t2, (4, 3, 0, 1), (4, 2)) * -0.5
     rdm1.ov = np.zeros((t2.shape[0], t2.shape[-1]))
@@ -86,8 +86,8 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     """
 
     rdm2 = Namespace()
-    rdm2.vvoo = l2.copy()
-    rdm2.oovv = t2.copy()
+    rdm2.vvoo = np.copy(l2)
+    rdm2.oovv = np.copy(t2)
     rdm2.oooo = np.zeros((t2.shape[0], t2.shape[0], t2.shape[0], t2.shape[0]))
     rdm2.ooov = np.zeros((t2.shape[0], t2.shape[0], t2.shape[0], t2.shape[-1]))
     rdm2.oovo = np.zeros((t2.shape[0], t2.shape[0], t2.shape[-1], t2.shape[0]))
@@ -103,7 +103,7 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.vvvo = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[0]))
     rdm2.vvvv = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[-1]))
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.transpose(0, 2, 1, 3)
+    rdm2 = np.transpose(rdm2, (0, 2, 1, 3))
     rdm1 = make_rdm1_f(t2=t2, l2=l2)
     delta = np.diag(np.concatenate([np.ones(t2.shape[0]), np.zeros(t2.shape[-1])]))
     rdm1 -= delta
@@ -161,14 +161,14 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, v=None, **kwargs):
 
     ints = kwargs["ints"]
     tmp1 = einsum(r2, (0, 1, 2), f.oo, (3, 1), (3, 0, 2))
-    tmp0 = f.oo.copy() * 4
+    tmp0 = np.copy(f.oo) * 4
     tmp0 += ints.tmp0
-    tmp0 += ints.tmp0.transpose((1, 0))
+    tmp0 += np.transpose(ints.tmp0, (1, 0))
     del ints.tmp0
     r2new = einsum(f.vv, (0, 1), r2, (2, 3, 1), (2, 3, 0))
     r2new += einsum(v.ooov, (0, 1, 2, 3), r1, (2,), (0, 1, 3)) * -1
     r2new += tmp1
-    r2new += tmp1.transpose((1, 0, 2)) * -1
+    r2new += np.transpose(tmp1, (1, 0, 2)) * -1
     del tmp1
     r1new = einsum(r2, (0, 1, 2), v.ovoo, (3, 2, 0, 1), (3,)) * -0.5
     r1new += einsum(r1, (0,), tmp0, (0, 1), (1,)) * -0.25
@@ -221,14 +221,14 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, v=None, **kwargs):
 
     ints = kwargs["ints"]
     tmp1 = einsum(f.vv, (0, 1), r2, (2, 1, 3), (3, 0, 2))
-    tmp0 = f.vv.copy() * -1
+    tmp0 = np.copy(f.vv) * -1
     tmp0 += ints.tmp0 * 0.25
-    tmp0 += ints.tmp0.transpose((1, 0)) * 0.25
+    tmp0 += np.transpose(ints.tmp0, (1, 0)) * 0.25
     del ints.tmp0
     r2new = einsum(r1, (0,), v.ovvv, (1, 0, 2, 3), (2, 3, 1)) * -1
     r2new += einsum(f.oo, (0, 1), r2, (2, 3, 1), (2, 3, 0)) * -1
-    r2new += tmp1.transpose((1, 2, 0)) * -1
-    r2new += tmp1.transpose((2, 1, 0))
+    r2new += np.transpose(tmp1, (1, 2, 0)) * -1
+    r2new += np.transpose(tmp1, (2, 1, 0))
     del tmp1
     r1new = einsum(r2, (0, 1, 2), v.ovvv, (2, 3, 0, 1), (3,)) * -0.5
     r1new += einsum(tmp0, (0, 1), r1, (0,), (1,)) * -1
@@ -288,26 +288,26 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp4 = einsum(f.vv, (0, 1), r2, (2, 3, 4, 1), (2, 3, 0, 4))
     tmp7 = einsum(r1, (0, 1), v.ovvv, (2, 1, 3, 4), (0, 2, 3, 4))
     tmp6 = einsum(r2, (0, 1, 2, 3), f.oo, (4, 1), (4, 0, 2, 3))
-    tmp5 = tmp3.transpose((1, 0, 2, 3)).copy() * -1
+    tmp5 = np.copy(np.transpose(tmp3, (1, 0, 2, 3))) * -1
     del tmp3
-    tmp5 += tmp4.transpose((1, 0, 2, 3)) * -1
+    tmp5 += np.transpose(tmp4, (1, 0, 2, 3)) * -1
     del tmp4
-    tmp8 = tmp6.transpose((0, 1, 3, 2)).copy() * -1
+    tmp8 = np.copy(np.transpose(tmp6, (0, 1, 3, 2))) * -1
     del tmp6
-    tmp8 += tmp7.transpose((0, 1, 3, 2))
+    tmp8 += np.transpose(tmp7, (0, 1, 3, 2))
     del tmp7
-    tmp2 = f.oo.copy()
-    tmp2 += ints.tmp0.transpose((1, 0)) * 0.5
+    tmp2 = np.copy(f.oo)
+    tmp2 += np.transpose(ints.tmp0, (1, 0)) * 0.5
     del ints.tmp0
-    tmp1 = f.vv.copy()
-    tmp1 += ints.tmp1.transpose((1, 0)) * -0.5
+    tmp1 = np.copy(f.vv)
+    tmp1 += np.transpose(ints.tmp1, (1, 0)) * -0.5
     del ints.tmp1
     tmp0 = einsum(v.oovv, (0, 1, 2, 3), r1, (1, 3), (0, 2))
-    r2new = tmp5.copy() * -1
-    r2new += tmp5.transpose((0, 1, 3, 2))
+    r2new = np.copy(tmp5) * -1
+    r2new += np.transpose(tmp5, (0, 1, 3, 2))
     del tmp5
     r2new += tmp8
-    r2new += tmp8.transpose((1, 0, 2, 3)) * -1
+    r2new += np.transpose(tmp8, (1, 0, 2, 3)) * -1
     del tmp8
     r1new = einsum(tmp0, (0, 1), t2, (2, 0, 3, 1), (2, 3))
     del tmp0

--- a/ebcc/codegen/GMP2.py
+++ b/ebcc/codegen/GMP2.py
@@ -105,17 +105,14 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
     rdm2 = rdm2.swapaxes(1, 2)
     rdm1 = make_rdm1_f(t2=t2, l2=l2)
-    nocc = t2.shape[0]
-    rdm1[np.diag_indices(nocc)] -= 1
-    for i in range(nocc):
-        rdm2[i, i, :, :] += rdm1.T
-        rdm2[:, :, i, i] += rdm1.T
-        rdm2[:, i, i, :] -= rdm1.T
-        rdm2[i, :, :, i] -= rdm1
-    for i in range(nocc):
-        for j in range(nocc):
-            rdm2[i, i, j, j] += 1
-            rdm2[i, j, j, i] -= 1
+    delta = np.diag(np.concatenate([np.ones(t2.shape[0]), np.zeros(t2.shape[-1])]))
+    rdm1 -= delta
+    rdm2 += einsum(delta, (0, 1), rdm1, (3, 2), (0, 1, 2, 3))
+    rdm2 += einsum(rdm1, (1, 0), delta, (2, 3), (0, 1, 2, 3))
+    rdm2 -= einsum(delta, (0, 3), rdm1, (2, 1), (0, 1, 2, 3))
+    rdm2 -= einsum(rdm1, (0, 3), delta, (1, 2), (0, 1, 2, 3))
+    rdm2 += einsum(delta, (0, 1), delta, (2, 3), (0, 1, 2, 3))
+    rdm2 -= einsum(delta, (0, 3), delta, (1, 2), (0, 1, 2, 3))
 
     return rdm2
 

--- a/ebcc/codegen/GMP3.py
+++ b/ebcc/codegen/GMP3.py
@@ -35,7 +35,7 @@ def energy(t2=None, v=None, **kwargs):
     tmp0 = einsum(t2, (0, 1, 2, 3), t2, (4, 5, 2, 3), (0, 4, 5, 1))
     e_mp = einsum(v.oooo, (0, 1, 2, 3), tmp0, (3, 0, 1, 2), ()) * -0.125
     del tmp0
-    tmp1 = v.oovv.copy() * 2
+    tmp1 = np.copy(v.oovv) * 2
     tmp1 += einsum(v.ovov, (0, 1, 2, 3), t2, (4, 2, 5, 1), (0, 4, 3, 5)) * -8
     tmp1 += einsum(v.vvvv, (0, 1, 2, 3), t2, (4, 5, 2, 3), (4, 5, 0, 1))
     e_mp += einsum(tmp1, (0, 1, 2, 3), t2, (0, 1, 2, 3), ()) * 0.125

--- a/ebcc/codegen/GQCISD.py
+++ b/ebcc/codegen/GQCISD.py
@@ -66,54 +66,54 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp4 = einsum(t2, (0, 1, 2, 3), v.oovv, (4, 1, 5, 3), (0, 4, 2, 5))
     tmp6 = einsum(t2, (0, 1, 2, 3), v.oovv, (0, 1, 4, 3), (2, 4))
     tmp8 = einsum(tmp2, (0, 1), t2, (2, 1, 3, 4), (2, 0, 3, 4))
-    t2new = tmp8.transpose((1, 0, 3, 2)).copy() * -0.5
-    t2new += tmp8.transpose((0, 1, 3, 2)) * 0.5
+    t2new = np.copy(np.transpose(tmp8, (1, 0, 3, 2))) * -0.5
+    t2new += np.transpose(tmp8, (0, 1, 3, 2)) * 0.5
     del tmp8
-    tmp15 = v.oooo.copy() * 2
+    tmp15 = np.copy(v.oooo) * 2
     tmp15 += einsum(v.oovv, (0, 1, 2, 3), t2, (4, 5, 2, 3), (0, 1, 4, 5))
     t2new += einsum(t2, (0, 1, 2, 3), tmp15, (0, 1, 4, 5), (4, 5, 2, 3)) * 0.25
     del tmp15
-    tmp11 = tmp9.transpose((1, 0, 2, 3)).copy() * -1
+    tmp11 = np.copy(np.transpose(tmp9, (1, 0, 2, 3))) * -1
     del tmp9
-    tmp11 += tmp10.transpose((1, 0, 2, 3)) * -1
+    tmp11 += np.transpose(tmp10, (1, 0, 2, 3)) * -1
     del tmp10
-    t2new += tmp11.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp11, (0, 1, 3, 2))
     t2new += tmp11 * -1
     del tmp11
     tmp5 = einsum(t2, (0, 1, 2, 3), tmp4, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp4
-    t2new += tmp5.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp5, (0, 1, 3, 2)) * -1
     t2new += tmp5
     del tmp5
     tmp14 = einsum(t2, (0, 1, 2, 3), v.ovov, (4, 3, 1, 5), (0, 4, 2, 5))
-    t2new += tmp14.transpose((1, 0, 3, 2)) * -1
-    t2new += tmp14.transpose((1, 0, 2, 3))
-    t2new += tmp14.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp14, (1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp14, (1, 0, 2, 3))
+    t2new += np.transpose(tmp14, (0, 1, 3, 2))
     t2new += tmp14 * -1
     del tmp14
     tmp13 = einsum(t2, (0, 1, 2, 3), f.oo, (4, 1), (4, 0, 2, 3))
-    t2new += tmp13.transpose((1, 0, 3, 2))
-    t2new += tmp13.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp13, (1, 0, 3, 2))
+    t2new += np.transpose(tmp13, (0, 1, 3, 2)) * -1
     del tmp13
     tmp7 = einsum(tmp6, (0, 1), t2, (2, 3, 4, 1), (2, 3, 4, 0))
     del tmp6
-    t2new += tmp7.transpose((0, 1, 3, 2)) * 0.5
+    t2new += np.transpose(tmp7, (0, 1, 3, 2)) * 0.5
     t2new += tmp7 * -0.5
     del tmp7
     tmp12 = einsum(t1, (0, 1), v.ovvv, (2, 1, 3, 4), (0, 2, 3, 4))
-    t2new += tmp12.transpose((1, 0, 3, 2)) * -1
-    t2new += tmp12.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp12, (1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp12, (0, 1, 3, 2))
     del tmp12
-    tmp0 = v.ovoo.transpose((0, 2, 3, 1)).copy() * -1
+    tmp0 = np.copy(np.transpose(v.ovoo, (0, 2, 3, 1))) * -1
     tmp0 += einsum(v.oovv, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
     t1new = einsum(t2, (0, 1, 2, 3), tmp0, (4, 0, 1, 3), (4, 2)) * 0.5
     del tmp0
-    tmp3 = f.oo.copy() * 2
-    tmp3 += tmp2.transpose((1, 0))
+    tmp3 = np.copy(f.oo) * 2
+    tmp3 += np.transpose(tmp2, (1, 0))
     del tmp2
     t1new += einsum(tmp3, (0, 1), t1, (0, 2), (1, 2)) * -0.5
     del tmp3
-    tmp1 = f.ov.copy()
+    tmp1 = np.copy(f.ov)
     tmp1 += einsum(v.oovv, (0, 1, 2, 3), t1, (1, 3), (0, 2))
     t1new += einsum(t2, (0, 1, 2, 3), tmp1, (1, 3), (0, 2))
     del tmp1

--- a/ebcc/codegen/RCC2.py
+++ b/ebcc/codegen/RCC2.py
@@ -37,9 +37,9 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp0 = v.ovov.transpose((0, 2, 3, 1)).copy() * -0.5
-    tmp0 += v.ovov.transpose((0, 2, 1, 3))
-    tmp1 = f.ov.copy()
+    tmp0 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -0.5
+    tmp0 += np.transpose(v.ovov, (0, 2, 1, 3))
+    tmp1 = np.copy(f.ov)
     tmp1 += einsum(t1, (0, 1), tmp0, (0, 2, 1, 3), (2, 3))
     del tmp0
     e_cc = einsum(v.ovov, (0, 1, 2, 3), t2, (0, 2, 1, 3), ()) * 2
@@ -79,12 +79,12 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp24 = einsum(tmp23, (0, 1, 2, 3), t1, (3, 4), (0, 2, 1, 4))
     del tmp23
     tmp22 = einsum(v.ovvv, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
-    tmp16 = tmp14.copy()
+    tmp16 = np.copy(tmp14)
     del tmp14
-    tmp16 += tmp15.transpose((2, 0, 1, 3))
+    tmp16 += np.transpose(tmp15, (2, 0, 1, 3))
     del tmp15
     tmp8 = einsum(f.ov, (0, 1), t1, (2, 1), (0, 2))
-    tmp29 = v.oooo.copy()
+    tmp29 = np.copy(v.oooo)
     tmp29 += einsum(t1, (0, 1), tmp2, (2, 3, 4, 1), (3, 0, 2, 4))
     tmp21 = einsum(t2, (0, 1, 2, 3), f.vv, (4, 3), (0, 1, 4, 2))
     tmp25 = einsum(tmp24, (0, 1, 2, 3), t1, (1, 4), (0, 2, 4, 3))
@@ -93,20 +93,20 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp17 = einsum(t1, (0, 1), tmp16, (0, 2, 3, 4), (2, 3, 4, 1))
     del tmp16
     tmp13 = einsum(t2, (0, 1, 2, 3), tmp8, (1, 4), (4, 0, 2, 3))
-    tmp4 = v.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp4 += v.ovov.transpose((0, 2, 1, 3)) * 2
-    tmp9 = v.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp9 += v.ovov.transpose((0, 2, 1, 3)) * 2
-    tmp10 = v.ooov.copy()
-    tmp10 += v.ooov.transpose((0, 2, 1, 3)) * -0.5
-    tmp0 = t2.copy()
+    tmp4 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -1
+    tmp4 += np.transpose(v.ovov, (0, 2, 1, 3)) * 2
+    tmp9 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -1
+    tmp9 += np.transpose(v.ovov, (0, 2, 1, 3)) * 2
+    tmp10 = np.copy(v.ooov)
+    tmp10 += np.transpose(v.ooov, (0, 2, 1, 3)) * -0.5
+    tmp0 = np.copy(t2)
     tmp0 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
-    tmp30 = v.ooov.transpose((0, 2, 1, 3)).copy() * -1
+    tmp30 = np.copy(np.transpose(v.ooov, (0, 2, 1, 3))) * -1
     tmp30 += einsum(t1, (0, 1), tmp29, (0, 2, 3, 4), (3, 2, 4, 1))
     del tmp29
     tmp19 = einsum(tmp2, (0, 1, 2, 3), t1, (2, 4), (0, 1, 4, 3))
     tmp12 = einsum(v.vvvv, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
-    tmp26 = tmp21.copy()
+    tmp26 = np.copy(tmp21)
     del tmp21
     tmp26 += tmp22
     del tmp22
@@ -115,49 +115,49 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp28 = einsum(tmp27, (0, 1, 2, 3), t1, (2, 4), (0, 1, 4, 3))
     del tmp27
     tmp20 = einsum(t2, (0, 1, 2, 3), f.oo, (4, 1), (4, 0, 2, 3))
-    tmp18 = tmp13.copy()
+    tmp18 = np.copy(tmp13)
     del tmp13
-    tmp18 += tmp17.transpose((0, 1, 3, 2))
+    tmp18 += np.transpose(tmp17, (0, 1, 3, 2))
     del tmp17
-    tmp1 = v.ovvv.copy()
-    tmp1 += v.ovvv.transpose((0, 2, 1, 3)) * -0.5
-    tmp3 = v.ooov.copy()
-    tmp3 += v.ooov.transpose((0, 2, 1, 3)) * -0.5
+    tmp1 = np.copy(v.ovvv)
+    tmp1 += np.transpose(v.ovvv, (0, 2, 1, 3)) * -0.5
+    tmp3 = np.copy(v.ooov)
+    tmp3 += np.transpose(v.ooov, (0, 2, 1, 3)) * -0.5
     tmp3 += tmp2 * -0.5
-    tmp3 += tmp2.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(tmp2, (0, 2, 1, 3))
     del tmp2
-    tmp5 = f.ov.copy()
+    tmp5 = np.copy(f.ov)
     tmp5 += einsum(t1, (0, 1), tmp4, (0, 2, 1, 3), (2, 3))
     del tmp4
-    tmp7 = v.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp7 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 2
     tmp7 += v.oovv * -1
-    tmp6 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp6 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp6 += t2 * -1
-    tmp11 = f.oo.copy() * 0.5
+    tmp11 = np.copy(f.oo) * 0.5
     tmp11 += tmp8 * 0.5
     del tmp8
     tmp11 += einsum(tmp0, (0, 1, 2, 3), tmp9, (0, 4, 2, 3), (4, 1)) * 0.5
     del tmp9
     tmp11 += einsum(tmp10, (0, 1, 2, 3), t1, (2, 3), (1, 0))
     del tmp10
-    t2new = v.ovov.transpose((0, 2, 1, 3)).copy()
+    t2new = np.copy(np.transpose(v.ovov, (0, 2, 1, 3)))
     t2new += einsum(v.ovoo, (0, 1, 2, 3), t1, (3, 4), (0, 2, 1, 4)) * -1
     t2new += einsum(tmp12, (0, 1, 2, 3), t1, (4, 2), (4, 0, 1, 3))
     del tmp12
-    t2new += tmp18.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp18.transpose((1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp18, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp18, (1, 0, 2, 3)) * -1
     del tmp18
     t2new += tmp19 * -1
-    t2new += tmp19.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp19, (1, 0, 3, 2)) * -1
     del tmp19
-    t2new += tmp20.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp20.transpose((1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp20, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp20, (1, 0, 2, 3)) * -1
     del tmp20
-    t2new += tmp26.transpose((0, 1, 3, 2))
-    t2new += tmp26.transpose((1, 0, 2, 3))
+    t2new += np.transpose(tmp26, (0, 1, 3, 2))
+    t2new += np.transpose(tmp26, (1, 0, 2, 3))
     del tmp26
     t2new += tmp28 * -1
-    t2new += tmp28.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp28, (1, 0, 3, 2)) * -1
     del tmp28
     t2new += einsum(t1, (0, 1), tmp30, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp30
@@ -203,8 +203,8 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
         Updated L2 residuals.
     """
 
-    tmp80 = v.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp80 += v.ovov.transpose((0, 2, 1, 3)) * 2
+    tmp80 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -1
+    tmp80 += np.transpose(v.ovov, (0, 2, 1, 3)) * 2
     tmp81 = einsum(t1, (0, 1), tmp80, (0, 2, 1, 3), (2, 3))
     del tmp80
     tmp8 = einsum(v.ovov, (0, 1, 2, 3), t1, (4, 3), (4, 0, 2, 1))
@@ -213,31 +213,31 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp79 = einsum(v.ooov, (0, 1, 2, 3), t1, (1, 3), (0, 2))
     tmp82 = einsum(t1, (0, 1), tmp81, (2, 1), (0, 2))
     tmp70 = einsum(v.ovvv, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
-    tmp5 = v.ovov.transpose((0, 2, 3, 1)).copy() * -0.5
-    tmp5 += v.ovov.transpose((0, 2, 1, 3))
+    tmp5 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -0.5
+    tmp5 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp2 = einsum(v.ovov, (0, 1, 2, 3), t2, (4, 5, 1, 3), (4, 5, 0, 2))
     tmp26 = einsum(tmp8, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
-    tmp16 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp16 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp16 += t2 * -0.5
     tmp36 = einsum(tmp17, (0, 1, 2, 3), t1, (4, 3), (1, 0, 2, 4))
     tmp35 = einsum(l2, (0, 1, 2, 3), t2, (4, 5, 0, 1), (2, 3, 4, 5))
     tmp102 = einsum(v.ooov, (0, 1, 2, 3), t1, (2, 3), (0, 1))
     tmp65 = einsum(v.ovvv, (0, 1, 2, 3), t1, (0, 1), (2, 3))
-    tmp73 = v.oovv.copy()
-    tmp73 += tmp24.transpose((0, 1, 3, 2))
-    tmp75 = tmp17.copy() * -1
-    tmp75 += tmp17.transpose((1, 0, 2, 3)) * 2
-    tmp83 = tmp79.copy()
+    tmp73 = np.copy(v.oovv)
+    tmp73 += np.transpose(tmp24, (0, 1, 3, 2))
+    tmp75 = np.copy(tmp17) * -1
+    tmp75 += np.transpose(tmp17, (1, 0, 2, 3)) * 2
+    tmp83 = np.copy(tmp79)
     del tmp79
     tmp83 += tmp82 * -1
     del tmp82
-    tmp71 = v.ovov.transpose((0, 2, 3, 1)).copy()
+    tmp71 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1)))
     tmp71 += tmp70
     del tmp70
-    tmp69 = l2.transpose((3, 2, 0, 1)).copy() * 2
-    tmp69 += l2.transpose((2, 3, 0, 1)) * -1
-    tmp77 = tmp8.copy() * 2
-    tmp77 += tmp8.transpose((0, 2, 1, 3)) * -1
+    tmp69 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * 2
+    tmp69 += np.transpose(l2, (2, 3, 0, 1)) * -1
+    tmp77 = np.copy(tmp8) * 2
+    tmp77 += np.transpose(tmp8, (0, 2, 1, 3)) * -1
     tmp51 = einsum(l1, (0, 1), t1, (2, 0), (1, 2))
     tmp89 = einsum(f.ov, (0, 1), t1, (2, 1), (0, 2))
     tmp12 = einsum(v.ooov, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
@@ -250,7 +250,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp25 = einsum(tmp24, (0, 1, 2, 3), t1, (4, 3), (0, 4, 1, 2))
     del tmp24
     tmp52 = einsum(tmp16, (0, 1, 2, 3), l2, (3, 2, 0, 4), (4, 1))
-    tmp37 = tmp35.transpose((1, 0, 3, 2)).copy()
+    tmp37 = np.copy(np.transpose(tmp35, (1, 0, 3, 2)))
     tmp37 += tmp36
     tmp103 = einsum(tmp102, (0, 1), l2, (2, 3, 4, 1), (4, 0, 2, 3))
     del tmp102
@@ -284,73 +284,73 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp93 = einsum(v.ooov, (0, 1, 2, 3), tmp17, (1, 4, 2, 5), (4, 0, 5, 3))
     tmp92 = einsum(tmp12, (0, 1, 2, 3), l2, (4, 5, 0, 1), (2, 3, 4, 5))
     tmp105 = einsum(v.ovvv, (0, 1, 2, 3), t1, (0, 3), (1, 2))
-    tmp60 = f.ov.copy()
+    tmp60 = np.copy(f.ov)
     tmp60 += tmp6
-    tmp62 = v.ooov.copy()
-    tmp62 += v.ovoo.transpose((0, 2, 3, 1)) * -0.5
-    tmp15 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp62 = np.copy(v.ooov)
+    tmp62 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -0.5
+    tmp15 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp15 += t2 * 2
-    tmp33 = tmp17.copy() * 2
-    tmp33 += tmp17.transpose((1, 0, 2, 3)) * -1
-    tmp9 = v.ooov.copy() * 2
-    tmp9 += v.ooov.transpose((0, 2, 1, 3)) * -1
+    tmp33 = np.copy(tmp17) * 2
+    tmp33 += np.transpose(tmp17, (1, 0, 2, 3)) * -1
+    tmp9 = np.copy(v.ooov) * 2
+    tmp9 += np.transpose(v.ooov, (0, 2, 1, 3)) * -1
     tmp9 += tmp8 * -1
-    tmp9 += tmp8.transpose((0, 2, 1, 3)) * 2
-    tmp4 = tmp1.copy() * 0.5
+    tmp9 += np.transpose(tmp8, (0, 2, 1, 3)) * 2
+    tmp4 = np.copy(tmp1) * 0.5
     del tmp1
     tmp4 += tmp3 * -0.5
     del tmp3
-    tmp10 = v.ooov.copy() * -0.5
-    tmp10 += v.ooov.transpose((0, 2, 1, 3))
+    tmp10 = np.copy(v.ooov) * -0.5
+    tmp10 += np.transpose(v.ooov, (0, 2, 1, 3))
     tmp10 += tmp8
-    tmp10 += tmp8.transpose((0, 2, 1, 3)) * -0.5
+    tmp10 += np.transpose(tmp8, (0, 2, 1, 3)) * -0.5
     tmp7 = einsum(t2, (0, 1, 2, 3), tmp6, (4, 2), (0, 1, 4, 3))
     del tmp6
-    tmp13 = v.oooo.transpose((0, 2, 1, 3)).copy() * 2
+    tmp13 = np.copy(np.transpose(v.oooo, (0, 2, 1, 3))) * 2
     tmp13 += v.oooo * -1
-    tmp13 += tmp12.transpose((2, 1, 0, 3)) * -1
-    tmp13 += tmp12.transpose((3, 2, 0, 1)) * 2
-    tmp11 = v.oovv.copy() * 2
-    tmp11 += v.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp13 += np.transpose(tmp12, (2, 1, 0, 3)) * -1
+    tmp13 += np.transpose(tmp12, (3, 2, 0, 1)) * 2
+    tmp11 = np.copy(v.oovv) * 2
+    tmp11 += np.transpose(v.ovov, (0, 2, 1, 3)) * -1
     tmp0 = einsum(f.ov, (0, 1), t2, (2, 3, 4, 1), (0, 2, 3, 4))
-    tmp30 = v.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp30 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 2
     tmp30 += v.oovv * -1
-    tmp31 = tmp12.transpose((0, 2, 1, 3)).copy() * -1
-    tmp31 += tmp12.transpose((0, 3, 2, 1)) * 2
+    tmp31 = np.copy(np.transpose(tmp12, (0, 2, 1, 3))) * -1
+    tmp31 += np.transpose(tmp12, (0, 3, 2, 1)) * 2
     del tmp12
-    tmp28 = tmp25.copy() * 2
+    tmp28 = np.copy(tmp25) * 2
     del tmp25
     tmp28 += tmp27 * -2
     del tmp27
-    tmp29 = v.ooov.copy()
-    tmp29 += v.ooov.transpose((0, 2, 1, 3)) * -0.5
+    tmp29 = np.copy(v.ooov)
+    tmp29 += np.transpose(v.ooov, (0, 2, 1, 3)) * -0.5
     tmp29 += tmp8 * -0.5
-    tmp29 += tmp8.transpose((0, 2, 1, 3))
+    tmp29 += np.transpose(tmp8, (0, 2, 1, 3))
     del tmp8
-    tmp18 = tmp17.copy() * -0.5
-    tmp18 += tmp17.transpose((1, 0, 2, 3))
-    tmp53 = tmp51.copy() * 0.5
+    tmp18 = np.copy(tmp17) * -0.5
+    tmp18 += np.transpose(tmp17, (1, 0, 2, 3))
+    tmp53 = np.copy(tmp51) * 0.5
     tmp53 += tmp52
     del tmp52
-    tmp50 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp50 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp50 += t2 * -1
-    tmp47 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp47 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp47 += t2
-    tmp22 = l2.transpose((3, 2, 0, 1)).copy() * 2
-    tmp22 += l2.transpose((2, 3, 0, 1)) * -1
+    tmp22 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * 2
+    tmp22 += np.transpose(l2, (2, 3, 0, 1)) * -1
     tmp38 = einsum(tmp37, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     del tmp37
-    tmp39 = tmp17.copy() * -1
-    tmp39 += tmp17.transpose((1, 0, 2, 3)) * 2
+    tmp39 = np.copy(tmp17) * -1
+    tmp39 += np.transpose(tmp17, (1, 0, 2, 3)) * 2
     tmp41 = einsum(t2, (0, 1, 2, 3), l1, (3, 4), (4, 0, 1, 2))
-    tmp42 = tmp17.copy()
-    tmp42 += tmp17.transpose((1, 0, 2, 3)) * -0.5
-    tmp58 = v.ovvv.copy()
-    tmp58 += v.ovvv.transpose((0, 2, 1, 3)) * -0.5
-    tmp107 = v.oooo.copy()
-    tmp107 += tmp26.transpose((0, 2, 3, 1))
+    tmp42 = np.copy(tmp17)
+    tmp42 += np.transpose(tmp17, (1, 0, 2, 3)) * -0.5
+    tmp58 = np.copy(v.ovvv)
+    tmp58 += np.transpose(v.ovvv, (0, 2, 1, 3)) * -0.5
+    tmp107 = np.copy(v.oooo)
+    tmp107 += np.transpose(tmp26, (0, 2, 3, 1))
     del tmp26
-    tmp104 = tmp101.copy()
+    tmp104 = np.copy(tmp101)
     del tmp101
     tmp104 += tmp103 * 2
     del tmp103
@@ -367,23 +367,23 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp72
     tmp86 += tmp74 * -1
     del tmp74
-    tmp86 += tmp76.transpose((1, 0, 3, 2)) * -1
+    tmp86 += np.transpose(tmp76, (1, 0, 3, 2)) * -1
     del tmp76
     tmp86 += tmp78 * -1
     del tmp78
-    tmp86 += tmp84.transpose((0, 1, 3, 2))
+    tmp86 += np.transpose(tmp84, (0, 1, 3, 2))
     del tmp84
     tmp86 += tmp85 * -1
     del tmp85
     tmp86 += einsum(tmp81, (0, 1), l1, (2, 3), (3, 0, 2, 1))
     del tmp81
-    tmp100 = tmp97.copy()
+    tmp100 = np.copy(tmp97)
     del tmp97
     tmp100 += tmp98
     del tmp98
     tmp100 += tmp99
     del tmp99
-    tmp96 = tmp87.copy()
+    tmp96 = np.copy(tmp87)
     del tmp87
     tmp96 += tmp88
     del tmp88
@@ -401,23 +401,23 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp95
     tmp106 = einsum(tmp105, (0, 1), l2, (2, 1, 3, 4), (3, 4, 2, 0))
     del tmp105
-    tmp63 = f.oo.copy()
+    tmp63 = np.copy(f.oo)
     tmp63 += einsum(tmp15, (0, 1, 2, 3), v.ovov, (4, 3, 0, 2), (1, 4))
     tmp63 += einsum(t1, (0, 1), tmp62, (2, 3, 0, 1), (3, 2)) * 2
     del tmp62
     tmp63 += einsum(tmp60, (0, 1), t1, (2, 1), (2, 0))
-    tmp34 = l2.transpose((3, 2, 0, 1)).copy()
+    tmp34 = np.copy(np.transpose(l2, (3, 2, 0, 1)))
     tmp34 += einsum(tmp33, (0, 1, 2, 3), t1, (1, 4), (0, 2, 3, 4))
     del tmp33
-    tmp14 = v.ooov.transpose((0, 2, 1, 3)).copy() * 0.5
-    tmp14 += v.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp14 += tmp0.transpose((1, 2, 0, 3)) * -1
-    tmp14 += tmp0.transpose((2, 1, 0, 3)) * 0.5
+    tmp14 = np.copy(np.transpose(v.ooov, (0, 2, 1, 3))) * 0.5
+    tmp14 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
+    tmp14 += np.transpose(tmp0, (1, 2, 0, 3)) * -1
+    tmp14 += np.transpose(tmp0, (2, 1, 0, 3)) * 0.5
     del tmp0
     tmp14 += tmp4
-    tmp14 += tmp4.transpose((1, 0, 2, 3)) * -2
+    tmp14 += np.transpose(tmp4, (1, 0, 2, 3)) * -2
     del tmp4
-    tmp14 += tmp7.transpose((1, 0, 2, 3)) * -1
+    tmp14 += np.transpose(tmp7, (1, 0, 2, 3)) * -1
     tmp14 += tmp7 * 0.5
     del tmp7
     tmp14 += einsum(tmp9, (0, 1, 2, 3), t2, (4, 2, 5, 3), (0, 4, 1, 5)) * 0.5
@@ -428,12 +428,12 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp11
     tmp14 += einsum(t1, (0, 1), tmp13, (0, 2, 3, 4), (3, 2, 4, 1)) * 0.5
     del tmp13
-    tmp49 = v.ovvv.copy() * -1
-    tmp49 += v.ovvv.transpose((0, 2, 3, 1)) * 2
-    tmp44 = tmp17.copy() * 2
-    tmp44 += tmp17.transpose((1, 0, 2, 3)) * -1
-    tmp32 = tmp28.copy() * -1
-    tmp32 += tmp28.transpose((1, 0, 2, 3)) * 0.5
+    tmp49 = np.copy(v.ovvv) * -1
+    tmp49 += np.transpose(v.ovvv, (0, 2, 3, 1)) * 2
+    tmp44 = np.copy(tmp17) * 2
+    tmp44 += np.transpose(tmp17, (1, 0, 2, 3)) * -1
+    tmp32 = np.copy(tmp28) * -1
+    tmp32 += np.transpose(tmp28, (1, 0, 2, 3)) * 0.5
     del tmp28
     tmp32 += einsum(tmp16, (0, 1, 2, 3), tmp29, (4, 5, 0, 3), (4, 1, 5, 2)) * -4
     del tmp29
@@ -445,75 +445,75 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp19 += einsum(tmp16, (0, 1, 2, 3), l2, (4, 3, 5, 0), (5, 1, 4, 2)) * 2
     tmp19 += einsum(t1, (0, 1), tmp18, (2, 0, 3, 4), (2, 3, 1, 4)) * 2
     del tmp18
-    tmp45 = tmp36.copy()
-    tmp45 += tmp36.transpose((0, 1, 3, 2)) * -0.5
-    tmp54 = t1.copy() * -0.5
+    tmp45 = np.copy(tmp36)
+    tmp45 += np.transpose(tmp36, (0, 1, 3, 2)) * -0.5
+    tmp54 = np.copy(t1) * -0.5
     tmp54 += einsum(tmp47, (0, 1, 2, 3), tmp17, (1, 0, 4, 3), (4, 2))
     tmp54 += einsum(l1, (0, 1), tmp50, (1, 2, 3, 0), (2, 3)) * -0.5
     del tmp50
     tmp54 += einsum(t1, (0, 1), tmp53, (0, 2), (2, 1))
-    tmp23 = l2.transpose((2, 3, 0, 1)).copy()
+    tmp23 = np.copy(np.transpose(l2, (2, 3, 0, 1)))
     tmp23 += einsum(tmp22, (0, 1, 2, 3), tmp16, (0, 4, 5, 3), (1, 4, 2, 5))
     del tmp22
-    tmp56 = v.ooov.copy() * -0.5
-    tmp56 += v.ooov.transpose((0, 2, 1, 3))
-    tmp40 = tmp17.transpose((0, 2, 1, 3)).copy() * 0.5
-    tmp40 += tmp17.transpose((1, 2, 0, 3)) * -1
+    tmp56 = np.copy(v.ooov) * -0.5
+    tmp56 += np.transpose(v.ooov, (0, 2, 1, 3))
+    tmp40 = np.copy(np.transpose(tmp17, (0, 2, 1, 3))) * 0.5
+    tmp40 += np.transpose(tmp17, (1, 2, 0, 3)) * -1
     del tmp17
-    tmp40 += tmp38.transpose((0, 2, 1, 3))
+    tmp40 += np.transpose(tmp38, (0, 2, 1, 3))
     tmp40 += tmp38 * -0.5
     del tmp38
     tmp40 += einsum(tmp39, (0, 1, 2, 3), tmp15, (1, 4, 3, 5), (0, 2, 4, 5)) * -0.5
     del tmp15
-    tmp55 = v.ovov.transpose((0, 2, 3, 1)).copy() * 2
-    tmp55 += v.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp57 = v.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp55 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * 2
+    tmp55 += np.transpose(v.ovov, (0, 2, 1, 3)) * -1
+    tmp57 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 2
     tmp57 += v.oovv * -1
     tmp48 = einsum(l1, (0, 1), t1, (1, 2), (0, 2)) * 0.5
     tmp48 += einsum(tmp47, (0, 1, 2, 3), l2, (4, 3, 0, 1), (4, 2))
     del tmp47
-    tmp43 = tmp41.copy() * -2
-    tmp43 += tmp41.transpose((0, 2, 1, 3))
+    tmp43 = np.copy(tmp41) * -2
+    tmp43 += np.transpose(tmp41, (0, 2, 1, 3))
     del tmp41
     tmp43 += einsum(t2, (0, 1, 2, 3), tmp39, (4, 1, 5, 3), (4, 5, 0, 2))
     del tmp39
     tmp43 += einsum(tmp42, (0, 1, 2, 3), t2, (4, 1, 3, 5), (0, 2, 4, 5)) * 2
     del tmp42
-    tmp46 = tmp35.transpose((1, 0, 2, 3)).copy() * -0.5
-    tmp46 += tmp35.transpose((1, 0, 3, 2))
+    tmp46 = np.copy(np.transpose(tmp35, (1, 0, 2, 3))) * -0.5
+    tmp46 += np.transpose(tmp35, (1, 0, 3, 2))
     del tmp35
-    tmp61 = tmp51.copy()
+    tmp61 = np.copy(tmp51)
     del tmp51
     tmp61 += einsum(tmp16, (0, 1, 2, 3), l2, (3, 2, 0, 4), (4, 1)) * 2
     del tmp16
-    tmp59 = f.vv.copy() * 0.5
+    tmp59 = np.copy(f.vv) * 0.5
     tmp59 += einsum(tmp58, (0, 1, 2, 3), t1, (0, 1), (3, 2))
     del tmp58
-    tmp21 = v.vvvv.transpose((0, 2, 1, 3)).copy() * -1
+    tmp21 = np.copy(np.transpose(v.vvvv, (0, 2, 1, 3))) * -1
     tmp21 += v.vvvv * 2
     tmp20 = einsum(l2, (0, 1, 2, 3), t1, (3, 4), (2, 0, 1, 4))
     l2new = einsum(v.ovov, (0, 1, 2, 3), tmp36, (4, 5, 2, 0), (1, 3, 5, 4))
     del tmp36
-    l2new += v.ovov.transpose((1, 3, 0, 2))
+    l2new += np.transpose(v.ovov, (1, 3, 0, 2))
     l2new += einsum(v.vvvv, (0, 1, 2, 3), l2, (3, 1, 4, 5), (0, 2, 5, 4))
-    l2new += tmp86.transpose((2, 3, 0, 1))
-    l2new += tmp86.transpose((3, 2, 1, 0))
+    l2new += np.transpose(tmp86, (2, 3, 0, 1))
+    l2new += np.transpose(tmp86, (3, 2, 1, 0))
     del tmp86
-    l2new += tmp96.transpose((3, 2, 0, 1))
-    l2new += tmp96.transpose((2, 3, 1, 0))
+    l2new += np.transpose(tmp96, (3, 2, 0, 1))
+    l2new += np.transpose(tmp96, (2, 3, 1, 0))
     del tmp96
-    l2new += tmp100.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp100.transpose((2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp100, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp100, (2, 3, 1, 0)) * -1
     del tmp100
-    l2new += tmp104.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp104.transpose((3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp104, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp104, (3, 2, 1, 0)) * -1
     del tmp104
-    l2new += tmp106.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp106.transpose((3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp106, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp106, (3, 2, 1, 0)) * -1
     del tmp106
     l2new += einsum(tmp107, (0, 1, 2, 3), l2, (4, 5, 3, 0), (4, 5, 2, 1))
     del tmp107
-    l1new = f.ov.transpose((1, 0)).copy()
+    l1new = np.copy(np.transpose(f.ov, (1, 0)))
     l1new += einsum(tmp14, (0, 1, 2, 3), l2, (4, 3, 1, 0), (4, 2)) * 2
     del tmp14
     l1new += einsum(tmp19, (0, 1, 2, 3), v.ovvv, (1, 4, 3, 2), (4, 0)) * -1
@@ -580,33 +580,33 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
         vv=np.eye(t2.shape[-1]),
     )
     tmp2 = einsum(l2, (0, 1, 2, 3), t1, (4, 1), (2, 3, 4, 0))
-    tmp5 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp5 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp5 += t2
     tmp0 = einsum(l1, (0, 1), t1, (2, 0), (1, 2))
-    tmp7 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp7 += l2.transpose((2, 3, 0, 1)) * 2
-    tmp3 = tmp2.copy() * -0.5
-    tmp3 += tmp2.transpose((1, 0, 2, 3))
+    tmp7 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp7 += np.transpose(l2, (2, 3, 0, 1)) * 2
+    tmp3 = np.copy(tmp2) * -0.5
+    tmp3 += np.transpose(tmp2, (1, 0, 2, 3))
     del tmp2
-    tmp4 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp4 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp4 += t2 * -1
-    tmp6 = tmp0.copy() * 0.5
+    tmp6 = np.copy(tmp0) * 0.5
     tmp6 += einsum(tmp5, (0, 1, 2, 3), l2, (2, 3, 0, 4), (4, 1))
     del tmp5
-    tmp1 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp1 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp1 += t2 * -0.5
     rdm1.vv = einsum(l1, (0, 1), t1, (1, 2), (0, 2)) * 2
     rdm1.vv += einsum(t2, (0, 1, 2, 3), tmp7, (0, 1, 4, 3), (4, 2)) * 2
     del tmp7
-    rdm1.vo = l1.copy() * 2
-    rdm1.ov = t1.copy() * 2
+    rdm1.vo = np.copy(l1) * 2
+    rdm1.ov = np.copy(t1) * 2
     rdm1.ov += einsum(t2, (0, 1, 2, 3), tmp3, (0, 1, 4, 3), (4, 2)) * -4
     del tmp3
     rdm1.ov += einsum(l1, (0, 1), tmp4, (1, 2, 3, 0), (2, 3)) * 2
     del tmp4
     rdm1.ov += einsum(tmp6, (0, 1), t1, (0, 2), (1, 2)) * -4
     del tmp6
-    rdm1.oo = tmp0.transpose((1, 0)).copy() * -2
+    rdm1.oo = np.copy(np.transpose(tmp0, (1, 0))) * -2
     del tmp0
     rdm1.oo += delta.oo * 2
     del delta
@@ -643,36 +643,36 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
         vv=np.eye(t2.shape[-1]),
     )
     tmp2 = einsum(l2, (0, 1, 2, 3), t1, (4, 1), (2, 3, 4, 0))
-    tmp9 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp9 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp9 += t2 * -1
-    tmp77 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp77 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp77 += t2 * -1
-    tmp16 = tmp2.copy() * -1
-    tmp16 += tmp2.transpose((1, 0, 2, 3)) * 2
-    tmp14 = tmp2.copy() * -1
-    tmp14 += tmp2.transpose((1, 0, 2, 3))
-    tmp5 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp16 = np.copy(tmp2) * -1
+    tmp16 += np.transpose(tmp2, (1, 0, 2, 3)) * 2
+    tmp14 = np.copy(tmp2) * -1
+    tmp14 += np.transpose(tmp2, (1, 0, 2, 3))
+    tmp5 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp5 += t2
-    tmp60 = l2.transpose((3, 2, 0, 1)).copy() * 2
-    tmp60 += l2.transpose((2, 3, 0, 1)) * -1
-    tmp44 = l2.transpose((3, 2, 0, 1)).copy() * 2
-    tmp44 += l2.transpose((2, 3, 0, 1)) * -1
+    tmp60 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * 2
+    tmp60 += np.transpose(l2, (2, 3, 0, 1)) * -1
+    tmp44 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * 2
+    tmp44 += np.transpose(l2, (2, 3, 0, 1)) * -1
     tmp79 = einsum(tmp9, (0, 1, 2, 3), l2, (4, 3, 5, 0), (1, 5, 2, 4))
     tmp88 = einsum(tmp2, (0, 1, 2, 3), t1, (1, 4), (0, 2, 3, 4))
     tmp78 = einsum(l2, (0, 1, 2, 3), tmp77, (2, 4, 5, 1), (4, 3, 5, 0))
     del tmp77
     tmp1 = einsum(l2, (0, 1, 2, 3), t2, (4, 5, 0, 1), (2, 3, 4, 5))
     tmp3 = einsum(t1, (0, 1), tmp2, (2, 3, 4, 1), (3, 2, 4, 0))
-    tmp53 = l2.transpose((3, 2, 0, 1)).copy()
-    tmp53 += l2.transpose((2, 3, 0, 1)) * -1
+    tmp53 = np.copy(np.transpose(l2, (3, 2, 0, 1)))
+    tmp53 += np.transpose(l2, (2, 3, 0, 1)) * -1
     tmp17 = einsum(tmp16, (0, 1, 2, 3), t2, (4, 1, 5, 3), (0, 2, 4, 5))
     del tmp16
     tmp25 = einsum(tmp2, (0, 1, 2, 3), t2, (4, 0, 3, 5), (1, 2, 4, 5))
     tmp12 = einsum(t2, (0, 1, 2, 3), l1, (3, 4), (4, 0, 1, 2))
     tmp15 = einsum(tmp14, (0, 1, 2, 3), t2, (4, 1, 3, 5), (0, 2, 4, 5))
     tmp0 = einsum(l1, (0, 1), t1, (2, 0), (1, 2))
-    tmp21 = tmp2.copy() * 2
-    tmp21 += tmp2.transpose((1, 0, 2, 3)) * -1
+    tmp21 = np.copy(tmp2) * 2
+    tmp21 += np.transpose(tmp2, (1, 0, 2, 3)) * -1
     tmp6 = einsum(tmp5, (0, 1, 2, 3), l2, (2, 3, 0, 4), (4, 1)) * 2
     tmp26 = einsum(tmp2, (0, 1, 2, 3), t2, (4, 1, 3, 5), (0, 2, 4, 5))
     tmp31 = einsum(tmp5, (0, 1, 2, 3), l2, (2, 3, 0, 4), (4, 1))
@@ -682,24 +682,24 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp90 = einsum(t2, (0, 1, 2, 3), tmp60, (0, 1, 4, 2), (4, 3))
     tmp65 = einsum(l2, (0, 1, 2, 3), t2, (4, 3, 1, 5), (2, 4, 0, 5))
     tmp51 = einsum(t2, (0, 1, 2, 3), tmp44, (1, 4, 5, 3), (4, 0, 5, 2))
-    tmp104 = tmp88.copy()
-    tmp104 += tmp78.transpose((1, 0, 3, 2))
-    tmp104 += tmp79.transpose((1, 0, 3, 2)) * -1
+    tmp104 = np.copy(tmp88)
+    tmp104 += np.transpose(tmp78, (1, 0, 3, 2))
+    tmp104 += np.transpose(tmp79, (1, 0, 3, 2)) * -1
     tmp101 = einsum(t2, (0, 1, 2, 3), tmp60, (1, 4, 5, 3), (4, 0, 5, 2))
-    tmp94 = tmp79.transpose((1, 0, 3, 2)).copy()
-    tmp94 += tmp78.transpose((1, 0, 3, 2)) * -1
-    tmp4 = tmp1.transpose((1, 0, 3, 2)).copy()
+    tmp94 = np.copy(np.transpose(tmp79, (1, 0, 3, 2)))
+    tmp94 += np.transpose(tmp78, (1, 0, 3, 2)) * -1
+    tmp4 = np.copy(np.transpose(tmp1, (1, 0, 3, 2)))
     tmp4 += tmp3
     tmp54 = einsum(tmp53, (0, 1, 2, 3), t2, (4, 0, 3, 5), (1, 4, 2, 5))
     tmp13 = einsum(t1, (0, 1), tmp3, (0, 2, 3, 4), (2, 4, 3, 1))
     tmp45 = einsum(tmp44, (0, 1, 2, 3), t2, (4, 0, 3, 5), (1, 4, 2, 5))
     del tmp44
-    tmp69 = tmp25.copy()
+    tmp69 = np.copy(tmp25)
     tmp69 += tmp17 * -1
-    tmp35 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp35 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp35 += t2 * 2
     tmp19 = einsum(t1, (0, 1), tmp1, (2, 0, 3, 4), (2, 3, 4, 1))
-    tmp47 = tmp12.copy()
+    tmp47 = np.copy(tmp12)
     tmp47 += tmp15
     tmp47 += tmp17 * -1
     tmp8 = einsum(tmp0, (0, 1), t1, (0, 2), (1, 2))
@@ -709,36 +709,36 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp23 = einsum(tmp6, (0, 1), t1, (0, 2), (1, 2)) * 0.5
     tmp61 = einsum(t2, (0, 1, 2, 3), tmp60, (0, 1, 4, 2), (4, 3)) * 0.5
     del tmp60
-    tmp72 = tmp12.copy()
+    tmp72 = np.copy(tmp12)
     tmp72 += tmp26 * -1
-    tmp29 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp29 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp29 += t2 * -1
-    tmp32 = tmp0.copy() * 0.5
+    tmp32 = np.copy(tmp0) * 0.5
     tmp32 += tmp31
     del tmp31
     tmp111 = einsum(l2, (0, 1, 2, 3), t2, (3, 2, 4, 5), (0, 1, 5, 4))
     tmp112 = einsum(tmp110, (0, 1, 2, 3), t1, (0, 4), (2, 1, 3, 4))
     tmp97 = einsum(t2, (0, 1, 2, 3), tmp2, (0, 1, 4, 5), (4, 5, 2, 3))
-    tmp91 = tmp81.copy()
+    tmp91 = np.copy(tmp81)
     tmp91 += tmp90
     del tmp90
-    tmp108 = tmp65.copy()
+    tmp108 = np.copy(tmp65)
     tmp108 += tmp88
     tmp108 += tmp51 * -1
     tmp67 = einsum(l2, (0, 1, 2, 3), t2, (4, 2, 1, 5), (3, 4, 0, 5))
     tmp105 = einsum(tmp104, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     del tmp104
     tmp93 = einsum(l1, (0, 1), t2, (2, 1, 3, 4), (2, 0, 3, 4))
-    tmp102 = tmp65.copy()
+    tmp102 = np.copy(tmp65)
     tmp102 += tmp88
     tmp102 += tmp101 * -1
     del tmp101
     tmp95 = einsum(tmp94, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     del tmp94
-    tmp84 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp84 += l2.transpose((2, 3, 0, 1)) * 2
-    tmp86 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp86 += l2.transpose((2, 3, 0, 1))
+    tmp84 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp84 += np.transpose(l2, (2, 3, 0, 1)) * 2
+    tmp86 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp86 += np.transpose(l2, (2, 3, 0, 1))
     tmp27 = einsum(tmp4, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     tmp55 = einsum(tmp54, (0, 1, 2, 3), t2, (4, 0, 2, 5), (1, 4, 3, 5))
     del tmp54
@@ -756,10 +756,10 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp48 = einsum(t1, (0, 1), tmp47, (0, 2, 3, 4), (2, 3, 4, 1))
     del tmp47
     tmp43 = einsum(t2, (0, 1, 2, 3), tmp0, (1, 4), (4, 0, 2, 3))
-    tmp11 = tmp8.copy()
+    tmp11 = np.copy(tmp8)
     tmp11 += tmp10 * -1
     del tmp10
-    tmp24 = tmp22.copy()
+    tmp24 = np.copy(tmp22)
     del tmp22
     tmp24 += tmp23
     del tmp23
@@ -772,30 +772,30 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp30 = einsum(l1, (0, 1), tmp29, (1, 2, 3, 0), (2, 3))
     del tmp29
     tmp33 = einsum(t1, (0, 1), tmp32, (0, 2), (2, 1)) * 2
-    tmp40 = tmp2.copy() * 2
-    tmp40 += tmp2.transpose((1, 0, 2, 3)) * -1
-    tmp113 = tmp111.transpose((1, 0, 3, 2)).copy()
-    tmp113 += tmp112.transpose((1, 0, 3, 2))
-    tmp107 = tmp97.copy()
+    tmp40 = np.copy(tmp2) * 2
+    tmp40 += np.transpose(tmp2, (1, 0, 2, 3)) * -1
+    tmp113 = np.copy(np.transpose(tmp111, (1, 0, 3, 2)))
+    tmp113 += np.transpose(tmp112, (1, 0, 3, 2))
+    tmp107 = np.copy(tmp97)
     tmp107 += einsum(tmp91, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     tmp109 = einsum(t1, (0, 1), tmp108, (0, 2, 3, 4), (2, 3, 4, 1))
     del tmp108
     tmp100 = einsum(t1, (0, 1), tmp67, (0, 2, 3, 4), (2, 3, 1, 4))
-    tmp82 = tmp81.copy() * 0.5
+    tmp82 = np.copy(tmp81) * 0.5
     tmp82 += tmp61
-    tmp106 = tmp93.copy()
-    tmp106 += tmp105.transpose((0, 1, 3, 2))
+    tmp106 = np.copy(tmp93)
+    tmp106 += np.transpose(tmp105, (0, 1, 3, 2))
     del tmp105
     tmp103 = einsum(tmp102, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     del tmp102
     tmp99 = einsum(tmp88, (0, 1, 2, 3), t1, (0, 4), (1, 2, 4, 3))
-    tmp98 = tmp97.copy()
+    tmp98 = np.copy(tmp97)
     tmp98 += einsum(tmp61, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
     del tmp61
-    tmp96 = tmp93.copy()
+    tmp96 = np.copy(tmp93)
     tmp96 += einsum(tmp81, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     del tmp81
-    tmp96 += tmp95.transpose((0, 1, 3, 2)) * -1
+    tmp96 += np.transpose(tmp95, (0, 1, 3, 2)) * -1
     del tmp95
     tmp83 = einsum(tmp2, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     tmp89 = einsum(tmp14, (0, 1, 2, 3), t1, (1, 4), (0, 2, 3, 4))
@@ -808,170 +808,170 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp80 = einsum(t1, (0, 1), tmp14, (0, 2, 3, 4), (2, 3, 4, 1))
     del tmp14
     tmp75 = einsum(tmp27, (0, 1, 2, 3), t1, (0, 4), (2, 1, 3, 4))
-    tmp56 = tmp50.copy()
+    tmp56 = np.copy(tmp50)
     del tmp50
     tmp56 += tmp52 * 2
-    tmp56 += tmp55.transpose((1, 0, 3, 2))
+    tmp56 += np.transpose(tmp55, (1, 0, 3, 2))
     del tmp55
     tmp68 = einsum(tmp67, (0, 1, 2, 3), t2, (4, 0, 2, 5), (1, 4, 3, 5))
-    tmp71 = tmp46.transpose((1, 0, 3, 2)).copy() * -1
-    tmp71 += tmp70.transpose((0, 1, 3, 2))
+    tmp71 = np.copy(np.transpose(tmp46, (1, 0, 3, 2))) * -1
+    tmp71 += np.transpose(tmp70, (0, 1, 3, 2))
     del tmp70
     tmp71 += einsum(tmp36, (0, 1), t1, (2, 3), (2, 0, 3, 1))
-    tmp76 = t1.copy()
+    tmp76 = np.copy(t1)
     tmp76 += tmp8 * -1
-    tmp59 = tmp57.copy()
+    tmp59 = np.copy(tmp57)
     del tmp57
     tmp59 += tmp58
-    tmp49 = tmp43.copy()
-    tmp49 += tmp46.transpose((1, 0, 3, 2)) * -1
+    tmp49 = np.copy(tmp43)
+    tmp49 += np.transpose(tmp46, (1, 0, 3, 2)) * -1
     del tmp46
-    tmp49 += tmp48.transpose((0, 1, 3, 2))
+    tmp49 += np.transpose(tmp48, (0, 1, 3, 2))
     del tmp48
     tmp49 += einsum(t1, (0, 1), tmp11, (2, 3), (0, 2, 1, 3)) * -1
-    tmp64 = tmp62.transpose((1, 0, 3, 2)).copy()
+    tmp64 = np.copy(np.transpose(tmp62, (1, 0, 3, 2)))
     del tmp62
-    tmp64 += tmp63.transpose((0, 1, 3, 2))
+    tmp64 += np.transpose(tmp63, (0, 1, 3, 2))
     del tmp63
     tmp64 += einsum(tmp24, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
     tmp66 = einsum(tmp65, (0, 1, 2, 3), t2, (4, 0, 2, 5), (1, 4, 3, 5))
-    tmp74 = tmp43.copy()
+    tmp74 = np.copy(tmp43)
     del tmp43
-    tmp74 += tmp73.transpose((0, 1, 3, 2))
+    tmp74 += np.transpose(tmp73, (0, 1, 3, 2))
     del tmp73
     tmp39 = einsum(t1, (0, 1), tmp0, (2, 3), (2, 0, 3, 1))
     tmp39 += tmp15
     tmp39 += tmp17 * -1
-    tmp34 = t1.copy() * -1
+    tmp34 = np.copy(t1) * -1
     tmp34 += tmp28
     tmp34 += tmp30 * -1
     del tmp30
     tmp34 += tmp33
-    tmp42 = tmp0.copy()
+    tmp42 = np.copy(tmp0)
     tmp42 += tmp6
     tmp41 = einsum(tmp40, (0, 1, 2, 3), t2, (4, 0, 5, 3), (1, 2, 4, 5))
     del tmp40
-    tmp37 = tmp28.copy()
+    tmp37 = np.copy(tmp28)
     del tmp28
     tmp37 += tmp33
     del tmp33
-    tmp38 = tmp12.copy()
-    tmp38 += tmp27.transpose((0, 2, 1, 3))
+    tmp38 = np.copy(tmp12)
+    tmp38 += np.transpose(tmp27, (0, 2, 1, 3))
     tmp38 += einsum(tmp6, (0, 1), t1, (2, 3), (0, 2, 1, 3))
-    tmp20 = tmp19.copy()
+    tmp20 = np.copy(tmp19)
     del tmp19
     tmp20 += einsum(tmp6, (0, 1), t1, (2, 3), (0, 2, 1, 3))
-    tmp18 = tmp12.copy()
+    tmp18 = np.copy(tmp12)
     tmp18 += tmp13
     del tmp13
     tmp18 += tmp15
     del tmp15
     tmp18 += tmp17 * -1
-    tmp7 = delta.oo.copy()
+    tmp7 = np.copy(delta.oo)
     tmp7 += tmp0 * -1
-    rdm2.vvvv = tmp113.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.vvvv = np.copy(np.transpose(tmp113, (0, 1, 3, 2))) * -2
     rdm2.vvvv += tmp113 * 2
     del tmp113
-    rdm2.vvvv += tmp111.transpose((1, 0, 3, 2)) * 2
+    rdm2.vvvv += np.transpose(tmp111, (1, 0, 3, 2)) * 2
     del tmp111
-    rdm2.vvvv += tmp112.transpose((1, 0, 3, 2)) * 2
+    rdm2.vvvv += np.transpose(tmp112, (1, 0, 3, 2)) * 2
     del tmp112
-    rdm2.vvvo = tmp110.transpose((1, 2, 3, 0)).copy() * -2
-    rdm2.vvvo += tmp110.transpose((2, 1, 3, 0)) * 4
-    rdm2.vvov = tmp110.transpose((1, 2, 0, 3)).copy() * 4
-    rdm2.vvov += tmp110.transpose((2, 1, 0, 3)) * -2
+    rdm2.vvvo = np.copy(np.transpose(tmp110, (1, 2, 3, 0))) * -2
+    rdm2.vvvo += np.transpose(tmp110, (2, 1, 3, 0)) * 4
+    rdm2.vvov = np.copy(np.transpose(tmp110, (1, 2, 0, 3))) * 4
+    rdm2.vvov += np.transpose(tmp110, (2, 1, 0, 3)) * -2
     del tmp110
-    rdm2.vovv = tmp106.transpose((1, 0, 2, 3)).copy() * -2
-    rdm2.vovv += tmp106.transpose((1, 0, 3, 2)) * 2
+    rdm2.vovv = np.copy(np.transpose(tmp106, (1, 0, 2, 3))) * -2
+    rdm2.vovv += np.transpose(tmp106, (1, 0, 3, 2)) * 2
     del tmp106
-    rdm2.vovv += tmp107.transpose((1, 0, 2, 3)) * -2
-    rdm2.vovv += tmp107.transpose((1, 0, 3, 2)) * 2
+    rdm2.vovv += np.transpose(tmp107, (1, 0, 2, 3)) * -2
+    rdm2.vovv += np.transpose(tmp107, (1, 0, 3, 2)) * 2
     del tmp107
-    rdm2.vovv += tmp93.transpose((1, 0, 3, 2)) * 2
-    rdm2.vovv += tmp100.transpose((1, 0, 3, 2)) * -2
-    rdm2.vovv += tmp97.transpose((1, 0, 2, 3)) * -2
-    rdm2.vovv += tmp109.transpose((1, 0, 3, 2)) * -2
+    rdm2.vovv += np.transpose(tmp93, (1, 0, 3, 2)) * 2
+    rdm2.vovv += np.transpose(tmp100, (1, 0, 3, 2)) * -2
+    rdm2.vovv += np.transpose(tmp97, (1, 0, 2, 3)) * -2
+    rdm2.vovv += np.transpose(tmp109, (1, 0, 3, 2)) * -2
     del tmp109
     rdm2.vovv += einsum(tmp82, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 4
-    rdm2.ovvv = tmp96.copy() * 2
-    rdm2.ovvv += tmp96.transpose((0, 1, 3, 2)) * -2
+    rdm2.ovvv = np.copy(tmp96) * 2
+    rdm2.ovvv += np.transpose(tmp96, (0, 1, 3, 2)) * -2
     del tmp96
     rdm2.ovvv += tmp98 * 2
-    rdm2.ovvv += tmp98.transpose((0, 1, 3, 2)) * -2
+    rdm2.ovvv += np.transpose(tmp98, (0, 1, 3, 2)) * -2
     del tmp98
     rdm2.ovvv += tmp99 * 2
-    rdm2.ovvv += tmp99.transpose((0, 1, 3, 2)) * -2
+    rdm2.ovvv += np.transpose(tmp99, (0, 1, 3, 2)) * -2
     del tmp99
     rdm2.ovvv += tmp93 * 2
     del tmp93
-    rdm2.ovvv += tmp97.transpose((0, 1, 3, 2)) * -2
+    rdm2.ovvv += np.transpose(tmp97, (0, 1, 3, 2)) * -2
     del tmp97
     rdm2.ovvv += tmp100 * -2
     del tmp100
     rdm2.ovvv += tmp103 * -2
     del tmp103
     rdm2.ovvv += einsum(tmp91, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
-    rdm2.vvoo = l2.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.vvoo = np.copy(np.transpose(l2, (0, 1, 3, 2))) * -2
     rdm2.vvoo += l2 * 4
     rdm2.vovo = einsum(l1, (0, 1), t1, (2, 3), (0, 2, 3, 1)) * -2
-    rdm2.vovo += tmp85.transpose((2, 1, 3, 0)) * -2
-    rdm2.vovo += tmp92.transpose((2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp85, (2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp92, (2, 1, 3, 0)) * -2
     del tmp92
-    rdm2.vovo += tmp89.transpose((2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp89, (2, 1, 3, 0)) * -2
     rdm2.vovo += einsum(delta.oo, (0, 1), tmp91, (2, 3), (2, 0, 3, 1)) * 4
-    rdm2.vovo += tmp67.transpose((2, 1, 3, 0)) * -2
-    rdm2.vovo += tmp83.transpose((2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp67, (2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp83, (2, 1, 3, 0)) * -2
     rdm2.voov = einsum(l1, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 4
-    rdm2.voov += tmp79.transpose((3, 0, 1, 2)) * 2
-    rdm2.voov += tmp78.transpose((3, 0, 1, 2)) * -2
-    rdm2.voov += tmp89.transpose((2, 1, 0, 3)) * 2
+    rdm2.voov += np.transpose(tmp79, (3, 0, 1, 2)) * 2
+    rdm2.voov += np.transpose(tmp78, (3, 0, 1, 2)) * -2
+    rdm2.voov += np.transpose(tmp89, (2, 1, 0, 3)) * 2
     del tmp89
     rdm2.voov += einsum(delta.oo, (0, 1), tmp91, (2, 3), (2, 0, 1, 3)) * -2
     del tmp91
-    rdm2.voov += tmp65.transpose((2, 1, 0, 3)) * -2
-    rdm2.voov += tmp88.transpose((2, 1, 0, 3)) * -2
-    rdm2.voov += tmp85.transpose((2, 1, 0, 3)) * 2
+    rdm2.voov += np.transpose(tmp65, (2, 1, 0, 3)) * -2
+    rdm2.voov += np.transpose(tmp88, (2, 1, 0, 3)) * -2
+    rdm2.voov += np.transpose(tmp85, (2, 1, 0, 3)) * 2
     rdm2.ovvo = einsum(l1, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 4
-    rdm2.ovvo += tmp85.transpose((1, 2, 3, 0)) * 4
+    rdm2.ovvo += np.transpose(tmp85, (1, 2, 3, 0)) * 4
     del tmp85
-    rdm2.ovvo += tmp87.transpose((1, 2, 3, 0)) * -2
+    rdm2.ovvo += np.transpose(tmp87, (1, 2, 3, 0)) * -2
     del tmp87
-    rdm2.ovvo += tmp80.transpose((1, 2, 3, 0)) * -2
+    rdm2.ovvo += np.transpose(tmp80, (1, 2, 3, 0)) * -2
     rdm2.ovvo += einsum(tmp82, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * -4
-    rdm2.ovvo += tmp65.transpose((1, 2, 3, 0)) * -2
+    rdm2.ovvo += np.transpose(tmp65, (1, 2, 3, 0)) * -2
     del tmp65
-    rdm2.ovvo += tmp88.transpose((1, 2, 3, 0)) * -2
+    rdm2.ovvo += np.transpose(tmp88, (1, 2, 3, 0)) * -2
     del tmp88
     rdm2.ovov = einsum(l1, (0, 1), t1, (2, 3), (2, 0, 1, 3)) * -2
-    rdm2.ovov += tmp78.transpose((0, 3, 1, 2)) * 2
+    rdm2.ovov += np.transpose(tmp78, (0, 3, 1, 2)) * 2
     del tmp78
-    rdm2.ovov += tmp79.transpose((0, 3, 1, 2)) * -2
+    rdm2.ovov += np.transpose(tmp79, (0, 3, 1, 2)) * -2
     del tmp79
-    rdm2.ovov += tmp80.transpose((1, 2, 0, 3)) * 2
+    rdm2.ovov += np.transpose(tmp80, (1, 2, 0, 3)) * 2
     del tmp80
     rdm2.ovov += einsum(tmp82, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1)) * 8
     del tmp82
-    rdm2.ovov += tmp67.transpose((1, 2, 0, 3)) * -2
+    rdm2.ovov += np.transpose(tmp67, (1, 2, 0, 3)) * -2
     del tmp67
-    rdm2.ovov += tmp83.transpose((1, 2, 0, 3)) * -2
+    rdm2.ovov += np.transpose(tmp83, (1, 2, 0, 3)) * -2
     del tmp83
-    rdm2.oovv = tmp49.copy() * 2
-    rdm2.oovv += tmp49.transpose((0, 1, 3, 2)) * -2
-    rdm2.oovv += tmp49.transpose((1, 0, 2, 3)) * -2
-    rdm2.oovv += tmp49.transpose((1, 0, 3, 2)) * 2
+    rdm2.oovv = np.copy(tmp49) * 2
+    rdm2.oovv += np.transpose(tmp49, (0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(tmp49, (1, 0, 2, 3)) * -2
+    rdm2.oovv += np.transpose(tmp49, (1, 0, 3, 2)) * 2
     del tmp49
     rdm2.oovv += tmp56 * 2
-    rdm2.oovv += tmp56.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(tmp56, (0, 1, 3, 2)) * -2
     del tmp56
     rdm2.oovv += tmp59 * 2
-    rdm2.oovv += tmp59.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(tmp59, (0, 1, 3, 2)) * -2
     del tmp59
     rdm2.oovv += tmp64 * -4
-    rdm2.oovv += tmp64.transpose((0, 1, 3, 2)) * 2
-    rdm2.oovv += tmp64.transpose((1, 0, 2, 3)) * 2
-    rdm2.oovv += tmp64.transpose((1, 0, 3, 2)) * -4
+    rdm2.oovv += np.transpose(tmp64, (0, 1, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp64, (1, 0, 2, 3)) * 2
+    rdm2.oovv += np.transpose(tmp64, (1, 0, 3, 2)) * -4
     del tmp64
-    rdm2.oovv += t2.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(t2, (0, 1, 3, 2)) * -2
     rdm2.oovv += t2 * 4
     rdm2.oovv += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 1, 3)) * -2
     rdm2.oovv += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
@@ -979,28 +979,28 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp8
     rdm2.oovv += tmp66 * 2
     del tmp66
-    rdm2.oovv += tmp68.transpose((0, 1, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp68, (0, 1, 3, 2)) * 2
     del tmp68
     rdm2.oovv += tmp71 * 2
-    rdm2.oovv += tmp71.transpose((1, 0, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp71, (1, 0, 3, 2)) * 2
     del tmp71
-    rdm2.oovv += tmp74.transpose((0, 1, 3, 2)) * -2
-    rdm2.oovv += tmp74.transpose((1, 0, 2, 3)) * -2
+    rdm2.oovv += np.transpose(tmp74, (0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(tmp74, (1, 0, 2, 3)) * -2
     del tmp74
     rdm2.oovv += tmp52 * 4
     del tmp52
     rdm2.oovv += tmp58 * 2
     del tmp58
-    rdm2.oovv += tmp75.transpose((0, 1, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp75, (0, 1, 3, 2)) * 2
     del tmp75
     rdm2.oovv += einsum(tmp76, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 2
     del tmp76
-    rdm2.vooo = tmp2.transpose((3, 2, 0, 1)).copy() * -4
-    rdm2.vooo += tmp2.transpose((3, 2, 1, 0)) * 2
+    rdm2.vooo = np.copy(np.transpose(tmp2, (3, 2, 0, 1))) * -4
+    rdm2.vooo += np.transpose(tmp2, (3, 2, 1, 0)) * 2
     rdm2.vooo += einsum(l1, (0, 1), delta.oo, (2, 3), (0, 2, 1, 3)) * 4
     rdm2.vooo += einsum(delta.oo, (0, 1), l1, (2, 3), (2, 0, 1, 3)) * -2
-    rdm2.ovoo = tmp2.transpose((2, 3, 0, 1)).copy() * 2
-    rdm2.ovoo += tmp2.transpose((2, 3, 1, 0)) * -4
+    rdm2.ovoo = np.copy(np.transpose(tmp2, (2, 3, 0, 1))) * 2
+    rdm2.ovoo += np.transpose(tmp2, (2, 3, 1, 0)) * -4
     del tmp2
     rdm2.ovoo += einsum(l1, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * -2
     rdm2.ovoo += einsum(delta.oo, (0, 1), l1, (2, 3), (0, 2, 1, 3)) * 4
@@ -1010,48 +1010,48 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oovo += einsum(delta.oo, (0, 1), tmp37, (2, 3), (2, 0, 3, 1)) * -2
     rdm2.oovo += einsum(delta.oo, (0, 1), tmp37, (2, 3), (0, 2, 3, 1)) * 2
     del tmp37
-    rdm2.oovo += tmp38.transpose((1, 2, 3, 0)) * -2
-    rdm2.oovo += tmp38.transpose((2, 1, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp38, (1, 2, 3, 0)) * -2
+    rdm2.oovo += np.transpose(tmp38, (2, 1, 3, 0)) * 2
     del tmp38
-    rdm2.oovo += tmp39.transpose((1, 2, 3, 0)) * -2
-    rdm2.oovo += tmp39.transpose((2, 1, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp39, (1, 2, 3, 0)) * -2
+    rdm2.oovo += np.transpose(tmp39, (2, 1, 3, 0)) * 2
     del tmp39
     rdm2.oovo += einsum(delta.oo, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
     rdm2.oovo += einsum(t1, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * -2
-    rdm2.oovo += tmp12.transpose((1, 2, 3, 0)) * -2
-    rdm2.oovo += tmp26.transpose((1, 2, 3, 0)) * 2
-    rdm2.oovo += tmp25.transpose((2, 1, 3, 0)) * 2
-    rdm2.oovo += tmp41.transpose((2, 1, 3, 0)) * -2
+    rdm2.oovo += np.transpose(tmp12, (1, 2, 3, 0)) * -2
+    rdm2.oovo += np.transpose(tmp26, (1, 2, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp25, (2, 1, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp41, (2, 1, 3, 0)) * -2
     del tmp41
-    rdm2.oovo += tmp27.transpose((1, 2, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp27, (1, 2, 3, 0)) * 2
     rdm2.oovo += einsum(delta.oo, (0, 1), tmp34, (2, 3), (2, 0, 3, 1)) * -2
     rdm2.oovo += einsum(tmp42, (0, 1), t1, (2, 3), (2, 1, 3, 0)) * -2
     del tmp42
     rdm2.ooov = einsum(delta.oo, (0, 1), tmp11, (2, 3), (2, 0, 1, 3)) * 2
     rdm2.ooov += einsum(delta.oo, (0, 1), tmp11, (2, 3), (0, 2, 1, 3)) * -2
     del tmp11
-    rdm2.ooov += tmp18.transpose((1, 2, 0, 3)) * 2
-    rdm2.ooov += tmp18.transpose((2, 1, 0, 3)) * -2
+    rdm2.ooov += np.transpose(tmp18, (1, 2, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp18, (2, 1, 0, 3)) * -2
     del tmp18
     rdm2.ooov += einsum(tmp0, (0, 1), t1, (2, 3), (2, 1, 0, 3)) * 2
     rdm2.ooov += einsum(t1, (0, 1), tmp0, (2, 3), (3, 0, 2, 1)) * -2
-    rdm2.ooov += tmp20.transpose((1, 2, 0, 3)) * 2
-    rdm2.ooov += tmp20.transpose((2, 1, 0, 3)) * -2
+    rdm2.ooov += np.transpose(tmp20, (1, 2, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp20, (2, 1, 0, 3)) * -2
     del tmp20
     rdm2.ooov += einsum(delta.oo, (0, 1), tmp24, (2, 3), (2, 0, 1, 3)) * 4
     rdm2.ooov += einsum(tmp24, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1)) * -4
     del tmp24
     rdm2.ooov += einsum(delta.oo, (0, 1), t1, (2, 3), (2, 0, 1, 3)) * -2
     rdm2.ooov += einsum(t1, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1)) * 2
-    rdm2.ooov += tmp12.transpose((2, 1, 0, 3)) * -2
+    rdm2.ooov += np.transpose(tmp12, (2, 1, 0, 3)) * -2
     del tmp12
-    rdm2.ooov += tmp25.transpose((1, 2, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp25, (1, 2, 0, 3)) * 2
     del tmp25
-    rdm2.ooov += tmp26.transpose((2, 1, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp26, (2, 1, 0, 3)) * 2
     del tmp26
-    rdm2.ooov += tmp17.transpose((1, 2, 0, 3)) * -2
+    rdm2.ooov += np.transpose(tmp17, (1, 2, 0, 3)) * -2
     del tmp17
-    rdm2.ooov += tmp27.transpose((2, 1, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp27, (2, 1, 0, 3)) * 2
     del tmp27
     rdm2.ooov += einsum(tmp34, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1)) * -2
     del tmp34
@@ -1062,8 +1062,8 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oooo += einsum(tmp0, (0, 1), delta.oo, (2, 3), (1, 2, 3, 0)) * 2
     rdm2.oooo += einsum(tmp0, (0, 1), delta.oo, (2, 3), (2, 1, 3, 0)) * -4
     del tmp0
-    rdm2.oooo += tmp4.transpose((3, 2, 0, 1)) * -2
-    rdm2.oooo += tmp4.transpose((2, 3, 0, 1)) * 2
+    rdm2.oooo += np.transpose(tmp4, (3, 2, 0, 1)) * -2
+    rdm2.oooo += np.transpose(tmp4, (2, 3, 0, 1)) * 2
     del tmp4
     rdm2.oooo += einsum(delta.oo, (0, 1), delta.oo, (2, 3), (0, 2, 1, 3)) * 2
     rdm2.oooo += einsum(delta.oo, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * -2
@@ -1072,14 +1072,14 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp6, (2, 3), (3, 0, 1, 2)) * 2
     rdm2.oooo += einsum(tmp6, (0, 1), delta.oo, (2, 3), (2, 1, 3, 0)) * -4
     del tmp6
-    rdm2.oooo += tmp1.transpose((3, 2, 1, 0)) * 2
+    rdm2.oooo += np.transpose(tmp1, (3, 2, 1, 0)) * 2
     del tmp1
-    rdm2.oooo += tmp3.transpose((3, 2, 1, 0)) * 2
+    rdm2.oooo += np.transpose(tmp3, (3, 2, 1, 0)) * 2
     del tmp3
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp7, (2, 3), (3, 0, 2, 1)) * 2
     del delta, tmp7
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.transpose(0, 2, 1, 3)
+    rdm2 = np.transpose(rdm2, (0, 2, 1, 3))
 
     return rdm2
 
@@ -1197,33 +1197,33 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     """
 
     ints = kwargs["ints"]
-    tmp9 = v.ovov.transpose((0, 2, 3, 1)).copy() * -0.5
-    tmp9 += v.ovov.transpose((0, 2, 1, 3))
-    tmp8 = ints.tmp45.transpose((1, 0)).copy() * 2
+    tmp9 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -0.5
+    tmp9 += np.transpose(v.ovov, (0, 2, 1, 3))
+    tmp8 = np.copy(np.transpose(ints.tmp45, (1, 0))) * 2
     del ints.tmp45
     tmp8 += f.vv * -1
-    tmp8 += ints.tmp43.transpose((1, 0)) * -1
+    tmp8 += np.transpose(ints.tmp43, (1, 0)) * -1
     del ints.tmp43
     tmp8 += einsum(f.ov, (0, 1), t1, (0, 2), (1, 2))
-    tmp4 = r2.copy()
-    tmp4 += r2.transpose((1, 0, 2)) * -0.5
+    tmp4 = np.copy(r2)
+    tmp4 += np.transpose(r2, (1, 0, 2)) * -0.5
     tmp10 = einsum(r2, (0, 1, 2), tmp9, (1, 0, 3, 2), (3,))
     del tmp9
-    tmp12 = f.oo.copy()
+    tmp12 = np.copy(f.oo)
     tmp12 += ints.tmp0
-    tmp12 += ints.tmp14.transpose((1, 0)) * 2
-    tmp12 += ints.tmp12.transpose((1, 0)) * -1
-    tmp5 = ints.tmp35.copy() * 2
+    tmp12 += np.transpose(ints.tmp14, (1, 0)) * 2
+    tmp12 += np.transpose(ints.tmp12, (1, 0)) * -1
+    tmp5 = np.copy(ints.tmp35) * 2
     del ints.tmp35
-    tmp5 += v.ovov.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp5 += ints.tmp33 * -1
     del ints.tmp33
     tmp5 += ints.tmp34 * -1
     del ints.tmp34
-    tmp7 = ints.tmp21.copy()
+    tmp7 = np.copy(ints.tmp21)
     del ints.tmp21
-    tmp7 += v.oooo.transpose((0, 2, 1, 3))
-    tmp13 = f.ov.copy()
+    tmp7 += np.transpose(v.oooo, (0, 2, 1, 3))
+    tmp13 = np.copy(f.ov)
     tmp13 += ints.tmp26 * 2
     del ints.tmp26
     tmp13 += ints.tmp40
@@ -1242,47 +1242,47 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp53
     tmp13 += ints.tmp54 * -1
     del ints.tmp54
-    tmp6 = ints.tmp32.copy()
+    tmp6 = np.copy(ints.tmp32)
     del ints.tmp32
     tmp6 += v.oovv * -1
-    tmp11 = ints.tmp19.copy()
+    tmp11 = np.copy(ints.tmp19)
     del ints.tmp19
-    tmp11 += ints.tmp29.transpose((1, 0, 2, 3)) * 2
+    tmp11 += np.transpose(ints.tmp29, (1, 0, 2, 3)) * 2
     del ints.tmp29
-    tmp11 += ints.tmp39.transpose((2, 1, 0, 3))
+    tmp11 += np.transpose(ints.tmp39, (2, 1, 0, 3))
     del ints.tmp39
-    tmp11 += v.ooov.transpose((0, 2, 1, 3))
-    tmp11 += ints.tmp28.transpose((1, 0, 2, 3)) * -1
+    tmp11 += np.transpose(v.ooov, (0, 2, 1, 3))
+    tmp11 += np.transpose(ints.tmp28, (1, 0, 2, 3)) * -1
     del ints.tmp28
-    tmp11 += ints.tmp31.transpose((1, 0, 2, 3)) * -1
+    tmp11 += np.transpose(ints.tmp31, (1, 0, 2, 3)) * -1
     del ints.tmp31
     tmp11 += ints.tmp42 * -1
     del ints.tmp42
-    tmp1 = f.ov.copy() * 0.5
+    tmp1 = np.copy(f.ov) * 0.5
     tmp1 += ints.tmp6
     del ints.tmp6
     tmp1 += ints.tmp5 * -0.5
     del ints.tmp5
-    tmp3 = f.oo.copy()
+    tmp3 = np.copy(f.oo)
     tmp3 += ints.tmp0
     del ints.tmp0
-    tmp3 += ints.tmp14.transpose((1, 0)) * 2
+    tmp3 += np.transpose(ints.tmp14, (1, 0)) * 2
     del ints.tmp14
-    tmp3 += ints.tmp17.transpose((1, 0)) * 2
+    tmp3 += np.transpose(ints.tmp17, (1, 0)) * 2
     del ints.tmp17
-    tmp3 += ints.tmp4.transpose((1, 0)) * 2
+    tmp3 += np.transpose(ints.tmp4, (1, 0)) * 2
     del ints.tmp4
-    tmp3 += ints.tmp12.transpose((1, 0)) * -1
+    tmp3 += np.transpose(ints.tmp12, (1, 0)) * -1
     del ints.tmp12
-    tmp3 += ints.tmp16.transpose((1, 0)) * -1
+    tmp3 += np.transpose(ints.tmp16, (1, 0)) * -1
     del ints.tmp16
-    tmp3 += ints.tmp3.transpose((1, 0)) * -1
+    tmp3 += np.transpose(ints.tmp3, (1, 0)) * -1
     del ints.tmp3
-    tmp2 = r2.copy() * 2
-    tmp2 += r2.transpose((1, 0, 2)) * -1
-    tmp0 = ints.tmp9.copy()
+    tmp2 = np.copy(r2) * 2
+    tmp2 += np.transpose(r2, (1, 0, 2)) * -1
+    tmp0 = np.copy(ints.tmp9)
     tmp0 += v.ooov * -0.5
-    tmp0 += v.ooov.transpose((0, 2, 1, 3))
+    tmp0 += np.transpose(v.ooov, (0, 2, 1, 3))
     r2new = einsum(tmp5, (0, 1, 2, 3), tmp4, (1, 4, 3), (0, 4, 2)) * 2
     del tmp5, tmp4
     r2new += einsum(tmp6, (0, 1, 2, 3), r2, (4, 1, 3), (4, 0, 2))
@@ -1416,43 +1416,43 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     """
 
     ints = kwargs["ints"]
-    tmp4 = v.ovov.transpose((0, 2, 3, 1)).copy() * 2
-    tmp4 += v.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp4 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * 2
+    tmp4 += np.transpose(v.ovov, (0, 2, 1, 3)) * -1
     tmp5 = einsum(r2, (0, 1, 2), tmp4, (2, 3, 1, 0), (3,))
     del tmp4
     tmp13 = einsum(f.ov, (0, 1), t1, (0, 2), (1, 2))
-    tmp6 = f.ov.copy()
+    tmp6 = np.copy(f.ov)
     tmp6 += ints.tmp7 * 2
     tmp6 += ints.tmp6 * -1
     tmp8 = einsum(r2, (0, 1, 2), v.ovov, (3, 0, 4, 1), (2, 3, 4))
     tmp16 = einsum(r1, (0,), f.ov, (1, 0), (1,))
     tmp16 += tmp5 * -1
-    tmp9 = r2.transpose((2, 0, 1)).copy() * -0.5
-    tmp9 += r2.transpose((2, 1, 0))
-    tmp14 = ints.tmp16.transpose((1, 0)).copy() * 2
+    tmp9 = np.copy(np.transpose(r2, (2, 0, 1))) * -0.5
+    tmp9 += np.transpose(r2, (2, 1, 0))
+    tmp14 = np.copy(np.transpose(ints.tmp16, (1, 0))) * 2
     tmp14 += f.vv * -1
-    tmp14 += ints.tmp14.transpose((1, 0)) * -1
+    tmp14 += np.transpose(ints.tmp14, (1, 0)) * -1
     tmp14 += tmp13
     del tmp13
-    tmp10 = ints.tmp55.copy() * 2
+    tmp10 = np.copy(ints.tmp55) * 2
     del ints.tmp55
-    tmp10 += v.ovov.transpose((0, 2, 1, 3))
+    tmp10 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp10 += ints.tmp53 * -1
     del ints.tmp53
     tmp10 += ints.tmp54 * -1
     del ints.tmp54
-    tmp12 = ints.tmp26.transpose((0, 2, 3, 1)).copy()
+    tmp12 = np.copy(np.transpose(ints.tmp26, (0, 2, 3, 1)))
     del ints.tmp26
-    tmp12 += ints.tmp48.transpose((0, 2, 3, 1)) * 2
+    tmp12 += np.transpose(ints.tmp48, (0, 2, 3, 1)) * 2
     del ints.tmp48
-    tmp12 += v.ovvv.transpose((0, 2, 3, 1))
+    tmp12 += np.transpose(v.ovvv, (0, 2, 3, 1))
     tmp12 += ints.tmp22 * -1
     del ints.tmp22
-    tmp12 += ints.tmp49.transpose((0, 3, 2, 1)) * -1
+    tmp12 += np.transpose(ints.tmp49, (0, 3, 2, 1)) * -1
     del ints.tmp49
-    tmp12 += ints.tmp50.transpose((0, 2, 3, 1)) * -1
+    tmp12 += np.transpose(ints.tmp50, (0, 2, 3, 1)) * -1
     del ints.tmp50
-    tmp17 = f.ov.copy()
+    tmp17 = np.copy(f.ov)
     tmp17 += ints.tmp32
     del ints.tmp32
     tmp17 += ints.tmp35 * 2
@@ -1471,38 +1471,38 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp44
     tmp17 += ints.tmp46 * -1
     del ints.tmp46
-    tmp11 = ints.tmp25.copy()
+    tmp11 = np.copy(ints.tmp25)
     del ints.tmp25
     tmp11 += v.oovv * -1
-    tmp15 = f.oo.copy()
+    tmp15 = np.copy(f.oo)
     tmp15 += ints.tmp33
     del ints.tmp33
-    tmp15 += ints.tmp39.transpose((1, 0)) * 2
+    tmp15 += np.transpose(ints.tmp39, (1, 0)) * 2
     del ints.tmp39
-    tmp15 += ints.tmp37.transpose((1, 0)) * -1
+    tmp15 += np.transpose(ints.tmp37, (1, 0)) * -1
     del ints.tmp37
-    tmp1 = f.ov.copy() * 0.5
+    tmp1 = np.copy(f.ov) * 0.5
     tmp1 += ints.tmp7
     del ints.tmp7
     tmp1 += ints.tmp6 * -0.5
     del ints.tmp6
-    tmp3 = f.vv.copy()
-    tmp3 += ints.tmp14.transpose((1, 0))
+    tmp3 = np.copy(f.vv)
+    tmp3 += np.transpose(ints.tmp14, (1, 0))
     del ints.tmp14
-    tmp3 += ints.tmp3.transpose((1, 0)) * 2
+    tmp3 += np.transpose(ints.tmp3, (1, 0)) * 2
     del ints.tmp3
-    tmp3 += ints.tmp16.transpose((1, 0)) * -2
+    tmp3 += np.transpose(ints.tmp16, (1, 0)) * -2
     del ints.tmp16
     tmp3 += ints.tmp5 * -1
     del ints.tmp5
-    tmp2 = r2.transpose((2, 0, 1)).copy() * 2
-    tmp2 += r2.transpose((2, 1, 0)) * -1
-    tmp7 = tmp5.copy() * -1
+    tmp2 = np.copy(np.transpose(r2, (2, 0, 1))) * 2
+    tmp2 += np.transpose(r2, (2, 1, 0)) * -1
+    tmp7 = np.copy(tmp5) * -1
     del tmp5
     tmp7 += einsum(r1, (0,), tmp6, (1, 0), (1,))
     del tmp6
-    tmp0 = v.ovvv.copy() * 2
-    tmp0 += v.ovvv.transpose((0, 2, 1, 3)) * -1
+    tmp0 = np.copy(v.ovvv) * 2
+    tmp0 += np.transpose(v.ovvv, (0, 2, 1, 3)) * -1
     r2new = einsum(v.vvvv, (0, 1, 2, 3), r2, (1, 3, 4), (0, 2, 4))
     r2new += einsum(tmp8, (0, 1, 2), t2, (2, 1, 3, 4), (4, 3, 0))
     del tmp8
@@ -1713,38 +1713,38 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     """
 
     ints = kwargs["ints"]
-    tmp12 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp12 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp12 += t2
-    tmp8 = ints.tmp115.copy() * 2
+    tmp8 = np.copy(ints.tmp115) * 2
     del ints.tmp115
-    tmp8 += v.ovov.transpose((0, 2, 1, 3))
+    tmp8 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp8 += ints.tmp112 * -1
     del ints.tmp112
     tmp8 += ints.tmp114 * -1
     del ints.tmp114
-    tmp9 = ints.tmp111.copy()
+    tmp9 = np.copy(ints.tmp111)
     del ints.tmp111
     tmp9 += v.oovv * -1
-    tmp14 = f.oo.copy()
-    tmp14 += ints.tmp0.transpose((1, 0))
+    tmp14 = np.copy(f.oo)
+    tmp14 += np.transpose(ints.tmp0, (1, 0))
     tmp14 += ints.tmp24 * 2
     tmp14 += ints.tmp22 * -1
-    tmp10 = ints.tmp81.copy()
+    tmp10 = np.copy(ints.tmp81)
     del ints.tmp81
-    tmp10 += v.oooo.transpose((0, 2, 1, 3))
-    tmp7 = r2.copy()
-    tmp7 += r2.transpose((1, 0, 2)) * -0.5
+    tmp10 += np.transpose(v.oooo, (0, 2, 1, 3))
+    tmp7 = np.copy(r2)
+    tmp7 += np.transpose(r2, (1, 0, 2)) * -0.5
     tmp13 = einsum(tmp12, (0, 1, 2, 3), r2, (1, 0, 3), (2,))
     del tmp12
-    tmp11 = ints.tmp131.copy() * 2
+    tmp11 = np.copy(ints.tmp131) * 2
     del ints.tmp131
     tmp11 += f.vv * -1
     tmp11 += ints.tmp129 * -1
     del ints.tmp129
     tmp11 += einsum(f.ov, (0, 1), t1, (0, 2), (2, 1))
-    tmp1 = ints.tmp108.copy()
+    tmp1 = np.copy(ints.tmp108)
     del ints.tmp108
-    tmp1 += ints.tmp14.transpose((1, 2, 0, 3))
+    tmp1 += np.transpose(ints.tmp14, (1, 2, 0, 3))
     del ints.tmp14
     tmp1 += ints.tmp32
     del ints.tmp32
@@ -1764,13 +1764,13 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp44
     tmp1 += ints.tmp70 * -2
     del ints.tmp70
-    tmp3 = ints.tmp33.transpose((0, 2, 1, 3)).copy()
+    tmp3 = np.copy(np.transpose(ints.tmp33, (0, 2, 1, 3)))
     del ints.tmp33
     tmp3 += ints.tmp35
     del ints.tmp35
-    tmp3 += ints.tmp57.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(ints.tmp57, (0, 2, 1, 3))
     del ints.tmp57
-    tmp3 += ints.tmp72.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(ints.tmp72, (0, 2, 1, 3))
     del ints.tmp72
     tmp3 += ints.tmp92
     del ints.tmp92
@@ -1778,15 +1778,15 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp21
     tmp3 += ints.tmp36 * -2
     del ints.tmp36
-    tmp3 += ints.tmp60.transpose((0, 2, 1, 3)) * -2
+    tmp3 += np.transpose(ints.tmp60, (0, 2, 1, 3)) * -2
     del ints.tmp60
-    tmp3 += ints.tmp6.transpose((1, 0, 2, 3)) * -1
+    tmp3 += np.transpose(ints.tmp6, (1, 0, 2, 3)) * -1
     del ints.tmp6
-    tmp2 = r2.copy() * 2
-    tmp2 += r2.transpose((1, 0, 2)) * -1
-    tmp4 = v.ooov.copy()
-    tmp4 += v.ovoo.transpose((0, 2, 3, 1)) * -0.5
-    tmp5 = ints.tmp104.copy() * 2
+    tmp2 = np.copy(r2) * 2
+    tmp2 += np.transpose(r2, (1, 0, 2)) * -1
+    tmp4 = np.copy(v.ooov)
+    tmp4 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -0.5
+    tmp5 = np.copy(ints.tmp104) * 2
     del ints.tmp104
     tmp5 += ints.tmp19
     del ints.tmp19
@@ -1837,10 +1837,10 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp87
     tmp5 += ints.tmp94 * -2
     del ints.tmp94
-    tmp6 = f.oo.copy()
-    tmp6 += ints.tmp0.transpose((1, 0))
+    tmp6 = np.copy(f.oo)
+    tmp6 += np.transpose(ints.tmp0, (1, 0))
     del ints.tmp0
-    tmp6 += ints.tmp13.transpose((1, 0)) * 2
+    tmp6 += np.transpose(ints.tmp13, (1, 0)) * 2
     del ints.tmp13
     tmp6 += ints.tmp24 * 2
     del ints.tmp24
@@ -1852,8 +1852,8 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp22
     tmp6 += ints.tmp85 * -1
     del ints.tmp85
-    tmp0 = r2.copy() * -0.5
-    tmp0 += r2.transpose((1, 0, 2))
+    tmp0 = np.copy(r2) * -0.5
+    tmp0 += np.transpose(r2, (1, 0, 2))
     r2new = einsum(r1, (0,), f.ov, (1, 2), (1, 0, 2)) * -1
     r2new += einsum(v.ovoo, (0, 1, 2, 3), r1, (3,), (0, 2, 1))
     r2new += einsum(tmp8, (0, 1, 2, 3), tmp7, (0, 4, 2), (1, 4, 3)) * 2
@@ -2037,52 +2037,52 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     ints = kwargs["ints"]
     tmp10 = einsum(r2, (0, 1, 2), t1, (3, 1), (2, 3, 0))
     tmp21 = einsum(f.ov, (0, 1), t1, (0, 2), (1, 2))
-    tmp24 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp24 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp24 += t2
-    tmp2 = r2.transpose((2, 0, 1)).copy()
-    tmp2 += r2.transpose((2, 1, 0)) * -0.5
-    tmp15 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp2 = np.copy(np.transpose(r2, (2, 0, 1)))
+    tmp2 += np.transpose(r2, (2, 1, 0)) * -0.5
+    tmp15 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp15 += t2 * -1
     tmp11 = einsum(tmp10, (0, 1, 2), t1, (3, 2), (0, 3, 1))
     del tmp10
-    tmp5 = r2.transpose((2, 0, 1)).copy() * -0.5
-    tmp5 += r2.transpose((2, 1, 0))
-    tmp22 = ints.tmp29.copy() * 2
+    tmp5 = np.copy(np.transpose(r2, (2, 0, 1))) * -0.5
+    tmp5 += np.transpose(r2, (2, 1, 0))
+    tmp22 = np.copy(ints.tmp29) * 2
     tmp22 += f.vv * -1
     tmp22 += ints.tmp27 * -1
-    tmp22 += tmp21.transpose((1, 0))
+    tmp22 += np.transpose(tmp21, (1, 0))
     del tmp21
-    tmp19 = ints.tmp88.copy() * 2
-    tmp19 += v.ovov.transpose((0, 2, 1, 3))
+    tmp19 = np.copy(ints.tmp88) * 2
+    tmp19 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp19 += ints.tmp87 * -1
     tmp19 += ints.tmp92 * -1
-    tmp20 = ints.tmp90.copy()
+    tmp20 = np.copy(ints.tmp90)
     tmp20 += v.oovv * -1
     tmp18 = einsum(r2, (0, 1, 2), t2, (3, 4, 0, 1), (2, 3, 4))
     tmp25 = einsum(r2, (0, 1, 2), tmp24, (2, 3, 0, 1), (3,))
     del tmp24
-    tmp23 = f.oo.copy()
-    tmp23 += ints.tmp10.transpose((1, 0))
+    tmp23 = np.copy(f.oo)
+    tmp23 += np.transpose(ints.tmp10, (1, 0))
     del ints.tmp10
     tmp23 += ints.tmp79 * 2
     del ints.tmp79
     tmp23 += ints.tmp83 * -1
     del ints.tmp83
-    tmp1 = ints.tmp24.copy()
-    tmp1 += ints.tmp46.transpose((0, 2, 1, 3)) * 0.5
-    tmp1 += ints.tmp53.transpose((0, 2, 1, 3)) * 0.5
-    tmp1 += ints.tmp76.transpose((0, 3, 1, 2))
-    tmp1 += ints.tmp37.transpose((0, 3, 1, 2)) * -0.5
-    tmp1 += ints.tmp48.transpose((0, 2, 1, 3)) * -1
-    tmp1 += ints.tmp51.transpose((0, 2, 1, 3)) * -1
+    tmp1 = np.copy(ints.tmp24)
+    tmp1 += np.transpose(ints.tmp46, (0, 2, 1, 3)) * 0.5
+    tmp1 += np.transpose(ints.tmp53, (0, 2, 1, 3)) * 0.5
+    tmp1 += np.transpose(ints.tmp76, (0, 3, 1, 2))
+    tmp1 += np.transpose(ints.tmp37, (0, 3, 1, 2)) * -0.5
+    tmp1 += np.transpose(ints.tmp48, (0, 2, 1, 3)) * -1
+    tmp1 += np.transpose(ints.tmp51, (0, 2, 1, 3)) * -1
     tmp3 = einsum(t1, (0, 1), tmp2, (2, 1, 3), (2, 0, 3))
     del tmp2
     tmp16 = einsum(r1, (0,), t1, (1, 0), (1,)) * 0.5
     tmp16 += einsum(r2, (0, 1, 2), tmp15, (2, 3, 1, 0), (3,)) * -0.5
     del tmp15
-    tmp9 = r2.transpose((2, 0, 1)).copy() * 2
-    tmp9 += r2.transpose((2, 1, 0)) * -1
-    tmp8 = ints.tmp106.copy()
+    tmp9 = np.copy(np.transpose(r2, (2, 0, 1))) * 2
+    tmp9 += np.transpose(r2, (2, 1, 0)) * -1
+    tmp8 = np.copy(ints.tmp106)
     del ints.tmp106
     tmp8 += ints.tmp113 * 2
     del ints.tmp113
@@ -2132,56 +2132,56 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp84
     tmp8 += ints.tmp96 * -1
     del ints.tmp96
-    tmp4 = ints.tmp107.copy()
+    tmp4 = np.copy(ints.tmp107)
     del ints.tmp107
     tmp4 += v.oovv
-    tmp4 += ints.tmp90.transpose((0, 1, 3, 2)) * -1
+    tmp4 += np.transpose(ints.tmp90, (0, 1, 3, 2)) * -1
     del ints.tmp90
-    tmp14 = f.vv.copy()
-    tmp14 += ints.tmp14.transpose((1, 0)) * 2
+    tmp14 = np.copy(f.vv)
+    tmp14 += np.transpose(ints.tmp14, (1, 0)) * 2
     del ints.tmp14
     tmp14 += ints.tmp27
     del ints.tmp27
-    tmp14 += ints.tmp16.transpose((1, 0)) * -1
+    tmp14 += np.transpose(ints.tmp16, (1, 0)) * -1
     del ints.tmp16
     tmp14 += ints.tmp29 * -2
     del ints.tmp29
-    tmp12 = tmp11.copy() * -0.5
-    tmp12 += tmp11.transpose((0, 2, 1))
-    tmp7 = ints.tmp109.copy()
+    tmp12 = np.copy(tmp11) * -0.5
+    tmp12 += np.transpose(tmp11, (0, 2, 1))
+    tmp7 = np.copy(ints.tmp109)
     del ints.tmp109
-    tmp7 += ints.tmp88.transpose((0, 1, 3, 2)) * 2
+    tmp7 += np.transpose(ints.tmp88, (0, 1, 3, 2)) * 2
     del ints.tmp88
-    tmp7 += v.ovov.transpose((0, 2, 3, 1))
-    tmp7 += ints.tmp87.transpose((0, 1, 3, 2)) * -1
+    tmp7 += np.transpose(v.ovov, (0, 2, 3, 1))
+    tmp7 += np.transpose(ints.tmp87, (0, 1, 3, 2)) * -1
     del ints.tmp87
-    tmp7 += ints.tmp92.transpose((0, 1, 3, 2)) * -1
+    tmp7 += np.transpose(ints.tmp92, (0, 1, 3, 2)) * -1
     del ints.tmp92
-    tmp13 = tmp11.copy() * 2
-    tmp13 += tmp11.transpose((0, 2, 1)) * -1
+    tmp13 = np.copy(tmp11) * 2
+    tmp13 += np.transpose(tmp11, (0, 2, 1)) * -1
     del tmp11
     tmp6 = einsum(tmp5, (0, 1, 2), t1, (3, 1), (0, 3, 2)) * 2
-    tmp17 = f.ov.copy()
+    tmp17 = np.copy(f.ov)
     tmp17 += ints.tmp17 * 2
     del ints.tmp17
     tmp17 += ints.tmp55 * -1
     del ints.tmp55
-    tmp0 = ints.tmp24.copy()
+    tmp0 = np.copy(ints.tmp24)
     del ints.tmp24
-    tmp0 += ints.tmp46.transpose((0, 2, 1, 3)) * 2
+    tmp0 += np.transpose(ints.tmp46, (0, 2, 1, 3)) * 2
     del ints.tmp46
-    tmp0 += ints.tmp53.transpose((0, 2, 1, 3)) * 2
+    tmp0 += np.transpose(ints.tmp53, (0, 2, 1, 3)) * 2
     del ints.tmp53
-    tmp0 += ints.tmp76.transpose((0, 3, 1, 2))
+    tmp0 += np.transpose(ints.tmp76, (0, 3, 1, 2))
     del ints.tmp76
-    tmp0 += ints.tmp37.transpose((0, 3, 1, 2)) * -2
+    tmp0 += np.transpose(ints.tmp37, (0, 3, 1, 2)) * -2
     del ints.tmp37
-    tmp0 += ints.tmp48.transpose((0, 2, 1, 3)) * -4
+    tmp0 += np.transpose(ints.tmp48, (0, 2, 1, 3)) * -4
     del ints.tmp48
-    tmp0 += ints.tmp51.transpose((0, 2, 1, 3)) * -1
+    tmp0 += np.transpose(ints.tmp51, (0, 2, 1, 3)) * -1
     del ints.tmp51
-    tmp0 += v.ovvv.transpose((0, 2, 1, 3)) * -2
-    tmp0 += v.ovvv.transpose((0, 2, 3, 1))
+    tmp0 += np.transpose(v.ovvv, (0, 2, 1, 3)) * -2
+    tmp0 += np.transpose(v.ovvv, (0, 2, 3, 1))
     r2new = einsum(r1, (0,), f.ov, (1, 2), (2, 0, 1)) * -1
     r2new += einsum(v.vvvv, (0, 1, 2, 3), r2, (1, 3, 4), (0, 2, 4))
     r2new += einsum(v.ovvv, (0, 1, 2, 3), r1, (3,), (1, 2, 0)) * -1

--- a/ebcc/codegen/RCC2.py
+++ b/ebcc/codegen/RCC2.py
@@ -1079,7 +1079,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp7, (2, 3), (3, 0, 2, 1)) * 2
     del delta, tmp7
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.swapaxes(1, 2)
+    rdm2 = rdm2.transpose(0, 2, 1, 3)
 
     return rdm2
 

--- a/ebcc/codegen/RCC3.py
+++ b/ebcc/codegen/RCC3.py
@@ -37,9 +37,9 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp0 = v.ovov.transpose((0, 2, 3, 1)).copy() * -0.5
-    tmp0 += v.ovov.transpose((0, 2, 1, 3))
-    tmp1 = f.ov.copy()
+    tmp0 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -0.5
+    tmp0 += np.transpose(v.ovov, (0, 2, 1, 3))
+    tmp1 = np.copy(f.ov)
     tmp1 += einsum(t1, (0, 1), tmp0, (0, 2, 1, 3), (2, 3))
     del tmp0
     e_cc = einsum(t1, (0, 1), tmp1, (0, 1), ()) * 2
@@ -77,14 +77,14 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     """
 
     tmp3 = einsum(t1, (0, 1), v.ovov, (2, 3, 4, 1), (0, 2, 4, 3))
-    tmp5 = v.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp5 += v.ovov.transpose((0, 2, 1, 3)) * 2
+    tmp5 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -1
+    tmp5 += np.transpose(v.ovov, (0, 2, 1, 3)) * 2
     tmp102 = einsum(t1, (0, 1), tmp3, (2, 3, 4, 1), (2, 0, 4, 3))
-    tmp26 = tmp3.copy() * -1
-    tmp26 += tmp3.transpose((0, 2, 1, 3)) * 2
+    tmp26 = np.copy(tmp3) * -1
+    tmp26 += np.transpose(tmp3, (0, 2, 1, 3)) * 2
     tmp6 = einsum(t1, (0, 1), tmp5, (0, 2, 1, 3), (2, 3))
     tmp47 = einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
-    tmp47 += t2.transpose((0, 1, 3, 2)) * -2
+    tmp47 += np.transpose(t2, (0, 1, 3, 2)) * -2
     tmp47 += t2
     tmp34 = einsum(f.ov, (0, 1), t2, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp103 = einsum(t1, (0, 1), tmp102, (2, 3, 0, 4), (3, 2, 4, 1))
@@ -93,32 +93,32 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp90 = einsum(t2, (0, 1, 2, 3), v.ooov, (4, 5, 6, 3), (0, 1, 4, 5, 6, 2))
     tmp40 = einsum(v.ovvv, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
     tmp56 = einsum(v.ooov, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
-    tmp1 = t2.copy()
+    tmp1 = np.copy(t2)
     tmp1 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     t2new = einsum(tmp1, (0, 1, 2, 3), v.vvvv, (4, 3, 5, 2), (1, 0, 4, 5))
     tmp10 = einsum(f.ov, (0, 1), t1, (2, 1), (0, 2))
     tmp19 = einsum(t1, (0, 1), v.ovov, (2, 3, 0, 1), (2, 3))
-    tmp22 = v.ovvv.copy() * 2
-    tmp22 += v.ovvv.transpose((0, 2, 3, 1)) * -1
-    tmp30 = v.ooov.copy() * 2
-    tmp30 += v.ooov.transpose((0, 2, 1, 3)) * -1
+    tmp22 = np.copy(v.ovvv) * 2
+    tmp22 += np.transpose(v.ovvv, (0, 2, 3, 1)) * -1
+    tmp30 = np.copy(v.ooov) * 2
+    tmp30 += np.transpose(v.ooov, (0, 2, 1, 3)) * -1
     tmp27 = einsum(t2, (0, 1, 2, 3), tmp26, (4, 5, 1, 3), (0, 4, 5, 2))
     del tmp26
     tmp25 = einsum(t2, (0, 1, 2, 3), v.ooov, (4, 1, 5, 2), (0, 4, 5, 3))
     tmp15 = einsum(t1, (0, 1), tmp3, (2, 3, 0, 4), (2, 3, 1, 4))
     tmp16 = einsum(tmp5, (0, 1, 2, 3), t2, (4, 0, 5, 2), (4, 1, 5, 3))
     del tmp5
-    tmp74 = v.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp74 += v.ovov.transpose((0, 2, 1, 3)) * -0.5
-    tmp69 = v.ovov.transpose((0, 2, 3, 1)).copy() * -0.5
-    tmp69 += v.ovov.transpose((0, 2, 1, 3))
+    tmp74 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1)))
+    tmp74 += np.transpose(v.ovov, (0, 2, 1, 3)) * -0.5
+    tmp69 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -0.5
+    tmp69 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp49 = einsum(t2, (0, 1, 2, 3), tmp6, (4, 2), (0, 1, 4, 3))
     tmp46 = einsum(tmp3, (0, 1, 2, 3), t2, (4, 2, 3, 5), (0, 4, 1, 5))
     tmp44 = einsum(t1, (0, 1), v.oovv, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp45 = einsum(v.ooov, (0, 1, 2, 3), t2, (4, 1, 5, 3), (4, 0, 2, 5))
     tmp48 = einsum(v.ooov, (0, 1, 2, 3), tmp47, (2, 4, 5, 3), (0, 1, 4, 5))
     del tmp47
-    tmp104 = tmp34.transpose((2, 1, 0, 3)).copy() * -1
+    tmp104 = np.copy(np.transpose(tmp34, (2, 1, 0, 3))) * -1
     tmp104 += tmp103
     del tmp103
     tmp100 = einsum(tmp99, (0, 1, 2, 3, 4, 5), t1, (4, 6), (0, 1, 2, 3, 6, 5))
@@ -133,24 +133,24 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp107 = einsum(t1, (0, 1), v.oooo, (2, 3, 4, 0), (2, 3, 4, 1))
     tmp81 = einsum(tmp1, (0, 1, 2, 3), v.ovov, (4, 2, 5, 3), (0, 1, 4, 5))
     tmp60 = einsum(v.ovov, (0, 1, 2, 3), t3, (4, 5, 2, 6, 1, 3), (4, 5, 0, 6))
-    tmp36 = f.oo.copy()
+    tmp36 = np.copy(f.oo)
     tmp36 += tmp10
-    tmp20 = f.ov.copy()
+    tmp20 = np.copy(f.ov)
     tmp20 += tmp19 * 2
     del tmp19
     tmp23 = einsum(tmp22, (0, 1, 2, 3), t1, (0, 1), (2, 3))
     del tmp22
     tmp31 = einsum(t1, (0, 1), tmp30, (2, 3, 0, 1), (2, 3))
     del tmp30
-    tmp28 = tmp3.copy()
+    tmp28 = np.copy(tmp3)
     tmp28 += tmp25 * -1
     del tmp25
-    tmp28 += tmp27.transpose((1, 0, 2, 3))
+    tmp28 += np.transpose(tmp27, (1, 0, 2, 3))
     del tmp27
-    tmp17 = tmp15.copy()
+    tmp17 = np.copy(tmp15)
     del tmp15
     tmp17 += tmp16 * -1
-    tmp72 = t3.transpose((0, 2, 1, 3, 5, 4)).copy()
+    tmp72 = np.copy(np.transpose(t3, (0, 2, 1, 3, 5, 4)))
     tmp72 += einsum(t1, (0, 1), t2, (2, 3, 4, 5), (0, 2, 3, 4, 1, 5)) * -1
     tmp67 = einsum(t1, (0, 1), v.ovov, (2, 1, 0, 3), (2, 3))
     tmp65 = einsum(t3, (0, 1, 2, 3, 4, 5), v.ovov, (6, 3, 2, 5), (0, 1, 6, 4))
@@ -158,17 +158,17 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp74
     tmp70 = einsum(tmp69, (0, 1, 2, 3), t2, (0, 1, 4, 3), (4, 2))
     del tmp69
-    tmp50 = tmp44.transpose((0, 2, 1, 3)).copy() * -1
-    tmp50 += tmp45.transpose((0, 2, 1, 3))
+    tmp50 = np.copy(np.transpose(tmp44, (0, 2, 1, 3))) * -1
+    tmp50 += np.transpose(tmp45, (0, 2, 1, 3))
     del tmp45
-    tmp50 += tmp46.transpose((0, 2, 1, 3))
+    tmp50 += np.transpose(tmp46, (0, 2, 1, 3))
     del tmp46
-    tmp50 += tmp48.transpose((2, 1, 0, 3))
+    tmp50 += np.transpose(tmp48, (2, 1, 0, 3))
     del tmp48
-    tmp50 += tmp49.transpose((1, 2, 0, 3)) * -1
+    tmp50 += np.transpose(tmp49, (1, 2, 0, 3)) * -1
     del tmp49
     tmp52 = einsum(t1, (0, 1), tmp6, (2, 1), (0, 2))
-    tmp8 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp8 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp8 += t2 * 2
     tmp105 = einsum(t2, (0, 1, 2, 3), tmp104, (4, 5, 1, 6), (0, 4, 5, 3, 2, 6))
     del tmp104
@@ -180,13 +180,13 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp118 = einsum(t2, (0, 1, 2, 3), tmp3, (4, 5, 1, 6), (4, 0, 5, 2, 3, 6))
     tmp120 = einsum(t1, (0, 1), tmp119, (2, 3, 4, 0, 5, 6), (2, 3, 4, 1, 5, 6))
     del tmp119
-    tmp93 = tmp89.transpose((0, 1, 3, 2, 4, 5)).copy()
+    tmp93 = np.copy(np.transpose(tmp89, (0, 1, 3, 2, 4, 5)))
     del tmp89
-    tmp93 += tmp91.transpose((0, 1, 3, 2, 4, 5))
+    tmp93 += np.transpose(tmp91, (0, 1, 3, 2, 4, 5))
     del tmp91
-    tmp93 += tmp92.transpose((0, 1, 3, 2, 4, 5)) * -1
+    tmp93 += np.transpose(tmp92, (0, 1, 3, 2, 4, 5)) * -1
     del tmp92
-    tmp113 = f.oo.copy()
+    tmp113 = np.copy(f.oo)
     tmp113 += tmp10
     t3new = einsum(t3, (0, 1, 2, 3, 4, 5), tmp113, (1, 6), (0, 6, 2, 3, 4, 5)) * -1
     tmp122 = einsum(t2, (0, 1, 2, 3), v.oovv, (4, 5, 6, 3), (0, 1, 4, 5, 2, 6))
@@ -195,8 +195,8 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp109
     tmp108 = einsum(t2, (0, 1, 2, 3), tmp107, (4, 1, 5, 6), (0, 5, 4, 6, 2, 3))
     del tmp107
-    tmp83 = v.oooo.copy()
-    tmp83 += tmp81.transpose((3, 1, 2, 0))
+    tmp83 = np.copy(v.oooo)
+    tmp83 += np.transpose(tmp81, (3, 1, 2, 0))
     tmp58 = einsum(v.ovvv, (0, 1, 2, 3), t3, (4, 5, 0, 1, 6, 3), (4, 5, 6, 2))
     tmp61 = einsum(t1, (0, 1), tmp60, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp60
@@ -204,14 +204,14 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp57 = einsum(tmp56, (0, 1, 2, 3), t2, (2, 3, 4, 5), (0, 1, 4, 5))
     del tmp56
     tmp55 = einsum(t3, (0, 1, 2, 3, 4, 5), v.ooov, (6, 0, 2, 5), (1, 6, 3, 4))
-    tmp78 = t2.copy()
+    tmp78 = np.copy(t2)
     tmp78 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     tmp37 = einsum(tmp36, (0, 1), t2, (2, 0, 3, 4), (2, 1, 4, 3))
     del tmp36
     tmp35 = einsum(t1, (0, 1), tmp34, (0, 2, 3, 4), (2, 3, 1, 4))
     del tmp34
     tmp14 = einsum(t2, (0, 1, 2, 3), v.ovov, (4, 5, 1, 2), (0, 4, 3, 5))
-    t2new += tmp14.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp14, (1, 0, 3, 2)) * -1
     tmp21 = einsum(t3, (0, 1, 2, 3, 4, 5), tmp20, (2, 5), (0, 1, 3, 4))
     del tmp20
     tmp24 = einsum(tmp23, (0, 1), t2, (2, 3, 1, 4), (2, 3, 4, 0))
@@ -241,208 +241,208 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp52
     tmp42 = einsum(tmp41, (0, 1, 2, 3), t2, (4, 1, 5, 3), (0, 4, 5, 2))
     tmp43 = einsum(tmp8, (0, 1, 2, 3), tmp40, (4, 0, 2, 5), (1, 4, 3, 5))
-    tmp12 = v.ooov.copy()
-    tmp12 += v.ooov.transpose((0, 2, 1, 3)) * -0.5
-    tmp11 = v.ovov.transpose((0, 2, 3, 1)).copy() * 2
-    tmp11 += v.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp106 = tmp101.copy()
+    tmp12 = np.copy(v.ooov)
+    tmp12 += np.transpose(v.ooov, (0, 2, 1, 3)) * -0.5
+    tmp11 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * 2
+    tmp11 += np.transpose(v.ovov, (0, 2, 1, 3)) * -1
+    tmp106 = np.copy(tmp101)
     del tmp101
-    tmp106 += tmp105.transpose((2, 1, 0, 5, 4, 3))
+    tmp106 += np.transpose(tmp105, (2, 1, 0, 5, 4, 3))
     del tmp105
-    t3new += tmp106.transpose((2, 1, 0, 4, 5, 3))
-    t3new += tmp106.transpose((2, 1, 0, 3, 5, 4)) * -1
-    t3new += tmp106.transpose((1, 2, 0, 5, 4, 3))
-    t3new += tmp106.transpose((1, 2, 0, 3, 4, 5)) * -1
-    t3new += tmp106.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new += tmp106.transpose((2, 0, 1, 4, 3, 5))
-    t3new += tmp106.transpose((1, 0, 2, 5, 3, 4))
-    t3new += tmp106.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new += tmp106.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new += tmp106.transpose((0, 2, 1, 3, 4, 5))
-    t3new += tmp106.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new += tmp106.transpose((0, 1, 2, 3, 5, 4))
+    t3new += np.transpose(tmp106, (2, 1, 0, 4, 5, 3))
+    t3new += np.transpose(tmp106, (2, 1, 0, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp106, (1, 2, 0, 5, 4, 3))
+    t3new += np.transpose(tmp106, (1, 2, 0, 3, 4, 5)) * -1
+    t3new += np.transpose(tmp106, (2, 0, 1, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp106, (2, 0, 1, 4, 3, 5))
+    t3new += np.transpose(tmp106, (1, 0, 2, 5, 3, 4))
+    t3new += np.transpose(tmp106, (1, 0, 2, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp106, (0, 2, 1, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp106, (0, 2, 1, 3, 4, 5))
+    t3new += np.transpose(tmp106, (0, 1, 2, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp106, (0, 1, 2, 3, 5, 4))
     del tmp106
     tmp97 = einsum(t3, (0, 1, 2, 3, 4, 5), f.vv, (6, 5), (0, 2, 1, 6, 3, 4))
-    t3new += tmp97.transpose((0, 2, 1, 4, 5, 3))
-    t3new += tmp97.transpose((0, 2, 1, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp97, (0, 2, 1, 4, 5, 3))
+    t3new += np.transpose(tmp97, (0, 2, 1, 3, 5, 4)) * -1
     del tmp97
     tmp96 = einsum(t1, (0, 1), tmp95, (2, 3, 4, 0, 5, 6), (2, 3, 4, 1, 5, 6))
     del tmp95
-    t3new += tmp96.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new += tmp96.transpose((2, 1, 0, 3, 4, 5))
-    t3new += tmp96.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new += tmp96.transpose((1, 2, 0, 3, 5, 4))
-    t3new += tmp96.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new += tmp96.transpose((2, 0, 1, 4, 3, 5))
-    t3new += tmp96.transpose((1, 0, 2, 5, 3, 4))
-    t3new += tmp96.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new += tmp96.transpose((0, 2, 1, 4, 5, 3))
-    t3new += tmp96.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new += tmp96.transpose((0, 1, 2, 5, 4, 3))
+    t3new += np.transpose(tmp96, (2, 1, 0, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp96, (2, 1, 0, 3, 4, 5))
+    t3new += np.transpose(tmp96, (1, 2, 0, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp96, (1, 2, 0, 3, 5, 4))
+    t3new += np.transpose(tmp96, (2, 0, 1, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp96, (2, 0, 1, 4, 3, 5))
+    t3new += np.transpose(tmp96, (1, 0, 2, 5, 3, 4))
+    t3new += np.transpose(tmp96, (1, 0, 2, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp96, (0, 2, 1, 4, 5, 3))
+    t3new += np.transpose(tmp96, (0, 2, 1, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp96, (0, 1, 2, 5, 4, 3))
     t3new += tmp96 * -1
     del tmp96
     tmp125 = einsum(t2, (0, 1, 2, 3), tmp124, (4, 1, 5, 6), (4, 0, 5, 6, 2, 3))
     del tmp124
-    t3new += tmp125.transpose((2, 1, 0, 5, 4, 3))
-    t3new += tmp125.transpose((2, 1, 0, 3, 4, 5)) * -1
-    t3new += tmp125.transpose((1, 2, 0, 4, 5, 3))
-    t3new += tmp125.transpose((1, 2, 0, 3, 5, 4)) * -1
-    t3new += tmp125.transpose((2, 0, 1, 5, 3, 4))
-    t3new += tmp125.transpose((2, 0, 1, 4, 3, 5)) * -1
-    t3new += tmp125.transpose((1, 0, 2, 5, 3, 4)) * -1
-    t3new += tmp125.transpose((1, 0, 2, 4, 3, 5))
-    t3new += tmp125.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new += tmp125.transpose((0, 2, 1, 3, 5, 4))
-    t3new += tmp125.transpose((0, 1, 2, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp125, (2, 1, 0, 5, 4, 3))
+    t3new += np.transpose(tmp125, (2, 1, 0, 3, 4, 5)) * -1
+    t3new += np.transpose(tmp125, (1, 2, 0, 4, 5, 3))
+    t3new += np.transpose(tmp125, (1, 2, 0, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp125, (2, 0, 1, 5, 3, 4))
+    t3new += np.transpose(tmp125, (2, 0, 1, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp125, (1, 0, 2, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp125, (1, 0, 2, 4, 3, 5))
+    t3new += np.transpose(tmp125, (0, 2, 1, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp125, (0, 2, 1, 3, 5, 4))
+    t3new += np.transpose(tmp125, (0, 1, 2, 5, 4, 3)) * -1
     t3new += tmp125
     del tmp125
     tmp88 = einsum(t2, (0, 1, 2, 3), tmp87, (4, 5, 1, 6), (4, 5, 0, 2, 3, 6))
     del tmp87
-    t3new += tmp88.transpose((2, 1, 0, 4, 5, 3))
-    t3new += tmp88.transpose((2, 1, 0, 3, 5, 4)) * -1
-    t3new += tmp88.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new += tmp88.transpose((1, 2, 0, 4, 3, 5))
-    t3new += tmp88.transpose((2, 0, 1, 5, 4, 3))
-    t3new += tmp88.transpose((2, 0, 1, 3, 4, 5)) * -1
-    t3new += tmp88.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new += tmp88.transpose((1, 0, 2, 3, 4, 5))
-    t3new += tmp88.transpose((0, 2, 1, 5, 3, 4))
-    t3new += tmp88.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new += tmp88.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new += tmp88.transpose((0, 1, 2, 3, 5, 4))
+    t3new += np.transpose(tmp88, (2, 1, 0, 4, 5, 3))
+    t3new += np.transpose(tmp88, (2, 1, 0, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp88, (1, 2, 0, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp88, (1, 2, 0, 4, 3, 5))
+    t3new += np.transpose(tmp88, (2, 0, 1, 5, 4, 3))
+    t3new += np.transpose(tmp88, (2, 0, 1, 3, 4, 5)) * -1
+    t3new += np.transpose(tmp88, (1, 0, 2, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp88, (1, 0, 2, 3, 4, 5))
+    t3new += np.transpose(tmp88, (0, 2, 1, 5, 3, 4))
+    t3new += np.transpose(tmp88, (0, 2, 1, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp88, (0, 1, 2, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp88, (0, 1, 2, 3, 5, 4))
     del tmp88
-    tmp126 = f.vv.copy()
+    tmp126 = np.copy(f.vv)
     tmp126 += einsum(f.ov, (0, 1), t1, (0, 2), (1, 2)) * -1
     t3new += einsum(tmp126, (0, 1), t3, (2, 3, 4, 5, 0, 6), (2, 3, 4, 5, 1, 6))
     del tmp126
     tmp98 = einsum(v.ovvv, (0, 1, 2, 3), t2, (4, 5, 6, 3), (4, 5, 0, 6, 1, 2))
-    t3new += tmp98.transpose((2, 1, 0, 4, 5, 3))
-    t3new += tmp98.transpose((2, 1, 0, 3, 5, 4)) * -1
-    t3new += tmp98.transpose((1, 2, 0, 5, 4, 3))
-    t3new += tmp98.transpose((1, 2, 0, 3, 4, 5)) * -1
-    t3new += tmp98.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new += tmp98.transpose((2, 0, 1, 4, 3, 5))
-    t3new += tmp98.transpose((1, 0, 2, 5, 3, 4))
-    t3new += tmp98.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new += tmp98.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new += tmp98.transpose((0, 2, 1, 3, 4, 5))
-    t3new += tmp98.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new += tmp98.transpose((0, 1, 2, 3, 5, 4))
+    t3new += np.transpose(tmp98, (2, 1, 0, 4, 5, 3))
+    t3new += np.transpose(tmp98, (2, 1, 0, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp98, (1, 2, 0, 5, 4, 3))
+    t3new += np.transpose(tmp98, (1, 2, 0, 3, 4, 5)) * -1
+    t3new += np.transpose(tmp98, (2, 0, 1, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp98, (2, 0, 1, 4, 3, 5))
+    t3new += np.transpose(tmp98, (1, 0, 2, 5, 3, 4))
+    t3new += np.transpose(tmp98, (1, 0, 2, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp98, (0, 2, 1, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp98, (0, 2, 1, 3, 4, 5))
+    t3new += np.transpose(tmp98, (0, 1, 2, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp98, (0, 1, 2, 3, 5, 4))
     del tmp98
-    tmp121 = tmp118.copy()
+    tmp121 = np.copy(tmp118)
     del tmp118
     tmp121 += tmp120
     del tmp120
-    t3new += tmp121.transpose((2, 1, 0, 5, 3, 4)) * -1
-    t3new += tmp121.transpose((2, 1, 0, 4, 3, 5))
-    t3new += tmp121.transpose((1, 2, 0, 4, 5, 3))
-    t3new += tmp121.transpose((1, 2, 0, 3, 5, 4)) * -1
-    t3new += tmp121.transpose((2, 0, 1, 5, 4, 3)) * -1
-    t3new += tmp121.transpose((2, 0, 1, 3, 4, 5))
-    t3new += tmp121.transpose((1, 0, 2, 5, 4, 3))
-    t3new += tmp121.transpose((1, 0, 2, 3, 4, 5)) * -1
-    t3new += tmp121.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new += tmp121.transpose((0, 2, 1, 3, 5, 4))
-    t3new += tmp121.transpose((0, 1, 2, 5, 3, 4))
-    t3new += tmp121.transpose((0, 1, 2, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp121, (2, 1, 0, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp121, (2, 1, 0, 4, 3, 5))
+    t3new += np.transpose(tmp121, (1, 2, 0, 4, 5, 3))
+    t3new += np.transpose(tmp121, (1, 2, 0, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp121, (2, 0, 1, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp121, (2, 0, 1, 3, 4, 5))
+    t3new += np.transpose(tmp121, (1, 0, 2, 5, 4, 3))
+    t3new += np.transpose(tmp121, (1, 0, 2, 3, 4, 5)) * -1
+    t3new += np.transpose(tmp121, (0, 2, 1, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp121, (0, 2, 1, 3, 5, 4))
+    t3new += np.transpose(tmp121, (0, 1, 2, 5, 3, 4))
+    t3new += np.transpose(tmp121, (0, 1, 2, 4, 3, 5)) * -1
     del tmp121
     tmp94 = einsum(t1, (0, 1), tmp93, (2, 3, 0, 4, 5, 6), (2, 3, 4, 1, 5, 6))
     del tmp93
-    t3new += tmp94.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new += tmp94.transpose((2, 1, 0, 3, 4, 5))
-    t3new += tmp94.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new += tmp94.transpose((1, 2, 0, 4, 3, 5))
-    t3new += tmp94.transpose((2, 0, 1, 4, 5, 3)) * -1
-    t3new += tmp94.transpose((2, 0, 1, 3, 5, 4))
-    t3new += tmp94.transpose((1, 0, 2, 4, 5, 3))
-    t3new += tmp94.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new += tmp94.transpose((0, 2, 1, 5, 3, 4))
-    t3new += tmp94.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new += tmp94.transpose((0, 1, 2, 5, 4, 3))
+    t3new += np.transpose(tmp94, (2, 1, 0, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp94, (2, 1, 0, 3, 4, 5))
+    t3new += np.transpose(tmp94, (1, 2, 0, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp94, (1, 2, 0, 4, 3, 5))
+    t3new += np.transpose(tmp94, (2, 0, 1, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp94, (2, 0, 1, 3, 5, 4))
+    t3new += np.transpose(tmp94, (1, 0, 2, 4, 5, 3))
+    t3new += np.transpose(tmp94, (1, 0, 2, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp94, (0, 2, 1, 5, 3, 4))
+    t3new += np.transpose(tmp94, (0, 2, 1, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp94, (0, 1, 2, 5, 4, 3))
     t3new += tmp94 * -1
     del tmp94
     tmp114 = einsum(tmp113, (0, 1), t3, (2, 3, 0, 4, 5, 6), (2, 3, 1, 4, 6, 5)) * -1
     del tmp113
-    t3new += tmp114.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new += tmp114.transpose((2, 1, 0, 4, 5, 3))
+    t3new += np.transpose(tmp114, (0, 1, 2, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp114, (2, 1, 0, 4, 5, 3))
     del tmp114
     tmp123 = einsum(t1, (0, 1), tmp122, (2, 3, 0, 4, 5, 6), (2, 3, 4, 1, 5, 6))
     del tmp122
-    t3new += tmp123.transpose((2, 1, 0, 4, 5, 3))
-    t3new += tmp123.transpose((2, 1, 0, 3, 5, 4)) * -1
-    t3new += tmp123.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new += tmp123.transpose((1, 2, 0, 4, 3, 5))
-    t3new += tmp123.transpose((2, 0, 1, 5, 4, 3))
-    t3new += tmp123.transpose((2, 0, 1, 3, 4, 5)) * -1
-    t3new += tmp123.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new += tmp123.transpose((1, 0, 2, 3, 4, 5))
-    t3new += tmp123.transpose((0, 2, 1, 5, 3, 4))
-    t3new += tmp123.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new += tmp123.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new += tmp123.transpose((0, 1, 2, 3, 5, 4))
+    t3new += np.transpose(tmp123, (2, 1, 0, 4, 5, 3))
+    t3new += np.transpose(tmp123, (2, 1, 0, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp123, (1, 2, 0, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp123, (1, 2, 0, 4, 3, 5))
+    t3new += np.transpose(tmp123, (2, 0, 1, 5, 4, 3))
+    t3new += np.transpose(tmp123, (2, 0, 1, 3, 4, 5)) * -1
+    t3new += np.transpose(tmp123, (1, 0, 2, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp123, (1, 0, 2, 3, 4, 5))
+    t3new += np.transpose(tmp123, (0, 2, 1, 5, 3, 4))
+    t3new += np.transpose(tmp123, (0, 2, 1, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp123, (0, 1, 2, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp123, (0, 1, 2, 3, 5, 4))
     del tmp123
     tmp117 = einsum(tmp44, (0, 1, 2, 3), t2, (4, 2, 5, 6), (0, 4, 1, 5, 6, 3))
     del tmp44
-    t3new += tmp117.transpose((2, 1, 0, 5, 3, 4))
-    t3new += tmp117.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new += tmp117.transpose((1, 2, 0, 5, 4, 3))
-    t3new += tmp117.transpose((1, 2, 0, 3, 4, 5)) * -1
-    t3new += tmp117.transpose((2, 0, 1, 4, 5, 3)) * -1
-    t3new += tmp117.transpose((2, 0, 1, 3, 5, 4))
-    t3new += tmp117.transpose((1, 0, 2, 4, 5, 3))
-    t3new += tmp117.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new += tmp117.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new += tmp117.transpose((0, 2, 1, 3, 4, 5))
-    t3new += tmp117.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new += tmp117.transpose((0, 1, 2, 4, 3, 5))
+    t3new += np.transpose(tmp117, (2, 1, 0, 5, 3, 4))
+    t3new += np.transpose(tmp117, (2, 1, 0, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp117, (1, 2, 0, 5, 4, 3))
+    t3new += np.transpose(tmp117, (1, 2, 0, 3, 4, 5)) * -1
+    t3new += np.transpose(tmp117, (2, 0, 1, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp117, (2, 0, 1, 3, 5, 4))
+    t3new += np.transpose(tmp117, (1, 0, 2, 4, 5, 3))
+    t3new += np.transpose(tmp117, (1, 0, 2, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp117, (0, 2, 1, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp117, (0, 2, 1, 3, 4, 5))
+    t3new += np.transpose(tmp117, (0, 1, 2, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp117, (0, 1, 2, 4, 3, 5))
     del tmp117
     tmp116 = einsum(t1, (0, 1), tmp115, (0, 2, 3, 4, 5, 6), (2, 3, 4, 1, 5, 6))
     del tmp115
-    t3new += tmp116.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new += tmp116.transpose((0, 2, 1, 3, 5, 4))
+    t3new += np.transpose(tmp116, (0, 2, 1, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp116, (0, 2, 1, 3, 5, 4))
     del tmp116
     tmp112 = einsum(v.ooov, (0, 1, 2, 3), t2, (4, 1, 5, 6), (4, 0, 2, 5, 6, 3))
-    t3new += tmp112.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new += tmp112.transpose((2, 1, 0, 3, 4, 5))
-    t3new += tmp112.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new += tmp112.transpose((1, 2, 0, 3, 5, 4))
-    t3new += tmp112.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new += tmp112.transpose((2, 0, 1, 4, 3, 5))
-    t3new += tmp112.transpose((1, 0, 2, 5, 3, 4))
-    t3new += tmp112.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new += tmp112.transpose((0, 2, 1, 4, 5, 3))
-    t3new += tmp112.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new += tmp112.transpose((0, 1, 2, 5, 4, 3))
+    t3new += np.transpose(tmp112, (2, 1, 0, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp112, (2, 1, 0, 3, 4, 5))
+    t3new += np.transpose(tmp112, (1, 2, 0, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp112, (1, 2, 0, 3, 5, 4))
+    t3new += np.transpose(tmp112, (2, 0, 1, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp112, (2, 0, 1, 4, 3, 5))
+    t3new += np.transpose(tmp112, (1, 0, 2, 5, 3, 4))
+    t3new += np.transpose(tmp112, (1, 0, 2, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp112, (0, 2, 1, 4, 5, 3))
+    t3new += np.transpose(tmp112, (0, 2, 1, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp112, (0, 1, 2, 5, 4, 3))
     t3new += tmp112 * -1
     del tmp112
-    tmp111 = tmp108.copy()
+    tmp111 = np.copy(tmp108)
     del tmp108
     tmp111 += tmp110
     del tmp110
-    t3new += tmp111.transpose((2, 1, 0, 5, 3, 4))
-    t3new += tmp111.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new += tmp111.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new += tmp111.transpose((1, 2, 0, 3, 5, 4))
-    t3new += tmp111.transpose((2, 0, 1, 5, 4, 3))
-    t3new += tmp111.transpose((2, 0, 1, 3, 4, 5)) * -1
-    t3new += tmp111.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new += tmp111.transpose((1, 0, 2, 3, 4, 5))
-    t3new += tmp111.transpose((0, 2, 1, 4, 5, 3))
-    t3new += tmp111.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new += tmp111.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new += tmp111.transpose((0, 1, 2, 4, 3, 5))
+    t3new += np.transpose(tmp111, (2, 1, 0, 5, 3, 4))
+    t3new += np.transpose(tmp111, (2, 1, 0, 4, 3, 5)) * -1
+    t3new += np.transpose(tmp111, (1, 2, 0, 4, 5, 3)) * -1
+    t3new += np.transpose(tmp111, (1, 2, 0, 3, 5, 4))
+    t3new += np.transpose(tmp111, (2, 0, 1, 5, 4, 3))
+    t3new += np.transpose(tmp111, (2, 0, 1, 3, 4, 5)) * -1
+    t3new += np.transpose(tmp111, (1, 0, 2, 5, 4, 3)) * -1
+    t3new += np.transpose(tmp111, (1, 0, 2, 3, 4, 5))
+    t3new += np.transpose(tmp111, (0, 2, 1, 4, 5, 3))
+    t3new += np.transpose(tmp111, (0, 2, 1, 3, 5, 4)) * -1
+    t3new += np.transpose(tmp111, (0, 1, 2, 5, 3, 4)) * -1
+    t3new += np.transpose(tmp111, (0, 1, 2, 4, 3, 5))
     del tmp111
-    tmp82 = v.oooo.copy()
-    tmp82 += tmp81.transpose((3, 1, 0, 2))
+    tmp82 = np.copy(v.oooo)
+    tmp82 += np.transpose(tmp81, (3, 1, 0, 2))
     del tmp81
     t2new += einsum(tmp82, (0, 1, 2, 3), t2, (0, 3, 4, 5), (2, 1, 5, 4))
     del tmp82
-    tmp84 = v.ooov.copy() * -1
+    tmp84 = np.copy(v.ooov) * -1
     tmp84 += einsum(t1, (0, 1), tmp83, (0, 2, 3, 4), (3, 4, 2, 1))
     del tmp83
     t2new += einsum(tmp84, (0, 1, 2, 3), t1, (0, 4), (2, 1, 3, 4))
     del tmp84
-    tmp62 = tmp55.copy()
+    tmp62 = np.copy(tmp55)
     del tmp55
     tmp62 += tmp57 * -1
     del tmp57
@@ -452,50 +452,50 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp59
     tmp62 += tmp61
     del tmp61
-    t2new += tmp62.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp62.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp62, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp62, (0, 1, 3, 2)) * -1
     del tmp62
     tmp79 = einsum(tmp78, (0, 1, 2, 3), tmp41, (4, 0, 3, 5), (4, 1, 5, 2))
     del tmp41, tmp78
-    t2new += tmp79.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp79.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp79, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp79, (0, 1, 3, 2)) * -1
     del tmp79
-    tmp38 = tmp35.copy()
+    tmp38 = np.copy(tmp35)
     del tmp35
-    tmp38 += tmp37.transpose((1, 0, 3, 2))
+    tmp38 += np.transpose(tmp37, (1, 0, 3, 2))
     del tmp37
-    t2new += tmp38.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp38.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp38, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp38, (0, 1, 3, 2)) * -1
     del tmp38
-    tmp86 = v.oovv.copy() * -1
+    tmp86 = np.copy(v.oovv) * -1
     tmp86 += einsum(t2, (0, 1, 2, 3), v.ovov, (4, 2, 1, 5), (0, 4, 3, 5))
     t2new += einsum(t2, (0, 1, 2, 3), tmp86, (4, 1, 5, 2), (0, 4, 5, 3))
     del tmp86
-    tmp80 = v.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp80 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 2
     tmp80 += v.oovv * -1
     tmp80 += tmp16 * 2
     del tmp16
     t2new += einsum(tmp80, (0, 1, 2, 3), t2, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp80
-    tmp85 = v.ovov.transpose((0, 2, 1, 3)).copy() * -1
+    tmp85 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * -1
     tmp85 += tmp14
     del tmp14
     t2new += einsum(tmp85, (0, 1, 2, 3), t2, (4, 1, 3, 5), (4, 0, 5, 2))
     del tmp85
-    tmp33 = tmp18.transpose((1, 0, 3, 2)).copy()
+    tmp33 = np.copy(np.transpose(tmp18, (1, 0, 3, 2)))
     del tmp18
     tmp33 += tmp21
     del tmp21
-    tmp33 += tmp24.transpose((1, 0, 2, 3))
+    tmp33 += np.transpose(tmp24, (1, 0, 2, 3))
     del tmp24
     tmp33 += tmp29 * -1
     del tmp29
-    tmp33 += tmp32.transpose((0, 1, 3, 2)) * -1
+    tmp33 += np.transpose(tmp32, (0, 1, 3, 2)) * -1
     del tmp32
-    t2new += tmp33.transpose((1, 0, 3, 2))
+    t2new += np.transpose(tmp33, (1, 0, 3, 2))
     t2new += tmp33
     del tmp33
-    tmp77 = tmp63.copy()
+    tmp77 = np.copy(tmp63)
     del tmp63
     tmp77 += tmp64
     del tmp64
@@ -503,36 +503,36 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp66
     tmp77 += tmp68
     del tmp68
-    tmp77 += tmp71.transpose((1, 0, 2, 3))
+    tmp77 += np.transpose(tmp71, (1, 0, 2, 3))
     del tmp71
-    tmp77 += tmp73.transpose((0, 1, 3, 2)) * -1
+    tmp77 += np.transpose(tmp73, (0, 1, 3, 2)) * -1
     del tmp73
-    tmp77 += tmp76.transpose((0, 1, 3, 2))
+    tmp77 += np.transpose(tmp76, (0, 1, 3, 2))
     del tmp76
-    t2new += tmp77.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp77, (1, 0, 3, 2)) * -1
     t2new += tmp77 * -1
     del tmp77
-    tmp54 = tmp39.copy()
+    tmp54 = np.copy(tmp39)
     del tmp39
     tmp54 += tmp40
     del tmp40
     tmp54 += tmp42 * -1
     del tmp42
-    tmp54 += tmp43.transpose((1, 0, 2, 3))
+    tmp54 += np.transpose(tmp43, (1, 0, 2, 3))
     del tmp43
     tmp54 += tmp51
     del tmp51
-    tmp54 += tmp53.transpose((1, 0, 3, 2)) * -1
+    tmp54 += np.transpose(tmp53, (1, 0, 3, 2)) * -1
     del tmp53
-    t2new += tmp54.transpose((1, 0, 2, 3))
-    t2new += tmp54.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp54, (1, 0, 2, 3))
+    t2new += np.transpose(tmp54, (0, 1, 3, 2))
     del tmp54
-    tmp7 = f.ov.copy()
+    tmp7 = np.copy(f.ov)
     tmp7 += tmp6
     del tmp6
     t1new = einsum(tmp8, (0, 1, 2, 3), tmp7, (0, 2), (1, 3))
     del tmp8, tmp7
-    tmp13 = f.oo.copy()
+    tmp13 = np.copy(f.oo)
     tmp13 += tmp10
     del tmp10
     tmp13 += einsum(tmp1, (0, 1, 2, 3), tmp11, (0, 4, 3, 2), (4, 1))
@@ -541,23 +541,23 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp12
     t1new += einsum(t1, (0, 1), tmp13, (0, 2), (2, 1)) * -1
     del tmp13
-    tmp4 = v.ooov.copy()
-    tmp4 += v.ooov.transpose((0, 2, 1, 3)) * -0.5
+    tmp4 = np.copy(v.ooov)
+    tmp4 += np.transpose(v.ooov, (0, 2, 1, 3)) * -0.5
     tmp4 += tmp3 * -0.5
-    tmp4 += tmp3.transpose((0, 2, 1, 3))
+    tmp4 += np.transpose(tmp3, (0, 2, 1, 3))
     del tmp3
     t1new += einsum(tmp4, (0, 1, 2, 3), t2, (1, 2, 4, 3), (0, 4)) * -2
     del tmp4
-    tmp0 = t3.transpose((0, 2, 1, 3, 5, 4)).copy() * -1
-    tmp0 += t3.transpose((0, 1, 2, 3, 5, 4))
-    tmp0 += t3.transpose((0, 1, 2, 4, 3, 5)) * 3
+    tmp0 = np.copy(np.transpose(t3, (0, 2, 1, 3, 5, 4))) * -1
+    tmp0 += np.transpose(t3, (0, 1, 2, 3, 5, 4))
+    tmp0 += np.transpose(t3, (0, 1, 2, 4, 3, 5)) * 3
     t1new += einsum(tmp0, (0, 1, 2, 3, 4, 5), v.ovov, (0, 4, 1, 3), (2, 5)) * 0.5
     del tmp0
-    tmp2 = v.ovvv.copy() * -0.5
-    tmp2 += v.ovvv.transpose((0, 2, 1, 3))
+    tmp2 = np.copy(v.ovvv) * -0.5
+    tmp2 += np.transpose(v.ovvv, (0, 2, 1, 3))
     t1new += einsum(tmp1, (0, 1, 2, 3), tmp2, (0, 3, 2, 4), (1, 4)) * 2
     del tmp1, tmp2
-    tmp9 = v.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp9 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 2
     tmp9 += v.oovv * -1
     t1new += einsum(t1, (0, 1), tmp9, (0, 2, 1, 3), (2, 3))
     del tmp9
@@ -568,7 +568,7 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t2new += einsum(t2, (0, 1, 2, 3), v.oovv, (4, 1, 5, 2), (4, 0, 3, 5)) * -1
     t2new += einsum(t2, (0, 1, 2, 3), v.ovov, (4, 5, 1, 3), (0, 4, 2, 5)) * 2
     t2new += einsum(t1, (0, 1), v.ooov, (2, 0, 3, 4), (2, 3, 1, 4)) * -1
-    t2new += v.ovov.transpose((0, 2, 1, 3))
+    t2new += np.transpose(v.ovov, (0, 2, 1, 3))
 
     return {f"t1new": t1new, f"t2new": t2new, f"t3new": t3new}
 

--- a/ebcc/codegen/RCCD.py
+++ b/ebcc/codegen/RCCD.py
@@ -422,7 +422,7 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.vvov = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[0], t2.shape[-1]))
     rdm2.vvvo = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[0]))
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.swapaxes(1, 2)
+    rdm2 = rdm2.transpose(0, 2, 1, 3)
 
     return rdm2
 

--- a/ebcc/codegen/RCCD.py
+++ b/ebcc/codegen/RCCD.py
@@ -57,12 +57,12 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
         Updated T2 residuals.
     """
 
-    tmp8 = v.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp8 += v.ovov.transpose((0, 2, 1, 3)) * -0.5
-    tmp5 = v.ovov.transpose((0, 2, 3, 1)).copy() * -0.5
-    tmp5 += v.ovov.transpose((0, 2, 1, 3))
-    tmp2 = v.ovov.transpose((0, 2, 3, 1)).copy() * 2
-    tmp2 += v.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp8 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1)))
+    tmp8 += np.transpose(v.ovov, (0, 2, 1, 3)) * -0.5
+    tmp5 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -0.5
+    tmp5 += np.transpose(v.ovov, (0, 2, 1, 3))
+    tmp2 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * 2
+    tmp2 += np.transpose(v.ovov, (0, 2, 1, 3)) * -1
     tmp9 = einsum(tmp8, (0, 1, 2, 3), t2, (4, 0, 2, 3), (4, 1)) * 2
     del tmp8
     tmp6 = einsum(t2, (0, 1, 2, 3), tmp5, (0, 1, 4, 3), (2, 4))
@@ -75,40 +75,40 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp7 = einsum(tmp6, (0, 1), t2, (2, 3, 1, 4), (2, 3, 4, 0)) * 2
     del tmp6
     tmp1 = einsum(t2, (0, 1, 2, 3), f.oo, (4, 1), (4, 0, 2, 3))
-    tmp13 = v.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp13 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 2
     tmp13 += v.oovv * -1
     tmp13 += tmp3 * 2
     tmp12 = einsum(f.vv, (0, 1), t2, (2, 3, 4, 1), (2, 3, 0, 4))
-    tmp15 = v.ovov.transpose((0, 2, 1, 3)).copy() * -1
+    tmp15 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * -1
     tmp15 += tmp0
-    tmp16 = v.oovv.copy() * -1
+    tmp16 = np.copy(v.oovv) * -1
     tmp16 += einsum(v.ovov, (0, 1, 2, 3), t2, (4, 2, 1, 5), (4, 0, 5, 3))
-    tmp14 = v.oooo.copy()
+    tmp14 = np.copy(v.oooo)
     tmp14 += einsum(v.ovov, (0, 1, 2, 3), t2, (4, 5, 1, 3), (0, 4, 2, 5))
-    tmp11 = tmp7.transpose((1, 0, 2, 3)).copy()
+    tmp11 = np.copy(np.transpose(tmp7, (1, 0, 2, 3)))
     del tmp7
-    tmp11 += tmp10.transpose((0, 1, 3, 2))
+    tmp11 += np.transpose(tmp10, (0, 1, 3, 2))
     del tmp10
     tmp4 = einsum(tmp3, (0, 1, 2, 3), t2, (4, 1, 3, 5), (4, 0, 5, 2))
     del tmp3
     t2new = einsum(t2, (0, 1, 2, 3), v.vvvv, (4, 2, 5, 3), (0, 1, 4, 5))
-    t2new += v.ovov.transpose((0, 2, 1, 3))
+    t2new += np.transpose(v.ovov, (0, 2, 1, 3))
     t2new += einsum(v.oovv, (0, 1, 2, 3), t2, (4, 1, 5, 3), (0, 4, 2, 5)) * -1
-    t2new += tmp0.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp0, (1, 0, 3, 2)) * -1
     del tmp0
     t2new += einsum(v.oovv, (0, 1, 2, 3), t2, (4, 1, 3, 5), (4, 0, 2, 5)) * -1
     t2new += einsum(v.ovov, (0, 1, 2, 3), t2, (4, 2, 5, 3), (0, 4, 1, 5)) * 2
-    t2new += tmp1.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp1.transpose((1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp1, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp1, (1, 0, 2, 3)) * -1
     del tmp1
-    t2new += tmp4.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp4, (1, 0, 3, 2)) * -1
     t2new += tmp4 * -1
     del tmp4
     t2new += tmp11 * -1
-    t2new += tmp11.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp11, (1, 0, 3, 2)) * -1
     del tmp11
-    t2new += tmp12.transpose((0, 1, 3, 2))
-    t2new += tmp12.transpose((1, 0, 2, 3))
+    t2new += np.transpose(tmp12, (0, 1, 3, 2))
+    t2new += np.transpose(tmp12, (1, 0, 2, 3))
     del tmp12
     t2new += einsum(tmp13, (0, 1, 2, 3), t2, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp13
@@ -142,33 +142,33 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
         Updated L2 residuals.
     """
 
-    tmp5 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp5 += l2.transpose((2, 3, 0, 1)) * 2
+    tmp5 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp5 += np.transpose(l2, (2, 3, 0, 1)) * 2
     tmp15 = einsum(v.ovov, (0, 1, 2, 3), t2, (4, 2, 1, 5), (4, 0, 5, 3))
     tmp10 = einsum(l2, (0, 1, 2, 3), t2, (4, 2, 1, 5), (3, 4, 0, 5))
     tmp6 = einsum(tmp5, (0, 1, 2, 3), t2, (4, 0, 5, 2), (4, 1, 5, 3))
     del tmp5
     tmp4 = einsum(t2, (0, 1, 2, 3), l2, (4, 2, 5, 1), (5, 0, 4, 3))
-    tmp26 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp26 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp26 += t2
-    tmp29 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp29 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp29 += t2 * -0.5
-    tmp19 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp19 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp19 += t2 * -1
-    tmp22 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp22 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp22 += t2 * 2
-    tmp16 = v.oovv.copy() * -1
+    tmp16 = np.copy(v.oovv) * -1
     tmp16 += tmp15
     del tmp15
-    tmp11 = tmp10.copy()
+    tmp11 = np.copy(tmp10)
     del tmp10
-    tmp11 += l2.transpose((3, 2, 0, 1)) * -1
-    tmp11 += l2.transpose((2, 3, 0, 1)) * 2
-    tmp8 = v.ovov.transpose((0, 2, 3, 1)).copy() * 2
-    tmp8 += v.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp7 = tmp4.copy()
+    tmp11 += np.transpose(l2, (3, 2, 0, 1)) * -1
+    tmp11 += np.transpose(l2, (2, 3, 0, 1)) * 2
+    tmp8 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * 2
+    tmp8 += np.transpose(v.ovov, (0, 2, 1, 3)) * -1
+    tmp7 = np.copy(tmp4)
     del tmp4
-    tmp7 += tmp6.transpose((1, 0, 3, 2)) * -1
+    tmp7 += np.transpose(tmp6, (1, 0, 3, 2)) * -1
     del tmp6
     tmp27 = einsum(l2, (0, 1, 2, 3), tmp26, (2, 3, 4, 1), (0, 4)) * 2
     del tmp26
@@ -195,47 +195,47 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp24 = einsum(tmp23, (0, 1), l2, (2, 3, 1, 4), (4, 0, 2, 3))
     del tmp23
     tmp1 = einsum(t2, (0, 1, 2, 3), l2, (2, 3, 4, 5), (4, 5, 0, 1))
-    tmp18 = tmp14.copy()
+    tmp18 = np.copy(tmp14)
     del tmp14
     tmp18 += tmp17
     del tmp17
-    tmp13 = tmp3.copy()
+    tmp13 = np.copy(tmp3)
     del tmp3
     tmp13 += tmp9
     del tmp9
-    tmp13 += tmp12.transpose((1, 0, 3, 2)) * -1
+    tmp13 += np.transpose(tmp12, (1, 0, 3, 2)) * -1
     del tmp12
-    tmp32 = tmp28.transpose((1, 0, 3, 2)).copy()
+    tmp32 = np.copy(np.transpose(tmp28, (1, 0, 3, 2)))
     del tmp28
-    tmp32 += tmp31.transpose((1, 0, 3, 2))
+    tmp32 += np.transpose(tmp31, (1, 0, 3, 2))
     del tmp31
     tmp0 = einsum(v.ovov, (0, 1, 2, 3), t2, (4, 5, 1, 3), (4, 5, 0, 2))
-    tmp25 = tmp21.transpose((1, 0, 2, 3)).copy()
+    tmp25 = np.copy(np.transpose(tmp21, (1, 0, 2, 3)))
     del tmp21
-    tmp25 += tmp24.transpose((0, 1, 3, 2))
+    tmp25 += np.transpose(tmp24, (0, 1, 3, 2))
     del tmp24
     tmp2 = einsum(l2, (0, 1, 2, 3), f.oo, (4, 3), (4, 2, 0, 1))
     l2new = einsum(l2, (0, 1, 2, 3), v.vvvv, (4, 1, 5, 0), (4, 5, 3, 2))
-    l2new += v.ovov.transpose((1, 3, 0, 2))
+    l2new += np.transpose(v.ovov, (1, 3, 0, 2))
     l2new += einsum(l2, (0, 1, 2, 3), tmp0, (3, 2, 4, 5), (0, 1, 5, 4))
     del tmp0
     l2new += einsum(v.ovov, (0, 1, 2, 3), tmp1, (4, 5, 0, 2), (1, 3, 4, 5))
     del tmp1
     l2new += einsum(l2, (0, 1, 2, 3), v.oooo, (4, 2, 5, 3), (0, 1, 4, 5))
-    l2new += tmp2.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp2.transpose((2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp2, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp2, (2, 3, 1, 0)) * -1
     del tmp2
-    l2new += tmp13.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp13.transpose((3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp13, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp13, (3, 2, 1, 0)) * -1
     del tmp13
-    l2new += tmp18.transpose((3, 2, 0, 1))
-    l2new += tmp18.transpose((2, 3, 1, 0))
+    l2new += np.transpose(tmp18, (3, 2, 0, 1))
+    l2new += np.transpose(tmp18, (2, 3, 1, 0))
     del tmp18
-    l2new += tmp25.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp25.transpose((3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp25, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp25, (3, 2, 1, 0)) * -1
     del tmp25
-    l2new += tmp32.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp32.transpose((2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp32, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp32, (2, 3, 1, 0)) * -1
     del tmp32
 
     return {f"l2new": l2new}
@@ -262,10 +262,10 @@ def make_rdm1_f(l2=None, t2=None, **kwargs):
         oo=np.eye(t2.shape[0]),
         vv=np.eye(t2.shape[-1]),
     )
-    tmp0 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp0 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp0 += t2 * -0.5
     rdm1.vv = einsum(l2, (0, 1, 2, 3), tmp0, (3, 2, 4, 1), (0, 4)) * 4
-    rdm1.oo = delta.oo.copy() * 2
+    rdm1.oo = np.copy(delta.oo) * 2
     del delta
     rdm1.oo += einsum(l2, (0, 1, 2, 3), tmp0, (2, 4, 1, 0), (4, 3)) * -4
     del tmp0
@@ -297,25 +297,25 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
         oo=np.eye(t2.shape[0]),
         vv=np.eye(t2.shape[-1]),
     )
-    tmp6 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp6 += l2.transpose((2, 3, 0, 1))
-    tmp3 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp3 += l2.transpose((2, 3, 0, 1)) * 2
-    tmp1 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp6 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp6 += np.transpose(l2, (2, 3, 0, 1))
+    tmp3 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp3 += np.transpose(l2, (2, 3, 0, 1)) * 2
+    tmp1 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp1 += t2
-    tmp13 = l2.transpose((3, 2, 0, 1)).copy() * 2
-    tmp13 += l2.transpose((2, 3, 0, 1)) * -1
+    tmp13 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * 2
+    tmp13 += np.transpose(l2, (2, 3, 0, 1)) * -1
     tmp7 = einsum(tmp6, (0, 1, 2, 3), t2, (4, 0, 2, 5), (4, 1, 5, 3))
     del tmp6
     tmp4 = einsum(tmp3, (0, 1, 2, 3), t2, (4, 0, 5, 2), (4, 1, 5, 3))
     tmp2 = einsum(tmp1, (0, 1, 2, 3), l2, (2, 3, 0, 4), (4, 1)) * 2
     del tmp1
     tmp14 = einsum(t2, (0, 1, 2, 3), tmp13, (0, 1, 3, 4), (2, 4)) * 0.5
-    tmp27 = l2.transpose((3, 2, 0, 1)).copy()
-    tmp27 += l2.transpose((2, 3, 0, 1)) * -1
-    tmp22 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp27 = np.copy(np.transpose(l2, (3, 2, 0, 1)))
+    tmp27 += np.transpose(l2, (2, 3, 0, 1)) * -1
+    tmp22 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp22 += t2 * -1
-    tmp24 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp24 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp24 += t2 * -1
     tmp8 = einsum(tmp7, (0, 1, 2, 3), t2, (4, 1, 3, 5), (4, 0, 5, 2))
     tmp5 = einsum(tmp4, (0, 1, 2, 3), t2, (4, 1, 5, 3), (4, 0, 5, 2))
@@ -335,75 +335,75 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     del tmp22
     tmp25 = einsum(l2, (0, 1, 2, 3), tmp24, (3, 4, 5, 1), (2, 4, 0, 5))
     del tmp24
-    tmp9 = tmp5.transpose((1, 0, 3, 2)).copy() * 2
+    tmp9 = np.copy(np.transpose(tmp5, (1, 0, 3, 2))) * 2
     tmp9 += tmp8
     del tmp8
     tmp21 = einsum(tmp20, (0, 1, 2, 3), t2, (4, 0, 2, 5), (1, 4, 3, 5))
-    tmp17 = tmp15.transpose((1, 0, 2, 3)).copy()
+    tmp17 = np.copy(np.transpose(tmp15, (1, 0, 2, 3)))
     del tmp15
-    tmp17 += tmp16.transpose((0, 1, 3, 2))
+    tmp17 += np.transpose(tmp16, (0, 1, 3, 2))
     del tmp16
     tmp19 = einsum(tmp18, (0, 1, 2, 3), t2, (4, 0, 2, 5), (1, 4, 3, 5))
     tmp12 = einsum(t2, (0, 1, 2, 3), tmp0, (1, 0, 4, 5), (4, 5, 3, 2))
     tmp11 = einsum(tmp10, (0, 1, 2, 3), t2, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp10
-    rdm2.vvvv = tmp29.transpose((1, 0, 2, 3)).copy() * -2
-    rdm2.vvvv += tmp29.transpose((1, 0, 3, 2)) * 4
+    rdm2.vvvv = np.copy(np.transpose(tmp29, (1, 0, 2, 3))) * -2
+    rdm2.vvvv += np.transpose(tmp29, (1, 0, 3, 2)) * 4
     del tmp29
-    rdm2.vvoo = l2.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.vvoo = np.copy(np.transpose(l2, (0, 1, 3, 2))) * -2
     rdm2.vvoo += l2 * 4
-    rdm2.vovo = tmp4.transpose((3, 0, 2, 1)).copy() * -2
-    rdm2.vovo += tmp28.transpose((3, 0, 2, 1)) * -2
+    rdm2.vovo = np.copy(np.transpose(tmp4, (3, 0, 2, 1))) * -2
+    rdm2.vovo += np.transpose(tmp28, (3, 0, 2, 1)) * -2
     del tmp28
     rdm2.vovo += einsum(delta.oo, (0, 1), tmp26, (2, 3), (3, 0, 2, 1)) * 4
-    rdm2.vovo += tmp20.transpose((2, 1, 3, 0)) * -2
-    rdm2.voov = tmp25.transpose((2, 1, 0, 3)).copy() * 2
-    rdm2.voov += tmp23.transpose((2, 1, 0, 3)) * -2
+    rdm2.vovo += np.transpose(tmp20, (2, 1, 3, 0)) * -2
+    rdm2.voov = np.copy(np.transpose(tmp25, (2, 1, 0, 3))) * 2
+    rdm2.voov += np.transpose(tmp23, (2, 1, 0, 3)) * -2
     rdm2.voov += einsum(delta.oo, (0, 1), tmp26, (2, 3), (3, 0, 1, 2)) * -2
     del tmp26
-    rdm2.voov += tmp18.transpose((2, 1, 0, 3)) * -2
-    rdm2.voov += tmp4.transpose((3, 0, 1, 2)) * 2
-    rdm2.ovvo = tmp4.transpose((0, 3, 2, 1)).copy() * 4
+    rdm2.voov += np.transpose(tmp18, (2, 1, 0, 3)) * -2
+    rdm2.voov += np.transpose(tmp4, (3, 0, 1, 2)) * 2
+    rdm2.ovvo = np.copy(np.transpose(tmp4, (0, 3, 2, 1))) * 4
     del tmp4
-    rdm2.ovvo += tmp7.transpose((0, 3, 2, 1)) * -2
+    rdm2.ovvo += np.transpose(tmp7, (0, 3, 2, 1)) * -2
     del tmp7
     rdm2.ovvo += einsum(tmp14, (0, 1), delta.oo, (2, 3), (2, 1, 0, 3)) * -4
-    rdm2.ovvo += tmp18.transpose((1, 2, 3, 0)) * -2
+    rdm2.ovvo += np.transpose(tmp18, (1, 2, 3, 0)) * -2
     del tmp18
-    rdm2.ovov = tmp23.transpose((1, 2, 0, 3)).copy() * 2
+    rdm2.ovov = np.copy(np.transpose(tmp23, (1, 2, 0, 3))) * 2
     del tmp23
-    rdm2.ovov += tmp25.transpose((1, 2, 0, 3)) * -2
+    rdm2.ovov += np.transpose(tmp25, (1, 2, 0, 3)) * -2
     del tmp25
     rdm2.ovov += einsum(tmp14, (0, 1), delta.oo, (2, 3), (2, 1, 3, 0)) * 8
     del tmp14
-    rdm2.ovov += tmp20.transpose((1, 2, 0, 3)) * -2
+    rdm2.ovov += np.transpose(tmp20, (1, 2, 0, 3)) * -2
     del tmp20
-    rdm2.oovv = tmp9.copy() * 2
-    rdm2.oovv += tmp9.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv = np.copy(tmp9) * 2
+    rdm2.oovv += np.transpose(tmp9, (0, 1, 3, 2)) * -2
     del tmp9
     rdm2.oovv += tmp11 * -4
-    rdm2.oovv += tmp11.transpose((0, 1, 3, 2)) * 2
-    rdm2.oovv += tmp11.transpose((1, 0, 2, 3)) * 2
-    rdm2.oovv += tmp11.transpose((1, 0, 3, 2)) * -4
+    rdm2.oovv += np.transpose(tmp11, (0, 1, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp11, (1, 0, 2, 3)) * 2
+    rdm2.oovv += np.transpose(tmp11, (1, 0, 3, 2)) * -4
     del tmp11
     rdm2.oovv += tmp12 * 4
-    rdm2.oovv += tmp12.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(tmp12, (0, 1, 3, 2)) * -2
     del tmp12
     rdm2.oovv += tmp17 * -4
-    rdm2.oovv += tmp17.transpose((0, 1, 3, 2)) * 2
-    rdm2.oovv += tmp17.transpose((1, 0, 2, 3)) * 2
-    rdm2.oovv += tmp17.transpose((1, 0, 3, 2)) * -4
+    rdm2.oovv += np.transpose(tmp17, (0, 1, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp17, (1, 0, 2, 3)) * 2
+    rdm2.oovv += np.transpose(tmp17, (1, 0, 3, 2)) * -4
     del tmp17
-    rdm2.oovv += t2.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(t2, (0, 1, 3, 2)) * -2
     rdm2.oovv += t2 * 4
     rdm2.oovv += tmp19 * 2
     del tmp19
-    rdm2.oovv += tmp21.transpose((0, 1, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp21, (0, 1, 3, 2)) * 2
     del tmp21
-    rdm2.oovv += tmp5.transpose((1, 0, 3, 2)) * 4
+    rdm2.oovv += np.transpose(tmp5, (1, 0, 3, 2)) * 4
     del tmp5
-    rdm2.oooo = tmp0.transpose((2, 3, 1, 0)).copy() * -2
-    rdm2.oooo += tmp0.transpose((3, 2, 1, 0)) * 4
+    rdm2.oooo = np.copy(np.transpose(tmp0, (2, 3, 1, 0))) * -2
+    rdm2.oooo += np.transpose(tmp0, (3, 2, 1, 0)) * 4
     del tmp0
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp2, (2, 3), (3, 0, 2, 1)) * -4
     rdm2.oooo += einsum(tmp2, (0, 1), delta.oo, (2, 3), (2, 1, 0, 3)) * 2
@@ -422,7 +422,7 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.vvov = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[0], t2.shape[-1]))
     rdm2.vvvo = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[0]))
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.transpose(0, 2, 1, 3)
+    rdm2 = np.transpose(rdm2, (0, 2, 1, 3))
 
     return rdm2
 
@@ -514,9 +514,9 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     """
 
     ints = kwargs["ints"]
-    tmp7 = v.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp7 += v.ovov.transpose((0, 2, 1, 3)) * -0.5
-    tmp10 = f.ov.copy()
+    tmp7 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1)))
+    tmp7 += np.transpose(v.ovov, (0, 2, 1, 3)) * -0.5
+    tmp10 = np.copy(f.ov)
     tmp10 += ints.tmp15 * 2
     del ints.tmp15
     tmp10 += ints.tmp27
@@ -529,47 +529,47 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp28
     tmp10 += ints.tmp39 * -1
     del ints.tmp39
-    tmp5 = ints.tmp21.copy()
+    tmp5 = np.copy(ints.tmp21)
     del ints.tmp21
     tmp5 += v.oovv * -1
-    tmp9 = ints.tmp18.copy() * 2
+    tmp9 = np.copy(ints.tmp18) * 2
     del ints.tmp18
-    tmp9 += ints.tmp26.transpose((1, 2, 0, 3))
+    tmp9 += np.transpose(ints.tmp26, (1, 2, 0, 3))
     del ints.tmp26
-    tmp9 += ints.tmp6.transpose((1, 0, 2, 3))
+    tmp9 += np.transpose(ints.tmp6, (1, 0, 2, 3))
     del ints.tmp6
-    tmp9 += v.ovoo.transpose((0, 2, 3, 1))
+    tmp9 += np.transpose(v.ovoo, (0, 2, 3, 1))
     tmp9 += ints.tmp17 * -1
     del ints.tmp17
     tmp9 += ints.tmp20 * -1
     del ints.tmp20
-    tmp9 += ints.tmp29.transpose((1, 0, 2, 3)) * -1
+    tmp9 += np.transpose(ints.tmp29, (1, 0, 2, 3)) * -1
     del ints.tmp29
     tmp8 = einsum(tmp7, (0, 1, 2, 3), r2, (0, 1, 3), (2,))
     del tmp7
-    tmp6 = f.vv.copy()
-    tmp6 += ints.tmp30.transpose((1, 0))
+    tmp6 = np.copy(f.vv)
+    tmp6 += np.transpose(ints.tmp30, (1, 0))
     del ints.tmp30
-    tmp6 += ints.tmp32.transpose((1, 0)) * -2
+    tmp6 += np.transpose(ints.tmp32, (1, 0)) * -2
     del ints.tmp32
-    tmp3 = r2.copy() * -0.5
-    tmp3 += r2.transpose((1, 0, 2))
-    tmp4 = ints.tmp24.copy() * 2
+    tmp3 = np.copy(r2) * -0.5
+    tmp3 += np.transpose(r2, (1, 0, 2))
+    tmp4 = np.copy(ints.tmp24) * 2
     del ints.tmp24
-    tmp4 += v.ovov.transpose((0, 2, 1, 3))
+    tmp4 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp4 += ints.tmp22 * -1
     del ints.tmp22
     tmp4 += ints.tmp23 * -1
     del ints.tmp23
-    tmp2 = f.oo.copy()
-    tmp2 += ints.tmp4.transpose((1, 0)) * 2
+    tmp2 = np.copy(f.oo)
+    tmp2 += np.transpose(ints.tmp4, (1, 0)) * 2
     del ints.tmp4
-    tmp2 += ints.tmp2.transpose((1, 0)) * -1
+    tmp2 += np.transpose(ints.tmp2, (1, 0)) * -1
     del ints.tmp2
-    tmp1 = r2.copy() * 2
-    tmp1 += r2.transpose((1, 0, 2)) * -1
-    tmp0 = v.ooov.copy() * -0.5
-    tmp0 += v.ovoo.transpose((0, 2, 3, 1))
+    tmp1 = np.copy(r2) * 2
+    tmp1 += np.transpose(r2, (1, 0, 2)) * -1
+    tmp0 = np.copy(v.ooov) * -0.5
+    tmp0 += np.transpose(v.ovoo, (0, 2, 3, 1))
     r2new = einsum(r2, (0, 1, 2), v.oooo, (3, 0, 4, 1), (3, 4, 2))
     r2new += einsum(ints.tmp8, (0, 1, 2, 3), r2, (3, 2, 4), (1, 0, 4))
     del ints.tmp8
@@ -681,38 +681,38 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     """
 
     ints = kwargs["ints"]
-    tmp8 = v.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp8 += v.ovov.transpose((0, 2, 1, 3)) * 2
-    tmp10 = f.oo.copy()
-    tmp10 += ints.tmp24.transpose((1, 0)) * 2
+    tmp8 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -1
+    tmp8 += np.transpose(v.ovov, (0, 2, 1, 3)) * 2
+    tmp10 = np.copy(f.oo)
+    tmp10 += np.transpose(ints.tmp24, (1, 0)) * 2
     del ints.tmp24
-    tmp10 += ints.tmp22.transpose((1, 0)) * -1
+    tmp10 += np.transpose(ints.tmp22, (1, 0)) * -1
     del ints.tmp22
-    tmp5 = ints.tmp35.copy() * 2
+    tmp5 = np.copy(ints.tmp35) * 2
     del ints.tmp35
-    tmp5 += v.ovov.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp5 += ints.tmp33 * -1
     del ints.tmp33
     tmp5 += ints.tmp34 * -1
     del ints.tmp34
-    tmp7 = ints.tmp11.copy()
+    tmp7 = np.copy(ints.tmp11)
     del ints.tmp11
     tmp7 += ints.tmp28 * 2
     del ints.tmp28
     tmp7 += v.ovvv
-    tmp7 += ints.tmp29.transpose((0, 1, 3, 2)) * -1
+    tmp7 += np.transpose(ints.tmp29, (0, 1, 3, 2)) * -1
     del ints.tmp29
     tmp7 += ints.tmp30 * -1
     del ints.tmp30
-    tmp7 += ints.tmp6.transpose((0, 3, 1, 2)) * -1
+    tmp7 += np.transpose(ints.tmp6, (0, 3, 1, 2)) * -1
     del ints.tmp6
     tmp9 = einsum(f.ov, (0, 1), r1, (1,), (0,))
     tmp9 += einsum(tmp8, (0, 1, 2, 3), r2, (2, 3, 0), (1,)) * -1
     del tmp8
-    tmp6 = ints.tmp9.copy()
+    tmp6 = np.copy(ints.tmp9)
     del ints.tmp9
     tmp6 += v.oovv * -1
-    tmp11 = f.ov.copy()
+    tmp11 = np.copy(f.ov)
     tmp11 += ints.tmp20 * 2
     del ints.tmp20
     tmp11 += ints.tmp27 * 2
@@ -726,17 +726,17 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp11 += ints.tmp38 * -2
     del ints.tmp38
     tmp3 = einsum(r2, (0, 1, 2), v.ovov, (3, 0, 4, 1), (2, 3, 4))
-    tmp4 = r2.transpose((2, 0, 1)).copy()
-    tmp4 += r2.transpose((2, 1, 0)) * -0.5
-    tmp2 = f.vv.copy()
-    tmp2 += ints.tmp2.transpose((1, 0))
+    tmp4 = np.copy(np.transpose(r2, (2, 0, 1)))
+    tmp4 += np.transpose(r2, (2, 1, 0)) * -0.5
+    tmp2 = np.copy(f.vv)
+    tmp2 += np.transpose(ints.tmp2, (1, 0))
     del ints.tmp2
-    tmp2 += ints.tmp4.transpose((1, 0)) * -2
+    tmp2 += np.transpose(ints.tmp4, (1, 0)) * -2
     del ints.tmp4
-    tmp1 = r2.transpose((2, 0, 1)).copy() * -1
-    tmp1 += r2.transpose((2, 1, 0)) * 2
-    tmp0 = v.ovvv.copy() * 2
-    tmp0 += v.ovvv.transpose((0, 2, 1, 3)) * -1
+    tmp1 = np.copy(np.transpose(r2, (2, 0, 1))) * -1
+    tmp1 += np.transpose(r2, (2, 1, 0)) * 2
+    tmp0 = np.copy(v.ovvv) * 2
+    tmp0 += np.transpose(v.ovvv, (0, 2, 1, 3)) * -1
     r2new = einsum(r2, (0, 1, 2), v.vvvv, (3, 0, 4, 1), (3, 4, 2))
     r2new += einsum(t2, (0, 1, 2, 3), tmp3, (4, 1, 0), (3, 2, 4))
     del tmp3
@@ -852,58 +852,58 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     """
 
     ints = kwargs["ints"]
-    tmp10 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp10 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp10 += t2 * -0.5
-    tmp5 = r2.copy() * -0.5
-    tmp5 += r2.transpose((1, 0, 2))
-    tmp7 = ints.tmp33.copy()
+    tmp5 = np.copy(r2) * -0.5
+    tmp5 += np.transpose(r2, (1, 0, 2))
+    tmp7 = np.copy(ints.tmp33)
     del ints.tmp33
     tmp7 += v.oovv * -1
-    tmp9 = f.vv.copy()
+    tmp9 = np.copy(f.vv)
     tmp9 += ints.tmp51
     del ints.tmp51
     tmp9 += ints.tmp53 * -2
     del ints.tmp53
-    tmp8 = ints.tmp49.copy()
+    tmp8 = np.copy(ints.tmp49)
     del ints.tmp49
-    tmp8 += v.oooo.transpose((0, 2, 1, 3))
-    tmp6 = ints.tmp37.copy() * 2
+    tmp8 += np.transpose(v.oooo, (0, 2, 1, 3))
+    tmp6 = np.copy(ints.tmp37) * 2
     del ints.tmp37
-    tmp6 += v.ovov.transpose((0, 2, 1, 3))
+    tmp6 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp6 += ints.tmp34 * -1
     del ints.tmp34
     tmp6 += ints.tmp36 * -1
     del ints.tmp36
     tmp11 = einsum(tmp10, (0, 1, 2, 3), r2, (0, 1, 3), (2,))
     del tmp10
-    tmp4 = f.oo.copy()
+    tmp4 = np.copy(f.oo)
     tmp4 += ints.tmp10 * 2
     del ints.tmp10
     tmp4 += ints.tmp8 * -1
     del ints.tmp8
-    tmp1 = ints.tmp18.copy()
-    tmp1 += ints.tmp22.transpose((0, 2, 1, 3))
-    tmp1 += ints.tmp3.transpose((1, 2, 0, 3)) * 0.5
+    tmp1 = np.copy(ints.tmp18)
+    tmp1 += np.transpose(ints.tmp22, (0, 2, 1, 3))
+    tmp1 += np.transpose(ints.tmp3, (1, 2, 0, 3)) * 0.5
     tmp1 += ints.tmp19 * -0.5
-    tmp1 += ints.tmp21.transpose((0, 2, 1, 3)) * -0.5
+    tmp1 += np.transpose(ints.tmp21, (0, 2, 1, 3)) * -0.5
     tmp1 += ints.tmp30 * -1
-    tmp0 = ints.tmp18.copy()
+    tmp0 = np.copy(ints.tmp18)
     del ints.tmp18
-    tmp0 += ints.tmp22.transpose((0, 2, 1, 3)) * 4
+    tmp0 += np.transpose(ints.tmp22, (0, 2, 1, 3)) * 4
     del ints.tmp22
-    tmp0 += ints.tmp3.transpose((1, 2, 0, 3)) * 2
+    tmp0 += np.transpose(ints.tmp3, (1, 2, 0, 3)) * 2
     del ints.tmp3
     tmp0 += ints.tmp19 * -2
     del ints.tmp19
-    tmp0 += ints.tmp21.transpose((0, 2, 1, 3)) * -2
+    tmp0 += np.transpose(ints.tmp21, (0, 2, 1, 3)) * -2
     del ints.tmp21
     tmp0 += ints.tmp30 * -1
     del ints.tmp30
-    tmp0 += v.ooov.transpose((0, 2, 1, 3)) * -1
-    tmp0 += v.ovoo.transpose((0, 2, 3, 1)) * 2
-    tmp3 = r2.copy() * 2
-    tmp3 += r2.transpose((1, 0, 2)) * -1
-    tmp2 = f.ov.copy() * 0.5
+    tmp0 += np.transpose(v.ooov, (0, 2, 1, 3)) * -1
+    tmp0 += np.transpose(v.ovoo, (0, 2, 3, 1)) * 2
+    tmp3 = np.copy(r2) * 2
+    tmp3 += np.transpose(r2, (1, 0, 2)) * -1
+    tmp2 = np.copy(f.ov) * 0.5
     tmp2 += ints.tmp12 * 0.5
     del ints.tmp12
     tmp2 += ints.tmp1
@@ -1026,45 +1026,45 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     """
 
     ints = kwargs["ints"]
-    tmp6 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp6 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp6 += t2 * -0.5
-    tmp10 = ints.tmp45.copy() * 2
+    tmp10 = np.copy(ints.tmp45) * 2
     del ints.tmp45
-    tmp10 += v.ovov.transpose((0, 2, 1, 3))
+    tmp10 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp10 += ints.tmp42 * -1
     del ints.tmp42
     tmp10 += ints.tmp44 * -1
     del ints.tmp44
-    tmp5 = f.vv.copy()
+    tmp5 = np.copy(f.vv)
     tmp5 += ints.tmp9
     del ints.tmp9
     tmp5 += ints.tmp11 * -2
     del ints.tmp11
-    tmp9 = r2.transpose((2, 0, 1)).copy()
-    tmp9 += r2.transpose((2, 1, 0)) * -0.5
+    tmp9 = np.copy(np.transpose(r2, (2, 0, 1)))
+    tmp9 += np.transpose(r2, (2, 1, 0)) * -0.5
     tmp8 = einsum(r2, (0, 1, 2), t2, (3, 4, 0, 1), (2, 3, 4))
     tmp13 = einsum(r2, (0, 1, 2), tmp6, (2, 3, 1, 0), (3,))
-    tmp12 = f.oo.copy()
+    tmp12 = np.copy(f.oo)
     tmp12 += ints.tmp39 * 2
     del ints.tmp39
     tmp12 += ints.tmp37 * -1
     del ints.tmp37
-    tmp11 = ints.tmp41.copy()
+    tmp11 = np.copy(ints.tmp41)
     del ints.tmp41
     tmp11 += v.oovv * -1
-    tmp1 = ints.tmp19.copy()
+    tmp1 = np.copy(ints.tmp19)
     del ints.tmp19
-    tmp1 += ints.tmp30.transpose((0, 1, 3, 2)) * 2
+    tmp1 += np.transpose(ints.tmp30, (0, 1, 3, 2)) * 2
     del ints.tmp30
-    tmp1 += ints.tmp28.transpose((0, 1, 3, 2)) * -1
+    tmp1 += np.transpose(ints.tmp28, (0, 1, 3, 2)) * -1
     del ints.tmp28
-    tmp1 += ints.tmp35.transpose((0, 1, 3, 2)) * -1
+    tmp1 += np.transpose(ints.tmp35, (0, 1, 3, 2)) * -1
     del ints.tmp35
     tmp7 = einsum(r2, (0, 1, 2), tmp6, (2, 3, 1, 0), (3,)) * 2
     del tmp6
-    tmp0 = r2.transpose((2, 0, 1)).copy() * 2
-    tmp0 += r2.transpose((2, 1, 0)) * -1
-    tmp3 = f.ov.copy() * 0.5
+    tmp0 = np.copy(np.transpose(r2, (2, 0, 1))) * 2
+    tmp0 += np.transpose(r2, (2, 1, 0)) * -1
+    tmp3 = np.copy(f.ov) * 0.5
     tmp3 += ints.tmp13 * 0.5
     del ints.tmp13
     tmp3 += ints.tmp1
@@ -1077,11 +1077,11 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp16
     tmp3 += ints.tmp25 * -0.5
     del ints.tmp25
-    tmp4 = r2.transpose((2, 0, 1)).copy() * -1
-    tmp4 += r2.transpose((2, 1, 0)) * 2
-    tmp2 = ints.tmp33.copy()
+    tmp4 = np.copy(np.transpose(r2, (2, 0, 1))) * -1
+    tmp4 += np.transpose(r2, (2, 1, 0)) * 2
+    tmp2 = np.copy(ints.tmp33)
     tmp2 += v.ovvv * 2
-    tmp2 += v.ovvv.transpose((0, 2, 3, 1)) * -1
+    tmp2 += np.transpose(v.ovvv, (0, 2, 3, 1)) * -1
     r2new = einsum(r2, (0, 1, 2), v.vvvv, (3, 0, 4, 1), (3, 4, 2))
     r2new += einsum(f.ov, (0, 1), r1, (2,), (1, 2, 0)) * -1
     r2new += einsum(tmp8, (0, 1, 2), v.ovov, (2, 3, 1, 4), (4, 3, 0))

--- a/ebcc/codegen/RCCSD.py
+++ b/ebcc/codegen/RCCSD.py
@@ -37,9 +37,9 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp0 = v.ovov.transpose((0, 2, 3, 1)).copy() * -0.5
-    tmp0 += v.ovov.transpose((0, 2, 1, 3))
-    tmp1 = f.ov.copy()
+    tmp0 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -0.5
+    tmp0 += np.transpose(v.ovov, (0, 2, 1, 3))
+    tmp1 = np.copy(f.ov)
     tmp1 += einsum(t1, (0, 1), tmp0, (0, 2, 1, 3), (2, 3))
     del tmp0
     e_cc = einsum(t1, (0, 1), tmp1, (0, 1), ()) * 2
@@ -73,72 +73,72 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     """
 
     tmp2 = einsum(v.ovov, (0, 1, 2, 3), t1, (4, 3), (4, 0, 2, 1))
-    tmp4 = v.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp4 += v.ovov.transpose((0, 2, 1, 3)) * 2
-    tmp47 = tmp2.copy() * -1
-    tmp47 += tmp2.transpose((0, 2, 1, 3)) * 2
-    tmp39 = v.ovov.transpose((0, 2, 3, 1)).copy() * 2
-    tmp39 += v.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp4 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -1
+    tmp4 += np.transpose(v.ovov, (0, 2, 1, 3)) * 2
+    tmp47 = np.copy(tmp2) * -1
+    tmp47 += np.transpose(tmp2, (0, 2, 1, 3)) * 2
+    tmp39 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * 2
+    tmp39 += np.transpose(v.ovov, (0, 2, 1, 3)) * -1
     tmp30 = einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
-    tmp30 += t2.transpose((0, 1, 3, 2)) * -2
+    tmp30 += np.transpose(t2, (0, 1, 3, 2)) * -2
     tmp30 += t2
     tmp5 = einsum(t1, (0, 1), tmp4, (0, 2, 1, 3), (2, 3))
     del tmp4
-    tmp51 = v.ooov.copy() * -1
-    tmp51 += v.ovoo.transpose((0, 2, 3, 1)) * 2
+    tmp51 = np.copy(v.ooov) * -1
+    tmp51 += np.transpose(v.ovoo, (0, 2, 3, 1)) * 2
     tmp48 = einsum(t2, (0, 1, 2, 3), tmp47, (4, 5, 1, 3), (4, 5, 0, 2))
     del tmp47
     tmp46 = einsum(t2, (0, 1, 2, 3), v.ooov, (4, 1, 5, 2), (0, 4, 5, 3))
-    tmp43 = v.ovvv.copy() * -1
-    tmp43 += v.ovvv.transpose((0, 2, 1, 3)) * 2
+    tmp43 = np.copy(v.ovvv) * -1
+    tmp43 += np.transpose(v.ovvv, (0, 2, 1, 3)) * 2
     tmp38 = einsum(tmp2, (0, 1, 2, 3), t1, (2, 4), (0, 1, 4, 3))
     tmp40 = einsum(t2, (0, 1, 2, 3), tmp39, (1, 4, 5, 3), (4, 0, 5, 2))
     del tmp39
-    tmp57 = v.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp57 += v.ovov.transpose((0, 2, 1, 3)) * -0.5
+    tmp57 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1)))
+    tmp57 += np.transpose(v.ovov, (0, 2, 1, 3)) * -0.5
     tmp31 = einsum(tmp30, (0, 1, 2, 3), v.ooov, (4, 5, 0, 3), (1, 4, 5, 2))
     del tmp30
     tmp27 = einsum(v.oovv, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
     tmp28 = einsum(v.ooov, (0, 1, 2, 3), t2, (4, 1, 5, 3), (4, 0, 2, 5))
     tmp32 = einsum(tmp5, (0, 1), t2, (2, 3, 1, 4), (0, 2, 3, 4))
     tmp29 = einsum(t2, (0, 1, 2, 3), tmp2, (4, 5, 1, 2), (4, 0, 5, 3))
-    tmp0 = t2.copy()
+    tmp0 = np.copy(t2)
     tmp0 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     t2new = einsum(tmp0, (0, 1, 2, 3), v.vvvv, (4, 3, 5, 2), (1, 0, 4, 5))
     tmp9 = einsum(f.ov, (0, 1), t1, (2, 1), (0, 2))
     tmp52 = einsum(tmp51, (0, 1, 2, 3), t1, (0, 3), (1, 2))
     del tmp51
-    tmp49 = tmp2.copy()
+    tmp49 = np.copy(tmp2)
     tmp49 += tmp46 * -1
     del tmp46
-    tmp49 += tmp48.transpose((0, 2, 1, 3))
+    tmp49 += np.transpose(tmp48, (0, 2, 1, 3))
     del tmp48
     tmp44 = einsum(t1, (0, 1), tmp43, (0, 2, 1, 3), (2, 3))
     del tmp43
-    tmp41 = tmp38.copy()
+    tmp41 = np.copy(tmp38)
     del tmp38
-    tmp41 += tmp40.transpose((1, 0, 3, 2)) * -1
+    tmp41 += np.transpose(tmp40, (1, 0, 3, 2)) * -1
     tmp55 = einsum(v.ovvv, (0, 1, 2, 3), t2, (4, 5, 1, 3), (4, 5, 0, 2))
     tmp60 = einsum(tmp57, (0, 1, 2, 3), t2, (4, 0, 2, 3), (1, 4)) * 2
     tmp58 = einsum(t2, (0, 1, 2, 3), tmp57, (0, 1, 3, 4), (4, 2))
     del tmp57
-    tmp25 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp25 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp25 += t2 * -1
     tmp23 = einsum(t1, (0, 1), v.ovvv, (2, 3, 4, 1), (0, 2, 3, 4))
-    tmp33 = tmp27.transpose((0, 2, 1, 3)).copy() * -1
+    tmp33 = np.copy(np.transpose(tmp27, (0, 2, 1, 3))) * -1
     del tmp27
-    tmp33 += tmp28.transpose((0, 2, 1, 3))
+    tmp33 += np.transpose(tmp28, (0, 2, 1, 3))
     del tmp28
-    tmp33 += tmp29.transpose((0, 2, 1, 3))
+    tmp33 += np.transpose(tmp29, (0, 2, 1, 3))
     del tmp29
-    tmp33 += tmp31.transpose((0, 2, 1, 3))
+    tmp33 += np.transpose(tmp31, (0, 2, 1, 3))
     del tmp31
-    tmp33 += tmp32.transpose((2, 0, 1, 3)) * -1
+    tmp33 += np.transpose(tmp32, (2, 0, 1, 3)) * -1
     del tmp32
     tmp19 = einsum(t1, (0, 1), v.ovvv, (2, 1, 3, 4), (0, 2, 3, 4))
     tmp35 = einsum(tmp5, (0, 1), t1, (2, 1), (0, 2))
     tmp66 = einsum(tmp0, (0, 1, 2, 3), v.ovov, (4, 2, 5, 3), (0, 1, 4, 5))
-    tmp16 = f.oo.copy()
+    tmp16 = np.copy(f.oo)
     tmp16 += tmp9
     tmp14 = einsum(f.ov, (0, 1), t2, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp53 = einsum(t2, (0, 1, 2, 3), tmp52, (4, 1), (4, 0, 3, 2))
@@ -155,7 +155,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp60
     tmp59 = einsum(t2, (0, 1, 2, 3), tmp58, (2, 4), (0, 1, 4, 3)) * 2
     del tmp58
-    tmp20 = t2.copy()
+    tmp20 = np.copy(t2)
     tmp20 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     tmp26 = einsum(tmp25, (0, 1, 2, 3), tmp23, (4, 0, 3, 5), (1, 4, 2, 5))
     del tmp25
@@ -167,8 +167,8 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp35
     tmp13 = einsum(t2, (0, 1, 2, 3), v.ovov, (4, 5, 1, 2), (0, 4, 3, 5))
     t2new += tmp13 * -1
-    tmp67 = v.oooo.copy()
-    tmp67 += tmp66.transpose((3, 1, 0, 2))
+    tmp67 = np.copy(v.oooo)
+    tmp67 += np.transpose(tmp66, (3, 1, 0, 2))
     del tmp66
     t2new += einsum(tmp67, (0, 1, 2, 3), t2, (0, 3, 4, 5), (2, 1, 5, 4))
     tmp63 = einsum(v.ooov, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
@@ -176,97 +176,97 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp16
     tmp15 = einsum(tmp14, (0, 1, 2, 3), t1, (0, 4), (1, 2, 4, 3))
     del tmp14
-    tmp10 = v.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp10 += v.ovov.transpose((0, 2, 1, 3)) * 2
-    tmp11 = v.ooov.copy() * -0.5
-    tmp11 += v.ovoo.transpose((0, 2, 3, 1))
-    tmp54 = tmp42.copy()
+    tmp10 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -1
+    tmp10 += np.transpose(v.ovov, (0, 2, 1, 3)) * 2
+    tmp11 = np.copy(v.ooov) * -0.5
+    tmp11 += np.transpose(v.ovoo, (0, 2, 3, 1))
+    tmp54 = np.copy(tmp42)
     del tmp42
-    tmp54 += tmp45.transpose((1, 0, 3, 2))
+    tmp54 += np.transpose(tmp45, (1, 0, 3, 2))
     del tmp45
-    tmp54 += tmp50.transpose((0, 1, 3, 2)) * -1
+    tmp54 += np.transpose(tmp50, (0, 1, 3, 2)) * -1
     del tmp50
-    tmp54 += tmp53.transpose((1, 0, 3, 2)) * -1
+    tmp54 += np.transpose(tmp53, (1, 0, 3, 2)) * -1
     del tmp53
-    t2new += tmp54.transpose((1, 0, 3, 2))
+    t2new += np.transpose(tmp54, (1, 0, 3, 2))
     t2new += tmp54
     del tmp54
-    tmp62 = tmp56.copy()
+    tmp62 = np.copy(tmp56)
     del tmp56
-    tmp62 += tmp59.transpose((1, 0, 3, 2))
+    tmp62 += np.transpose(tmp59, (1, 0, 3, 2))
     del tmp59
-    tmp62 += tmp61.transpose((1, 0, 3, 2))
+    tmp62 += np.transpose(tmp61, (1, 0, 3, 2))
     del tmp61
-    t2new += tmp62.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp62, (1, 0, 3, 2)) * -1
     t2new += tmp62 * -1
     del tmp62
-    tmp69 = v.oovv.copy() * -1
+    tmp69 = np.copy(v.oovv) * -1
     tmp69 += einsum(v.ovov, (0, 1, 2, 3), t2, (4, 2, 1, 5), (4, 0, 5, 3))
     t2new += einsum(t2, (0, 1, 2, 3), tmp69, (4, 1, 5, 2), (4, 0, 3, 5))
     del tmp69
     tmp21 = einsum(tmp20, (0, 1, 2, 3), tmp19, (4, 0, 3, 5), (4, 1, 5, 2))
     del tmp19, tmp20
-    t2new += tmp21.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp21.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp21, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp21, (0, 1, 3, 2)) * -1
     del tmp21
-    tmp37 = tmp22.copy()
+    tmp37 = np.copy(tmp22)
     del tmp22
     tmp37 += tmp23
     del tmp23
     tmp37 += tmp24 * -1
     del tmp24
-    tmp37 += tmp26.transpose((1, 0, 2, 3))
+    tmp37 += np.transpose(tmp26, (1, 0, 2, 3))
     del tmp26
-    tmp37 += tmp34.transpose((0, 1, 3, 2))
+    tmp37 += np.transpose(tmp34, (0, 1, 3, 2))
     del tmp34
-    tmp37 += tmp36.transpose((0, 1, 3, 2)) * -1
+    tmp37 += np.transpose(tmp36, (0, 1, 3, 2)) * -1
     del tmp36
-    t2new += tmp37.transpose((1, 0, 2, 3))
-    t2new += tmp37.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp37, (1, 0, 2, 3))
+    t2new += np.transpose(tmp37, (0, 1, 3, 2))
     del tmp37
-    tmp70 = v.ovov.transpose((0, 2, 1, 3)).copy() * -1
+    tmp70 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * -1
     tmp70 += tmp13
     del tmp13
     t2new += einsum(t2, (0, 1, 2, 3), tmp70, (4, 1, 5, 2), (4, 0, 5, 3))
     del tmp70
-    tmp65 = v.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp65 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 2
     tmp65 += v.oovv * -1
-    tmp65 += tmp40.transpose((1, 0, 3, 2)) * 2
+    tmp65 += np.transpose(tmp40, (1, 0, 3, 2)) * 2
     del tmp40
     t2new += einsum(t2, (0, 1, 2, 3), tmp65, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp65
-    tmp68 = v.ooov.transpose((0, 2, 1, 3)).copy() * -1
+    tmp68 = np.copy(np.transpose(v.ooov, (0, 2, 1, 3))) * -1
     tmp68 += einsum(tmp67, (0, 1, 2, 3), t1, (0, 4), (2, 1, 3, 4))
     del tmp67
     t2new += einsum(t1, (0, 1), tmp68, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp68
     tmp64 = einsum(t2, (0, 1, 2, 3), tmp63, (4, 5, 0, 1), (4, 5, 2, 3))
     del tmp63
-    t2new += tmp64.transpose((1, 0, 2, 3))
-    t2new += tmp64.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp64, (1, 0, 2, 3))
+    t2new += np.transpose(tmp64, (0, 1, 3, 2))
     del tmp64
-    tmp18 = tmp15.copy()
+    tmp18 = np.copy(tmp15)
     del tmp15
-    tmp18 += tmp17.transpose((0, 1, 3, 2))
+    tmp18 += np.transpose(tmp17, (0, 1, 3, 2))
     del tmp17
-    t2new += tmp18.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp18.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp18, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp18, (0, 1, 3, 2)) * -1
     del tmp18
-    tmp6 = f.ov.copy()
+    tmp6 = np.copy(f.ov)
     tmp6 += tmp5
     del tmp5
-    tmp1 = v.ovvv.copy()
-    tmp1 += v.ovvv.transpose((0, 2, 1, 3)) * -0.5
+    tmp1 = np.copy(v.ovvv)
+    tmp1 += np.transpose(v.ovvv, (0, 2, 1, 3)) * -0.5
     t1new = einsum(tmp0, (0, 1, 2, 3), tmp1, (0, 2, 3, 4), (1, 4)) * 2
     del tmp1
-    tmp3 = v.ooov.copy()
-    tmp3 += v.ooov.transpose((0, 2, 1, 3)) * -0.5
+    tmp3 = np.copy(v.ooov)
+    tmp3 += np.transpose(v.ooov, (0, 2, 1, 3)) * -0.5
     tmp3 += tmp2 * -0.5
-    tmp3 += tmp2.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(tmp2, (0, 2, 1, 3))
     del tmp2
     t1new += einsum(t2, (0, 1, 2, 3), tmp3, (4, 0, 1, 3), (4, 2)) * -2
     del tmp3
-    tmp12 = f.oo.copy() * 0.5
+    tmp12 = np.copy(f.oo) * 0.5
     tmp12 += tmp9 * 0.5
     del tmp9
     tmp12 += einsum(tmp10, (0, 1, 2, 3), tmp0, (0, 4, 2, 3), (1, 4)) * 0.5
@@ -275,18 +275,18 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp11
     t1new += einsum(tmp12, (0, 1), t1, (0, 2), (1, 2)) * -2
     del tmp12
-    tmp8 = v.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp8 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 2
     tmp8 += v.oovv * -1
     t1new += einsum(t1, (0, 1), tmp8, (0, 2, 1, 3), (2, 3))
     del tmp8
-    tmp7 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp7 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp7 += t2 * 2
     t1new += einsum(tmp7, (0, 1, 2, 3), tmp6, (0, 2), (1, 3))
     del tmp7, tmp6
     t1new += einsum(f.vv, (0, 1), t1, (2, 1), (2, 0))
     t1new += f.ov
     t2new += einsum(v.ovoo, (0, 1, 2, 3), t1, (3, 4), (0, 2, 1, 4)) * -1
-    t2new += v.ovov.transpose((0, 2, 1, 3))
+    t2new += np.transpose(v.ovov, (0, 2, 1, 3))
     t2new += einsum(t2, (0, 1, 2, 3), v.oovv, (4, 1, 5, 3), (0, 4, 2, 5)) * -1
     t2new += einsum(v.oovv, (0, 1, 2, 3), t2, (4, 1, 3, 5), (4, 0, 2, 5)) * -1
     t2new += einsum(t2, (0, 1, 2, 3), v.ovov, (4, 5, 1, 3), (0, 4, 2, 5)) * 2
@@ -320,15 +320,15 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
         Updated L2 residuals.
     """
 
-    tmp97 = v.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp97 += v.ovov.transpose((0, 2, 1, 3)) * 2
-    tmp15 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp97 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -1
+    tmp97 += np.transpose(v.ovov, (0, 2, 1, 3)) * 2
+    tmp15 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp15 += t2 * 2
     tmp98 = einsum(t1, (0, 1), tmp97, (0, 2, 1, 3), (2, 3))
     del tmp97
-    tmp85 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp85 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp85 += t2 * 2
-    tmp16 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp16 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp16 += t2 * -0.5
     tmp17 = einsum(l2, (0, 1, 2, 3), t1, (4, 1), (2, 3, 4, 0))
     tmp8 = einsum(v.ovov, (0, 1, 2, 3), t1, (4, 3), (4, 0, 2, 1))
@@ -344,51 +344,51 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp24 = einsum(t1, (0, 1), v.ovvv, (2, 1, 3, 4), (0, 2, 3, 4))
     tmp53 = einsum(l2, (0, 1, 2, 3), tmp16, (2, 4, 1, 0), (3, 4)) * 2
     tmp50 = einsum(l1, (0, 1), t1, (2, 0), (1, 2))
-    tmp5 = v.ovov.transpose((0, 2, 3, 1)).copy() * -0.5
-    tmp5 += v.ovov.transpose((0, 2, 1, 3))
+    tmp5 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -0.5
+    tmp5 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp2 = einsum(t2, (0, 1, 2, 3), v.ovov, (4, 2, 5, 3), (0, 1, 4, 5))
     l2new = einsum(l2, (0, 1, 2, 3), tmp2, (2, 3, 4, 5), (0, 1, 4, 5))
     tmp36 = einsum(tmp17, (0, 1, 2, 3), t1, (4, 3), (1, 0, 2, 4))
     tmp35 = einsum(l2, (0, 1, 2, 3), t2, (4, 5, 0, 1), (2, 3, 4, 5))
     tmp26 = einsum(t1, (0, 1), tmp8, (2, 3, 4, 1), (0, 2, 3, 4))
-    tmp74 = tmp72.transpose((1, 0)).copy()
+    tmp74 = np.copy(np.transpose(tmp72, (1, 0)))
     del tmp72
-    tmp74 += tmp73.transpose((1, 0))
+    tmp74 += np.transpose(tmp73, (1, 0))
     del tmp73
     tmp70 = einsum(v.ovov, (0, 1, 2, 3), tmp15, (0, 2, 4, 3), (1, 4)) * 0.5
-    tmp100 = tmp96.copy()
+    tmp100 = np.copy(tmp96)
     del tmp96
     tmp100 += tmp99 * -1
     del tmp99
-    tmp92 = tmp17.copy() * 2
-    tmp92 += tmp17.transpose((1, 0, 2, 3)) * -1
-    tmp82 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp82 += l2.transpose((2, 3, 0, 1)) * 2
-    tmp87 = v.ovov.transpose((0, 2, 1, 3)).copy()
-    tmp87 += tmp83.transpose((0, 1, 3, 2))
+    tmp92 = np.copy(tmp17) * 2
+    tmp92 += np.transpose(tmp17, (1, 0, 2, 3)) * -1
+    tmp82 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp82 += np.transpose(l2, (2, 3, 0, 1)) * 2
+    tmp87 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3)))
+    tmp87 += np.transpose(tmp83, (0, 1, 3, 2))
     del tmp83
     tmp87 += tmp84 * -1
     del tmp84
-    tmp87 += tmp86.transpose((1, 0, 3, 2))
+    tmp87 += np.transpose(tmp86, (1, 0, 3, 2))
     del tmp86
-    tmp94 = tmp8.copy() * 2
-    tmp94 += tmp8.transpose((0, 2, 1, 3)) * -1
-    tmp90 = v.oovv.copy()
-    tmp90 += tmp24.transpose((0, 1, 3, 2))
+    tmp94 = np.copy(tmp8) * 2
+    tmp94 += np.transpose(tmp8, (0, 2, 1, 3)) * -1
+    tmp90 = np.copy(v.oovv)
+    tmp90 += np.transpose(tmp24, (0, 1, 3, 2))
     tmp90 += tmp89 * -1
     del tmp89
     tmp78 = einsum(t1, (0, 1), v.ovvv, (0, 1, 2, 3), (2, 3))
     tmp12 = einsum(v.ooov, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
     tmp108 = einsum(f.ov, (0, 1), t1, (2, 1), (0, 2))
     tmp65 = einsum(tmp16, (0, 1, 2, 3), l2, (4, 2, 0, 1), (4, 3)) * 2
-    tmp54 = tmp50.copy()
+    tmp54 = np.copy(tmp50)
     tmp54 += tmp53
     del tmp53
     tmp6 = einsum(t1, (0, 1), tmp5, (0, 2, 1, 3), (2, 3)) * 2
     tmp1 = einsum(v.ovvv, (0, 1, 2, 3), t2, (4, 5, 1, 3), (4, 5, 0, 2))
     tmp3 = einsum(tmp2, (0, 1, 2, 3), t1, (3, 4), (0, 1, 2, 4))
     del tmp2
-    tmp37 = tmp35.transpose((1, 0, 3, 2)).copy()
+    tmp37 = np.copy(np.transpose(tmp35, (1, 0, 3, 2)))
     tmp37 += tmp36
     l2new += einsum(v.ovov, (0, 1, 2, 3), tmp37, (4, 5, 0, 2), (3, 1, 5, 4))
     tmp25 = einsum(t1, (0, 1), tmp24, (2, 3, 4, 1), (2, 0, 3, 4))
@@ -430,76 +430,76 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp65
     tmp64 = einsum(tmp8, (0, 1, 2, 3), l1, (4, 0), (1, 2, 4, 3))
     tmp67 = einsum(tmp54, (0, 1), v.ovov, (2, 3, 1, 4), (2, 0, 4, 3))
-    tmp39 = tmp17.copy() * 2
-    tmp39 += tmp17.transpose((1, 0, 2, 3)) * -1
-    tmp43 = tmp17.copy() * -0.5
-    tmp43 += tmp17.transpose((1, 0, 2, 3))
+    tmp39 = np.copy(tmp17) * 2
+    tmp39 += np.transpose(tmp17, (1, 0, 2, 3)) * -1
+    tmp43 = np.copy(tmp17) * -0.5
+    tmp43 += np.transpose(tmp17, (1, 0, 2, 3))
     tmp42 = einsum(t2, (0, 1, 2, 3), l1, (3, 4), (4, 0, 1, 2))
     tmp7 = einsum(t2, (0, 1, 2, 3), tmp6, (4, 2), (0, 1, 4, 3))
-    tmp9 = v.ooov.copy() * -1
-    tmp9 += v.ooov.transpose((0, 2, 1, 3)) * 2
+    tmp9 = np.copy(v.ooov) * -1
+    tmp9 += np.transpose(v.ooov, (0, 2, 1, 3)) * 2
     tmp9 += tmp8 * 2
-    tmp9 += tmp8.transpose((0, 2, 1, 3)) * -1
-    tmp13 = v.oooo.transpose((0, 2, 1, 3)).copy() * 2
+    tmp9 += np.transpose(tmp8, (0, 2, 1, 3)) * -1
+    tmp13 = np.copy(np.transpose(v.oooo, (0, 2, 1, 3))) * 2
     tmp13 += v.oooo * -1
-    tmp13 += tmp12.transpose((2, 1, 0, 3)) * -1
-    tmp13 += tmp12.transpose((3, 2, 0, 1)) * 2
+    tmp13 += np.transpose(tmp12, (2, 1, 0, 3)) * -1
+    tmp13 += np.transpose(tmp12, (3, 2, 0, 1)) * 2
     tmp0 = einsum(t2, (0, 1, 2, 3), f.ov, (4, 3), (4, 0, 1, 2))
-    tmp10 = v.ooov.copy()
-    tmp10 += v.ooov.transpose((0, 2, 1, 3)) * -0.5
+    tmp10 = np.copy(v.ooov)
+    tmp10 += np.transpose(v.ooov, (0, 2, 1, 3)) * -0.5
     tmp10 += tmp8 * -0.5
-    tmp10 += tmp8.transpose((0, 2, 1, 3))
+    tmp10 += np.transpose(tmp8, (0, 2, 1, 3))
     del tmp8
-    tmp4 = tmp1.copy() * 0.5
+    tmp4 = np.copy(tmp1) * 0.5
     del tmp1
     tmp4 += tmp3 * -0.5
     del tmp3
-    tmp11 = v.oovv.copy() * 2
-    tmp11 += v.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp11 = np.copy(v.oovv) * 2
+    tmp11 += np.transpose(v.ovov, (0, 2, 1, 3)) * -1
     tmp38 = einsum(tmp37, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     del tmp37
-    tmp40 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp40 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp40 += t2 * -1
-    tmp31 = tmp12.transpose((0, 2, 1, 3)).copy() * 2
-    tmp31 += tmp12.transpose((0, 3, 2, 1)) * -1
+    tmp31 = np.copy(np.transpose(tmp12, (0, 2, 1, 3))) * 2
+    tmp31 += np.transpose(tmp12, (0, 3, 2, 1)) * -1
     del tmp12
-    tmp28 = tmp25.copy() * 2
+    tmp28 = np.copy(tmp25) * 2
     del tmp25
     tmp28 += tmp27 * -2
     del tmp27
-    tmp29 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp29 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp29 += t2
-    tmp30 = v.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp30 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 2
     tmp30 += v.oovv * -1
-    tmp33 = tmp17.copy() * -1
-    tmp33 += tmp17.transpose((1, 0, 2, 3)) * 2
-    tmp60 = v.ooov.copy() * -0.5
-    tmp60 += v.ovoo.transpose((0, 2, 3, 1))
-    tmp61 = f.ov.copy()
+    tmp33 = np.copy(tmp17) * -1
+    tmp33 += np.transpose(tmp17, (1, 0, 2, 3)) * 2
+    tmp60 = np.copy(v.ooov) * -0.5
+    tmp60 += np.transpose(v.ovoo, (0, 2, 3, 1))
+    tmp61 = np.copy(f.ov)
     tmp61 += tmp6
     del tmp6
-    tmp57 = v.ovvv.copy() * -0.5
-    tmp57 += v.ovvv.transpose((0, 2, 1, 3))
-    tmp22 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp22 += l2.transpose((2, 3, 0, 1)) * 2
-    tmp51 = tmp50.copy() * 0.5
+    tmp57 = np.copy(v.ovvv) * -0.5
+    tmp57 += np.transpose(v.ovvv, (0, 2, 1, 3))
+    tmp22 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp22 += np.transpose(l2, (2, 3, 0, 1)) * 2
+    tmp51 = np.copy(tmp50) * 0.5
     del tmp50
     tmp51 += einsum(l2, (0, 1, 2, 3), tmp16, (2, 4, 1, 0), (3, 4))
-    tmp18 = tmp17.copy()
-    tmp18 += tmp17.transpose((1, 0, 2, 3)) * -0.5
+    tmp18 = np.copy(tmp17)
+    tmp18 += np.transpose(tmp17, (1, 0, 2, 3)) * -0.5
     tmp105 = einsum(l2, (0, 1, 2, 3), tmp104, (4, 1), (2, 3, 0, 4))
     del tmp104
-    l2new += tmp105.transpose((3, 2, 1, 0)) * -1
-    l2new += tmp105.transpose((2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp105, (3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp105, (2, 3, 0, 1)) * -1
     del tmp105
-    tmp76 = tmp69.copy()
+    tmp76 = np.copy(tmp69)
     del tmp69
-    tmp76 += tmp71.transpose((1, 0, 2, 3))
+    tmp76 += np.transpose(tmp71, (1, 0, 2, 3))
     del tmp71
-    tmp76 += tmp75.transpose((0, 1, 3, 2))
+    tmp76 += np.transpose(tmp75, (0, 1, 3, 2))
     del tmp75
-    l2new += tmp76.transpose((3, 2, 1, 0)) * -1
-    l2new += tmp76.transpose((2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp76, (3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp76, (2, 3, 0, 1)) * -1
     del tmp76
     tmp103 = einsum(f.ov, (0, 1), l1, (2, 3), (0, 3, 1, 2))
     tmp103 += tmp77
@@ -514,20 +514,20 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp88
     tmp103 += tmp91 * -1
     del tmp91
-    tmp103 += tmp93.transpose((1, 0, 3, 2)) * -1
+    tmp103 += np.transpose(tmp93, (1, 0, 3, 2)) * -1
     del tmp93
     tmp103 += tmp95 * -1
     del tmp95
-    tmp103 += tmp101.transpose((0, 1, 3, 2))
+    tmp103 += np.transpose(tmp101, (0, 1, 3, 2))
     del tmp101
     tmp103 += tmp102 * -1
     del tmp102
     tmp103 += einsum(tmp98, (0, 1), l1, (2, 3), (3, 0, 2, 1))
     del tmp98
-    l2new += tmp103.transpose((3, 2, 1, 0))
-    l2new += tmp103.transpose((2, 3, 0, 1))
+    l2new += np.transpose(tmp103, (3, 2, 1, 0))
+    l2new += np.transpose(tmp103, (2, 3, 0, 1))
     del tmp103
-    tmp115 = tmp106.copy()
+    tmp115 = np.copy(tmp106)
     del tmp106
     tmp115 += tmp107
     del tmp107
@@ -543,42 +543,42 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp113
     tmp115 += tmp114 * -1
     del tmp114
-    l2new += tmp115.transpose((2, 3, 1, 0))
-    l2new += tmp115.transpose((3, 2, 0, 1))
+    l2new += np.transpose(tmp115, (2, 3, 1, 0))
+    l2new += np.transpose(tmp115, (3, 2, 0, 1))
     del tmp115
-    tmp116 = v.oooo.copy()
-    tmp116 += tmp26.transpose((0, 2, 3, 1))
+    tmp116 = np.copy(v.oooo)
+    tmp116 += np.transpose(tmp26, (0, 2, 3, 1))
     del tmp26
     l2new += einsum(l2, (0, 1, 2, 3), tmp116, (3, 4, 5, 2), (0, 1, 5, 4))
     del tmp116
-    tmp68 = tmp63.copy()
+    tmp68 = np.copy(tmp63)
     del tmp63
     tmp68 += tmp64
     del tmp64
-    tmp68 += tmp66.transpose((1, 0, 3, 2))
+    tmp68 += np.transpose(tmp66, (1, 0, 3, 2))
     del tmp66
-    tmp68 += tmp67.transpose((1, 0, 3, 2))
+    tmp68 += np.transpose(tmp67, (1, 0, 3, 2))
     del tmp67
-    l2new += tmp68.transpose((2, 3, 1, 0)) * -1
-    l2new += tmp68.transpose((3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp68, (2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp68, (3, 2, 0, 1)) * -1
     del tmp68
-    tmp44 = tmp42.copy() * -2
-    tmp44 += tmp42.transpose((0, 2, 1, 3))
+    tmp44 = np.copy(tmp42) * -2
+    tmp44 += np.transpose(tmp42, (0, 2, 1, 3))
     del tmp42
     tmp44 += einsum(t2, (0, 1, 2, 3), tmp39, (1, 4, 5, 3), (4, 5, 0, 2))
     tmp44 += einsum(t2, (0, 1, 2, 3), tmp43, (1, 4, 5, 2), (4, 5, 0, 3)) * 2
     del tmp43
     l1new = einsum(v.ovov, (0, 1, 2, 3), tmp44, (4, 2, 0, 3), (1, 4))
     del tmp44
-    tmp14 = v.ooov.transpose((0, 2, 1, 3)).copy() * 0.5
-    tmp14 += v.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp14 += tmp0.transpose((1, 2, 0, 3)) * -1
-    tmp14 += tmp0.transpose((2, 1, 0, 3)) * 0.5
+    tmp14 = np.copy(np.transpose(v.ooov, (0, 2, 1, 3))) * 0.5
+    tmp14 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
+    tmp14 += np.transpose(tmp0, (1, 2, 0, 3)) * -1
+    tmp14 += np.transpose(tmp0, (2, 1, 0, 3)) * 0.5
     del tmp0
     tmp14 += tmp4
-    tmp14 += tmp4.transpose((1, 0, 2, 3)) * -2
+    tmp14 += np.transpose(tmp4, (1, 0, 2, 3)) * -2
     del tmp4
-    tmp14 += tmp7.transpose((1, 0, 2, 3)) * -1
+    tmp14 += np.transpose(tmp7, (1, 0, 2, 3)) * -1
     tmp14 += tmp7 * 0.5
     del tmp7
     tmp14 += einsum(t2, (0, 1, 2, 3), tmp9, (4, 1, 5, 3), (4, 0, 5, 2)) * 0.5
@@ -590,17 +590,17 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp13
     l1new += einsum(l2, (0, 1, 2, 3), tmp14, (3, 2, 4, 1), (0, 4)) * 2
     del tmp14
-    tmp41 = tmp17.transpose((0, 2, 1, 3)).copy() * 0.5
-    tmp41 += tmp17.transpose((1, 2, 0, 3)) * -1
-    tmp41 += tmp38.transpose((0, 2, 1, 3))
+    tmp41 = np.copy(np.transpose(tmp17, (0, 2, 1, 3))) * 0.5
+    tmp41 += np.transpose(tmp17, (1, 2, 0, 3)) * -1
+    tmp41 += np.transpose(tmp38, (0, 2, 1, 3))
     tmp41 += tmp38 * -0.5
     del tmp38
     tmp41 += einsum(tmp40, (0, 1, 2, 3), tmp39, (0, 4, 5, 3), (4, 5, 1, 2)) * -0.5
     del tmp39, tmp40
     l1new += einsum(v.ovov, (0, 1, 2, 3), tmp41, (4, 2, 0, 1), (3, 4)) * 2
     del tmp41
-    tmp32 = tmp28.copy() * -1
-    tmp32 += tmp28.transpose((1, 0, 2, 3)) * 0.5
+    tmp32 = np.copy(tmp28) * -1
+    tmp32 += np.transpose(tmp28, (1, 0, 2, 3)) * 0.5
     del tmp28
     tmp32 += einsum(tmp29, (0, 1, 2, 3), tmp10, (4, 5, 0, 2), (4, 1, 5, 3)) * -4
     del tmp10
@@ -610,12 +610,12 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp31
     l1new += einsum(tmp32, (0, 1, 2, 3), l2, (4, 3, 0, 1), (4, 2))
     del tmp32
-    tmp34 = l2.transpose((3, 2, 0, 1)).copy()
+    tmp34 = np.copy(np.transpose(l2, (3, 2, 0, 1)))
     tmp34 += einsum(tmp33, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     del tmp33
     l1new += einsum(tmp34, (0, 1, 2, 3), v.ovvv, (1, 3, 4, 2), (4, 0)) * -1
     del tmp34
-    tmp62 = f.oo.copy()
+    tmp62 = np.copy(f.oo)
     tmp62 += einsum(tmp15, (0, 1, 2, 3), v.ovov, (4, 3, 0, 2), (1, 4))
     tmp62 += einsum(t1, (0, 1), tmp60, (0, 2, 3, 1), (2, 3)) * 2
     del tmp60
@@ -624,31 +624,31 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l1new += einsum(tmp62, (0, 1), l1, (2, 0), (2, 1)) * -1
     del tmp62
     tmp20 = einsum(l2, (0, 1, 2, 3), t1, (3, 4), (2, 0, 1, 4))
-    tmp55 = v.ooov.copy() * 2
-    tmp55 += v.ovoo.transpose((0, 2, 3, 1)) * -1
+    tmp55 = np.copy(v.ooov) * 2
+    tmp55 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
     l1new += einsum(tmp55, (0, 1, 2, 3), tmp54, (1, 0), (3, 2)) * -1
     del tmp55
     tmp48 = einsum(l1, (0, 1), t1, (1, 2), (0, 2)) * 0.5
     tmp48 += einsum(tmp16, (0, 1, 2, 3), l2, (4, 2, 0, 1), (4, 3))
-    tmp58 = f.vv.copy() * 0.5
+    tmp58 = np.copy(f.vv) * 0.5
     tmp58 += einsum(t1, (0, 1), tmp57, (0, 2, 1, 3), (3, 2))
     del tmp57
     l1new += einsum(l1, (0, 1), tmp58, (0, 2), (2, 1)) * 2
     del tmp58
-    tmp49 = v.ovvv.copy() * 2
-    tmp49 += v.ovvv.transpose((0, 2, 1, 3)) * -1
+    tmp49 = np.copy(v.ovvv) * 2
+    tmp49 += np.transpose(v.ovvv, (0, 2, 1, 3)) * -1
     l1new += einsum(tmp49, (0, 1, 2, 3), tmp48, (3, 2), (1, 0)) * 2
     del tmp49, tmp48
-    tmp21 = v.vvvv.transpose((0, 2, 3, 1)).copy() * 2
+    tmp21 = np.copy(np.transpose(v.vvvv, (0, 2, 3, 1))) * 2
     tmp21 += v.vvvv * -1
     l1new += einsum(tmp21, (0, 1, 2, 3), tmp20, (4, 2, 0, 3), (1, 4))
     del tmp21, tmp20
-    tmp23 = l2.transpose((2, 3, 0, 1)).copy()
+    tmp23 = np.copy(np.transpose(l2, (2, 3, 0, 1)))
     tmp23 += einsum(tmp22, (0, 1, 2, 3), tmp16, (0, 4, 5, 2), (1, 4, 3, 5))
     del tmp22
     l1new += einsum(tmp23, (0, 1, 2, 3), v.ovvv, (1, 3, 4, 2), (4, 0)) * 2
     del tmp23
-    tmp52 = t1.copy() * -0.5
+    tmp52 = np.copy(t1) * -0.5
     tmp52 += einsum(tmp29, (0, 1, 2, 3), tmp17, (1, 0, 4, 3), (4, 2))
     del tmp29
     tmp52 += einsum(l1, (0, 1), tmp15, (1, 2, 0, 3), (2, 3)) * -0.5
@@ -656,23 +656,23 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp51
     l1new += einsum(tmp52, (0, 1), tmp5, (0, 2, 1, 3), (3, 2)) * -4
     del tmp52
-    tmp46 = tmp36.copy() * -0.5
-    tmp46 += tmp36.transpose((0, 1, 3, 2))
+    tmp46 = np.copy(tmp36) * -0.5
+    tmp46 += np.transpose(tmp36, (0, 1, 3, 2))
     del tmp36
     l1new += einsum(v.ooov, (0, 1, 2, 3), tmp46, (4, 0, 1, 2), (3, 4)) * 2
     del tmp46
-    tmp45 = tmp17.copy() * -1
-    tmp45 += tmp17.transpose((1, 0, 2, 3)) * 2
+    tmp45 = np.copy(tmp17) * -1
+    tmp45 += np.transpose(tmp17, (1, 0, 2, 3)) * 2
     del tmp17
     l1new += einsum(tmp45, (0, 1, 2, 3), v.oovv, (0, 2, 4, 3), (4, 1)) * -1
     del tmp45
-    tmp59 = f.ov.copy() * 0.5
+    tmp59 = np.copy(f.ov) * 0.5
     tmp59 += einsum(t1, (0, 1), tmp5, (0, 2, 1, 3), (2, 3))
     del tmp5
     l1new += einsum(tmp54, (0, 1), tmp59, (1, 2), (2, 0)) * -2
     del tmp54, tmp59
-    tmp47 = tmp35.transpose((1, 0, 2, 3)).copy() * 2
-    tmp47 += tmp35.transpose((1, 0, 3, 2)) * -1
+    tmp47 = np.copy(np.transpose(tmp35, (1, 0, 2, 3))) * 2
+    tmp47 += np.transpose(tmp35, (1, 0, 3, 2)) * -1
     del tmp35
     l1new += einsum(tmp47, (0, 1, 2, 3), v.ooov, (3, 0, 2, 4), (4, 1))
     del tmp47
@@ -684,12 +684,12 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp18
     l1new += einsum(v.ovvv, (0, 1, 2, 3), tmp19, (4, 0, 3, 2), (1, 4)) * -1
     del tmp19
-    tmp56 = v.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp56 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 2
     tmp56 += v.oovv * -1
     l1new += einsum(l1, (0, 1), tmp56, (1, 2, 0, 3), (3, 2))
     del tmp56
-    l1new += f.ov.transpose((1, 0))
-    l2new += v.ovov.transpose((1, 3, 0, 2))
+    l1new += np.transpose(f.ov, (1, 0))
+    l2new += np.transpose(v.ovov, (1, 3, 0, 2))
     l2new += einsum(l2, (0, 1, 2, 3), v.vvvv, (4, 1, 5, 0), (4, 5, 3, 2))
 
     return {f"l1new": l1new, f"l2new": l2new}
@@ -721,37 +721,37 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
         vv=np.eye(t2.shape[-1]),
     )
     tmp0 = einsum(l1, (0, 1), t1, (2, 0), (1, 2))
-    rdm1.oo = tmp0.transpose((1, 0)).copy() * -2
-    tmp5 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    rdm1.oo = np.copy(np.transpose(tmp0, (1, 0))) * -2
+    tmp5 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp5 += t2
     tmp2 = einsum(l2, (0, 1, 2, 3), t1, (4, 1), (2, 3, 4, 0))
-    tmp7 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp7 += l2.transpose((2, 3, 0, 1)) * 2
+    tmp7 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp7 += np.transpose(l2, (2, 3, 0, 1)) * 2
     rdm1.vv = einsum(t2, (0, 1, 2, 3), tmp7, (0, 1, 4, 3), (4, 2)) * 2
     del tmp7
-    tmp6 = tmp0.copy()
+    tmp6 = np.copy(tmp0)
     del tmp0
     tmp6 += einsum(l2, (0, 1, 2, 3), tmp5, (2, 4, 0, 1), (3, 4)) * 2
     del tmp5
     rdm1.ov = einsum(tmp6, (0, 1), t1, (0, 2), (1, 2)) * -2
     del tmp6
-    tmp3 = tmp2.copy()
-    tmp3 += tmp2.transpose((1, 0, 2, 3)) * -0.5
+    tmp3 = np.copy(tmp2)
+    tmp3 += np.transpose(tmp2, (1, 0, 2, 3)) * -0.5
     del tmp2
     rdm1.ov += einsum(t2, (0, 1, 2, 3), tmp3, (1, 0, 4, 3), (4, 2)) * -4
     del tmp3
-    tmp4 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp4 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp4 += t2 * 2
     rdm1.ov += einsum(tmp4, (0, 1, 2, 3), l1, (2, 0), (1, 3)) * 2
     del tmp4
-    tmp1 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp1 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp1 += t2 * -0.5
     rdm1.oo += einsum(l2, (0, 1, 2, 3), tmp1, (2, 4, 1, 0), (4, 3)) * -4
     del tmp1
     rdm1.oo += delta.oo * 2
     del delta
     rdm1.ov += t1 * 2
-    rdm1.vo = l1.copy() * 2
+    rdm1.vo = np.copy(l1) * 2
     rdm1.vv += einsum(l1, (0, 1), t1, (1, 2), (0, 2)) * 2
     rdm1 = np.block([[rdm1.oo, rdm1.ov], [rdm1.vo, rdm1.vv]])
 
@@ -784,72 +784,72 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
         vv=np.eye(t2.shape[-1]),
     )
     tmp4 = einsum(l2, (0, 1, 2, 3), t1, (4, 1), (2, 3, 4, 0))
-    rdm2.vooo = tmp4.transpose((3, 2, 1, 0)).copy()
-    rdm2.vooo += tmp4.transpose((3, 2, 0, 1)) * -1
-    rdm2.vooo += tmp4.transpose((3, 2, 0, 1)) * -1
-    rdm2.vooo += tmp4.transpose((3, 2, 0, 1)) * -1
-    rdm2.vooo += tmp4.transpose((3, 2, 1, 0))
-    rdm2.vooo += tmp4.transpose((3, 2, 0, 1)) * -1
-    rdm2.ovoo = tmp4.transpose((2, 3, 1, 0)).copy() * -1
-    rdm2.ovoo += tmp4.transpose((2, 3, 0, 1))
-    rdm2.ovoo += tmp4.transpose((2, 3, 1, 0)) * -1
-    rdm2.ovoo += tmp4.transpose((2, 3, 1, 0)) * -1
-    rdm2.ovoo += tmp4.transpose((2, 3, 1, 0)) * -1
-    rdm2.ovoo += tmp4.transpose((2, 3, 0, 1))
-    tmp92 = t2.transpose((0, 1, 3, 2)).copy()
+    rdm2.vooo = np.copy(np.transpose(tmp4, (3, 2, 1, 0)))
+    rdm2.vooo += np.transpose(tmp4, (3, 2, 0, 1)) * -1
+    rdm2.vooo += np.transpose(tmp4, (3, 2, 0, 1)) * -1
+    rdm2.vooo += np.transpose(tmp4, (3, 2, 0, 1)) * -1
+    rdm2.vooo += np.transpose(tmp4, (3, 2, 1, 0))
+    rdm2.vooo += np.transpose(tmp4, (3, 2, 0, 1)) * -1
+    rdm2.ovoo = np.copy(np.transpose(tmp4, (2, 3, 1, 0))) * -1
+    rdm2.ovoo += np.transpose(tmp4, (2, 3, 0, 1))
+    rdm2.ovoo += np.transpose(tmp4, (2, 3, 1, 0)) * -1
+    rdm2.ovoo += np.transpose(tmp4, (2, 3, 1, 0)) * -1
+    rdm2.ovoo += np.transpose(tmp4, (2, 3, 1, 0)) * -1
+    rdm2.ovoo += np.transpose(tmp4, (2, 3, 0, 1))
+    tmp92 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp92 += t2 * -1
-    tmp90 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp90 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp90 += t2 * -1
-    tmp16 = tmp4.copy() * 2
-    tmp16 += tmp4.transpose((1, 0, 2, 3)) * -1
-    tmp0 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp16 = np.copy(tmp4) * 2
+    tmp16 += np.transpose(tmp4, (1, 0, 2, 3)) * -1
+    tmp0 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp0 += t2
-    tmp14 = tmp4.copy()
-    tmp14 += tmp4.transpose((1, 0, 2, 3)) * -1
-    tmp55 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp55 += l2.transpose((2, 3, 0, 1)) * 2
+    tmp14 = np.copy(tmp4)
+    tmp14 += np.transpose(tmp4, (1, 0, 2, 3)) * -1
+    tmp55 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp55 += np.transpose(l2, (2, 3, 0, 1)) * 2
     tmp93 = einsum(tmp92, (0, 1, 2, 3), l2, (4, 3, 0, 5), (1, 5, 2, 4))
     del tmp92
     tmp91 = einsum(tmp90, (0, 1, 2, 3), l2, (4, 3, 5, 0), (1, 5, 2, 4))
     del tmp90
     tmp84 = einsum(tmp4, (0, 1, 2, 3), t1, (1, 4), (0, 2, 3, 4))
-    rdm2.voov = tmp84.transpose((2, 1, 0, 3)).copy() * -1
-    rdm2.voov += tmp84.transpose((2, 1, 0, 3)) * -1
-    rdm2.ovvo = tmp84.transpose((1, 2, 3, 0)).copy() * -1
-    rdm2.ovvo += tmp84.transpose((1, 2, 3, 0)) * -1
-    tmp40 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp40 += l2.transpose((2, 3, 0, 1)) * 2
+    rdm2.voov = np.copy(np.transpose(tmp84, (2, 1, 0, 3))) * -1
+    rdm2.voov += np.transpose(tmp84, (2, 1, 0, 3)) * -1
+    rdm2.ovvo = np.copy(np.transpose(tmp84, (1, 2, 3, 0))) * -1
+    rdm2.ovvo += np.transpose(tmp84, (1, 2, 3, 0)) * -1
+    tmp40 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp40 += np.transpose(l2, (2, 3, 0, 1)) * 2
     tmp5 = einsum(tmp4, (0, 1, 2, 3), t1, (4, 3), (1, 0, 2, 4))
-    rdm2.oooo = tmp5.transpose((3, 2, 1, 0)).copy()
-    rdm2.oooo += tmp5.transpose((3, 2, 1, 0))
+    rdm2.oooo = np.copy(np.transpose(tmp5, (3, 2, 1, 0)))
+    rdm2.oooo += np.transpose(tmp5, (3, 2, 1, 0))
     tmp3 = einsum(l2, (0, 1, 2, 3), t2, (4, 5, 0, 1), (2, 3, 4, 5))
-    rdm2.oooo += tmp3.transpose((3, 2, 1, 0))
-    rdm2.oooo += tmp3.transpose((3, 2, 1, 0))
+    rdm2.oooo += np.transpose(tmp3, (3, 2, 1, 0))
+    rdm2.oooo += np.transpose(tmp3, (3, 2, 1, 0))
     tmp17 = einsum(t2, (0, 1, 2, 3), tmp16, (1, 4, 5, 3), (4, 5, 0, 2))
     del tmp16
-    rdm2.oovo = tmp17.transpose((2, 1, 3, 0)).copy() * -1
-    rdm2.oovo += tmp17.transpose((2, 1, 3, 0)) * -1
-    rdm2.ooov = tmp17.transpose((1, 2, 0, 3)).copy() * -1
-    rdm2.ooov += tmp17.transpose((1, 2, 0, 3)) * -1
+    rdm2.oovo = np.copy(np.transpose(tmp17, (2, 1, 3, 0))) * -1
+    rdm2.oovo += np.transpose(tmp17, (2, 1, 3, 0)) * -1
+    rdm2.ooov = np.copy(np.transpose(tmp17, (1, 2, 0, 3))) * -1
+    rdm2.ooov += np.transpose(tmp17, (1, 2, 0, 3)) * -1
     tmp25 = einsum(t2, (0, 1, 2, 3), tmp4, (1, 4, 5, 2), (4, 5, 0, 3))
-    rdm2.oovo += tmp25.transpose((2, 1, 3, 0))
-    rdm2.oovo += tmp25.transpose((2, 1, 3, 0))
-    rdm2.ooov += tmp25.transpose((1, 2, 0, 3))
-    rdm2.ooov += tmp25.transpose((1, 2, 0, 3))
+    rdm2.oovo += np.transpose(tmp25, (2, 1, 3, 0))
+    rdm2.oovo += np.transpose(tmp25, (2, 1, 3, 0))
+    rdm2.ooov += np.transpose(tmp25, (1, 2, 0, 3))
+    rdm2.ooov += np.transpose(tmp25, (1, 2, 0, 3))
     tmp12 = einsum(t2, (0, 1, 2, 3), l1, (3, 4), (4, 0, 1, 2))
-    rdm2.oovo += tmp12.transpose((1, 2, 3, 0)) * -1
-    rdm2.oovo += tmp12.transpose((1, 2, 3, 0)) * -1
-    rdm2.ooov += tmp12.transpose((2, 1, 0, 3)) * -1
-    rdm2.ooov += tmp12.transpose((2, 1, 0, 3)) * -1
+    rdm2.oovo += np.transpose(tmp12, (1, 2, 3, 0)) * -1
+    rdm2.oovo += np.transpose(tmp12, (1, 2, 3, 0)) * -1
+    rdm2.ooov += np.transpose(tmp12, (2, 1, 0, 3)) * -1
+    rdm2.ooov += np.transpose(tmp12, (2, 1, 0, 3)) * -1
     tmp26 = einsum(t2, (0, 1, 2, 3), tmp4, (4, 1, 5, 2), (4, 5, 0, 3))
-    rdm2.oovo += tmp26.transpose((1, 2, 3, 0))
-    rdm2.oovo += tmp26.transpose((1, 2, 3, 0))
-    rdm2.ooov += tmp26.transpose((2, 1, 0, 3))
-    rdm2.ooov += tmp26.transpose((2, 1, 0, 3))
-    tmp43 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp43 += l2.transpose((2, 3, 0, 1))
-    tmp8 = tmp4.copy() * 2
-    tmp8 += tmp4.transpose((1, 0, 2, 3)) * -1
+    rdm2.oovo += np.transpose(tmp26, (1, 2, 3, 0))
+    rdm2.oovo += np.transpose(tmp26, (1, 2, 3, 0))
+    rdm2.ooov += np.transpose(tmp26, (2, 1, 0, 3))
+    rdm2.ooov += np.transpose(tmp26, (2, 1, 0, 3))
+    tmp43 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp43 += np.transpose(l2, (2, 3, 0, 1))
+    tmp8 = np.copy(tmp4) * 2
+    tmp8 += np.transpose(tmp4, (1, 0, 2, 3)) * -1
     tmp1 = einsum(l2, (0, 1, 2, 3), tmp0, (2, 4, 0, 1), (3, 4)) * 2
     rdm2.oooo += einsum(tmp1, (0, 1), delta.oo, (2, 3), (2, 1, 3, 0)) * -1
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp1, (2, 3), (3, 0, 1, 2))
@@ -864,7 +864,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oooo += einsum(tmp1, (0, 1), delta.oo, (2, 3), (2, 1, 0, 3))
     rdm2.oooo += einsum(tmp1, (0, 1), delta.oo, (2, 3), (1, 2, 0, 3)) * -1
     tmp15 = einsum(tmp14, (0, 1, 2, 3), t2, (4, 0, 3, 5), (1, 2, 4, 5))
-    tmp20 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp20 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp20 += t2 * 2
     tmp2 = einsum(l1, (0, 1), t1, (2, 0), (1, 2))
     rdm2.ooov += einsum(tmp2, (0, 1), t1, (2, 3), (1, 2, 0, 3)) * -1
@@ -884,47 +884,47 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp31 = einsum(l2, (0, 1, 2, 3), tmp0, (2, 4, 0, 1), (3, 4))
     del tmp0
     tmp110 = einsum(l2, (0, 1, 2, 3), t1, (3, 4), (2, 0, 1, 4))
-    rdm2.vvvo = tmp110.transpose((2, 1, 3, 0)).copy()
-    rdm2.vvvo += tmp110.transpose((1, 2, 3, 0)) * -1
-    rdm2.vvvo += tmp110.transpose((2, 1, 3, 0))
-    rdm2.vvvo += tmp110.transpose((2, 1, 3, 0))
-    rdm2.vvvo += tmp110.transpose((2, 1, 3, 0))
-    rdm2.vvvo += tmp110.transpose((1, 2, 3, 0)) * -1
-    rdm2.vvov = tmp110.transpose((2, 1, 0, 3)).copy() * -1
-    rdm2.vvov += tmp110.transpose((1, 2, 0, 3))
-    rdm2.vvov += tmp110.transpose((1, 2, 0, 3))
-    rdm2.vvov += tmp110.transpose((1, 2, 0, 3))
-    rdm2.vvov += tmp110.transpose((2, 1, 0, 3)) * -1
-    rdm2.vvov += tmp110.transpose((1, 2, 0, 3))
+    rdm2.vvvo = np.copy(np.transpose(tmp110, (2, 1, 3, 0)))
+    rdm2.vvvo += np.transpose(tmp110, (1, 2, 3, 0)) * -1
+    rdm2.vvvo += np.transpose(tmp110, (2, 1, 3, 0))
+    rdm2.vvvo += np.transpose(tmp110, (2, 1, 3, 0))
+    rdm2.vvvo += np.transpose(tmp110, (2, 1, 3, 0))
+    rdm2.vvvo += np.transpose(tmp110, (1, 2, 3, 0)) * -1
+    rdm2.vvov = np.copy(np.transpose(tmp110, (2, 1, 0, 3))) * -1
+    rdm2.vvov += np.transpose(tmp110, (1, 2, 0, 3))
+    rdm2.vvov += np.transpose(tmp110, (1, 2, 0, 3))
+    rdm2.vvov += np.transpose(tmp110, (1, 2, 0, 3))
+    rdm2.vvov += np.transpose(tmp110, (2, 1, 0, 3)) * -1
+    rdm2.vvov += np.transpose(tmp110, (1, 2, 0, 3))
     tmp76 = einsum(l1, (0, 1), t1, (1, 2), (0, 2))
     tmp77 = einsum(t2, (0, 1, 2, 3), tmp55, (0, 1, 4, 3), (4, 2))
-    tmp104 = tmp84.copy()
-    tmp104 += tmp93.transpose((1, 0, 3, 2))
-    tmp104 += tmp91.transpose((1, 0, 3, 2)) * -1
+    tmp104 = np.copy(tmp84)
+    tmp104 += np.transpose(tmp93, (1, 0, 3, 2))
+    tmp104 += np.transpose(tmp91, (1, 0, 3, 2)) * -1
     tmp41 = einsum(t2, (0, 1, 2, 3), tmp40, (1, 4, 3, 5), (4, 0, 5, 2))
     del tmp40
     tmp60 = einsum(t2, (0, 1, 2, 3), l2, (4, 2, 5, 1), (5, 0, 4, 3))
-    rdm2.voov += tmp60.transpose((2, 1, 0, 3)) * -1
-    rdm2.voov += tmp60.transpose((2, 1, 0, 3)) * -1
-    rdm2.ovvo += tmp60.transpose((1, 2, 3, 0)) * -1
-    rdm2.ovvo += tmp60.transpose((1, 2, 3, 0)) * -1
-    tmp94 = tmp91.transpose((1, 0, 3, 2)).copy()
+    rdm2.voov += np.transpose(tmp60, (2, 1, 0, 3)) * -1
+    rdm2.voov += np.transpose(tmp60, (2, 1, 0, 3)) * -1
+    rdm2.ovvo += np.transpose(tmp60, (1, 2, 3, 0)) * -1
+    rdm2.ovvo += np.transpose(tmp60, (1, 2, 3, 0)) * -1
+    tmp94 = np.copy(np.transpose(tmp91, (1, 0, 3, 2)))
     del tmp91
-    tmp94 += tmp93.transpose((1, 0, 3, 2)) * -1
+    tmp94 += np.transpose(tmp93, (1, 0, 3, 2)) * -1
     del tmp93
     tmp101 = einsum(t2, (0, 1, 2, 3), tmp55, (1, 4, 3, 5), (4, 0, 5, 2))
-    tmp6 = tmp3.transpose((1, 0, 3, 2)).copy()
+    tmp6 = np.copy(np.transpose(tmp3, (1, 0, 3, 2)))
     tmp6 += tmp5
-    rdm2.oooo += tmp6.transpose((2, 3, 0, 1))
-    rdm2.oooo += tmp6.transpose((3, 2, 0, 1)) * -1
-    rdm2.oooo += tmp6.transpose((2, 3, 0, 1))
-    rdm2.oooo += tmp6.transpose((3, 2, 0, 1)) * -1
+    rdm2.oooo += np.transpose(tmp6, (2, 3, 0, 1))
+    rdm2.oooo += np.transpose(tmp6, (3, 2, 0, 1)) * -1
+    rdm2.oooo += np.transpose(tmp6, (2, 3, 0, 1))
+    rdm2.oooo += np.transpose(tmp6, (3, 2, 0, 1)) * -1
     tmp23 = einsum(tmp3, (0, 1, 2, 3), t1, (1, 4), (0, 2, 3, 4))
     del tmp3
-    tmp64 = tmp25.copy()
+    tmp64 = np.copy(tmp25)
     del tmp25
     tmp64 += tmp17 * -1
-    tmp67 = tmp12.copy()
+    tmp67 = np.copy(tmp12)
     tmp67 += tmp26 * -1
     del tmp26
     tmp44 = einsum(t2, (0, 1, 2, 3), tmp43, (1, 4, 2, 5), (4, 0, 5, 3))
@@ -934,7 +934,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp55
     tmp9 = einsum(tmp8, (0, 1, 2, 3), t2, (0, 1, 3, 4), (2, 4)) * 0.5
     tmp10 = einsum(tmp1, (0, 1), t1, (0, 2), (1, 2)) * 0.5
-    tmp49 = tmp12.copy()
+    tmp49 = np.copy(tmp12)
     tmp49 += tmp15
     tmp49 += tmp17 * -1
     tmp21 = einsum(tmp20, (0, 1, 2, 3), l1, (2, 0), (1, 3))
@@ -945,24 +945,24 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp19 = einsum(tmp2, (0, 1), t1, (0, 2), (1, 2))
     rdm2.oovv = einsum(t1, (0, 1), tmp19, (2, 3), (0, 2, 1, 3)) * -1
     rdm2.oovv += einsum(t1, (0, 1), tmp19, (2, 3), (0, 2, 1, 3)) * -1
-    tmp29 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp29 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp29 += t2 * 2
-    tmp32 = tmp2.copy() * 0.5
+    tmp32 = np.copy(tmp2) * 0.5
     tmp32 += tmp31
     del tmp31
     tmp112 = einsum(tmp110, (0, 1, 2, 3), t1, (0, 4), (2, 1, 3, 4))
     del tmp110
-    rdm2.vvvv = tmp112.transpose((1, 0, 3, 2)).copy()
-    rdm2.vvvv += tmp112.transpose((1, 0, 3, 2))
+    rdm2.vvvv = np.copy(np.transpose(tmp112, (1, 0, 3, 2)))
+    rdm2.vvvv += np.transpose(tmp112, (1, 0, 3, 2))
     tmp111 = einsum(l2, (0, 1, 2, 3), t2, (3, 2, 4, 5), (0, 1, 5, 4))
-    rdm2.vvvv += tmp111.transpose((1, 0, 3, 2))
-    rdm2.vvvv += tmp111.transpose((1, 0, 3, 2))
+    rdm2.vvvv += np.transpose(tmp111, (1, 0, 3, 2))
+    rdm2.vvvv += np.transpose(tmp111, (1, 0, 3, 2))
     tmp62 = einsum(l2, (0, 1, 2, 3), t2, (4, 2, 1, 5), (3, 4, 0, 5))
-    rdm2.vovo = tmp62.transpose((2, 1, 3, 0)).copy() * -1
-    rdm2.vovo += tmp62.transpose((2, 1, 3, 0)) * -1
-    rdm2.ovov = tmp62.transpose((1, 2, 0, 3)).copy() * -1
-    rdm2.ovov += tmp62.transpose((1, 2, 0, 3)) * -1
-    tmp78 = tmp76.copy()
+    rdm2.vovo = np.copy(np.transpose(tmp62, (2, 1, 3, 0))) * -1
+    rdm2.vovo += np.transpose(tmp62, (2, 1, 3, 0)) * -1
+    rdm2.ovov = np.copy(np.transpose(tmp62, (1, 2, 0, 3))) * -1
+    rdm2.ovov += np.transpose(tmp62, (1, 2, 0, 3)) * -1
+    tmp78 = np.copy(tmp76)
     tmp78 += tmp77
     del tmp77
     rdm2.vovv = einsum(t1, (0, 1), tmp78, (2, 3), (2, 0, 3, 1))
@@ -976,37 +976,37 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.ovov += einsum(tmp78, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1))
     rdm2.ovov += einsum(tmp78, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1))
     tmp97 = einsum(t2, (0, 1, 2, 3), tmp4, (1, 0, 4, 5), (4, 5, 3, 2))
-    rdm2.vovv += tmp97.transpose((1, 0, 2, 3)) * -1
-    rdm2.vovv += tmp97.transpose((1, 0, 2, 3)) * -1
-    rdm2.ovvv = tmp97.transpose((0, 1, 3, 2)).copy() * -1
-    rdm2.ovvv += tmp97.transpose((0, 1, 3, 2)) * -1
+    rdm2.vovv += np.transpose(tmp97, (1, 0, 2, 3)) * -1
+    rdm2.vovv += np.transpose(tmp97, (1, 0, 2, 3)) * -1
+    rdm2.ovvv = np.copy(np.transpose(tmp97, (0, 1, 3, 2))) * -1
+    rdm2.ovvv += np.transpose(tmp97, (0, 1, 3, 2)) * -1
     tmp105 = einsum(t1, (0, 1), tmp104, (0, 2, 3, 4), (2, 3, 4, 1))
     del tmp104
     tmp89 = einsum(t2, (0, 1, 2, 3), l1, (4, 1), (0, 4, 2, 3))
-    rdm2.vovv += tmp89.transpose((1, 0, 3, 2))
-    rdm2.vovv += tmp89.transpose((1, 0, 3, 2))
+    rdm2.vovv += np.transpose(tmp89, (1, 0, 3, 2))
+    rdm2.vovv += np.transpose(tmp89, (1, 0, 3, 2))
     rdm2.ovvv += tmp89
     rdm2.ovvv += tmp89
-    tmp108 = tmp60.copy()
+    tmp108 = np.copy(tmp60)
     tmp108 += tmp84
     tmp108 += tmp41 * -1
     tmp95 = einsum(tmp94, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     del tmp94
-    tmp102 = tmp60.copy()
+    tmp102 = np.copy(tmp60)
     tmp102 += tmp84
     tmp102 += tmp101 * -1
     del tmp101
-    tmp80 = l2.transpose((3, 2, 0, 1)).copy() * 2
-    tmp80 += l2.transpose((2, 3, 0, 1)) * -1
-    tmp85 = tmp4.copy() * -1
-    tmp85 += tmp4.transpose((1, 0, 2, 3))
-    tmp72 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp80 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * 2
+    tmp80 += np.transpose(l2, (2, 3, 0, 1)) * -1
+    tmp85 = np.copy(tmp4) * -1
+    tmp85 += np.transpose(tmp4, (1, 0, 2, 3))
+    tmp72 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp72 += t2
-    tmp82 = l2.transpose((3, 2, 0, 1)).copy()
-    tmp82 += l2.transpose((2, 3, 0, 1)) * -1
+    tmp82 = np.copy(np.transpose(l2, (3, 2, 0, 1)))
+    tmp82 += np.transpose(l2, (2, 3, 0, 1)) * -1
     tmp53 = einsum(tmp6, (0, 1, 2, 3), t2, (0, 1, 4, 5), (2, 3, 4, 5))
-    rdm2.oovv += tmp53.transpose((1, 0, 3, 2))
-    rdm2.oovv += tmp53.transpose((1, 0, 3, 2))
+    rdm2.oovv += np.transpose(tmp53, (1, 0, 3, 2))
+    rdm2.oovv += np.transpose(tmp53, (1, 0, 3, 2))
     tmp52 = einsum(tmp23, (0, 1, 2, 3), t1, (0, 4), (2, 1, 3, 4))
     tmp48 = einsum(tmp41, (0, 1, 2, 3), t2, (4, 0, 2, 5), (1, 4, 3, 5))
     tmp65 = einsum(tmp64, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
@@ -1016,20 +1016,20 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp67
     tmp42 = einsum(t2, (0, 1, 2, 3), tmp41, (1, 4, 3, 5), (4, 0, 5, 2))
     del tmp41
-    rdm2.oovv += tmp42.transpose((1, 0, 3, 2)) * 2
-    rdm2.oovv += tmp42.transpose((1, 0, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp42, (1, 0, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp42, (1, 0, 3, 2)) * 2
     tmp45 = einsum(tmp44, (0, 1, 2, 3), t2, (4, 0, 2, 5), (1, 4, 3, 5))
     del tmp44
     tmp39 = einsum(tmp13, (0, 1, 2, 3), t1, (0, 4), (1, 2, 4, 3))
     tmp27 = einsum(tmp6, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     del tmp6
-    rdm2.oovo += tmp27.transpose((1, 2, 3, 0))
-    rdm2.oovo += tmp27.transpose((1, 2, 3, 0))
-    rdm2.ooov += tmp27.transpose((2, 1, 0, 3))
-    rdm2.ooov += tmp27.transpose((2, 1, 0, 3))
+    rdm2.oovo += np.transpose(tmp27, (1, 2, 3, 0))
+    rdm2.oovo += np.transpose(tmp27, (1, 2, 3, 0))
+    rdm2.ooov += np.transpose(tmp27, (2, 1, 0, 3))
+    rdm2.ooov += np.transpose(tmp27, (2, 1, 0, 3))
     tmp57 = einsum(tmp56, (0, 1), t2, (2, 3, 0, 4), (2, 3, 1, 4)) * 2
     tmp58 = einsum(tmp1, (0, 1), t2, (2, 0, 3, 4), (2, 1, 4, 3))
-    tmp11 = tmp9.copy()
+    tmp11 = np.copy(tmp9)
     del tmp9
     tmp11 += tmp10
     del tmp10
@@ -1039,7 +1039,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.ooov += einsum(delta.oo, (0, 1), tmp11, (2, 3), (2, 0, 1, 3)) * 2
     tmp50 = einsum(tmp49, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     del tmp49
-    tmp22 = tmp19.copy()
+    tmp22 = np.copy(tmp19)
     tmp22 += tmp21 * -1
     rdm2.ooov += einsum(delta.oo, (0, 1), tmp22, (2, 3), (0, 2, 1, 3)) * -1
     rdm2.ooov += einsum(tmp22, (0, 1), delta.oo, (2, 3), (0, 2, 3, 1))
@@ -1051,60 +1051,60 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp29
     tmp33 = einsum(tmp32, (0, 1), t1, (0, 2), (1, 2)) * 2
     del tmp32
-    tmp113 = tmp111.transpose((1, 0, 3, 2)).copy()
+    tmp113 = np.copy(np.transpose(tmp111, (1, 0, 3, 2)))
     del tmp111
-    tmp113 += tmp112.transpose((1, 0, 3, 2))
+    tmp113 += np.transpose(tmp112, (1, 0, 3, 2))
     del tmp112
     rdm2.vvvv += tmp113
-    rdm2.vvvv += tmp113.transpose((0, 1, 3, 2)) * -1
+    rdm2.vvvv += np.transpose(tmp113, (0, 1, 3, 2)) * -1
     rdm2.vvvv += tmp113
-    rdm2.vvvv += tmp113.transpose((0, 1, 3, 2)) * -1
+    rdm2.vvvv += np.transpose(tmp113, (0, 1, 3, 2)) * -1
     del tmp113
     tmp100 = einsum(t1, (0, 1), tmp62, (0, 2, 3, 4), (2, 3, 1, 4))
-    rdm2.vovv += tmp100.transpose((1, 0, 3, 2)) * -1
-    rdm2.vovv += tmp100.transpose((1, 0, 3, 2)) * -1
+    rdm2.vovv += np.transpose(tmp100, (1, 0, 3, 2)) * -1
+    rdm2.vovv += np.transpose(tmp100, (1, 0, 3, 2)) * -1
     rdm2.ovvv += tmp100 * -1
     rdm2.ovvv += tmp100 * -1
     del tmp100
-    tmp107 = tmp97.copy()
+    tmp107 = np.copy(tmp97)
     tmp107 += einsum(tmp78, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     del tmp78
-    rdm2.vovv += tmp107.transpose((1, 0, 3, 2))
-    rdm2.vovv += tmp107.transpose((1, 0, 2, 3)) * -1
-    rdm2.vovv += tmp107.transpose((1, 0, 3, 2))
-    rdm2.vovv += tmp107.transpose((1, 0, 2, 3)) * -1
+    rdm2.vovv += np.transpose(tmp107, (1, 0, 3, 2))
+    rdm2.vovv += np.transpose(tmp107, (1, 0, 2, 3)) * -1
+    rdm2.vovv += np.transpose(tmp107, (1, 0, 3, 2))
+    rdm2.vovv += np.transpose(tmp107, (1, 0, 2, 3)) * -1
     del tmp107
-    tmp106 = tmp89.copy()
-    tmp106 += tmp105.transpose((0, 1, 3, 2))
+    tmp106 = np.copy(tmp89)
+    tmp106 += np.transpose(tmp105, (0, 1, 3, 2))
     del tmp105
-    rdm2.vovv += tmp106.transpose((1, 0, 3, 2))
-    rdm2.vovv += tmp106.transpose((1, 0, 2, 3)) * -1
-    rdm2.vovv += tmp106.transpose((1, 0, 3, 2))
-    rdm2.vovv += tmp106.transpose((1, 0, 2, 3)) * -1
+    rdm2.vovv += np.transpose(tmp106, (1, 0, 3, 2))
+    rdm2.vovv += np.transpose(tmp106, (1, 0, 2, 3)) * -1
+    rdm2.vovv += np.transpose(tmp106, (1, 0, 3, 2))
+    rdm2.vovv += np.transpose(tmp106, (1, 0, 2, 3)) * -1
     del tmp106
     tmp109 = einsum(t1, (0, 1), tmp108, (0, 2, 3, 4), (2, 3, 4, 1))
     del tmp108
-    rdm2.vovv += tmp109.transpose((1, 0, 3, 2)) * -1
-    rdm2.vovv += tmp109.transpose((1, 0, 3, 2)) * -1
+    rdm2.vovv += np.transpose(tmp109, (1, 0, 3, 2)) * -1
+    rdm2.vovv += np.transpose(tmp109, (1, 0, 3, 2)) * -1
     del tmp109
     tmp99 = einsum(t1, (0, 1), tmp84, (0, 2, 3, 4), (2, 3, 1, 4))
     del tmp84
-    rdm2.ovvv += tmp99.transpose((0, 1, 3, 2)) * -1
+    rdm2.ovvv += np.transpose(tmp99, (0, 1, 3, 2)) * -1
     rdm2.ovvv += tmp99
-    rdm2.ovvv += tmp99.transpose((0, 1, 3, 2)) * -1
+    rdm2.ovvv += np.transpose(tmp99, (0, 1, 3, 2)) * -1
     rdm2.ovvv += tmp99
     del tmp99
-    tmp96 = tmp89.copy()
+    tmp96 = np.copy(tmp89)
     del tmp89
     tmp96 += einsum(tmp76, (0, 1), t1, (2, 3), (2, 0, 3, 1))
-    tmp96 += tmp95.transpose((0, 1, 3, 2)) * -1
+    tmp96 += np.transpose(tmp95, (0, 1, 3, 2)) * -1
     del tmp95
-    rdm2.ovvv += tmp96.transpose((0, 1, 3, 2)) * -1
+    rdm2.ovvv += np.transpose(tmp96, (0, 1, 3, 2)) * -1
     rdm2.ovvv += tmp96
-    rdm2.ovvv += tmp96.transpose((0, 1, 3, 2)) * -1
+    rdm2.ovvv += np.transpose(tmp96, (0, 1, 3, 2)) * -1
     rdm2.ovvv += tmp96
     del tmp96
-    tmp88 = tmp76.copy() * 0.5
+    tmp88 = np.copy(tmp76) * 0.5
     del tmp76
     tmp88 += tmp56
     rdm2.ovvv += einsum(tmp88, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
@@ -1119,88 +1119,88 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.ovvv += tmp103 * -1
     rdm2.ovvv += tmp103 * -1
     del tmp103
-    tmp98 = tmp97.copy()
+    tmp98 = np.copy(tmp97)
     del tmp97
     tmp98 += einsum(tmp56, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
     del tmp56
-    rdm2.ovvv += tmp98.transpose((0, 1, 3, 2)) * -1
+    rdm2.ovvv += np.transpose(tmp98, (0, 1, 3, 2)) * -1
     rdm2.ovvv += tmp98
-    rdm2.ovvv += tmp98.transpose((0, 1, 3, 2)) * -1
+    rdm2.ovvv += np.transpose(tmp98, (0, 1, 3, 2)) * -1
     rdm2.ovvv += tmp98
     del tmp98
     tmp87 = einsum(t2, (0, 1, 2, 3), tmp43, (1, 4, 5, 2), (4, 0, 5, 3))
     del tmp43
-    rdm2.vovo += tmp87.transpose((2, 1, 3, 0)) * -1
-    rdm2.vovo += tmp87.transpose((2, 1, 3, 0)) * -1
+    rdm2.vovo += np.transpose(tmp87, (2, 1, 3, 0)) * -1
+    rdm2.vovo += np.transpose(tmp87, (2, 1, 3, 0)) * -1
     del tmp87
     tmp81 = einsum(t2, (0, 1, 2, 3), tmp80, (1, 4, 5, 3), (4, 0, 5, 2))
     del tmp80
-    rdm2.vovo += tmp81.transpose((2, 1, 3, 0)) * -1
-    rdm2.vovo += tmp81.transpose((2, 1, 3, 0)) * -1
-    rdm2.voov += tmp81.transpose((2, 1, 0, 3))
-    rdm2.voov += tmp81.transpose((2, 1, 0, 3))
-    rdm2.ovvo += tmp81.transpose((1, 2, 3, 0))
-    rdm2.ovvo += tmp81.transpose((1, 2, 3, 0))
-    rdm2.ovvo += tmp81.transpose((1, 2, 3, 0))
-    rdm2.ovvo += tmp81.transpose((1, 2, 3, 0))
+    rdm2.vovo += np.transpose(tmp81, (2, 1, 3, 0)) * -1
+    rdm2.vovo += np.transpose(tmp81, (2, 1, 3, 0)) * -1
+    rdm2.voov += np.transpose(tmp81, (2, 1, 0, 3))
+    rdm2.voov += np.transpose(tmp81, (2, 1, 0, 3))
+    rdm2.ovvo += np.transpose(tmp81, (1, 2, 3, 0))
+    rdm2.ovvo += np.transpose(tmp81, (1, 2, 3, 0))
+    rdm2.ovvo += np.transpose(tmp81, (1, 2, 3, 0))
+    rdm2.ovvo += np.transpose(tmp81, (1, 2, 3, 0))
     del tmp81
     tmp86 = einsum(tmp85, (0, 1, 2, 3), t1, (1, 4), (0, 2, 3, 4))
     del tmp85
-    rdm2.vovo += tmp86.transpose((2, 1, 3, 0)) * -1
-    rdm2.vovo += tmp86.transpose((2, 1, 3, 0)) * -1
-    rdm2.voov += tmp86.transpose((2, 1, 0, 3))
-    rdm2.voov += tmp86.transpose((2, 1, 0, 3))
+    rdm2.vovo += np.transpose(tmp86, (2, 1, 3, 0)) * -1
+    rdm2.vovo += np.transpose(tmp86, (2, 1, 3, 0)) * -1
+    rdm2.voov += np.transpose(tmp86, (2, 1, 0, 3))
+    rdm2.voov += np.transpose(tmp86, (2, 1, 0, 3))
     del tmp86
     tmp79 = einsum(tmp4, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     del tmp4
-    rdm2.vovo += tmp79.transpose((2, 1, 3, 0)) * -1
-    rdm2.vovo += tmp79.transpose((2, 1, 3, 0)) * -1
-    rdm2.ovov += tmp79.transpose((1, 2, 0, 3)) * -1
-    rdm2.ovov += tmp79.transpose((1, 2, 0, 3)) * -1
+    rdm2.vovo += np.transpose(tmp79, (2, 1, 3, 0)) * -1
+    rdm2.vovo += np.transpose(tmp79, (2, 1, 3, 0)) * -1
+    rdm2.ovov += np.transpose(tmp79, (1, 2, 0, 3)) * -1
+    rdm2.ovov += np.transpose(tmp79, (1, 2, 0, 3)) * -1
     del tmp79
     tmp73 = einsum(tmp72, (0, 1, 2, 3), l2, (4, 2, 0, 5), (1, 5, 3, 4))
     del tmp72
-    rdm2.voov += tmp73.transpose((3, 0, 1, 2)) * -1
-    rdm2.voov += tmp73.transpose((3, 0, 1, 2)) * -1
-    rdm2.ovov += tmp73.transpose((0, 3, 1, 2))
-    rdm2.ovov += tmp73.transpose((0, 3, 1, 2))
+    rdm2.voov += np.transpose(tmp73, (3, 0, 1, 2)) * -1
+    rdm2.voov += np.transpose(tmp73, (3, 0, 1, 2)) * -1
+    rdm2.ovov += np.transpose(tmp73, (0, 3, 1, 2))
+    rdm2.ovov += np.transpose(tmp73, (0, 3, 1, 2))
     del tmp73
     tmp74 = einsum(l2, (0, 1, 2, 3), tmp20, (3, 4, 1, 5), (4, 2, 5, 0))
     del tmp20
-    rdm2.voov += tmp74.transpose((3, 0, 1, 2))
-    rdm2.voov += tmp74.transpose((3, 0, 1, 2))
-    rdm2.ovov += tmp74.transpose((0, 3, 1, 2)) * -1
-    rdm2.ovov += tmp74.transpose((0, 3, 1, 2)) * -1
+    rdm2.voov += np.transpose(tmp74, (3, 0, 1, 2))
+    rdm2.voov += np.transpose(tmp74, (3, 0, 1, 2))
+    rdm2.ovov += np.transpose(tmp74, (0, 3, 1, 2)) * -1
+    rdm2.ovov += np.transpose(tmp74, (0, 3, 1, 2)) * -1
     del tmp74
     tmp75 = einsum(tmp14, (0, 1, 2, 3), t1, (1, 4), (0, 2, 3, 4))
     del tmp14
-    rdm2.ovvo += tmp75.transpose((1, 2, 3, 0)) * -1
-    rdm2.ovvo += tmp75.transpose((1, 2, 3, 0)) * -1
-    rdm2.ovov += tmp75.transpose((1, 2, 0, 3))
-    rdm2.ovov += tmp75.transpose((1, 2, 0, 3))
+    rdm2.ovvo += np.transpose(tmp75, (1, 2, 3, 0)) * -1
+    rdm2.ovvo += np.transpose(tmp75, (1, 2, 3, 0)) * -1
+    rdm2.ovov += np.transpose(tmp75, (1, 2, 0, 3))
+    rdm2.ovov += np.transpose(tmp75, (1, 2, 0, 3))
     del tmp75
     tmp83 = einsum(tmp82, (0, 1, 2, 3), t2, (4, 0, 3, 5), (1, 4, 2, 5))
     del tmp82
-    rdm2.ovvo += tmp83.transpose((1, 2, 3, 0)) * -1
-    rdm2.ovvo += tmp83.transpose((1, 2, 3, 0)) * -1
+    rdm2.ovvo += np.transpose(tmp83, (1, 2, 3, 0)) * -1
+    rdm2.ovvo += np.transpose(tmp83, (1, 2, 3, 0)) * -1
     del tmp83
-    tmp54 = tmp52.copy()
+    tmp54 = np.copy(tmp52)
     del tmp52
-    tmp54 += tmp53.transpose((1, 0, 3, 2))
+    tmp54 += np.transpose(tmp53, (1, 0, 3, 2))
     del tmp53
-    rdm2.oovv += tmp54.transpose((0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp54, (0, 1, 3, 2)) * -1
     rdm2.oovv += tmp54
-    rdm2.oovv += tmp54.transpose((0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp54, (0, 1, 3, 2)) * -1
     rdm2.oovv += tmp54
     del tmp54
-    tmp66 = tmp48.copy() * -1
-    tmp66 += tmp65.transpose((0, 1, 3, 2))
+    tmp66 = np.copy(tmp48) * -1
+    tmp66 += np.transpose(tmp65, (0, 1, 3, 2))
     del tmp65
     tmp66 += einsum(tmp21, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     del tmp21
-    rdm2.oovv += tmp66.transpose((1, 0, 3, 2))
+    rdm2.oovv += np.transpose(tmp66, (1, 0, 3, 2))
     rdm2.oovv += tmp66
-    rdm2.oovv += tmp66.transpose((1, 0, 3, 2))
+    rdm2.oovv += np.transpose(tmp66, (1, 0, 3, 2))
     rdm2.oovv += tmp66
     del tmp66
     tmp61 = einsum(tmp60, (0, 1, 2, 3), t2, (4, 0, 2, 5), (4, 1, 5, 3))
@@ -1208,94 +1208,94 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oovv += tmp61
     rdm2.oovv += tmp61
     del tmp61
-    tmp69 = tmp47.copy()
-    tmp69 += tmp68.transpose((0, 1, 3, 2))
+    tmp69 = np.copy(tmp47)
+    tmp69 += np.transpose(tmp68, (0, 1, 3, 2))
     del tmp68
-    rdm2.oovv += tmp69.transpose((1, 0, 2, 3)) * -1
-    rdm2.oovv += tmp69.transpose((0, 1, 3, 2)) * -1
-    rdm2.oovv += tmp69.transpose((1, 0, 2, 3)) * -1
-    rdm2.oovv += tmp69.transpose((0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp69, (1, 0, 2, 3)) * -1
+    rdm2.oovv += np.transpose(tmp69, (0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp69, (1, 0, 2, 3)) * -1
+    rdm2.oovv += np.transpose(tmp69, (0, 1, 3, 2)) * -1
     del tmp69
-    tmp46 = tmp39.copy()
+    tmp46 = np.copy(tmp39)
     del tmp39
-    tmp46 += tmp42.transpose((1, 0, 3, 2)) * 2
+    tmp46 += np.transpose(tmp42, (1, 0, 3, 2)) * 2
     del tmp42
     tmp46 += tmp45
     del tmp45
-    rdm2.oovv += tmp46.transpose((0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp46, (0, 1, 3, 2)) * -1
     rdm2.oovv += tmp46
-    rdm2.oovv += tmp46.transpose((0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp46, (0, 1, 3, 2)) * -1
     rdm2.oovv += tmp46
     del tmp46
-    tmp71 = t1.copy()
+    tmp71 = np.copy(t1)
     tmp71 += tmp19 * -1
     del tmp19
     rdm2.oovv += einsum(t1, (0, 1), tmp71, (2, 3), (2, 0, 3, 1))
     rdm2.oovv += einsum(t1, (0, 1), tmp71, (2, 3), (2, 0, 3, 1))
     del tmp71
     tmp70 = einsum(tmp27, (0, 1, 2, 3), t1, (0, 4), (2, 1, 3, 4))
-    rdm2.oovv += tmp70.transpose((0, 1, 3, 2))
-    rdm2.oovv += tmp70.transpose((0, 1, 3, 2))
+    rdm2.oovv += np.transpose(tmp70, (0, 1, 3, 2))
+    rdm2.oovv += np.transpose(tmp70, (0, 1, 3, 2))
     del tmp70
-    tmp59 = tmp57.transpose((1, 0, 3, 2)).copy()
+    tmp59 = np.copy(np.transpose(tmp57, (1, 0, 3, 2)))
     del tmp57
-    tmp59 += tmp58.transpose((0, 1, 3, 2))
+    tmp59 += np.transpose(tmp58, (0, 1, 3, 2))
     del tmp58
     tmp59 += einsum(tmp11, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
     del tmp11
-    rdm2.oovv += tmp59.transpose((1, 0, 3, 2)) * -1
-    rdm2.oovv += tmp59.transpose((1, 0, 2, 3))
-    rdm2.oovv += tmp59.transpose((0, 1, 3, 2))
+    rdm2.oovv += np.transpose(tmp59, (1, 0, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp59, (1, 0, 2, 3))
+    rdm2.oovv += np.transpose(tmp59, (0, 1, 3, 2))
     rdm2.oovv += tmp59 * -1
-    rdm2.oovv += tmp59.transpose((1, 0, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp59, (1, 0, 3, 2)) * -1
     rdm2.oovv += tmp59 * -1
-    rdm2.oovv += tmp59.transpose((1, 0, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp59, (1, 0, 3, 2)) * -1
     rdm2.oovv += tmp59 * -1
-    rdm2.oovv += tmp59.transpose((1, 0, 3, 2)) * -1
-    rdm2.oovv += tmp59.transpose((1, 0, 2, 3))
-    rdm2.oovv += tmp59.transpose((0, 1, 3, 2))
+    rdm2.oovv += np.transpose(tmp59, (1, 0, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp59, (1, 0, 2, 3))
+    rdm2.oovv += np.transpose(tmp59, (0, 1, 3, 2))
     rdm2.oovv += tmp59 * -1
     del tmp59
     tmp63 = einsum(tmp62, (0, 1, 2, 3), t2, (4, 0, 2, 5), (4, 1, 5, 3))
     del tmp62
-    rdm2.oovv += tmp63.transpose((0, 1, 3, 2))
-    rdm2.oovv += tmp63.transpose((0, 1, 3, 2))
+    rdm2.oovv += np.transpose(tmp63, (0, 1, 3, 2))
+    rdm2.oovv += np.transpose(tmp63, (0, 1, 3, 2))
     del tmp63
-    tmp51 = tmp47.copy()
+    tmp51 = np.copy(tmp47)
     del tmp47
     tmp51 += tmp48 * -1
     del tmp48
-    tmp51 += tmp50.transpose((0, 1, 3, 2))
+    tmp51 += np.transpose(tmp50, (0, 1, 3, 2))
     del tmp50
     tmp51 += einsum(t1, (0, 1), tmp22, (2, 3), (0, 2, 1, 3)) * -1
     del tmp22
-    rdm2.oovv += tmp51.transpose((1, 0, 3, 2))
-    rdm2.oovv += tmp51.transpose((1, 0, 2, 3)) * -1
-    rdm2.oovv += tmp51.transpose((0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp51, (1, 0, 3, 2))
+    rdm2.oovv += np.transpose(tmp51, (1, 0, 2, 3)) * -1
+    rdm2.oovv += np.transpose(tmp51, (0, 1, 3, 2)) * -1
     rdm2.oovv += tmp51
-    rdm2.oovv += tmp51.transpose((1, 0, 3, 2))
-    rdm2.oovv += tmp51.transpose((1, 0, 2, 3)) * -1
-    rdm2.oovv += tmp51.transpose((0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(tmp51, (1, 0, 3, 2))
+    rdm2.oovv += np.transpose(tmp51, (1, 0, 2, 3)) * -1
+    rdm2.oovv += np.transpose(tmp51, (0, 1, 3, 2)) * -1
     rdm2.oovv += tmp51
     del tmp51
     tmp38 = einsum(tmp2, (0, 1), t1, (2, 3), (0, 2, 1, 3))
     tmp38 += tmp15
     tmp38 += tmp17 * -1
-    rdm2.oovo += tmp38.transpose((2, 1, 3, 0))
-    rdm2.oovo += tmp38.transpose((1, 2, 3, 0)) * -1
-    rdm2.oovo += tmp38.transpose((2, 1, 3, 0))
-    rdm2.oovo += tmp38.transpose((1, 2, 3, 0)) * -1
+    rdm2.oovo += np.transpose(tmp38, (2, 1, 3, 0))
+    rdm2.oovo += np.transpose(tmp38, (1, 2, 3, 0)) * -1
+    rdm2.oovo += np.transpose(tmp38, (2, 1, 3, 0))
+    rdm2.oovo += np.transpose(tmp38, (1, 2, 3, 0)) * -1
     del tmp38
-    tmp37 = tmp12.copy()
-    tmp37 += tmp27.transpose((0, 2, 1, 3))
+    tmp37 = np.copy(tmp12)
+    tmp37 += np.transpose(tmp27, (0, 2, 1, 3))
     del tmp27
     tmp37 += einsum(tmp1, (0, 1), t1, (2, 3), (0, 2, 1, 3))
-    rdm2.oovo += tmp37.transpose((2, 1, 3, 0))
-    rdm2.oovo += tmp37.transpose((1, 2, 3, 0)) * -1
-    rdm2.oovo += tmp37.transpose((2, 1, 3, 0))
-    rdm2.oovo += tmp37.transpose((1, 2, 3, 0)) * -1
+    rdm2.oovo += np.transpose(tmp37, (2, 1, 3, 0))
+    rdm2.oovo += np.transpose(tmp37, (1, 2, 3, 0)) * -1
+    rdm2.oovo += np.transpose(tmp37, (2, 1, 3, 0))
+    rdm2.oovo += np.transpose(tmp37, (1, 2, 3, 0)) * -1
     del tmp37
-    tmp34 = t1.copy() * -1
+    tmp34 = np.copy(t1) * -1
     tmp34 += tmp28
     tmp34 += tmp30 * -1
     del tmp30
@@ -1305,14 +1305,14 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.ooov += einsum(delta.oo, (0, 1), tmp34, (2, 3), (0, 2, 1, 3)) * -1
     rdm2.ooov += einsum(delta.oo, (0, 1), tmp34, (2, 3), (0, 2, 1, 3)) * -1
     del tmp34
-    tmp35 = tmp2.copy()
+    tmp35 = np.copy(tmp2)
     tmp35 += tmp1
     rdm2.oovo += einsum(tmp35, (0, 1), t1, (2, 3), (2, 1, 3, 0)) * -1
     rdm2.oovo += einsum(tmp35, (0, 1), t1, (2, 3), (2, 1, 3, 0)) * -1
     rdm2.ooov += einsum(tmp35, (0, 1), t1, (2, 3), (1, 2, 0, 3)) * -1
     rdm2.ooov += einsum(tmp35, (0, 1), t1, (2, 3), (1, 2, 0, 3)) * -1
     del tmp35
-    tmp36 = tmp28.copy()
+    tmp36 = np.copy(tmp28)
     del tmp28
     tmp36 += tmp33
     del tmp33
@@ -1321,16 +1321,16 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oovo += einsum(tmp36, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3))
     rdm2.oovo += einsum(delta.oo, (0, 1), tmp36, (2, 3), (2, 0, 3, 1)) * -1
     del tmp36
-    tmp24 = tmp23.copy()
+    tmp24 = np.copy(tmp23)
     del tmp23
     tmp24 += einsum(tmp1, (0, 1), t1, (2, 3), (0, 2, 1, 3))
     del tmp1
-    rdm2.ooov += tmp24.transpose((2, 1, 0, 3)) * -1
-    rdm2.ooov += tmp24.transpose((1, 2, 0, 3))
-    rdm2.ooov += tmp24.transpose((2, 1, 0, 3)) * -1
-    rdm2.ooov += tmp24.transpose((1, 2, 0, 3))
+    rdm2.ooov += np.transpose(tmp24, (2, 1, 0, 3)) * -1
+    rdm2.ooov += np.transpose(tmp24, (1, 2, 0, 3))
+    rdm2.ooov += np.transpose(tmp24, (2, 1, 0, 3)) * -1
+    rdm2.ooov += np.transpose(tmp24, (1, 2, 0, 3))
     del tmp24
-    tmp18 = tmp12.copy()
+    tmp18 = np.copy(tmp12)
     del tmp12
     tmp18 += tmp13
     del tmp13
@@ -1338,12 +1338,12 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp15
     tmp18 += tmp17 * -1
     del tmp17
-    rdm2.ooov += tmp18.transpose((2, 1, 0, 3)) * -1
-    rdm2.ooov += tmp18.transpose((1, 2, 0, 3))
-    rdm2.ooov += tmp18.transpose((2, 1, 0, 3)) * -1
-    rdm2.ooov += tmp18.transpose((1, 2, 0, 3))
+    rdm2.ooov += np.transpose(tmp18, (2, 1, 0, 3)) * -1
+    rdm2.ooov += np.transpose(tmp18, (1, 2, 0, 3))
+    rdm2.ooov += np.transpose(tmp18, (2, 1, 0, 3)) * -1
+    rdm2.ooov += np.transpose(tmp18, (1, 2, 0, 3))
     del tmp18
-    tmp7 = delta.oo.copy()
+    tmp7 = np.copy(delta.oo)
     tmp7 += tmp2 * -1
     del tmp2
     rdm2.oooo += einsum(tmp7, (0, 1), delta.oo, (2, 3), (1, 2, 0, 3))
@@ -1374,13 +1374,13 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.vooo += einsum(delta.oo, (0, 1), l1, (2, 3), (2, 0, 3, 1))
     rdm2.vooo += einsum(delta.oo, (0, 1), l1, (2, 3), (2, 0, 1, 3)) * -1
     del delta
-    rdm2.oovv += t2.transpose((0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(t2, (0, 1, 3, 2)) * -1
     rdm2.oovv += t2
     rdm2.oovv += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.oovv += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     rdm2.oovv += t2
     rdm2.oovv += t2
-    rdm2.oovv += t2.transpose((0, 1, 3, 2)) * -1
+    rdm2.oovv += np.transpose(t2, (0, 1, 3, 2)) * -1
     rdm2.oovv += t2
     rdm2.oovv += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.oovv += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
@@ -1396,14 +1396,14 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.voov += einsum(l1, (0, 1), t1, (2, 3), (0, 2, 1, 3))
     rdm2.vovo += einsum(l1, (0, 1), t1, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.vovo += einsum(l1, (0, 1), t1, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.vvoo = l2.transpose((0, 1, 3, 2)).copy() * -1
+    rdm2.vvoo = np.copy(np.transpose(l2, (0, 1, 3, 2))) * -1
     rdm2.vvoo += l2
     rdm2.vvoo += l2
     rdm2.vvoo += l2
-    rdm2.vvoo += l2.transpose((0, 1, 3, 2)) * -1
+    rdm2.vvoo += np.transpose(l2, (0, 1, 3, 2)) * -1
     rdm2.vvoo += l2
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.transpose(0, 2, 1, 3)
+    rdm2 = np.transpose(rdm2, (0, 2, 1, 3))
 
     return rdm2
 
@@ -1589,15 +1589,15 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     """
 
     ints = kwargs["ints"]
-    tmp12 = r2.copy() * 2
-    tmp12 += r2.transpose((1, 0, 2)) * -1
-    tmp13 = ints.tmp9.copy()
-    tmp13 += v.ooov.transpose((0, 2, 1, 3))
-    tmp1 = f.ov.copy() * 0.5
+    tmp12 = np.copy(r2) * 2
+    tmp12 += np.transpose(r2, (1, 0, 2)) * -1
+    tmp13 = np.copy(ints.tmp9)
+    tmp13 += np.transpose(v.ooov, (0, 2, 1, 3))
+    tmp1 = np.copy(f.ov) * 0.5
     tmp1 += ints.tmp6
     tmp1 += ints.tmp5 * -0.5
-    tmp15 = v.ovov.transpose((0, 2, 3, 1)).copy() * -0.5
-    tmp15 += v.ovov.transpose((0, 2, 1, 3))
+    tmp15 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -0.5
+    tmp15 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp14 = einsum(tmp12, (0, 1, 2), tmp13, (3, 0, 4, 2), (1, 4, 3)) * -1
     del tmp12
     tmp14 += einsum(tmp13, (0, 1, 2, 3), r2, (4, 2, 3), (0, 1, 4))
@@ -1605,73 +1605,73 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp13
     r2new = einsum(tmp14, (0, 1, 2), t1, (1, 3), (2, 0, 3))
     del tmp14
-    tmp7 = ints.tmp25.copy()
-    tmp7 += ints.tmp30.transpose((1, 0, 2, 3))
+    tmp7 = np.copy(ints.tmp25)
+    tmp7 += np.transpose(ints.tmp30, (1, 0, 2, 3))
     tmp7 += ints.tmp90
     r2new += einsum(tmp7, (0, 1, 2, 3), r2, (3, 2, 4), (1, 0, 4))
     del tmp7
-    tmp6 = ints.tmp22.copy()
+    tmp6 = np.copy(ints.tmp22)
     tmp6 += v.oovv
     tmp6 += ints.tmp49 * -1
     r2new += einsum(tmp6, (0, 1, 2, 3), r2, (1, 4, 3), (0, 4, 2)) * -1
     r2new += einsum(r2, (0, 1, 2), tmp6, (3, 1, 4, 2), (0, 3, 4)) * -1
     del tmp6
-    tmp9 = ints.tmp21.copy()
-    tmp9 += ints.tmp69.transpose((1, 0)) * 2
+    tmp9 = np.copy(ints.tmp21)
+    tmp9 += np.transpose(ints.tmp69, (1, 0)) * 2
     tmp9 += f.vv * -1
-    tmp9 += ints.tmp19.transpose((1, 0)) * -2
-    tmp9 += ints.tmp67.transpose((1, 0)) * -1
+    tmp9 += np.transpose(ints.tmp19, (1, 0)) * -2
+    tmp9 += np.transpose(ints.tmp67, (1, 0)) * -1
     tmp9 += einsum(t1, (0, 1), tmp1, (0, 2), (2, 1)) * 2
     r2new += einsum(r2, (0, 1, 2), tmp9, (2, 3), (0, 1, 3)) * -1
     del tmp9
-    tmp10 = ints.tmp100.copy()
-    tmp10 += ints.tmp103.transpose((0, 2, 1, 3))
-    tmp10 += ints.tmp27.transpose((1, 0, 2, 3))
-    tmp10 += ints.tmp35.transpose((1, 0, 2, 3))
-    tmp10 += ints.tmp36.transpose((1, 0, 2, 3))
-    tmp10 += ints.tmp37.transpose((1, 0, 2, 3))
-    tmp10 += ints.tmp42.transpose((2, 0, 1, 3))
+    tmp10 = np.copy(ints.tmp100)
+    tmp10 += np.transpose(ints.tmp103, (0, 2, 1, 3))
+    tmp10 += np.transpose(ints.tmp27, (1, 0, 2, 3))
+    tmp10 += np.transpose(ints.tmp35, (1, 0, 2, 3))
+    tmp10 += np.transpose(ints.tmp36, (1, 0, 2, 3))
+    tmp10 += np.transpose(ints.tmp37, (1, 0, 2, 3))
+    tmp10 += np.transpose(ints.tmp42, (2, 0, 1, 3))
     tmp10 += ints.tmp45
     tmp10 += ints.tmp48
-    tmp10 += ints.tmp66.transpose((1, 0, 2, 3))
+    tmp10 += np.transpose(ints.tmp66, (1, 0, 2, 3))
     tmp10 += ints.tmp75
-    tmp10 += ints.tmp92.transpose((1, 0, 2, 3))
-    tmp10 += ints.tmp23.transpose((1, 0, 2, 3)) * -1
-    tmp10 += ints.tmp34.transpose((1, 0, 2, 3)) * -2
+    tmp10 += np.transpose(ints.tmp92, (1, 0, 2, 3))
+    tmp10 += np.transpose(ints.tmp23, (1, 0, 2, 3)) * -1
+    tmp10 += np.transpose(ints.tmp34, (1, 0, 2, 3)) * -2
     tmp10 += ints.tmp46 * -2
-    tmp10 += ints.tmp60.transpose((1, 2, 0, 3)) * -1
+    tmp10 += np.transpose(ints.tmp60, (1, 2, 0, 3)) * -1
     tmp10 += ints.tmp76 * -2
-    tmp10 += ints.tmp89.transpose((1, 0, 2, 3)) * -1
+    tmp10 += np.transpose(ints.tmp89, (1, 0, 2, 3)) * -1
     tmp10 += ints.tmp94 * -1
-    tmp10 += ints.tmp9.transpose((1, 0, 2, 3)) * -1
-    tmp10 += v.ovoo.transpose((0, 2, 3, 1)) * -1
+    tmp10 += np.transpose(ints.tmp9, (1, 0, 2, 3)) * -1
+    tmp10 += np.transpose(v.ovoo, (0, 2, 3, 1)) * -1
     r2new += einsum(tmp10, (0, 1, 2, 3), r1, (2,), (0, 1, 3)) * -1
     del tmp10
     tmp16 = einsum(r2, (0, 1, 2), tmp15, (0, 1, 2, 3), (3,))
     del tmp15
     r2new += einsum(tmp16, (0,), t2, (1, 2, 3, 0), (1, 2, 3)) * -2
     del tmp16
-    tmp4 = r2.copy()
-    tmp4 += r2.transpose((1, 0, 2)) * -0.5
-    tmp5 = ints.tmp52.copy() * 2
-    tmp5 += ints.tmp83.transpose((0, 1, 3, 2))
-    tmp5 += v.ovov.transpose((0, 2, 1, 3))
+    tmp4 = np.copy(r2)
+    tmp4 += np.transpose(r2, (1, 0, 2)) * -0.5
+    tmp5 = np.copy(ints.tmp52) * 2
+    tmp5 += np.transpose(ints.tmp83, (0, 1, 3, 2))
+    tmp5 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp5 += ints.tmp50 * -1
     tmp5 += ints.tmp51 * -1
     r2new += einsum(tmp5, (0, 1, 2, 3), tmp4, (1, 4, 3), (0, 4, 2)) * 2
     del tmp5, tmp4
-    tmp11 = f.oo.copy() * 0.5
+    tmp11 = np.copy(f.oo) * 0.5
     tmp11 += ints.tmp0 * 0.5
-    tmp11 += ints.tmp14.transpose((1, 0))
-    tmp11 += ints.tmp17.transpose((1, 0))
-    tmp11 += ints.tmp4.transpose((1, 0))
-    tmp11 += ints.tmp12.transpose((1, 0)) * -0.5
-    tmp11 += ints.tmp16.transpose((1, 0)) * -0.5
-    tmp11 += ints.tmp3.transpose((1, 0)) * -0.5
+    tmp11 += np.transpose(ints.tmp14, (1, 0))
+    tmp11 += np.transpose(ints.tmp17, (1, 0))
+    tmp11 += np.transpose(ints.tmp4, (1, 0))
+    tmp11 += np.transpose(ints.tmp12, (1, 0)) * -0.5
+    tmp11 += np.transpose(ints.tmp16, (1, 0)) * -0.5
+    tmp11 += np.transpose(ints.tmp3, (1, 0)) * -0.5
     r2new += einsum(r2, (0, 1, 2), tmp11, (1, 3), (0, 3, 2)) * -2
     r2new += einsum(tmp11, (0, 1), r2, (0, 2, 3), (1, 2, 3)) * -2
     del tmp11
-    tmp17 = ints.tmp101.copy() * 2
+    tmp17 = np.copy(ints.tmp101) * 2
     tmp17 += ints.tmp109 * 2
     tmp17 += ints.tmp29
     tmp17 += ints.tmp39
@@ -1699,27 +1699,27 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp17 += ints.tmp99 * -1
     r2new += einsum(tmp17, (0, 1), r1, (2,), (0, 2, 1))
     del tmp17
-    tmp8 = ints.tmp30.copy()
-    tmp8 += v.oooo.transpose((0, 2, 3, 1))
+    tmp8 = np.copy(ints.tmp30)
+    tmp8 += np.transpose(v.oooo, (0, 2, 3, 1))
     r2new += einsum(tmp8, (0, 1, 2, 3), r2, (2, 3, 4), (1, 0, 4))
     del tmp8
-    tmp2 = r2.copy() * -1
-    tmp2 += r2.transpose((1, 0, 2)) * 2
+    tmp2 = np.copy(r2) * -1
+    tmp2 += np.transpose(r2, (1, 0, 2)) * 2
     r1new = einsum(tmp2, (0, 1, 2), tmp1, (1, 2), (0,)) * -2
     del tmp1, tmp2
-    tmp0 = ints.tmp9.copy()
+    tmp0 = np.copy(ints.tmp9)
     tmp0 += v.ooov * -0.5
-    tmp0 += v.ooov.transpose((0, 2, 1, 3))
+    tmp0 += np.transpose(v.ooov, (0, 2, 1, 3))
     r1new += einsum(tmp0, (0, 1, 2, 3), r2, (1, 2, 3), (0,)) * 2
     del tmp0
-    tmp3 = f.oo.copy()
+    tmp3 = np.copy(f.oo)
     tmp3 += ints.tmp0
-    tmp3 += ints.tmp14.transpose((1, 0)) * 2
-    tmp3 += ints.tmp17.transpose((1, 0)) * 2
-    tmp3 += ints.tmp4.transpose((1, 0)) * 2
-    tmp3 += ints.tmp12.transpose((1, 0)) * -1
-    tmp3 += ints.tmp16.transpose((1, 0)) * -1
-    tmp3 += ints.tmp3.transpose((1, 0)) * -1
+    tmp3 += np.transpose(ints.tmp14, (1, 0)) * 2
+    tmp3 += np.transpose(ints.tmp17, (1, 0)) * 2
+    tmp3 += np.transpose(ints.tmp4, (1, 0)) * 2
+    tmp3 += np.transpose(ints.tmp12, (1, 0)) * -1
+    tmp3 += np.transpose(ints.tmp16, (1, 0)) * -1
+    tmp3 += np.transpose(ints.tmp3, (1, 0)) * -1
     r1new += einsum(tmp3, (0, 1), r1, (0,), (1,)) * -1
     del tmp3
     r1new += einsum(ints.tmp9, (0, 1, 2, 3), r2, (2, 1, 3), (0,)) * -1
@@ -1878,24 +1878,24 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     """
 
     ints = kwargs["ints"]
-    tmp1 = f.ov.copy() * 0.5
+    tmp1 = np.copy(f.ov) * 0.5
     tmp1 += ints.tmp7
     tmp1 += ints.tmp6 * -0.5
-    tmp4 = v.ovov.transpose((0, 2, 3, 1)).copy() * 2
-    tmp4 += v.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp6 = f.ov.copy()
+    tmp4 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * 2
+    tmp4 += np.transpose(v.ovov, (0, 2, 1, 3)) * -1
+    tmp6 = np.copy(f.ov)
     tmp6 += ints.tmp7 * 2
     tmp6 += ints.tmp6 * -1
     tmp9 = einsum(v.ovov, (0, 1, 2, 3), r2, (1, 3, 4), (4, 0, 2))
     r2new = einsum(t2, (0, 1, 2, 3), tmp9, (4, 1, 0), (3, 2, 4))
-    tmp20 = ints.tmp60.copy()
-    tmp20 += v.ooov.transpose((0, 2, 1, 3))
-    tmp12 = r2.transpose((2, 0, 1)).copy()
+    tmp20 = np.copy(ints.tmp60)
+    tmp20 += np.transpose(v.ooov, (0, 2, 1, 3))
+    tmp12 = np.copy(np.transpose(r2, (2, 0, 1)))
     tmp12 += einsum(r1, (0,), t1, (1, 2), (1, 2, 0)) * -1
-    tmp14 = ints.tmp60.copy() * -0.5
-    tmp14 += ints.tmp60.transpose((0, 2, 1, 3))
+    tmp14 = np.copy(ints.tmp60) * -0.5
+    tmp14 += np.transpose(ints.tmp60, (0, 2, 1, 3))
     tmp14 += v.ooov
-    tmp14 += v.ooov.transpose((0, 2, 1, 3)) * -0.5
+    tmp14 += np.transpose(v.ooov, (0, 2, 1, 3)) * -0.5
     tmp16 = einsum(tmp1, (0, 1), t1, (0, 2), (2, 1)) * 2
     tmp5 = einsum(tmp4, (0, 1, 2, 3), r2, (3, 2, 0), (1,))
     del tmp4
@@ -1907,12 +1907,12 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp21 += einsum(tmp20, (0, 1, 2, 3), tmp12, (1, 4, 3), (0, 2, 4))
     r2new += einsum(tmp21, (0, 1, 2), t1, (1, 3), (3, 2, 0))
     del tmp21
-    tmp13 = ints.tmp51.copy()
+    tmp13 = np.copy(ints.tmp51)
     tmp13 += v.oovv
     tmp13 += ints.tmp28 * -1
     r2new += einsum(tmp13, (0, 1, 2, 3), tmp12, (1, 4, 3), (4, 2, 0)) * -1
     del tmp12, tmp13
-    tmp23 = ints.tmp107.copy() * 2
+    tmp23 = np.copy(ints.tmp107) * 2
     tmp23 += ints.tmp108 * 2
     tmp23 += ints.tmp32
     tmp23 += ints.tmp55
@@ -1946,71 +1946,71 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r2new += einsum(t1, (0, 1), tmp22, (2, 0, 3), (3, 1, 2))
     del tmp22
     tmp10 = einsum(t1, (0, 1), r1, (2,), (0, 2, 1)) * 0.5
-    tmp10 += r2.transpose((2, 0, 1))
-    tmp10 += r2.transpose((2, 1, 0)) * -0.5
-    tmp19 = f.oo.copy()
-    tmp19 += ints.tmp34.transpose((1, 0)) * 2
+    tmp10 += np.transpose(r2, (2, 0, 1))
+    tmp10 += np.transpose(r2, (2, 1, 0)) * -0.5
+    tmp19 = np.copy(f.oo)
+    tmp19 += np.transpose(ints.tmp34, (1, 0)) * 2
     tmp19 += ints.tmp47
-    tmp19 += ints.tmp58.transpose((1, 0)) * 2
-    tmp19 += ints.tmp67.transpose((1, 0)) * 2
-    tmp19 += ints.tmp33.transpose((1, 0)) * -1
-    tmp19 += ints.tmp56.transpose((1, 0)) * -1
-    tmp19 += ints.tmp66.transpose((1, 0)) * -1
+    tmp19 += np.transpose(ints.tmp58, (1, 0)) * 2
+    tmp19 += np.transpose(ints.tmp67, (1, 0)) * 2
+    tmp19 += np.transpose(ints.tmp33, (1, 0)) * -1
+    tmp19 += np.transpose(ints.tmp56, (1, 0)) * -1
+    tmp19 += np.transpose(ints.tmp66, (1, 0)) * -1
     r2new += einsum(tmp19, (0, 1), r2, (2, 3, 0), (2, 3, 1)) * -1
     del tmp19
-    tmp15 = ints.tmp51.copy()
+    tmp15 = np.copy(ints.tmp51)
     tmp15 += v.oovv
     tmp15 += ints.tmp28 * -1
     tmp15 += einsum(tmp14, (0, 1, 2, 3), t1, (1, 4), (0, 2, 4, 3)) * 2
     del tmp14
     r2new += einsum(r2, (0, 1, 2), tmp15, (3, 2, 4, 0), (4, 1, 3)) * -1
     del tmp15
-    tmp11 = ints.tmp104.copy() * 2
-    tmp11 += ints.tmp52.transpose((0, 1, 3, 2))
-    tmp11 += v.ovov.transpose((0, 2, 1, 3))
+    tmp11 = np.copy(ints.tmp104) * 2
+    tmp11 += np.transpose(ints.tmp52, (0, 1, 3, 2))
+    tmp11 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp11 += ints.tmp102 * -1
     tmp11 += ints.tmp103 * -1
     r2new += einsum(tmp11, (0, 1, 2, 3), tmp10, (1, 3, 4), (2, 4, 0)) * 2
     del tmp11, tmp10
-    tmp17 = ints.tmp16.transpose((1, 0)).copy() * 2
+    tmp17 = np.copy(np.transpose(ints.tmp16, (1, 0))) * 2
     tmp17 += ints.tmp5
     tmp17 += f.vv * -1
-    tmp17 += ints.tmp14.transpose((1, 0)) * -1
-    tmp17 += ints.tmp3.transpose((1, 0)) * -2
-    tmp17 += tmp16.transpose((1, 0))
+    tmp17 += np.transpose(ints.tmp14, (1, 0)) * -1
+    tmp17 += np.transpose(ints.tmp3, (1, 0)) * -2
+    tmp17 += np.transpose(tmp16, (1, 0))
     del tmp16
     r2new += einsum(tmp17, (0, 1), r2, (2, 0, 3), (2, 1, 3)) * -1
     r2new += einsum(tmp17, (0, 1), r2, (0, 2, 3), (1, 2, 3)) * -1
     del tmp17
-    tmp8 = tmp5.copy() * -1
+    tmp8 = np.copy(tmp5) * -1
     del tmp5
     tmp8 += tmp7
     del tmp7
     r2new += einsum(t2, (0, 1, 2, 3), tmp8, (1,), (2, 3, 0))
     r1new = einsum(t1, (0, 1), tmp8, (0,), (1,)) * -1
     del tmp8
-    tmp18 = ints.tmp36.transpose((0, 2, 3, 1)).copy()
+    tmp18 = np.copy(np.transpose(ints.tmp36, (0, 2, 3, 1)))
     tmp18 += ints.tmp49
-    tmp18 += ints.tmp61.transpose((0, 1, 3, 2))
-    tmp18 += ints.tmp97.transpose((0, 2, 3, 1)) * 2
-    tmp18 += v.ovvv.transpose((0, 2, 3, 1))
+    tmp18 += np.transpose(ints.tmp61, (0, 1, 3, 2))
+    tmp18 += np.transpose(ints.tmp97, (0, 2, 3, 1)) * 2
+    tmp18 += np.transpose(v.ovvv, (0, 2, 3, 1))
     tmp18 += ints.tmp25 * -1
-    tmp18 += ints.tmp98.transpose((0, 3, 2, 1)) * -1
-    tmp18 += ints.tmp99.transpose((0, 2, 3, 1)) * -1
+    tmp18 += np.transpose(ints.tmp98, (0, 3, 2, 1)) * -1
+    tmp18 += np.transpose(ints.tmp99, (0, 2, 3, 1)) * -1
     r2new += einsum(r1, (0,), tmp18, (1, 2, 0, 3), (3, 2, 1)) * -1
     del tmp18
-    tmp2 = r2.transpose((2, 0, 1)).copy() * -1
-    tmp2 += r2.transpose((2, 1, 0)) * 2
+    tmp2 = np.copy(np.transpose(r2, (2, 0, 1))) * -1
+    tmp2 += np.transpose(r2, (2, 1, 0)) * 2
     r1new += einsum(tmp2, (0, 1, 2), tmp1, (0, 2), (1,)) * -2
     del tmp1, tmp2
-    tmp0 = v.ovvv.copy() * 2
-    tmp0 += v.ovvv.transpose((0, 2, 1, 3)) * -1
+    tmp0 = np.copy(v.ovvv) * 2
+    tmp0 += np.transpose(v.ovvv, (0, 2, 1, 3)) * -1
     r1new += einsum(tmp0, (0, 1, 2, 3), r2, (1, 2, 0), (3,)) * -1
     del tmp0
-    tmp3 = f.vv.copy()
-    tmp3 += ints.tmp14.transpose((1, 0))
-    tmp3 += ints.tmp3.transpose((1, 0)) * 2
-    tmp3 += ints.tmp16.transpose((1, 0)) * -2
+    tmp3 = np.copy(f.vv)
+    tmp3 += np.transpose(ints.tmp14, (1, 0))
+    tmp3 += np.transpose(ints.tmp3, (1, 0)) * 2
+    tmp3 += np.transpose(ints.tmp16, (1, 0)) * -2
     tmp3 += ints.tmp5 * -1
     r1new += einsum(r1, (0,), tmp3, (0, 1), (1,))
     del tmp3
@@ -2200,53 +2200,53 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     """
 
     ints = kwargs["ints"]
-    tmp18 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp18 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp18 += t2
-    tmp15 = f.ov.copy()
+    tmp15 = np.copy(f.ov)
     tmp15 += ints.tmp17 * 2
     tmp15 += ints.tmp47 * -1
     tmp11 = einsum(t1, (0, 1), r2, (2, 3, 1), (2, 3, 0))
-    tmp10 = ints.tmp107.copy()
+    tmp10 = np.copy(ints.tmp107)
     tmp10 += ints.tmp81
-    tmp10 += ints.tmp90.transpose((0, 1, 3, 2))
-    tmp10 += v.oooo.transpose((0, 2, 1, 3))
-    tmp17 = f.oo.copy() * 0.5
-    tmp17 += ints.tmp0.transpose((1, 0)) * 0.5
+    tmp10 += np.transpose(ints.tmp90, (0, 1, 3, 2))
+    tmp10 += np.transpose(v.oooo, (0, 2, 1, 3))
+    tmp17 = np.copy(f.oo) * 0.5
+    tmp17 += np.transpose(ints.tmp0, (1, 0)) * 0.5
     tmp17 += ints.tmp13
     tmp17 += ints.tmp24
     tmp17 += ints.tmp86
     tmp17 += ints.tmp12 * -0.5
     tmp17 += ints.tmp22 * -0.5
     tmp17 += ints.tmp85 * -0.5
-    tmp14 = ints.tmp20.copy()
-    tmp14 += v.ooov.transpose((0, 2, 1, 3))
-    tmp8 = ints.tmp117.copy() * 2
-    tmp8 += ints.tmp99.transpose((0, 1, 3, 2))
-    tmp8 += v.ovov.transpose((0, 2, 1, 3))
+    tmp14 = np.copy(ints.tmp20)
+    tmp14 += np.transpose(v.ooov, (0, 2, 1, 3))
+    tmp8 = np.copy(ints.tmp117) * 2
+    tmp8 += np.transpose(ints.tmp99, (0, 1, 3, 2))
+    tmp8 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp8 += ints.tmp114 * -1
     tmp8 += ints.tmp116 * -1
     tmp19 = einsum(r2, (0, 1, 2), tmp18, (1, 0, 3, 2), (3,))
     del tmp18
-    tmp7 = r2.copy()
-    tmp7 += r2.transpose((1, 0, 2)) * -0.5
-    tmp9 = ints.tmp112.copy()
+    tmp7 = np.copy(r2)
+    tmp7 += np.transpose(r2, (1, 0, 2)) * -0.5
+    tmp9 = np.copy(ints.tmp112)
     tmp9 += v.oovv
-    tmp9 += ints.tmp113.transpose((0, 1, 3, 2)) * -1
-    tmp13 = ints.tmp20.copy()
-    tmp13 += v.ooov.transpose((0, 2, 1, 3))
-    tmp16 = ints.tmp136.copy() * 2
-    tmp16 += ints.tmp97.transpose((1, 0))
+    tmp9 += np.transpose(ints.tmp113, (0, 1, 3, 2)) * -1
+    tmp13 = np.copy(ints.tmp20)
+    tmp13 += np.transpose(v.ooov, (0, 2, 1, 3))
+    tmp16 = np.copy(ints.tmp136) * 2
+    tmp16 += np.transpose(ints.tmp97, (1, 0))
     tmp16 += f.vv * -1
     tmp16 += ints.tmp134 * -1
     tmp16 += ints.tmp93 * -2
     tmp16 += einsum(tmp15, (0, 1), t1, (0, 2), (2, 1))
-    tmp12 = tmp11.copy() * -0.5
-    tmp12 += tmp11.transpose((1, 0, 2))
-    tmp0 = r2.copy() * -0.5
-    tmp0 += r2.transpose((1, 0, 2))
-    tmp2 = r2.copy() * 2
-    tmp2 += r2.transpose((1, 0, 2)) * -1
-    tmp5 = ints.tmp104.copy() * 2
+    tmp12 = np.copy(tmp11) * -0.5
+    tmp12 += np.transpose(tmp11, (1, 0, 2))
+    tmp0 = np.copy(r2) * -0.5
+    tmp0 += np.transpose(r2, (1, 0, 2))
+    tmp2 = np.copy(r2) * 2
+    tmp2 += np.transpose(r2, (1, 0, 2)) * -1
+    tmp5 = np.copy(ints.tmp104) * 2
     tmp5 += ints.tmp19
     tmp5 += ints.tmp1
     tmp5 += ints.tmp29 * 2
@@ -2272,25 +2272,25 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp5 += ints.tmp78 * -1
     tmp5 += ints.tmp87 * -1
     tmp5 += ints.tmp94 * -2
-    tmp3 = ints.tmp33.transpose((0, 2, 1, 3)).copy()
+    tmp3 = np.copy(np.transpose(ints.tmp33, (0, 2, 1, 3)))
     tmp3 += ints.tmp35
-    tmp3 += ints.tmp57.transpose((0, 2, 1, 3))
-    tmp3 += ints.tmp72.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(ints.tmp57, (0, 2, 1, 3))
+    tmp3 += np.transpose(ints.tmp72, (0, 2, 1, 3))
     tmp3 += ints.tmp92
     tmp3 += ints.tmp21 * -1
     tmp3 += ints.tmp36 * -2
-    tmp3 += ints.tmp60.transpose((0, 2, 1, 3)) * -2
-    tmp3 += ints.tmp6.transpose((1, 0, 2, 3)) * -1
-    tmp6 = f.oo.copy()
-    tmp6 += ints.tmp0.transpose((1, 0))
-    tmp6 += ints.tmp13.transpose((1, 0)) * 2
+    tmp3 += np.transpose(ints.tmp60, (0, 2, 1, 3)) * -2
+    tmp3 += np.transpose(ints.tmp6, (1, 0, 2, 3)) * -1
+    tmp6 = np.copy(f.oo)
+    tmp6 += np.transpose(ints.tmp0, (1, 0))
+    tmp6 += np.transpose(ints.tmp13, (1, 0)) * 2
     tmp6 += ints.tmp24 * 2
     tmp6 += ints.tmp86 * 2
     tmp6 += ints.tmp12 * -1
     tmp6 += ints.tmp22 * -1
     tmp6 += ints.tmp85 * -1
-    tmp1 = ints.tmp108.copy()
-    tmp1 += ints.tmp14.transpose((1, 2, 0, 3))
+    tmp1 = np.copy(ints.tmp108)
+    tmp1 += np.transpose(ints.tmp14, (1, 2, 0, 3))
     tmp1 += ints.tmp32
     tmp1 += ints.tmp69
     tmp1 += ints.tmp73
@@ -2300,8 +2300,8 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp1 += ints.tmp20 * -1
     tmp1 += ints.tmp44 * -1
     tmp1 += ints.tmp70 * -2
-    tmp4 = v.ooov.copy() * -0.5
-    tmp4 += v.ovoo.transpose((0, 2, 3, 1))
+    tmp4 = np.copy(v.ooov) * -0.5
+    tmp4 += np.transpose(v.ovoo, (0, 2, 3, 1))
     r2new = einsum(r2, (0, 1, 2), ints.tmp90, (1, 0, 3, 4), (3, 4, 2))
     r2new += einsum(tmp8, (0, 1, 2, 3), tmp7, (0, 4, 2), (1, 4, 3)) * 2
     del tmp8, tmp7
@@ -2491,33 +2491,33 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     """
 
     ints = kwargs["ints"]
-    tmp19 = f.ov.copy()
+    tmp19 = np.copy(f.ov)
     tmp19 += ints.tmp17 * 2
     tmp19 += ints.tmp55 * -1
-    tmp16 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp16 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp16 += t2 * 2
-    tmp22 = ints.tmp69.copy()
-    tmp22 += v.ooov.transpose((0, 2, 1, 3))
+    tmp22 = np.copy(ints.tmp69)
+    tmp22 += np.transpose(v.ooov, (0, 2, 1, 3))
     tmp10 = einsum(t1, (0, 1), r2, (2, 1, 3), (3, 0, 2))
     tmp26 = einsum(t1, (0, 1), tmp19, (0, 2), (1, 2))
     tmp17 = einsum(tmp16, (0, 1, 2, 3), r2, (2, 3, 0), (1,)) * 0.5
     del tmp16
     tmp15 = einsum(t1, (0, 1), r1, (1,), (0,))
     tmp24 = einsum(tmp22, (0, 1, 2, 3), t1, (1, 4), (0, 2, 4, 3))
-    tmp2 = r2.transpose((2, 0, 1)).copy()
-    tmp2 += r2.transpose((2, 1, 0)) * -0.5
-    tmp5 = r2.transpose((2, 0, 1)).copy() * -0.5
-    tmp5 += r2.transpose((2, 1, 0))
+    tmp2 = np.copy(np.transpose(r2, (2, 0, 1)))
+    tmp2 += np.transpose(r2, (2, 1, 0)) * -0.5
+    tmp5 = np.copy(np.transpose(r2, (2, 0, 1))) * -0.5
+    tmp5 += np.transpose(r2, (2, 1, 0))
     tmp11 = einsum(t1, (0, 1), tmp10, (2, 3, 1), (2, 0, 3))
-    tmp28 = f.oo.copy()
-    tmp28 += ints.tmp10.transpose((1, 0))
+    tmp28 = np.copy(f.oo)
+    tmp28 += np.transpose(ints.tmp10, (1, 0))
     tmp28 += ints.tmp112 * 2
     tmp28 += ints.tmp79 * 2
     tmp28 += ints.tmp97 * 2
     tmp28 += ints.tmp110 * -1
     tmp28 += ints.tmp83 * -1
     tmp28 += ints.tmp95 * -1
-    tmp27 = ints.tmp16.transpose((1, 0)).copy()
+    tmp27 = np.copy(np.transpose(ints.tmp16, (1, 0)))
     tmp27 += ints.tmp29 * 2
     tmp27 += f.vv * -1
     tmp27 += ints.tmp14 * -2
@@ -2525,43 +2525,43 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp27 += tmp26
     del tmp26
     tmp20 = einsum(t2, (0, 1, 2, 3), r2, (2, 3, 4), (4, 0, 1))
-    tmp18 = tmp15.copy() * 0.5
+    tmp18 = np.copy(tmp15) * 0.5
     del tmp15
     tmp18 += tmp17 * -1
     del tmp17
     tmp21 = einsum(r2, (0, 1, 2), t1, (3, 0), (2, 3, 1))
-    tmp23 = ints.tmp87.transpose((0, 1, 3, 2)).copy()
-    tmp23 += ints.tmp92.transpose((0, 1, 3, 2))
+    tmp23 = np.copy(np.transpose(ints.tmp87, (0, 1, 3, 2)))
+    tmp23 += np.transpose(ints.tmp92, (0, 1, 3, 2))
     tmp23 += ints.tmp109 * -1
-    tmp23 += ints.tmp88.transpose((0, 1, 3, 2)) * -2
-    tmp23 += v.ovov.transpose((0, 2, 3, 1)) * -1
+    tmp23 += np.transpose(ints.tmp88, (0, 1, 3, 2)) * -2
+    tmp23 += np.transpose(v.ovov, (0, 2, 3, 1)) * -1
     tmp23 += einsum(tmp22, (0, 1, 2, 3), t1, (2, 4), (0, 1, 3, 4))
     del tmp22
-    tmp25 = ints.tmp90.transpose((0, 1, 3, 2)).copy()
+    tmp25 = np.copy(np.transpose(ints.tmp90, (0, 1, 3, 2)))
     tmp25 += ints.tmp107 * -1
     tmp25 += v.oovv * -1
-    tmp25 += tmp24.transpose((0, 1, 3, 2))
+    tmp25 += np.transpose(tmp24, (0, 1, 3, 2))
     del tmp24
-    tmp0 = ints.tmp24.copy()
-    tmp0 += ints.tmp46.transpose((0, 2, 1, 3)) * 2
-    tmp0 += ints.tmp53.transpose((0, 2, 1, 3)) * 2
-    tmp0 += ints.tmp76.transpose((0, 3, 1, 2))
-    tmp0 += ints.tmp37.transpose((0, 3, 1, 2)) * -2
-    tmp0 += ints.tmp48.transpose((0, 2, 1, 3)) * -4
-    tmp0 += ints.tmp51.transpose((0, 2, 1, 3)) * -1
-    tmp0 += v.ovvv.transpose((0, 2, 1, 3)) * -2
-    tmp0 += v.ovvv.transpose((0, 2, 3, 1))
-    tmp14 = f.vv.copy()
-    tmp14 += ints.tmp14.transpose((1, 0)) * 2
+    tmp0 = np.copy(ints.tmp24)
+    tmp0 += np.transpose(ints.tmp46, (0, 2, 1, 3)) * 2
+    tmp0 += np.transpose(ints.tmp53, (0, 2, 1, 3)) * 2
+    tmp0 += np.transpose(ints.tmp76, (0, 3, 1, 2))
+    tmp0 += np.transpose(ints.tmp37, (0, 3, 1, 2)) * -2
+    tmp0 += np.transpose(ints.tmp48, (0, 2, 1, 3)) * -4
+    tmp0 += np.transpose(ints.tmp51, (0, 2, 1, 3)) * -1
+    tmp0 += np.transpose(v.ovvv, (0, 2, 1, 3)) * -2
+    tmp0 += np.transpose(v.ovvv, (0, 2, 3, 1))
+    tmp14 = np.copy(f.vv)
+    tmp14 += np.transpose(ints.tmp14, (1, 0)) * 2
     tmp14 += ints.tmp27
-    tmp14 += ints.tmp16.transpose((1, 0)) * -1
+    tmp14 += np.transpose(ints.tmp16, (1, 0)) * -1
     tmp14 += ints.tmp29 * -2
-    tmp7 = ints.tmp109.copy()
-    tmp7 += ints.tmp88.transpose((0, 1, 3, 2)) * 2
-    tmp7 += v.ovov.transpose((0, 2, 3, 1))
-    tmp7 += ints.tmp87.transpose((0, 1, 3, 2)) * -1
-    tmp7 += ints.tmp92.transpose((0, 1, 3, 2)) * -1
-    tmp8 = ints.tmp106.copy()
+    tmp7 = np.copy(ints.tmp109)
+    tmp7 += np.transpose(ints.tmp88, (0, 1, 3, 2)) * 2
+    tmp7 += np.transpose(v.ovov, (0, 2, 3, 1))
+    tmp7 += np.transpose(ints.tmp87, (0, 1, 3, 2)) * -1
+    tmp7 += np.transpose(ints.tmp92, (0, 1, 3, 2)) * -1
+    tmp8 = np.copy(ints.tmp106)
     tmp8 += ints.tmp113 * 2
     tmp8 += ints.tmp11
     tmp8 += ints.tmp19
@@ -2587,25 +2587,25 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp8 += ints.tmp73 * -1
     tmp8 += ints.tmp84 * -1
     tmp8 += ints.tmp96 * -1
-    tmp9 = r2.transpose((2, 0, 1)).copy() * 2
-    tmp9 += r2.transpose((2, 1, 0)) * -1
+    tmp9 = np.copy(np.transpose(r2, (2, 0, 1))) * 2
+    tmp9 += np.transpose(r2, (2, 1, 0)) * -1
     tmp3 = einsum(tmp2, (0, 1, 2), t1, (3, 1), (0, 3, 2))
     tmp6 = einsum(t1, (0, 1), tmp5, (2, 1, 3), (2, 0, 3)) * 2
     del tmp5
-    tmp13 = tmp11.copy() * 2
-    tmp13 += tmp11.transpose((0, 2, 1)) * -1
-    tmp1 = ints.tmp24.copy()
-    tmp1 += ints.tmp46.transpose((0, 2, 1, 3)) * 0.5
-    tmp1 += ints.tmp53.transpose((0, 2, 1, 3)) * 0.5
-    tmp1 += ints.tmp76.transpose((0, 3, 1, 2))
-    tmp1 += ints.tmp37.transpose((0, 3, 1, 2)) * -0.5
-    tmp1 += ints.tmp48.transpose((0, 2, 1, 3)) * -1
-    tmp1 += ints.tmp51.transpose((0, 2, 1, 3)) * -1
-    tmp4 = ints.tmp107.copy()
+    tmp13 = np.copy(tmp11) * 2
+    tmp13 += np.transpose(tmp11, (0, 2, 1)) * -1
+    tmp1 = np.copy(ints.tmp24)
+    tmp1 += np.transpose(ints.tmp46, (0, 2, 1, 3)) * 0.5
+    tmp1 += np.transpose(ints.tmp53, (0, 2, 1, 3)) * 0.5
+    tmp1 += np.transpose(ints.tmp76, (0, 3, 1, 2))
+    tmp1 += np.transpose(ints.tmp37, (0, 3, 1, 2)) * -0.5
+    tmp1 += np.transpose(ints.tmp48, (0, 2, 1, 3)) * -1
+    tmp1 += np.transpose(ints.tmp51, (0, 2, 1, 3)) * -1
+    tmp4 = np.copy(ints.tmp107)
     tmp4 += v.oovv
-    tmp4 += ints.tmp90.transpose((0, 1, 3, 2)) * -1
-    tmp12 = tmp11.copy() * -0.5
-    tmp12 += tmp11.transpose((0, 2, 1))
+    tmp4 += np.transpose(ints.tmp90, (0, 1, 3, 2)) * -1
+    tmp12 = np.copy(tmp11) * -0.5
+    tmp12 += np.transpose(tmp11, (0, 2, 1))
     r2new = einsum(v.ovov, (0, 1, 2, 3), tmp20, (4, 2, 0), (3, 1, 4))
     del tmp20
     r2new += einsum(tmp11, (0, 1, 2), v.ovov, (1, 3, 2, 4), (3, 4, 0))

--- a/ebcc/codegen/RCCSD.py
+++ b/ebcc/codegen/RCCSD.py
@@ -1403,7 +1403,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.vvoo += l2.transpose((0, 1, 3, 2)) * -1
     rdm2.vvoo += l2
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.swapaxes(1, 2)
+    rdm2 = rdm2.transpose(0, 2, 1, 3)
 
     return rdm2
 

--- a/ebcc/codegen/RCCSDT.py
+++ b/ebcc/codegen/RCCSDT.py
@@ -6757,7 +6757,7 @@ def make_rdm2_f(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, t3=None,
 
     rdm2_f = pack_2e(rdm2_f_oooo, rdm2_f_ooov, rdm2_f_oovo, rdm2_f_ovoo, rdm2_f_vooo, rdm2_f_oovv, rdm2_f_ovov, rdm2_f_ovvo, rdm2_f_voov, rdm2_f_vovo, rdm2_f_vvoo, rdm2_f_ovvv, rdm2_f_vovv, rdm2_f_vvov, rdm2_f_vvvo, rdm2_f_vvvv)
 
-    rdm2_f = rdm2_f.transpose(0, 2, 1, 3)
+    rdm2_f = np.transpose(rdm2_f, (0, 2, 1, 3))
 
     return rdm2_f
 

--- a/ebcc/codegen/RCCSDT.py
+++ b/ebcc/codegen/RCCSDT.py
@@ -6757,7 +6757,7 @@ def make_rdm2_f(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, t3=None,
 
     rdm2_f = pack_2e(rdm2_f_oooo, rdm2_f_ooov, rdm2_f_oovo, rdm2_f_ovoo, rdm2_f_vooo, rdm2_f_oovv, rdm2_f_ovov, rdm2_f_ovvo, rdm2_f_voov, rdm2_f_vovo, rdm2_f_vvoo, rdm2_f_ovvv, rdm2_f_vovv, rdm2_f_vvov, rdm2_f_vvvo, rdm2_f_vvvv)
 
-    rdm2_f = rdm2_f.swapaxes(1, 2)
+    rdm2_f = rdm2_f.transpose(0, 2, 1, 3)
 
     return rdm2_f
 

--- a/ebcc/codegen/RCCSD_SD_1_1.py
+++ b/ebcc/codegen/RCCSD_SD_1_1.py
@@ -29,10 +29,10 @@ def energy(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=No
 def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # T1, T2, S1, S2 and U11 amplitudes
@@ -501,10 +501,10 @@ def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # L1, L2, LS1 , LS2 and LU11 amplitudes
@@ -1351,10 +1351,10 @@ def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)
@@ -1424,10 +1424,10 @@ def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)
@@ -1946,10 +1946,10 @@ def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # Single boson DM
@@ -1967,10 +1967,10 @@ def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None,
 def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # Boson 1RDM
@@ -1984,10 +1984,10 @@ def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_eb_coup_rdm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)

--- a/ebcc/codegen/RCCSD_SD_1_2.py
+++ b/ebcc/codegen/RCCSD_SD_1_2.py
@@ -29,10 +29,10 @@ def energy(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=No
 def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, u12=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # T1, T2, S1, S2, U11 and U12 amplitudes
@@ -633,10 +633,10 @@ def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, u12=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, lu12=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # L1, L2, LS1, LS2, LU11 and LU12 amplitudes
@@ -1706,10 +1706,10 @@ def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, u12=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, lu12=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)
@@ -1791,10 +1791,10 @@ def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, u12=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, lu12=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)
@@ -2440,10 +2440,10 @@ def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, u12=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, lu12=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # Single boson DM
@@ -2462,10 +2462,10 @@ def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None,
 def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, u12=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, lu12=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # Boson 1RDM
@@ -2480,10 +2480,10 @@ def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_eb_coup_rdm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, s2=None, u11=None, u12=None, l1=None, l2=None, ls1=None, ls2=None, lu11=None, lu12=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)

--- a/ebcc/codegen/RCCSD_S_1_1.py
+++ b/ebcc/codegen/RCCSD_S_1_1.py
@@ -33,10 +33,10 @@ def energy(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=No
 def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, u11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # T1, T2, S1 and U11 amplitudes
@@ -481,10 +481,10 @@ def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, u11=None, l1=None, l2=None, ls1=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # L1, L2, LS1 and LU11 amplitudes
@@ -1300,10 +1300,10 @@ def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, u11=None, l1=None, l2=None, ls1=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)
@@ -1373,10 +1373,10 @@ def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, u11=None, l1=None, l2=None, ls1=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)
@@ -1890,10 +1890,10 @@ def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, u11=None, l1=None, l2=None, ls1=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # Single boson DM
@@ -1910,10 +1910,10 @@ def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None,
 def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, u11=None, l1=None, l2=None, ls1=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     # Boson 1RDM
@@ -1926,10 +1926,10 @@ def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
 def make_eb_coup_rdm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nbos=None, t1=None, t2=None, s1=None, u11=None, l1=None, l2=None, ls1=None, lu11=None, **kwargs):
     # Get boson coupling creation array:
     gc = Namespace(
-        boo=g.boo.transpose(0, 2, 1),
-        bov=g.bvo.transpose(0, 2, 1),
-        bvo=g.bov.transpose(0, 2, 1),
-        bvv=g.bvv.transpose(0, 2, 1),
+        boo=np.transpose(g.boo, (0, 2, 1)),
+        bov=np.transpose(g.bvo, (0, 2, 1)),
+        bvo=np.transpose(g.bov, (0, 2, 1)),
+        bvv=np.transpose(g.bvv, (0, 2, 1)),
     )
 
     delta_oo = np.eye(nocc)

--- a/ebcc/codegen/RCCSDtp.py
+++ b/ebcc/codegen/RCCSDtp.py
@@ -25,8 +25,8 @@ def update_amps(f=None, v=None, space=None, t1=None, t2=None, t3=None, **kwargs)
     nvir = space.ncvir
     naocc = space.naocc
     navir = space.navir
-    so = np.ones((nocc,), dtype=bool)
-    sv = np.ones((nvir,), dtype=bool)
+    so = np.ones((nocc,), dtype=np.bool_)
+    sv = np.ones((nvir,), dtype=np.bool_)
     sO = space.active[space.correlated][space.occupied[space.correlated]]
     sV = space.active[space.correlated][space.virtual[space.correlated]]
 

--- a/ebcc/codegen/RDCD.py
+++ b/ebcc/codegen/RDCD.py
@@ -57,12 +57,12 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
         Updated T2 residuals.
     """
 
-    tmp9 = v.ovov.transpose((0, 2, 3, 1)).copy() * -0.5
-    tmp9 += v.ovov.transpose((0, 2, 1, 3))
-    tmp6 = v.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp6 += v.ovov.transpose((0, 2, 1, 3)) * -0.5
+    tmp9 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -0.5
+    tmp9 += np.transpose(v.ovov, (0, 2, 1, 3))
+    tmp6 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1)))
+    tmp6 += np.transpose(v.ovov, (0, 2, 1, 3)) * -0.5
     tmp0 = einsum(t2, (0, 1, 2, 3), v.ovov, (4, 5, 1, 2), (0, 4, 3, 5))
-    t2new = tmp0.transpose((1, 0, 3, 2)).copy() * -1
+    t2new = np.copy(np.transpose(tmp0, (1, 0, 3, 2))) * -1
     tmp10 = einsum(t2, (0, 1, 2, 3), tmp9, (1, 4, 3, 2), (0, 4)) * 2
     del tmp9
     tmp7 = einsum(t2, (0, 1, 2, 3), tmp6, (0, 1, 3, 4), (2, 4))
@@ -75,33 +75,33 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp8 = einsum(tmp7, (0, 1), t2, (2, 3, 1, 4), (2, 3, 4, 0))
     del tmp7
     tmp1 = einsum(t2, (0, 1, 2, 3), v.ovov, (4, 5, 1, 3), (0, 4, 2, 5))
-    t2new += tmp1.transpose((1, 0, 3, 2)) * 2
-    tmp14 = v.ovov.transpose((0, 2, 1, 3)).copy() * -1
+    t2new += np.transpose(tmp1, (1, 0, 3, 2)) * 2
+    tmp14 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * -1
     tmp14 += tmp0
     del tmp0
     t2new += einsum(t2, (0, 1, 2, 3), tmp14, (4, 1, 5, 2), (0, 4, 3, 5))
     del tmp14
-    tmp4 = tmp2.copy()
+    tmp4 = np.copy(tmp2)
     del tmp2
     tmp4 += tmp3 * -1
     del tmp3
-    t2new += tmp4.transpose((1, 0, 2, 3))
-    t2new += tmp4.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp4, (1, 0, 2, 3))
+    t2new += np.transpose(tmp4, (0, 1, 3, 2))
     del tmp4
-    tmp12 = tmp5.copy() * 2
+    tmp12 = np.copy(tmp5) * 2
     del tmp5
-    tmp12 += tmp8.transpose((1, 0, 2, 3))
+    tmp12 += np.transpose(tmp8, (1, 0, 2, 3))
     del tmp8
-    tmp12 += tmp11.transpose((0, 1, 3, 2))
+    tmp12 += np.transpose(tmp11, (0, 1, 3, 2))
     del tmp11
-    t2new += tmp12.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp12, (1, 0, 3, 2)) * -1
     t2new += tmp12 * -1
     del tmp12
     tmp13 = einsum(t2, (0, 1, 2, 3), f.oo, (4, 1), (4, 0, 2, 3))
-    t2new += tmp13.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp13.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp13, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp13, (0, 1, 3, 2)) * -1
     del tmp13
-    tmp15 = v.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp15 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 2
     tmp15 += v.oovv * -1
     tmp15 += tmp1 * 4
     del tmp1
@@ -109,7 +109,7 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     del tmp15
     t2new += einsum(v.oooo, (0, 1, 2, 3), t2, (3, 1, 4, 5), (0, 2, 5, 4))
     t2new += einsum(v.vvvv, (0, 1, 2, 3), t2, (4, 5, 1, 3), (4, 5, 0, 2))
-    t2new += v.ovov.transpose((0, 2, 1, 3))
+    t2new += np.transpose(v.ovov, (0, 2, 1, 3))
     t2new += einsum(t2, (0, 1, 2, 3), v.oovv, (4, 1, 5, 3), (4, 0, 5, 2)) * -1
 
     return {f"t2new": t2new}

--- a/ebcc/codegen/RDCSD.py
+++ b/ebcc/codegen/RDCSD.py
@@ -37,9 +37,9 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp0 = v.ovov.transpose((0, 2, 3, 1)).copy() * -0.5
-    tmp0 += v.ovov.transpose((0, 2, 1, 3))
-    tmp1 = f.ov.copy()
+    tmp0 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -0.5
+    tmp0 += np.transpose(v.ovov, (0, 2, 1, 3))
+    tmp1 = np.copy(f.ov)
     tmp1 += einsum(t1, (0, 1), tmp0, (0, 2, 1, 3), (2, 3))
     del tmp0
     e_cc = einsum(t1, (0, 1), tmp1, (0, 1), ()) * 2
@@ -73,19 +73,19 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     """
 
     tmp1 = einsum(v.ovov, (0, 1, 2, 3), t1, (4, 3), (4, 0, 2, 1))
-    tmp3 = v.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp3 += v.ovov.transpose((0, 2, 1, 3)) * 2
-    tmp30 = tmp1.copy() * -1
-    tmp30 += tmp1.transpose((0, 2, 1, 3)) * 2
+    tmp3 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -1
+    tmp3 += np.transpose(v.ovov, (0, 2, 1, 3)) * 2
+    tmp30 = np.copy(tmp1) * -1
+    tmp30 += np.transpose(tmp1, (0, 2, 1, 3)) * 2
     tmp4 = einsum(tmp3, (0, 1, 2, 3), t1, (0, 2), (1, 3))
     del tmp3
     tmp48 = einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
-    tmp48 += t2.transpose((0, 1, 3, 2)) * -2
+    tmp48 += np.transpose(t2, (0, 1, 3, 2)) * -2
     tmp48 += t2
-    tmp34 = v.ooov.copy() * 2
-    tmp34 += v.ooov.transpose((0, 2, 1, 3)) * -1
-    tmp25 = v.ovvv.copy() * -1
-    tmp25 += v.ovvv.transpose((0, 2, 1, 3)) * 2
+    tmp34 = np.copy(v.ooov) * 2
+    tmp34 += np.transpose(v.ooov, (0, 2, 1, 3)) * -1
+    tmp25 = np.copy(v.ovvv) * -1
+    tmp25 += np.transpose(v.ovvv, (0, 2, 1, 3)) * 2
     tmp31 = einsum(tmp30, (0, 1, 2, 3), t2, (4, 2, 5, 3), (0, 1, 4, 5))
     del tmp30
     tmp29 = einsum(tmp1, (0, 1, 2, 3), t2, (4, 1, 3, 5), (0, 4, 2, 5))
@@ -96,44 +96,44 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp46 = einsum(t2, (0, 1, 2, 3), v.ooov, (4, 1, 5, 3), (0, 4, 5, 2))
     tmp47 = einsum(tmp1, (0, 1, 2, 3), t2, (4, 2, 3, 5), (0, 4, 1, 5))
     tmp45 = einsum(v.oovv, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
-    tmp12 = v.ovov.transpose((0, 2, 3, 1)).copy() * -0.5
-    tmp12 += v.ovov.transpose((0, 2, 1, 3))
+    tmp12 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -0.5
+    tmp12 += np.transpose(v.ovov, (0, 2, 1, 3))
     tmp60 = einsum(t1, (0, 1), f.ov, (2, 1), (2, 0))
     tmp35 = einsum(t1, (0, 1), tmp34, (2, 3, 0, 1), (2, 3))
     del tmp34
     tmp26 = einsum(t1, (0, 1), tmp25, (0, 2, 1, 3), (2, 3))
     del tmp25
-    tmp32 = tmp1.copy() * -1
+    tmp32 = np.copy(tmp1) * -1
     tmp32 += tmp28
     del tmp28
     tmp32 += tmp29
     del tmp29
-    tmp32 += tmp31.transpose((0, 2, 1, 3)) * -1
+    tmp32 += np.transpose(tmp31, (0, 2, 1, 3)) * -1
     del tmp31
-    tmp67 = t2.copy()
+    tmp67 = np.copy(t2)
     tmp67 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     t2new = einsum(tmp67, (0, 1, 2, 3), v.vvvv, (4, 3, 5, 2), (1, 0, 4, 5))
-    tmp51 = tmp45.transpose((0, 2, 1, 3)).copy() * -1
+    tmp51 = np.copy(np.transpose(tmp45, (0, 2, 1, 3))) * -1
     del tmp45
-    tmp51 += tmp46.transpose((0, 2, 1, 3))
+    tmp51 += np.transpose(tmp46, (0, 2, 1, 3))
     del tmp46
-    tmp51 += tmp47.transpose((0, 2, 1, 3))
+    tmp51 += np.transpose(tmp47, (0, 2, 1, 3))
     del tmp47
-    tmp51 += tmp49.transpose((2, 1, 0, 3))
+    tmp51 += np.transpose(tmp49, (2, 1, 0, 3))
     del tmp49
-    tmp51 += tmp50.transpose((2, 0, 1, 3)) * -1
+    tmp51 += np.transpose(tmp50, (2, 0, 1, 3)) * -1
     del tmp50
     tmp53 = einsum(t1, (0, 1), tmp4, (2, 1), (2, 0))
     tmp41 = einsum(v.ovvv, (0, 1, 2, 3), t1, (4, 1), (4, 0, 2, 3))
-    tmp43 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp43 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp43 += t2 * -1
     tmp39 = einsum(t1, (0, 1), v.ovvv, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp15 = einsum(v.ovov, (0, 1, 2, 3), t2, (4, 2, 3, 5), (4, 0, 5, 1))
-    t2new += tmp15.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp15, (1, 0, 3, 2)) * -1
     tmp17 = einsum(t2, (0, 1, 2, 3), v.ovvv, (4, 2, 5, 3), (0, 1, 4, 5))
     tmp22 = einsum(tmp12, (0, 1, 2, 3), t2, (4, 0, 3, 2), (1, 4)) * 2
     tmp20 = einsum(tmp12, (0, 1, 2, 3), t2, (0, 1, 2, 4), (3, 4))
-    tmp61 = f.oo.copy()
+    tmp61 = np.copy(f.oo)
     tmp61 += tmp60
     del tmp60
     tmp58 = einsum(t2, (0, 1, 2, 3), f.ov, (4, 3), (4, 0, 1, 2))
@@ -144,8 +144,8 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp33 = einsum(t1, (0, 1), tmp32, (2, 3, 0, 4), (2, 3, 4, 1))
     del tmp32
     tmp16 = einsum(v.ovov, (0, 1, 2, 3), t2, (4, 2, 5, 3), (4, 0, 5, 1))
-    t2new += tmp16.transpose((1, 0, 3, 2)) * 2
-    tmp68 = v.oooo.copy()
+    t2new += np.transpose(tmp16, (1, 0, 3, 2)) * 2
+    tmp68 = np.copy(v.oooo)
     tmp68 += einsum(tmp67, (0, 1, 2, 3), v.ovov, (4, 3, 5, 2), (4, 1, 0, 5))
     del tmp67
     tmp64 = einsum(t1, (0, 1), v.ooov, (2, 3, 4, 1), (0, 2, 3, 4))
@@ -165,56 +165,56 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp22
     tmp21 = einsum(tmp20, (0, 1), t2, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp20
-    tmp56 = t2.copy()
+    tmp56 = np.copy(t2)
     tmp56 += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     tmp62 = einsum(t2, (0, 1, 2, 3), tmp61, (1, 4), (4, 0, 3, 2))
     del tmp61
     tmp59 = einsum(tmp58, (0, 1, 2, 3), t1, (0, 4), (1, 2, 4, 3))
     del tmp58
-    tmp8 = v.ovvv.copy() * -0.5
-    tmp8 += v.ovvv.transpose((0, 2, 1, 3))
-    tmp13 = f.ov.copy() * 0.5
+    tmp8 = np.copy(v.ovvv) * -0.5
+    tmp8 += np.transpose(v.ovvv, (0, 2, 1, 3))
+    tmp13 = np.copy(f.ov) * 0.5
     tmp13 += einsum(t1, (0, 1), tmp12, (0, 2, 1, 3), (2, 3))
     del tmp12
-    tmp10 = v.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp10 += v.ovov.transpose((0, 2, 1, 3)) * 2
-    tmp11 = v.ooov.copy()
-    tmp11 += v.ooov.transpose((0, 2, 1, 3)) * -0.5
-    tmp37 = tmp27.transpose((1, 0, 3, 2)).copy()
+    tmp10 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -1
+    tmp10 += np.transpose(v.ovov, (0, 2, 1, 3)) * 2
+    tmp11 = np.copy(v.ooov)
+    tmp11 += np.transpose(v.ooov, (0, 2, 1, 3)) * -0.5
+    tmp37 = np.copy(np.transpose(tmp27, (1, 0, 3, 2)))
     del tmp27
-    tmp37 += tmp33.transpose((0, 1, 3, 2))
+    tmp37 += np.transpose(tmp33, (0, 1, 3, 2))
     del tmp33
-    tmp37 += tmp36.transpose((1, 0, 3, 2)) * -1
+    tmp37 += np.transpose(tmp36, (1, 0, 3, 2)) * -1
     del tmp36
-    t2new += tmp37.transpose((1, 0, 3, 2))
+    t2new += np.transpose(tmp37, (1, 0, 3, 2))
     t2new += tmp37
     del tmp37
-    tmp70 = v.ovov.transpose((0, 2, 1, 3)).copy() * 0.5
+    tmp70 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 0.5
     tmp70 += v.oovv * -0.25
     tmp70 += tmp16
     del tmp16
     t2new += einsum(tmp70, (0, 1, 2, 3), t2, (4, 1, 5, 3), (4, 0, 5, 2)) * 4
     del tmp70
-    tmp69 = v.ooov.transpose((0, 2, 1, 3)).copy() * -1
+    tmp69 = np.copy(np.transpose(v.ooov, (0, 2, 1, 3))) * -1
     tmp69 += einsum(t1, (0, 1), tmp68, (0, 2, 3, 4), (3, 2, 4, 1))
     del tmp68
     t2new += einsum(t1, (0, 1), tmp69, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp69
     tmp65 = einsum(tmp64, (0, 1, 2, 3), t2, (3, 2, 4, 5), (0, 1, 5, 4))
     del tmp64
-    t2new += tmp65.transpose((1, 0, 2, 3))
-    t2new += tmp65.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp65, (1, 0, 2, 3))
+    t2new += np.transpose(tmp65, (0, 1, 3, 2))
     del tmp65
-    tmp71 = v.ovov.transpose((0, 2, 1, 3)).copy() * -1
+    tmp71 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * -1
     tmp71 += tmp15
     del tmp15
     t2new += einsum(t2, (0, 1, 2, 3), tmp71, (4, 1, 5, 2), (0, 4, 3, 5))
     del tmp71
-    tmp66 = v.oooo.copy()
+    tmp66 = np.copy(v.oooo)
     tmp66 += einsum(t1, (0, 1), tmp1, (2, 3, 4, 1), (3, 0, 4, 2))
     t2new += einsum(tmp66, (0, 1, 2, 3), t2, (0, 2, 4, 5), (1, 3, 4, 5))
     del tmp66
-    tmp55 = tmp38.copy()
+    tmp55 = np.copy(tmp38)
     del tmp38
     tmp55 += tmp39
     del tmp39
@@ -222,51 +222,51 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp40
     tmp55 += tmp42 * -1
     del tmp42
-    tmp55 += tmp44.transpose((1, 0, 2, 3))
+    tmp55 += np.transpose(tmp44, (1, 0, 2, 3))
     del tmp44
-    tmp55 += tmp52.transpose((0, 1, 3, 2))
+    tmp55 += np.transpose(tmp52, (0, 1, 3, 2))
     del tmp52
-    tmp55 += tmp54.transpose((0, 1, 3, 2)) * -1
+    tmp55 += np.transpose(tmp54, (0, 1, 3, 2)) * -1
     del tmp54
-    t2new += tmp55.transpose((1, 0, 2, 3))
-    t2new += tmp55.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp55, (1, 0, 2, 3))
+    t2new += np.transpose(tmp55, (0, 1, 3, 2))
     del tmp55
-    tmp24 = tmp18.copy()
+    tmp24 = np.copy(tmp18)
     del tmp18
     tmp24 += tmp19 * 2
     del tmp19
-    tmp24 += tmp21.transpose((1, 0, 3, 2))
+    tmp24 += np.transpose(tmp21, (1, 0, 3, 2))
     del tmp21
-    tmp24 += tmp23.transpose((1, 0, 3, 2))
+    tmp24 += np.transpose(tmp23, (1, 0, 3, 2))
     del tmp23
-    t2new += tmp24.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp24, (1, 0, 3, 2)) * -1
     t2new += tmp24 * -1
     del tmp24
     tmp57 = einsum(tmp41, (0, 1, 2, 3), tmp56, (1, 4, 5, 2), (0, 4, 3, 5))
     del tmp41, tmp56
-    t2new += tmp57.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp57.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp57, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp57, (0, 1, 3, 2)) * -1
     del tmp57
-    tmp63 = tmp59.copy()
+    tmp63 = np.copy(tmp59)
     del tmp59
-    tmp63 += tmp62.transpose((0, 1, 3, 2))
+    tmp63 += np.transpose(tmp62, (0, 1, 3, 2))
     del tmp62
-    t2new += tmp63.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp63.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp63, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp63, (0, 1, 3, 2)) * -1
     del tmp63
-    tmp9 = f.vv.copy()
+    tmp9 = np.copy(f.vv)
     tmp9 += einsum(t1, (0, 1), tmp8, (0, 2, 1, 3), (2, 3)) * 2
     del tmp8
     t1new = einsum(tmp9, (0, 1), t1, (2, 0), (2, 1))
     del tmp9
-    tmp2 = v.ooov.copy() * -0.5
-    tmp2 += v.ooov.transpose((0, 2, 1, 3))
+    tmp2 = np.copy(v.ooov) * -0.5
+    tmp2 += np.transpose(v.ooov, (0, 2, 1, 3))
     tmp2 += tmp1
-    tmp2 += tmp1.transpose((0, 2, 1, 3)) * -0.5
+    tmp2 += np.transpose(tmp1, (0, 2, 1, 3)) * -0.5
     del tmp1
     t1new += einsum(t2, (0, 1, 2, 3), tmp2, (4, 0, 1, 2), (4, 3)) * -2
     del tmp2
-    tmp14 = f.oo.copy()
+    tmp14 = np.copy(f.oo)
     tmp14 += einsum(tmp10, (0, 1, 2, 3), t2, (4, 0, 3, 2), (1, 4))
     del tmp10
     tmp14 += einsum(tmp11, (0, 1, 2, 3), t1, (2, 3), (1, 0)) * 2
@@ -275,23 +275,23 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp13
     t1new += einsum(t1, (0, 1), tmp14, (0, 2), (2, 1)) * -1
     del tmp14
-    tmp6 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp6 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp6 += t2 * 2
-    tmp0 = v.ovvv.copy()
-    tmp0 += v.ovvv.transpose((0, 2, 1, 3)) * -0.5
+    tmp0 = np.copy(v.ovvv)
+    tmp0 += np.transpose(v.ovvv, (0, 2, 1, 3)) * -0.5
     t1new += einsum(tmp0, (0, 1, 2, 3), t2, (4, 0, 2, 1), (4, 3)) * 2
     del tmp0
-    tmp5 = f.ov.copy()
+    tmp5 = np.copy(f.ov)
     tmp5 += tmp4
     del tmp4
     t1new += einsum(tmp6, (0, 1, 2, 3), tmp5, (0, 2), (1, 3))
     del tmp6, tmp5
-    tmp7 = v.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp7 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 2
     tmp7 += v.oovv * -1
     t1new += einsum(t1, (0, 1), tmp7, (0, 2, 1, 3), (2, 3))
     del tmp7
     t1new += f.ov
-    t2new += v.ovov.transpose((0, 2, 1, 3))
+    t2new += np.transpose(v.ovov, (0, 2, 1, 3))
     t2new += einsum(t1, (0, 1), v.ovoo, (2, 3, 4, 0), (2, 4, 3, 1)) * -1
     t2new += einsum(t2, (0, 1, 2, 3), v.oovv, (4, 1, 5, 3), (4, 0, 5, 2)) * -1
 

--- a/ebcc/codegen/RDFCC2.py
+++ b/ebcc/codegen/RDFCC2.py
@@ -1106,7 +1106,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oooo += einsum(tmp7, (0, 1), delta.oo, (2, 3), (1, 2, 0, 3)) * 2
     del delta, tmp7
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.swapaxes(1, 2)
+    rdm2 = rdm2.transpose(0, 2, 1, 3)
 
     return rdm2
 

--- a/ebcc/codegen/RDFCC2.py
+++ b/ebcc/codegen/RDFCC2.py
@@ -37,7 +37,7 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp1 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp1 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp1 += t2 * 2
     tmp0 = einsum(v.xov, (0, 1, 2), t1, (1, 2), (0,))
     tmp3 = einsum(v.xov, (0, 1, 2), t1, (3, 2), (3, 1, 0))
@@ -45,7 +45,7 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp0
     tmp2 += einsum(v.xov, (0, 1, 2), tmp1, (1, 3, 2, 4), (3, 4, 0)) * 0.5
     del tmp1
-    tmp4 = f.ov.copy()
+    tmp4 = np.copy(f.ov)
     tmp4 += einsum(tmp3, (0, 1, 2), v.xov, (2, 0, 3), (1, 3)) * -0.5
     del tmp3
     e_cc = einsum(tmp2, (0, 1, 2), v.xov, (2, 0, 1), ()) * 2
@@ -81,17 +81,17 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp2 = einsum(v.xov, (0, 1, 2), t1, (3, 2), (3, 1, 0))
     tmp6 = einsum(t1, (0, 1), v.xoo, (2, 3, 0), (3, 1, 2))
     tmp26 = einsum(tmp2, (0, 1, 2), v.xoo, (2, 3, 4), (0, 3, 4, 1))
-    tmp21 = v.xoo.transpose((1, 2, 0)).copy()
-    tmp21 += tmp2.transpose((1, 0, 2))
+    tmp21 = np.copy(np.transpose(v.xoo, (1, 2, 0)))
+    tmp21 += np.transpose(tmp2, (1, 0, 2))
     tmp15 = einsum(t1, (0, 1), v.xvv, (2, 3, 1), (0, 3, 2))
-    tmp29 = v.xov.transpose((1, 2, 0)).copy() * -1
+    tmp29 = np.copy(np.transpose(v.xov, (1, 2, 0))) * -1
     tmp29 += tmp6
     tmp27 = einsum(tmp26, (0, 1, 2, 3), t1, (3, 4), (0, 1, 2, 4))
     del tmp26
     tmp16 = einsum(t1, (0, 1), f.ov, (2, 1), (2, 0))
     tmp18 = einsum(t2, (0, 1, 2, 3), f.ov, (4, 3), (4, 0, 1, 2))
     tmp0 = einsum(v.xov, (0, 1, 2), t1, (1, 2), (0,))
-    tmp5 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp5 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp5 += t2 * 2
     tmp9 = einsum(tmp2, (0, 1, 2), v.xov, (2, 0, 3), (1, 3))
     tmp22 = einsum(tmp21, (0, 1, 2), v.xov, (2, 3, 4), (0, 1, 3, 4))
@@ -110,15 +110,15 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp18
     tmp1 = einsum(v.xov, (0, 1, 2), tmp0, (0,), (1, 2))
     tmp7 = einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 0.5
-    tmp7 += t2.transpose((0, 1, 3, 2)) * -1
+    tmp7 += np.transpose(t2, (0, 1, 3, 2)) * -1
     tmp7 += t2 * 0.5
-    tmp12 = tmp6.copy() * -1
+    tmp12 = np.copy(tmp6) * -1
     tmp12 += einsum(t1, (0, 1), tmp0, (2,), (0, 1, 2)) * 2
     tmp12 += einsum(tmp5, (0, 1, 2, 3), v.xov, (4, 0, 2), (1, 3, 4))
-    tmp13 = f.ov.copy()
+    tmp13 = np.copy(f.ov)
     tmp13 += tmp9 * -1
-    tmp3 = v.xoo.transpose((1, 2, 0)).copy()
-    tmp3 += tmp2.transpose((1, 0, 2))
+    tmp3 = np.copy(np.transpose(v.xoo, (1, 2, 0)))
+    tmp3 += np.transpose(tmp2, (1, 0, 2))
     del tmp2
     tmp24 = einsum(t2, (0, 1, 2, 3), f.oo, (4, 1), (4, 0, 2, 3))
     tmp23 = einsum(t1, (0, 1), tmp22, (0, 2, 3, 4), (2, 3, 4, 1))
@@ -127,26 +127,26 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp34
     tmp33 = einsum(t1, (0, 1), tmp32, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp32
-    tmp31 = tmp25.copy()
+    tmp31 = np.copy(tmp25)
     del tmp25
     tmp31 += tmp28
     del tmp28
-    tmp31 += tmp30.transpose((1, 0, 2, 3)) * -1
+    tmp31 += np.transpose(tmp30, (1, 0, 2, 3)) * -1
     del tmp30
-    tmp20 = tmp17.copy()
+    tmp20 = np.copy(tmp17)
     del tmp17
     tmp20 += tmp19
     del tmp19
-    tmp10 = f.ov.copy()
+    tmp10 = np.copy(f.ov)
     tmp10 += tmp1 * 2
     tmp10 += tmp9 * -1
     del tmp9
-    tmp8 = tmp6.copy() * 0.5
+    tmp8 = np.copy(tmp6) * 0.5
     del tmp6
     tmp8 += einsum(t1, (0, 1), tmp0, (2,), (0, 1, 2)) * -1
     tmp8 += einsum(v.xov, (0, 1, 2), tmp7, (1, 3, 4, 2), (3, 4, 0))
     del tmp7
-    tmp14 = f.oo.copy()
+    tmp14 = np.copy(f.oo)
     tmp14 += einsum(v.xoo, (0, 1, 2), tmp0, (0,), (1, 2)) * 2
     del tmp0
     tmp14 += einsum(tmp12, (0, 1, 2), v.xov, (2, 3, 1), (3, 0))
@@ -155,29 +155,29 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp13
     tmp4 = einsum(tmp3, (0, 1, 2), v.xov, (2, 3, 4), (1, 3, 0, 4))
     del tmp3
-    tmp11 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp11 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp11 += t2 * 2
     t2new = einsum(v.xov, (0, 1, 2), v.xov, (0, 3, 4), (3, 1, 4, 2))
     t2new += einsum(tmp15, (0, 1, 2), tmp15, (3, 4, 2), (3, 0, 4, 1))
     del tmp15
-    t2new += tmp20.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp20.transpose((1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp20, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp20, (1, 0, 2, 3)) * -1
     del tmp20
-    t2new += tmp23.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp23.transpose((1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp23, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp23, (1, 0, 2, 3)) * -1
     del tmp23
-    t2new += tmp24.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp24.transpose((1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp24, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp24, (1, 0, 2, 3)) * -1
     del tmp24
-    t2new += tmp31.transpose((0, 1, 3, 2))
-    t2new += tmp31.transpose((1, 0, 2, 3))
+    t2new += np.transpose(tmp31, (0, 1, 3, 2))
+    t2new += np.transpose(tmp31, (1, 0, 2, 3))
     del tmp31
     t2new += tmp33 * -1
-    t2new += tmp33.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp33, (1, 0, 3, 2)) * -1
     del tmp33
     t2new += einsum(tmp35, (0, 1, 2, 3), t1, (2, 4), (0, 1, 4, 3))
     del tmp35
-    t1new = tmp1.copy() * 2
+    t1new = np.copy(tmp1) * 2
     del tmp1
     t1new += f.ov
     t1new += einsum(t1, (0, 1), f.vv, (2, 1), (0, 2))
@@ -226,22 +226,22 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp13 = einsum(v.xov, (0, 1, 2), tmp12, (0,), (1, 2))
     tmp14 = einsum(tmp4, (0, 1, 2), v.xov, (2, 0, 3), (1, 3))
     tmp6 = einsum(v.xov, (0, 1, 2), v.xov, (0, 3, 4), (3, 1, 4, 2))
-    tmp98 = tmp33.copy() * -1
-    tmp98 += tmp33.transpose((1, 0, 2, 3)) * 2
-    tmp94 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp94 += l2.transpose((2, 3, 0, 1)) * 2
-    tmp93 = v.xov.transpose((1, 2, 0)).copy()
+    tmp98 = np.copy(tmp33) * -1
+    tmp98 += np.transpose(tmp33, (1, 0, 2, 3)) * 2
+    tmp94 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp94 += np.transpose(l2, (2, 3, 0, 1)) * 2
+    tmp93 = np.copy(np.transpose(v.xov, (1, 2, 0)))
     tmp93 += tmp0
-    tmp96 = tmp33.copy() * 2
-    tmp96 += tmp33.transpose((1, 0, 2, 3)) * -1
-    tmp102 = tmp13.copy() * 2
+    tmp96 = np.copy(tmp33) * 2
+    tmp96 += np.transpose(tmp33, (1, 0, 2, 3)) * -1
+    tmp102 = np.copy(tmp13) * 2
     tmp102 += tmp14 * -1
-    tmp28 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp28 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp28 += t2 * -0.5
     tmp7 = einsum(tmp6, (0, 1, 2, 3), t2, (4, 5, 3, 2), (4, 5, 1, 0))
     tmp8 = einsum(tmp4, (0, 1, 2), tmp4, (3, 4, 2), (3, 0, 4, 1))
-    tmp79 = v.xoo.transpose((1, 2, 0)).copy()
-    tmp79 += tmp4.transpose((1, 0, 2))
+    tmp79 = np.copy(np.transpose(v.xoo, (1, 2, 0)))
+    tmp79 += np.transpose(tmp4, (1, 0, 2))
     tmp50 = einsum(l1, (0, 1), t1, (2, 0), (1, 2))
     tmp99 = einsum(tmp4, (0, 1, 2), tmp98, (0, 3, 1, 4), (3, 4, 2))
     del tmp98
@@ -252,10 +252,10 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp62 = einsum(tmp4, (0, 1, 2), v.xoo, (2, 3, 0), (3, 1))
     tmp103 = einsum(tmp102, (0, 1), t1, (2, 1), (2, 0))
     tmp51 = einsum(tmp28, (0, 1, 2, 3), l2, (3, 2, 0, 4), (4, 1))
-    tmp20 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp20 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp20 += t2 * 2
     tmp2 = einsum(v.xov, (0, 1, 2), v.xvv, (0, 3, 4), (1, 3, 4, 2))
-    tmp9 = tmp7.copy()
+    tmp9 = np.copy(tmp7)
     del tmp7
     tmp9 += tmp8
     tmp56 = einsum(tmp28, (0, 1, 2, 3), l2, (3, 2, 0, 4), (4, 1)) * 2
@@ -267,42 +267,42 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp77 = einsum(tmp4, (0, 1, 2), v.xov, (2, 3, 4), (0, 3, 1, 4))
     tmp72 = einsum(l1, (0, 1), v.xvv, (2, 3, 0), (1, 3, 2))
     tmp109 = einsum(v.xov, (0, 1, 2), tmp50, (3, 1), (3, 2, 0))
-    tmp100 = tmp95.copy()
+    tmp100 = np.copy(tmp95)
     del tmp95
     tmp100 += tmp97 * -1
     del tmp97
     tmp100 += tmp99 * -1
     del tmp99
-    tmp104 = tmp62.copy()
+    tmp104 = np.copy(tmp62)
     tmp104 += tmp103 * -1
     del tmp103
     tmp65 = einsum(v.xvv, (0, 1, 2), tmp12, (0,), (1, 2))
     tmp84 = einsum(v.xov, (0, 1, 2), tmp0, (1, 3, 0), (2, 3))
     tmp47 = einsum(t1, (0, 1), tmp33, (2, 3, 4, 1), (3, 2, 4, 0))
     tmp45 = einsum(t2, (0, 1, 2, 3), l2, (2, 3, 4, 5), (4, 5, 0, 1))
-    tmp19 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp19 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp19 += t2
-    tmp52 = tmp50.copy() * 0.5
+    tmp52 = np.copy(tmp50) * 0.5
     tmp52 += tmp51
     del tmp51
-    tmp39 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp39 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp39 += t2 * -1
     tmp21 = einsum(tmp20, (0, 1, 2, 3), v.xov, (4, 0, 2), (1, 3, 4))
-    tmp42 = tmp33.copy() * -1
-    tmp42 += tmp33.transpose((1, 0, 2, 3)) * 2
-    tmp43 = tmp33.copy()
-    tmp43 += tmp33.transpose((1, 0, 2, 3)) * -0.5
+    tmp42 = np.copy(tmp33) * -1
+    tmp42 += np.transpose(tmp33, (1, 0, 2, 3)) * 2
+    tmp43 = np.copy(tmp33)
+    tmp43 += np.transpose(tmp33, (1, 0, 2, 3)) * -0.5
     tmp41 = einsum(l1, (0, 1), t2, (2, 3, 4, 0), (1, 2, 3, 4))
     tmp23 = einsum(v.xoo, (0, 1, 2), v.xoo, (0, 3, 4), (1, 3, 4, 2))
-    tmp17 = v.xoo.transpose((1, 2, 0)).copy()
-    tmp17 += tmp4.transpose((1, 0, 2))
+    tmp17 = np.copy(np.transpose(v.xoo, (1, 2, 0)))
+    tmp17 += np.transpose(tmp4, (1, 0, 2))
     tmp5 = einsum(tmp4, (0, 1, 2), tmp0, (3, 4, 2), (0, 3, 1, 4))
     tmp3 = einsum(tmp2, (0, 1, 2, 3), t2, (4, 5, 3, 2), (4, 5, 0, 1))
     tmp10 = einsum(t1, (0, 1), tmp9, (2, 3, 4, 0), (2, 3, 4, 1)) * 2
     del tmp9
-    tmp15 = tmp13.copy() * 2
+    tmp15 = np.copy(tmp13) * 2
     tmp15 += tmp14 * -1
-    tmp57 = tmp50.copy()
+    tmp57 = np.copy(tmp50)
     del tmp50
     tmp57 += tmp56
     del tmp56
@@ -338,51 +338,51 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp84
     tmp83 = einsum(tmp75, (0, 1, 2, 3), l1, (4, 1), (0, 2, 4, 3))
     del tmp75
-    tmp63 = f.ov.copy()
+    tmp63 = np.copy(f.ov)
     tmp63 += tmp13 * 2
     tmp63 += tmp14 * -1
-    tmp48 = tmp47.copy() * -1
-    tmp48 += tmp47.transpose((0, 1, 3, 2)) * 2
-    tmp46 = tmp45.transpose((1, 0, 2, 3)).copy()
-    tmp46 += tmp45.transpose((1, 0, 3, 2)) * -0.5
+    tmp48 = np.copy(tmp47) * -1
+    tmp48 += np.transpose(tmp47, (0, 1, 3, 2)) * 2
+    tmp46 = np.copy(np.transpose(tmp45, (1, 0, 2, 3)))
+    tmp46 += np.transpose(tmp45, (1, 0, 3, 2)) * -0.5
     del tmp45
-    tmp53 = t1.copy() * -0.5
+    tmp53 = np.copy(t1) * -0.5
     tmp53 += einsum(tmp19, (0, 1, 2, 3), tmp33, (0, 1, 4, 2), (4, 3))
     tmp53 += einsum(tmp20, (0, 1, 2, 3), l1, (2, 0), (1, 3)) * -0.5
     tmp53 += einsum(tmp52, (0, 1), t1, (0, 2), (1, 2))
-    tmp35 = tmp33.copy() * -0.5
-    tmp35 += tmp33.transpose((1, 0, 2, 3))
-    tmp49 = tmp47.copy() * -0.5
-    tmp49 += tmp47.transpose((0, 1, 3, 2))
+    tmp35 = np.copy(tmp33) * -0.5
+    tmp35 += np.transpose(tmp33, (1, 0, 2, 3))
+    tmp49 = np.copy(tmp47) * -0.5
+    tmp49 += np.transpose(tmp47, (0, 1, 3, 2))
     tmp40 = einsum(tmp39, (0, 1, 2, 3), l2, (4, 2, 0, 5), (5, 1, 4, 3))
     del tmp39
     tmp40 += einsum(l2, (0, 1, 2, 3), tmp19, (3, 4, 1, 5), (2, 4, 0, 5)) * 2
-    tmp31 = v.xov.transpose((1, 2, 0)).copy()
+    tmp31 = np.copy(np.transpose(v.xov, (1, 2, 0)))
     tmp31 += tmp0
     tmp31 += tmp21
-    tmp44 = tmp41.copy() * -1
-    tmp44 += tmp41.transpose((0, 2, 1, 3)) * 0.5
+    tmp44 = np.copy(tmp41) * -1
+    tmp44 += np.transpose(tmp41, (0, 2, 1, 3)) * 0.5
     del tmp41
     tmp44 += einsum(t2, (0, 1, 2, 3), tmp42, (4, 1, 5, 3), (4, 5, 0, 2)) * 0.5
     del tmp42
     tmp44 += einsum(t2, (0, 1, 2, 3), tmp43, (4, 1, 5, 2), (4, 5, 0, 3))
     del tmp43
     tmp27 = einsum(t2, (0, 1, 2, 3), f.ov, (4, 3), (4, 0, 1, 2))
-    tmp22 = v.xov.transpose((1, 2, 0)).copy()
+    tmp22 = np.copy(np.transpose(v.xov, (1, 2, 0)))
     tmp22 += tmp21
-    tmp29 = tmp23.transpose((3, 2, 1, 0)).copy() * 0.5
-    tmp29 += tmp24.transpose((1, 0, 3, 2)) * 0.5
-    tmp29 += tmp24.transpose((3, 0, 2, 1)) * -1
+    tmp29 = np.copy(np.transpose(tmp23, (3, 2, 1, 0))) * 0.5
+    tmp29 += np.transpose(tmp24, (1, 0, 3, 2)) * 0.5
+    tmp29 += np.transpose(tmp24, (3, 0, 2, 1)) * -1
     tmp18 = einsum(tmp17, (0, 1, 2), v.xov, (2, 3, 4), (3, 0, 1, 4))
     tmp1 = einsum(tmp0, (0, 1, 2), v.xoo, (2, 3, 4), (0, 3, 4, 1))
-    tmp32 = l2.transpose((3, 2, 0, 1)).copy() * -0.5
-    tmp32 += l2.transpose((2, 3, 0, 1))
-    tmp34 = tmp33.copy() * 2
-    tmp34 += tmp33.transpose((1, 0, 2, 3)) * -1
+    tmp32 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -0.5
+    tmp32 += np.transpose(l2, (2, 3, 0, 1))
+    tmp34 = np.copy(tmp33) * 2
+    tmp34 += np.transpose(tmp33, (1, 0, 2, 3)) * -1
     tmp36 = einsum(l2, (0, 1, 2, 3), tmp28, (2, 3, 1, 4), (0, 4)) * 2
-    tmp37 = v.xoo.transpose((1, 2, 0)).copy()
+    tmp37 = np.copy(np.transpose(v.xoo, (1, 2, 0)))
     tmp37 += tmp4
-    tmp11 = tmp3.copy() * 2
+    tmp11 = np.copy(tmp3) * 2
     del tmp3
     tmp11 += tmp5 * 2
     del tmp5
@@ -390,19 +390,19 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp10
     tmp16 = einsum(tmp15, (0, 1), t2, (2, 3, 1, 4), (2, 3, 0, 4))
     del tmp15
-    tmp25 = tmp23.transpose((3, 2, 1, 0)).copy()
-    tmp25 += tmp24.transpose((1, 0, 3, 2))
-    tmp25 += tmp24.transpose((3, 0, 2, 1)) * -0.5
+    tmp25 = np.copy(np.transpose(tmp23, (3, 2, 1, 0)))
+    tmp25 += np.transpose(tmp24, (1, 0, 3, 2))
+    tmp25 += np.transpose(tmp24, (3, 0, 2, 1)) * -0.5
     del tmp24
     tmp55 = einsum(l1, (0, 1), t1, (1, 2), (0, 2)) * 0.5
     tmp55 += einsum(l2, (0, 1, 2, 3), tmp20, (2, 3, 4, 1), (4, 0)) * 0.5
-    tmp58 = l1.transpose((1, 0)).copy()
+    tmp58 = np.copy(np.transpose(l1, (1, 0)))
     tmp58 += t1
     tmp58 += einsum(tmp33, (0, 1, 2, 3), tmp20, (0, 1, 3, 4), (2, 4)) * -1
     del tmp33, tmp20
     tmp58 += einsum(tmp19, (0, 1, 2, 3), l1, (2, 0), (1, 3)) * 2
     tmp58 += einsum(tmp57, (0, 1), t1, (0, 2), (1, 2)) * -1
-    tmp82 = tmp68.copy()
+    tmp82 = np.copy(tmp68)
     del tmp68
     tmp82 += tmp70 * -1
     del tmp70
@@ -418,13 +418,13 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp78
     tmp82 += tmp81 * -1
     del tmp81
-    tmp111 = tmp108.copy()
+    tmp111 = np.copy(tmp108)
     del tmp108
     tmp111 += tmp110
     del tmp110
-    tmp113 = tmp23.transpose((3, 2, 1, 0)).copy()
+    tmp113 = np.copy(np.transpose(tmp23, (3, 2, 1, 0)))
     del tmp23
-    tmp113 += tmp8.transpose((0, 3, 1, 2))
+    tmp113 += np.transpose(tmp8, (0, 3, 1, 2))
     del tmp8
     tmp67 = einsum(v.xvv, (0, 1, 2), v.xvv, (0, 3, 4), (1, 3, 4, 2))
     tmp87 = einsum(f.oo, (0, 1), l2, (2, 3, 4, 1), (0, 4, 2, 3))
@@ -440,23 +440,23 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp91
     tmp107 += tmp92 * -1
     del tmp92
-    tmp107 += tmp101.transpose((1, 0, 3, 2))
+    tmp107 += np.transpose(tmp101, (1, 0, 3, 2))
     del tmp101
-    tmp107 += tmp105.transpose((0, 1, 3, 2))
+    tmp107 += np.transpose(tmp105, (0, 1, 3, 2))
     del tmp105
     tmp107 += tmp106 * -1
     del tmp106
     tmp107 += einsum(tmp102, (0, 1), l1, (2, 3), (3, 0, 2, 1))
     del tmp102
-    tmp86 = tmp83.copy()
+    tmp86 = np.copy(tmp83)
     del tmp83
     tmp86 += tmp85
     del tmp85
-    tmp66 = f.vv.copy()
-    tmp66 += tmp65.transpose((1, 0)) * 2
+    tmp66 = np.copy(f.vv)
+    tmp66 += np.transpose(tmp65, (1, 0)) * 2
     del tmp65
-    tmp64 = f.oo.copy()
-    tmp64 += tmp61.transpose((1, 0)) * 2
+    tmp64 = np.copy(f.oo)
+    tmp64 += np.transpose(tmp61, (1, 0)) * 2
     del tmp61
     tmp64 += tmp62 * -1
     del tmp62
@@ -481,14 +481,14 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp53
     tmp54 += einsum(v.xoo, (0, 1, 2), tmp52, (2, 3), (3, 1, 0))
     del tmp52
-    tmp60 = f.ov.copy() * 0.5
+    tmp60 = np.copy(f.ov) * 0.5
     tmp60 += tmp13
     del tmp13
     tmp60 += tmp14 * -0.5
     del tmp14
-    tmp30 = tmp1.transpose((0, 2, 1, 3)).copy() * -1
-    tmp30 += tmp27.transpose((1, 0, 2, 3)) * -1
-    tmp30 += tmp27.transpose((2, 0, 1, 3)) * 0.5
+    tmp30 = np.copy(np.transpose(tmp1, (0, 2, 1, 3))) * -1
+    tmp30 += np.transpose(tmp27, (1, 0, 2, 3)) * -1
+    tmp30 += np.transpose(tmp27, (2, 0, 1, 3)) * 0.5
     del tmp27
     tmp30 += einsum(tmp18, (0, 1, 2, 3), tmp28, (1, 4, 3, 5), (2, 0, 4, 5))
     del tmp28
@@ -505,13 +505,13 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp36
     tmp38 += einsum(tmp37, (0, 1, 2), l1, (3, 0), (1, 3, 2))
     del tmp37
-    tmp26 = tmp1.transpose((0, 2, 1, 3)).copy()
+    tmp26 = np.copy(np.transpose(tmp1, (0, 2, 1, 3)))
     del tmp1
-    tmp26 += tmp11.transpose((0, 2, 1, 3)) * -1
-    tmp26 += tmp11.transpose((1, 2, 0, 3)) * 0.5
+    tmp26 += np.transpose(tmp11, (0, 2, 1, 3)) * -1
+    tmp26 += np.transpose(tmp11, (1, 2, 0, 3)) * 0.5
     del tmp11
-    tmp26 += tmp16.transpose((1, 2, 0, 3))
-    tmp26 += tmp16.transpose((0, 2, 1, 3)) * -2
+    tmp26 += np.transpose(tmp16, (1, 2, 0, 3))
+    tmp26 += np.transpose(tmp16, (0, 2, 1, 3)) * -2
     del tmp16
     tmp26 += einsum(tmp18, (0, 1, 2, 3), tmp19, (1, 4, 3, 5), (2, 0, 4, 5)) * 2
     del tmp19, tmp18
@@ -524,32 +524,32 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp59 += einsum(v.xov, (0, 1, 2), tmp58, (1, 2), (0,))
     del tmp58
     tmp59 += einsum(tmp57, (0, 1), v.xoo, (2, 1, 0), (2,)) * -1
-    l2new = tmp6.transpose((3, 2, 1, 0)).copy()
+    l2new = np.copy(np.transpose(tmp6, (3, 2, 1, 0)))
     l2new += einsum(tmp67, (0, 1, 2, 3), l2, (3, 2, 4, 5), (0, 1, 4, 5))
     del tmp67
     l2new += einsum(tmp47, (0, 1, 2, 3), tmp6, (2, 3, 4, 5), (5, 4, 1, 0))
     del tmp6, tmp47
-    l2new += tmp82.transpose((3, 2, 0, 1))
-    l2new += tmp82.transpose((2, 3, 1, 0))
+    l2new += np.transpose(tmp82, (3, 2, 0, 1))
+    l2new += np.transpose(tmp82, (2, 3, 1, 0))
     del tmp82
-    l2new += tmp86.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp86.transpose((3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp86, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp86, (3, 2, 1, 0)) * -1
     del tmp86
-    l2new += tmp87.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp87.transpose((2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp87, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp87, (2, 3, 1, 0)) * -1
     del tmp87
-    l2new += tmp107.transpose((2, 3, 0, 1))
-    l2new += tmp107.transpose((3, 2, 1, 0))
+    l2new += np.transpose(tmp107, (2, 3, 0, 1))
+    l2new += np.transpose(tmp107, (3, 2, 1, 0))
     del tmp107
-    l2new += tmp111.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp111.transpose((2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp111, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp111, (2, 3, 1, 0)) * -1
     del tmp111
-    l2new += tmp112.transpose((2, 3, 0, 1)) * -2
-    l2new += tmp112.transpose((3, 2, 1, 0)) * -2
+    l2new += np.transpose(tmp112, (2, 3, 0, 1)) * -2
+    l2new += np.transpose(tmp112, (3, 2, 1, 0)) * -2
     del tmp112
     l2new += einsum(tmp113, (0, 1, 2, 3), l2, (4, 5, 2, 0), (4, 5, 1, 3))
     del tmp113
-    l1new = f.ov.transpose((1, 0)).copy()
+    l1new = np.copy(np.transpose(f.ov, (1, 0)))
     l1new += einsum(l2, (0, 1, 2, 3), tmp26, (2, 4, 3, 1), (0, 4))
     del tmp26
     l1new += einsum(tmp30, (0, 1, 2, 3), l2, (4, 3, 2, 0), (4, 1)) * 2
@@ -595,36 +595,36 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
         oo=np.eye(t2.shape[0]),
         vv=np.eye(t2.shape[-1]),
     )
-    tmp5 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp5 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp5 += t2 * -0.5
     tmp0 = einsum(l1, (0, 1), t1, (2, 0), (1, 2))
     tmp2 = einsum(l2, (0, 1, 2, 3), t1, (4, 1), (2, 3, 4, 0))
-    tmp7 = l2.transpose((3, 2, 0, 1)).copy() * 2
-    tmp7 += l2.transpose((2, 3, 0, 1)) * -1
-    tmp6 = tmp0.copy()
+    tmp7 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * 2
+    tmp7 += np.transpose(l2, (2, 3, 0, 1)) * -1
+    tmp6 = np.copy(tmp0)
     tmp6 += einsum(tmp5, (0, 1, 2, 3), l2, (3, 2, 0, 4), (4, 1)) * 2
     del tmp5
-    tmp4 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp4 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp4 += t2 * 2
-    tmp3 = tmp2.copy()
-    tmp3 += tmp2.transpose((1, 0, 2, 3)) * -0.5
+    tmp3 = np.copy(tmp2)
+    tmp3 += np.transpose(tmp2, (1, 0, 2, 3)) * -0.5
     del tmp2
-    tmp1 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp1 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp1 += t2
     rdm1.vv = einsum(l1, (0, 1), t1, (1, 2), (0, 2)) * 2
     rdm1.vv += einsum(t2, (0, 1, 2, 3), tmp7, (0, 1, 4, 2), (4, 3)) * 2
     del tmp7
-    rdm1.vo = l1.copy() * 2
-    rdm1.ov = t1.copy() * 2
+    rdm1.vo = np.copy(l1) * 2
+    rdm1.ov = np.copy(t1) * 2
     rdm1.ov += einsum(t2, (0, 1, 2, 3), tmp3, (0, 1, 4, 2), (4, 3)) * -4
     del tmp3
     rdm1.ov += einsum(tmp4, (0, 1, 2, 3), l1, (2, 0), (1, 3)) * 2
     del tmp4
     rdm1.ov += einsum(tmp6, (0, 1), t1, (0, 2), (1, 2)) * -2
     del tmp6
-    rdm1.oo = delta.oo.copy() * 2
+    rdm1.oo = np.copy(delta.oo) * 2
     del delta
-    rdm1.oo += tmp0.transpose((1, 0)) * -2
+    rdm1.oo += np.transpose(tmp0, (1, 0)) * -2
     del tmp0
     rdm1.oo += einsum(tmp1, (0, 1, 2, 3), l2, (2, 3, 0, 4), (1, 4)) * -4
     del tmp1
@@ -659,27 +659,27 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
         vv=np.eye(t2.shape[-1]),
     )
     tmp1 = einsum(l2, (0, 1, 2, 3), t1, (4, 1), (2, 3, 4, 0))
-    tmp22 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp22 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp22 += t2 * 2
-    tmp79 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp79 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp79 += t2
-    tmp4 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp4 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp4 += t2 * -0.5
-    tmp16 = tmp1.copy() * -1
-    tmp16 += tmp1.transpose((1, 0, 2, 3)) * 2
-    tmp14 = tmp1.copy() * -1
-    tmp14 += tmp1.transpose((1, 0, 2, 3))
-    tmp62 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp62 += l2.transpose((2, 3, 0, 1)) * 2
-    tmp45 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp45 += l2.transpose((2, 3, 0, 1)) * 2
+    tmp16 = np.copy(tmp1) * -1
+    tmp16 += np.transpose(tmp1, (1, 0, 2, 3)) * 2
+    tmp14 = np.copy(tmp1) * -1
+    tmp14 += np.transpose(tmp1, (1, 0, 2, 3))
+    tmp62 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp62 += np.transpose(l2, (2, 3, 0, 1)) * 2
+    tmp45 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp45 += np.transpose(l2, (2, 3, 0, 1)) * 2
     tmp81 = einsum(l2, (0, 1, 2, 3), tmp22, (3, 4, 1, 5), (4, 2, 5, 0))
     tmp80 = einsum(l2, (0, 1, 2, 3), tmp79, (2, 4, 1, 5), (4, 3, 5, 0))
     del tmp79
     tmp92 = einsum(t1, (0, 1), tmp1, (2, 0, 3, 4), (2, 3, 4, 1))
     tmp5 = einsum(tmp4, (0, 1, 2, 3), l2, (3, 2, 0, 4), (4, 1)) * 2
-    tmp8 = tmp1.copy() * -1
-    tmp8 += tmp1.transpose((1, 0, 2, 3)) * 2
+    tmp8 = np.copy(tmp1) * -1
+    tmp8 += np.transpose(tmp1, (1, 0, 2, 3)) * 2
     tmp12 = einsum(l1, (0, 1), t2, (2, 3, 4, 0), (1, 2, 3, 4))
     tmp26 = einsum(t2, (0, 1, 2, 3), tmp1, (4, 1, 5, 2), (4, 5, 0, 3))
     tmp6 = einsum(l1, (0, 1), t1, (2, 0), (1, 2))
@@ -688,8 +688,8 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp15 = einsum(t2, (0, 1, 2, 3), tmp14, (4, 1, 5, 2), (4, 5, 0, 3))
     tmp25 = einsum(t2, (0, 1, 2, 3), tmp1, (1, 4, 5, 2), (4, 5, 0, 3))
     tmp0 = einsum(t2, (0, 1, 2, 3), l2, (3, 2, 4, 5), (5, 4, 0, 1))
-    tmp54 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp54 += l2.transpose((2, 3, 0, 1))
+    tmp54 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp54 += np.transpose(l2, (2, 3, 0, 1))
     tmp2 = einsum(t1, (0, 1), tmp1, (2, 3, 4, 1), (2, 3, 0, 4))
     tmp31 = einsum(tmp4, (0, 1, 2, 3), l2, (3, 2, 0, 4), (4, 1))
     del tmp4
@@ -698,45 +698,45 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp85 = einsum(tmp62, (0, 1, 2, 3), t2, (0, 1, 4, 3), (2, 4))
     tmp52 = einsum(tmp45, (0, 1, 2, 3), t2, (4, 0, 5, 2), (1, 4, 3, 5))
     tmp67 = einsum(l2, (0, 1, 2, 3), t2, (4, 3, 1, 5), (2, 4, 0, 5))
-    tmp107 = tmp92.copy()
-    tmp107 += tmp80.transpose((1, 0, 3, 2))
-    tmp107 += tmp81.transpose((1, 0, 3, 2)) * -1
-    tmp97 = tmp81.transpose((1, 0, 3, 2)).copy()
-    tmp97 += tmp80.transpose((1, 0, 3, 2)) * -1
+    tmp107 = np.copy(tmp92)
+    tmp107 += np.transpose(tmp80, (1, 0, 3, 2))
+    tmp107 += np.transpose(tmp81, (1, 0, 3, 2)) * -1
+    tmp97 = np.copy(np.transpose(tmp81, (1, 0, 3, 2)))
+    tmp97 += np.transpose(tmp80, (1, 0, 3, 2)) * -1
     tmp104 = einsum(tmp62, (0, 1, 2, 3), t2, (4, 0, 5, 2), (1, 4, 3, 5))
     tmp63 = einsum(tmp62, (0, 1, 2, 3), t2, (0, 1, 4, 3), (2, 4)) * 0.5
     del tmp62
     tmp10 = einsum(tmp5, (0, 1), t1, (0, 2), (1, 2)) * 0.5
     tmp9 = einsum(t2, (0, 1, 2, 3), tmp8, (0, 1, 4, 3), (4, 2)) * 0.5
-    tmp74 = tmp12.copy()
+    tmp74 = np.copy(tmp12)
     tmp74 += tmp26 * -1
     tmp23 = einsum(tmp22, (0, 1, 2, 3), l1, (2, 0), (1, 3))
     del tmp22
     tmp21 = einsum(tmp6, (0, 1), t1, (0, 2), (1, 2))
-    tmp48 = tmp12.copy()
+    tmp48 = np.copy(tmp12)
     tmp48 += tmp15
     tmp48 += tmp17 * -1
     tmp46 = einsum(t2, (0, 1, 2, 3), tmp45, (1, 4, 2, 5), (4, 0, 5, 3))
     del tmp45
-    tmp71 = tmp25.copy()
+    tmp71 = np.copy(tmp25)
     tmp71 += tmp17 * -1
     tmp19 = einsum(tmp0, (0, 1, 2, 3), t1, (1, 4), (0, 2, 3, 4))
     tmp55 = einsum(tmp54, (0, 1, 2, 3), t2, (4, 0, 2, 5), (1, 4, 3, 5))
     tmp13 = einsum(tmp2, (0, 1, 2, 3), t1, (0, 4), (1, 3, 2, 4))
-    tmp3 = tmp0.transpose((1, 0, 3, 2)).copy()
+    tmp3 = np.copy(np.transpose(tmp0, (1, 0, 3, 2)))
     tmp3 += tmp2
-    tmp32 = tmp6.copy() * 0.5
+    tmp32 = np.copy(tmp6) * 0.5
     tmp32 += tmp31
     del tmp31
-    tmp29 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp29 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp29 += t2 * 2
     tmp115 = einsum(t1, (0, 1), tmp113, (0, 2, 3, 4), (3, 2, 4, 1))
     tmp114 = einsum(t2, (0, 1, 2, 3), l2, (4, 5, 1, 0), (4, 5, 3, 2))
     tmp100 = einsum(tmp1, (0, 1, 2, 3), t2, (1, 0, 4, 5), (2, 3, 5, 4))
-    tmp86 = tmp84.copy()
+    tmp86 = np.copy(tmp84)
     tmp86 += tmp85
     del tmp85
-    tmp111 = tmp67.copy()
+    tmp111 = np.copy(tmp67)
     tmp111 += tmp92
     tmp111 += tmp52 * -1
     tmp69 = einsum(t2, (0, 1, 2, 3), l2, (4, 2, 1, 5), (5, 0, 4, 3))
@@ -745,25 +745,25 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp96 = einsum(l1, (0, 1), t2, (2, 1, 3, 4), (2, 0, 3, 4))
     tmp98 = einsum(t1, (0, 1), tmp97, (0, 2, 3, 4), (2, 3, 4, 1))
     del tmp97
-    tmp105 = tmp67.copy()
+    tmp105 = np.copy(tmp67)
     tmp105 += tmp92
     tmp105 += tmp104 * -1
     del tmp104
-    tmp88 = l2.transpose((3, 2, 0, 1)).copy() * 2
-    tmp88 += l2.transpose((2, 3, 0, 1)) * -1
-    tmp82 = tmp1.copy()
-    tmp82 += tmp1.transpose((1, 0, 2, 3)) * -1
-    tmp90 = l2.transpose((3, 2, 0, 1)).copy()
-    tmp90 += l2.transpose((2, 3, 0, 1)) * -1
+    tmp88 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * 2
+    tmp88 += np.transpose(l2, (2, 3, 0, 1)) * -1
+    tmp82 = np.copy(tmp1)
+    tmp82 += np.transpose(tmp1, (1, 0, 2, 3)) * -1
+    tmp90 = np.copy(np.transpose(l2, (3, 2, 0, 1)))
+    tmp90 += np.transpose(l2, (2, 3, 0, 1)) * -1
     tmp65 = einsum(t2, (0, 1, 2, 3), tmp5, (1, 4), (0, 4, 3, 2))
     tmp64 = einsum(tmp63, (0, 1), t2, (2, 3, 0, 4), (2, 3, 1, 4)) * 2
-    tmp11 = tmp9.copy()
+    tmp11 = np.copy(tmp9)
     tmp11 += tmp10
     del tmp10
     tmp44 = einsum(t2, (0, 1, 2, 3), tmp6, (1, 4), (4, 0, 2, 3))
     tmp75 = einsum(t1, (0, 1), tmp74, (0, 2, 3, 4), (2, 3, 4, 1))
     del tmp74
-    tmp24 = tmp21.copy()
+    tmp24 = np.copy(tmp21)
     tmp24 += tmp23 * -1
     tmp49 = einsum(t1, (0, 1), tmp48, (0, 2, 3, 4), (2, 3, 4, 1))
     del tmp48
@@ -783,30 +783,30 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp28 = einsum(t2, (0, 1, 2, 3), tmp8, (0, 1, 4, 3), (4, 2))
     del tmp8
     tmp33 = einsum(tmp32, (0, 1), t1, (0, 2), (1, 2)) * 2
-    tmp38 = tmp1.copy() * 2
-    tmp38 += tmp1.transpose((1, 0, 2, 3)) * -1
+    tmp38 = np.copy(tmp1) * 2
+    tmp38 += np.transpose(tmp1, (1, 0, 2, 3)) * -1
     tmp40 = einsum(tmp29, (0, 1, 2, 3), l1, (2, 0), (1, 3)) * 0.5
     tmp41 = einsum(tmp32, (0, 1), t1, (0, 2), (1, 2))
     tmp30 = einsum(tmp29, (0, 1, 2, 3), l1, (2, 0), (1, 3))
     del tmp29
-    tmp116 = tmp114.transpose((1, 0, 3, 2)).copy()
-    tmp116 += tmp115.transpose((1, 0, 3, 2))
-    tmp95 = tmp84.copy() * 0.5
+    tmp116 = np.copy(np.transpose(tmp114, (1, 0, 3, 2)))
+    tmp116 += np.transpose(tmp115, (1, 0, 3, 2))
+    tmp95 = np.copy(tmp84) * 0.5
     tmp95 += tmp63
-    tmp110 = tmp100.copy()
+    tmp110 = np.copy(tmp100)
     tmp110 += einsum(tmp86, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     tmp112 = einsum(t1, (0, 1), tmp111, (0, 2, 3, 4), (2, 3, 4, 1))
     del tmp111
     tmp103 = einsum(t1, (0, 1), tmp69, (0, 2, 3, 4), (2, 3, 1, 4))
-    tmp109 = tmp96.copy()
-    tmp109 += tmp108.transpose((0, 1, 3, 2))
+    tmp109 = np.copy(tmp96)
+    tmp109 += np.transpose(tmp108, (0, 1, 3, 2))
     del tmp108
-    tmp99 = tmp96.copy()
+    tmp99 = np.copy(tmp96)
     tmp99 += einsum(tmp84, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     del tmp84
-    tmp99 += tmp98.transpose((0, 1, 3, 2)) * -1
+    tmp99 += np.transpose(tmp98, (0, 1, 3, 2)) * -1
     del tmp98
-    tmp101 = tmp100.copy()
+    tmp101 = np.copy(tmp100)
     tmp101 += einsum(t1, (0, 1), tmp63, (2, 3), (0, 2, 1, 3)) * 2
     del tmp63
     tmp102 = einsum(tmp92, (0, 1, 2, 3), t1, (0, 4), (1, 2, 4, 3))
@@ -823,179 +823,179 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp82
     tmp91 = einsum(tmp90, (0, 1, 2, 3), t2, (4, 0, 3, 5), (1, 4, 2, 5))
     del tmp90
-    tmp66 = tmp64.transpose((1, 0, 3, 2)).copy()
+    tmp66 = np.copy(np.transpose(tmp64, (1, 0, 3, 2)))
     del tmp64
-    tmp66 += tmp65.transpose((0, 1, 3, 2))
+    tmp66 += np.transpose(tmp65, (0, 1, 3, 2))
     del tmp65
     tmp66 += einsum(tmp11, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
-    tmp76 = tmp44.copy()
-    tmp76 += tmp75.transpose((0, 1, 3, 2))
+    tmp76 = np.copy(tmp44)
+    tmp76 += np.transpose(tmp75, (0, 1, 3, 2))
     del tmp75
     tmp70 = einsum(tmp69, (0, 1, 2, 3), t2, (4, 0, 2, 5), (1, 4, 3, 5))
     tmp68 = einsum(t2, (0, 1, 2, 3), tmp67, (1, 4, 2, 5), (0, 4, 3, 5))
-    tmp50 = tmp44.copy()
+    tmp50 = np.copy(tmp44)
     del tmp44
-    tmp50 += tmp47.transpose((1, 0, 3, 2)) * -1
-    tmp50 += tmp49.transpose((0, 1, 3, 2))
+    tmp50 += np.transpose(tmp47, (1, 0, 3, 2)) * -1
+    tmp50 += np.transpose(tmp49, (0, 1, 3, 2))
     del tmp49
     tmp50 += einsum(tmp24, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * -1
-    tmp78 = t1.copy()
+    tmp78 = np.copy(t1)
     tmp78 += tmp21 * -1
-    tmp73 = tmp47.transpose((1, 0, 3, 2)).copy() * -1
+    tmp73 = np.copy(np.transpose(tmp47, (1, 0, 3, 2))) * -1
     del tmp47
-    tmp73 += tmp72.transpose((0, 1, 3, 2))
+    tmp73 += np.transpose(tmp72, (0, 1, 3, 2))
     del tmp72
     tmp73 += einsum(tmp23, (0, 1), t1, (2, 3), (2, 0, 3, 1))
-    tmp61 = tmp58.copy()
+    tmp61 = np.copy(tmp58)
     tmp61 += tmp59
     tmp61 += tmp60
     del tmp60
-    tmp57 = tmp51.copy()
+    tmp57 = np.copy(tmp51)
     del tmp51
-    tmp57 += tmp53.transpose((1, 0, 3, 2)) * 2
+    tmp57 += np.transpose(tmp53, (1, 0, 3, 2)) * 2
     tmp57 += tmp56
     del tmp56
     tmp77 = einsum(t1, (0, 1), tmp27, (0, 2, 3, 4), (3, 2, 4, 1))
-    tmp35 = tmp28.copy()
+    tmp35 = np.copy(tmp28)
     tmp35 += tmp33
     tmp39 = einsum(t2, (0, 1, 2, 3), tmp38, (1, 4, 5, 3), (4, 5, 0, 2))
     del tmp38
-    tmp43 = tmp6.copy()
+    tmp43 = np.copy(tmp6)
     tmp43 += tmp5
     tmp36 = einsum(tmp6, (0, 1), t1, (2, 3), (0, 2, 1, 3))
     tmp36 += tmp15
     tmp36 += tmp17 * -1
-    tmp42 = t1.copy() * -0.5
+    tmp42 = np.copy(t1) * -0.5
     tmp42 += tmp9
     del tmp9
     tmp42 += tmp40 * -1
     del tmp40
     tmp42 += tmp41
     del tmp41
-    tmp37 = tmp12.copy()
-    tmp37 += tmp27.transpose((0, 2, 1, 3))
+    tmp37 = np.copy(tmp12)
+    tmp37 += np.transpose(tmp27, (0, 2, 1, 3))
     tmp37 += einsum(t1, (0, 1), tmp5, (2, 3), (2, 0, 3, 1))
-    tmp34 = t1.copy() * -1
+    tmp34 = np.copy(t1) * -1
     tmp34 += tmp28
     del tmp28
     tmp34 += tmp30 * -1
     del tmp30
     tmp34 += tmp33
     del tmp33
-    tmp18 = tmp12.copy()
+    tmp18 = np.copy(tmp12)
     tmp18 += tmp13
     del tmp13
     tmp18 += tmp15
     del tmp15
     tmp18 += tmp17 * -1
-    tmp20 = tmp19.copy()
+    tmp20 = np.copy(tmp19)
     del tmp19
     tmp20 += einsum(t1, (0, 1), tmp5, (2, 3), (2, 0, 3, 1))
-    tmp7 = delta.oo.copy()
+    tmp7 = np.copy(delta.oo)
     tmp7 += tmp6 * -1
-    rdm2.vvvv = tmp116.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.vvvv = np.copy(np.transpose(tmp116, (0, 1, 3, 2))) * -2
     rdm2.vvvv += tmp116 * 2
     del tmp116
-    rdm2.vvvv += tmp114.transpose((1, 0, 3, 2)) * 2
+    rdm2.vvvv += np.transpose(tmp114, (1, 0, 3, 2)) * 2
     del tmp114
-    rdm2.vvvv += tmp115.transpose((1, 0, 3, 2)) * 2
+    rdm2.vvvv += np.transpose(tmp115, (1, 0, 3, 2)) * 2
     del tmp115
-    rdm2.vvvo = tmp113.transpose((1, 2, 3, 0)).copy() * -2
-    rdm2.vvvo += tmp113.transpose((2, 1, 3, 0)) * 4
-    rdm2.vvov = tmp113.transpose((1, 2, 0, 3)).copy() * 4
-    rdm2.vvov += tmp113.transpose((2, 1, 0, 3)) * -2
+    rdm2.vvvo = np.copy(np.transpose(tmp113, (1, 2, 3, 0))) * -2
+    rdm2.vvvo += np.transpose(tmp113, (2, 1, 3, 0)) * 4
+    rdm2.vvov = np.copy(np.transpose(tmp113, (1, 2, 0, 3))) * 4
+    rdm2.vvov += np.transpose(tmp113, (2, 1, 0, 3)) * -2
     del tmp113
-    rdm2.vovv = tmp109.transpose((1, 0, 2, 3)).copy() * -2
-    rdm2.vovv += tmp109.transpose((1, 0, 3, 2)) * 2
+    rdm2.vovv = np.copy(np.transpose(tmp109, (1, 0, 2, 3))) * -2
+    rdm2.vovv += np.transpose(tmp109, (1, 0, 3, 2)) * 2
     del tmp109
-    rdm2.vovv += tmp110.transpose((1, 0, 2, 3)) * -2
-    rdm2.vovv += tmp110.transpose((1, 0, 3, 2)) * 2
+    rdm2.vovv += np.transpose(tmp110, (1, 0, 2, 3)) * -2
+    rdm2.vovv += np.transpose(tmp110, (1, 0, 3, 2)) * 2
     del tmp110
-    rdm2.vovv += tmp96.transpose((1, 0, 3, 2)) * 2
-    rdm2.vovv += tmp103.transpose((1, 0, 3, 2)) * -2
-    rdm2.vovv += tmp100.transpose((1, 0, 2, 3)) * -2
-    rdm2.vovv += tmp112.transpose((1, 0, 3, 2)) * -2
+    rdm2.vovv += np.transpose(tmp96, (1, 0, 3, 2)) * 2
+    rdm2.vovv += np.transpose(tmp103, (1, 0, 3, 2)) * -2
+    rdm2.vovv += np.transpose(tmp100, (1, 0, 2, 3)) * -2
+    rdm2.vovv += np.transpose(tmp112, (1, 0, 3, 2)) * -2
     del tmp112
     rdm2.vovv += einsum(tmp95, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 4
-    rdm2.ovvv = tmp99.copy() * 2
-    rdm2.ovvv += tmp99.transpose((0, 1, 3, 2)) * -2
+    rdm2.ovvv = np.copy(tmp99) * 2
+    rdm2.ovvv += np.transpose(tmp99, (0, 1, 3, 2)) * -2
     del tmp99
     rdm2.ovvv += tmp101 * 2
-    rdm2.ovvv += tmp101.transpose((0, 1, 3, 2)) * -2
+    rdm2.ovvv += np.transpose(tmp101, (0, 1, 3, 2)) * -2
     del tmp101
     rdm2.ovvv += tmp102 * 2
-    rdm2.ovvv += tmp102.transpose((0, 1, 3, 2)) * -2
+    rdm2.ovvv += np.transpose(tmp102, (0, 1, 3, 2)) * -2
     del tmp102
     rdm2.ovvv += tmp96 * 2
     del tmp96
-    rdm2.ovvv += tmp100.transpose((0, 1, 3, 2)) * -2
+    rdm2.ovvv += np.transpose(tmp100, (0, 1, 3, 2)) * -2
     del tmp100
     rdm2.ovvv += tmp103 * -2
     del tmp103
     rdm2.ovvv += tmp106 * -2
     del tmp106
     rdm2.ovvv += einsum(tmp86, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
-    rdm2.vvoo = l2.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.vvoo = np.copy(np.transpose(l2, (0, 1, 3, 2))) * -2
     rdm2.vvoo += l2 * 4
     rdm2.vovo = einsum(l1, (0, 1), t1, (2, 3), (0, 2, 3, 1)) * -2
-    rdm2.vovo += tmp89.transpose((2, 1, 3, 0)) * -2
-    rdm2.vovo += tmp94.transpose((2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp89, (2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp94, (2, 1, 3, 0)) * -2
     del tmp94
-    rdm2.vovo += tmp93.transpose((2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp93, (2, 1, 3, 0)) * -2
     rdm2.vovo += einsum(delta.oo, (0, 1), tmp95, (2, 3), (2, 0, 3, 1)) * 8
     del tmp95
-    rdm2.vovo += tmp69.transpose((2, 1, 3, 0)) * -2
-    rdm2.vovo += tmp87.transpose((2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp69, (2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp87, (2, 1, 3, 0)) * -2
     rdm2.voov = einsum(l1, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 4
-    rdm2.voov += tmp81.transpose((3, 0, 1, 2)) * 2
-    rdm2.voov += tmp80.transpose((3, 0, 1, 2)) * -2
-    rdm2.voov += tmp93.transpose((2, 1, 0, 3)) * 2
+    rdm2.voov += np.transpose(tmp81, (3, 0, 1, 2)) * 2
+    rdm2.voov += np.transpose(tmp80, (3, 0, 1, 2)) * -2
+    rdm2.voov += np.transpose(tmp93, (2, 1, 0, 3)) * 2
     del tmp93
     rdm2.voov += einsum(tmp86, (0, 1), delta.oo, (2, 3), (0, 2, 3, 1)) * -2
-    rdm2.voov += tmp67.transpose((2, 1, 0, 3)) * -2
-    rdm2.voov += tmp92.transpose((2, 1, 0, 3)) * -2
-    rdm2.voov += tmp89.transpose((2, 1, 0, 3)) * 2
+    rdm2.voov += np.transpose(tmp67, (2, 1, 0, 3)) * -2
+    rdm2.voov += np.transpose(tmp92, (2, 1, 0, 3)) * -2
+    rdm2.voov += np.transpose(tmp89, (2, 1, 0, 3)) * 2
     rdm2.ovvo = einsum(l1, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 4
-    rdm2.ovvo += tmp89.transpose((1, 2, 3, 0)) * 4
+    rdm2.ovvo += np.transpose(tmp89, (1, 2, 3, 0)) * 4
     del tmp89
-    rdm2.ovvo += tmp91.transpose((1, 2, 3, 0)) * -2
+    rdm2.ovvo += np.transpose(tmp91, (1, 2, 3, 0)) * -2
     del tmp91
-    rdm2.ovvo += tmp83.transpose((1, 2, 3, 0)) * -2
+    rdm2.ovvo += np.transpose(tmp83, (1, 2, 3, 0)) * -2
     rdm2.ovvo += einsum(tmp86, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * -2
-    rdm2.ovvo += tmp67.transpose((1, 2, 3, 0)) * -2
+    rdm2.ovvo += np.transpose(tmp67, (1, 2, 3, 0)) * -2
     del tmp67
-    rdm2.ovvo += tmp92.transpose((1, 2, 3, 0)) * -2
+    rdm2.ovvo += np.transpose(tmp92, (1, 2, 3, 0)) * -2
     del tmp92
     rdm2.ovov = einsum(l1, (0, 1), t1, (2, 3), (2, 0, 1, 3)) * -2
-    rdm2.ovov += tmp80.transpose((0, 3, 1, 2)) * 2
+    rdm2.ovov += np.transpose(tmp80, (0, 3, 1, 2)) * 2
     del tmp80
-    rdm2.ovov += tmp81.transpose((0, 3, 1, 2)) * -2
+    rdm2.ovov += np.transpose(tmp81, (0, 3, 1, 2)) * -2
     del tmp81
-    rdm2.ovov += tmp83.transpose((1, 2, 0, 3)) * 2
+    rdm2.ovov += np.transpose(tmp83, (1, 2, 0, 3)) * 2
     del tmp83
     rdm2.ovov += einsum(tmp86, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1)) * 4
     del tmp86
-    rdm2.ovov += tmp69.transpose((1, 2, 0, 3)) * -2
+    rdm2.ovov += np.transpose(tmp69, (1, 2, 0, 3)) * -2
     del tmp69
-    rdm2.ovov += tmp87.transpose((1, 2, 0, 3)) * -2
+    rdm2.ovov += np.transpose(tmp87, (1, 2, 0, 3)) * -2
     del tmp87
-    rdm2.oovv = tmp50.copy() * 2
-    rdm2.oovv += tmp50.transpose((0, 1, 3, 2)) * -2
-    rdm2.oovv += tmp50.transpose((1, 0, 2, 3)) * -2
-    rdm2.oovv += tmp50.transpose((1, 0, 3, 2)) * 2
+    rdm2.oovv = np.copy(tmp50) * 2
+    rdm2.oovv += np.transpose(tmp50, (0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(tmp50, (1, 0, 2, 3)) * -2
+    rdm2.oovv += np.transpose(tmp50, (1, 0, 3, 2)) * 2
     del tmp50
     rdm2.oovv += tmp57 * 2
-    rdm2.oovv += tmp57.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(tmp57, (0, 1, 3, 2)) * -2
     del tmp57
     rdm2.oovv += tmp61 * 2
-    rdm2.oovv += tmp61.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(tmp61, (0, 1, 3, 2)) * -2
     del tmp61
     rdm2.oovv += tmp66 * -4
-    rdm2.oovv += tmp66.transpose((0, 1, 3, 2)) * 2
-    rdm2.oovv += tmp66.transpose((1, 0, 2, 3)) * 2
-    rdm2.oovv += tmp66.transpose((1, 0, 3, 2)) * -4
+    rdm2.oovv += np.transpose(tmp66, (0, 1, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp66, (1, 0, 2, 3)) * 2
+    rdm2.oovv += np.transpose(tmp66, (1, 0, 3, 2)) * -4
     del tmp66
-    rdm2.oovv += t2.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(t2, (0, 1, 3, 2)) * -2
     rdm2.oovv += t2 * 4
     rdm2.oovv += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 3, 1)) * -2
     rdm2.oovv += einsum(t1, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
@@ -1003,53 +1003,53 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp21
     rdm2.oovv += tmp68 * 2
     del tmp68
-    rdm2.oovv += tmp70.transpose((0, 1, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp70, (0, 1, 3, 2)) * 2
     del tmp70
     rdm2.oovv += tmp58 * 2
     del tmp58
     rdm2.oovv += tmp59 * 2
     del tmp59
     rdm2.oovv += tmp73 * 2
-    rdm2.oovv += tmp73.transpose((1, 0, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp73, (1, 0, 3, 2)) * 2
     del tmp73
-    rdm2.oovv += tmp76.transpose((0, 1, 3, 2)) * -2
-    rdm2.oovv += tmp76.transpose((1, 0, 2, 3)) * -2
+    rdm2.oovv += np.transpose(tmp76, (0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(tmp76, (1, 0, 2, 3)) * -2
     del tmp76
     rdm2.oovv += tmp53 * 4
     del tmp53
-    rdm2.oovv += tmp77.transpose((0, 1, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp77, (0, 1, 3, 2)) * 2
     del tmp77
     rdm2.oovv += einsum(t1, (0, 1), tmp78, (2, 3), (2, 0, 3, 1)) * 2
     del tmp78
     rdm2.vooo = einsum(l1, (0, 1), delta.oo, (2, 3), (0, 2, 1, 3)) * 4
     rdm2.vooo += einsum(l1, (0, 1), delta.oo, (2, 3), (0, 2, 3, 1)) * -2
-    rdm2.vooo += tmp1.transpose((3, 2, 0, 1)) * -4
-    rdm2.vooo += tmp1.transpose((3, 2, 1, 0)) * 2
+    rdm2.vooo += np.transpose(tmp1, (3, 2, 0, 1)) * -4
+    rdm2.vooo += np.transpose(tmp1, (3, 2, 1, 0)) * 2
     rdm2.ovoo = einsum(l1, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * -2
     rdm2.ovoo += einsum(l1, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1)) * 4
-    rdm2.ovoo += tmp1.transpose((2, 3, 0, 1)) * 2
-    rdm2.ovoo += tmp1.transpose((2, 3, 1, 0)) * -4
+    rdm2.ovoo += np.transpose(tmp1, (2, 3, 0, 1)) * 2
+    rdm2.ovoo += np.transpose(tmp1, (2, 3, 1, 0)) * -4
     del tmp1
     rdm2.oovo = einsum(delta.oo, (0, 1), tmp35, (2, 3), (2, 0, 3, 1)) * -2
     rdm2.oovo += einsum(tmp35, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * 2
     del tmp35
-    rdm2.oovo += tmp36.transpose((1, 2, 3, 0)) * -2
-    rdm2.oovo += tmp36.transpose((2, 1, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp36, (1, 2, 3, 0)) * -2
+    rdm2.oovo += np.transpose(tmp36, (2, 1, 3, 0)) * 2
     del tmp36
-    rdm2.oovo += tmp37.transpose((1, 2, 3, 0)) * -2
-    rdm2.oovo += tmp37.transpose((2, 1, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp37, (1, 2, 3, 0)) * -2
+    rdm2.oovo += np.transpose(tmp37, (2, 1, 3, 0)) * 2
     del tmp37
     rdm2.oovo += einsum(delta.oo, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
     rdm2.oovo += einsum(delta.oo, (0, 1), t1, (2, 3), (0, 2, 3, 1)) * -2
     rdm2.oovo += einsum(tmp23, (0, 1), delta.oo, (2, 3), (0, 2, 1, 3)) * 2
     rdm2.oovo += einsum(tmp23, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * -2
     del tmp23
-    rdm2.oovo += tmp26.transpose((1, 2, 3, 0)) * 2
-    rdm2.oovo += tmp25.transpose((2, 1, 3, 0)) * 2
-    rdm2.oovo += tmp12.transpose((1, 2, 3, 0)) * -2
-    rdm2.oovo += tmp39.transpose((2, 1, 3, 0)) * -2
+    rdm2.oovo += np.transpose(tmp26, (1, 2, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp25, (2, 1, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp12, (1, 2, 3, 0)) * -2
+    rdm2.oovo += np.transpose(tmp39, (2, 1, 3, 0)) * -2
     del tmp39
-    rdm2.oovo += tmp27.transpose((1, 2, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp27, (1, 2, 3, 0)) * 2
     rdm2.oovo += einsum(delta.oo, (0, 1), tmp42, (2, 3), (2, 0, 3, 1)) * -4
     del tmp42
     rdm2.oovo += einsum(tmp43, (0, 1), t1, (2, 3), (2, 1, 3, 0)) * -2
@@ -1057,11 +1057,11 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.ooov = einsum(tmp11, (0, 1), delta.oo, (2, 3), (0, 2, 3, 1)) * 4
     rdm2.ooov += einsum(tmp11, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1)) * -4
     del tmp11
-    rdm2.ooov += tmp18.transpose((1, 2, 0, 3)) * 2
-    rdm2.ooov += tmp18.transpose((2, 1, 0, 3)) * -2
+    rdm2.ooov += np.transpose(tmp18, (1, 2, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp18, (2, 1, 0, 3)) * -2
     del tmp18
-    rdm2.ooov += tmp20.transpose((1, 2, 0, 3)) * 2
-    rdm2.ooov += tmp20.transpose((2, 1, 0, 3)) * -2
+    rdm2.ooov += np.transpose(tmp20, (1, 2, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp20, (2, 1, 0, 3)) * -2
     del tmp20
     rdm2.ooov += einsum(delta.oo, (0, 1), t1, (2, 3), (2, 0, 1, 3)) * -2
     rdm2.ooov += einsum(delta.oo, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 2
@@ -1070,22 +1070,22 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.ooov += einsum(delta.oo, (0, 1), tmp24, (2, 3), (2, 0, 1, 3)) * 2
     rdm2.ooov += einsum(delta.oo, (0, 1), tmp24, (2, 3), (0, 2, 1, 3)) * -2
     del tmp24
-    rdm2.ooov += tmp25.transpose((1, 2, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp25, (1, 2, 0, 3)) * 2
     del tmp25
-    rdm2.ooov += tmp26.transpose((2, 1, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp26, (2, 1, 0, 3)) * 2
     del tmp26
-    rdm2.ooov += tmp12.transpose((2, 1, 0, 3)) * -2
+    rdm2.ooov += np.transpose(tmp12, (2, 1, 0, 3)) * -2
     del tmp12
-    rdm2.ooov += tmp17.transpose((1, 2, 0, 3)) * -2
+    rdm2.ooov += np.transpose(tmp17, (1, 2, 0, 3)) * -2
     del tmp17
-    rdm2.ooov += tmp27.transpose((2, 1, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp27, (2, 1, 0, 3)) * 2
     del tmp27
     rdm2.ooov += einsum(tmp34, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1)) * -2
     del tmp34
     rdm2.ooov += einsum(tmp32, (0, 1), t1, (2, 3), (1, 2, 0, 3)) * -4
     del tmp32
-    rdm2.oooo = tmp3.transpose((3, 2, 0, 1)).copy() * -2
-    rdm2.oooo += tmp3.transpose((2, 3, 0, 1)) * 2
+    rdm2.oooo = np.copy(np.transpose(tmp3, (3, 2, 0, 1))) * -2
+    rdm2.oooo += np.transpose(tmp3, (2, 3, 0, 1)) * 2
     del tmp3
     rdm2.oooo += einsum(delta.oo, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1)) * 2
     rdm2.oooo += einsum(delta.oo, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * -2
@@ -1099,14 +1099,14 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oooo += einsum(tmp6, (0, 1), delta.oo, (2, 3), (1, 2, 3, 0)) * 2
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp6, (2, 3), (0, 3, 1, 2)) * -4
     del tmp6
-    rdm2.oooo += tmp0.transpose((3, 2, 1, 0)) * 2
+    rdm2.oooo += np.transpose(tmp0, (3, 2, 1, 0)) * 2
     del tmp0
-    rdm2.oooo += tmp2.transpose((3, 2, 1, 0)) * 2
+    rdm2.oooo += np.transpose(tmp2, (3, 2, 1, 0)) * 2
     del tmp2
     rdm2.oooo += einsum(tmp7, (0, 1), delta.oo, (2, 3), (1, 2, 0, 3)) * 2
     del delta, tmp7
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.transpose(0, 2, 1, 3)
+    rdm2 = np.transpose(rdm2, (0, 2, 1, 3))
 
     return rdm2
 
@@ -1238,40 +1238,40 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     """
 
     ints = kwargs["ints"]
-    tmp3 = r2.copy() * 2
-    tmp3 += r2.transpose((1, 0, 2)) * -1
-    tmp5 = ints.tmp35.copy() * 0.5
+    tmp3 = np.copy(r2) * 2
+    tmp3 += np.transpose(r2, (1, 0, 2)) * -1
+    tmp5 = np.copy(ints.tmp35) * 0.5
     tmp5 += ints.tmp47
     tmp5 += ints.tmp46 * -0.5
-    tmp10 = ints.tmp60.transpose((1, 0)).copy() * 2
+    tmp10 = np.copy(np.transpose(ints.tmp60, (1, 0))) * 2
     del ints.tmp60
     tmp10 += f.vv * -1
-    tmp10 += ints.tmp58.transpose((1, 0)) * -1
+    tmp10 += np.transpose(ints.tmp58, (1, 0)) * -1
     del ints.tmp58
     tmp10 += einsum(t1, (0, 1), f.ov, (0, 2), (2, 1))
     tmp8 = einsum(tmp3, (0, 1, 2), v.xov, (3, 0, 2), (1, 3)) * 0.5
-    tmp12 = ints.tmp1.copy()
-    tmp12 += ints.tmp30.transpose((0, 2, 1, 3))
+    tmp12 = np.copy(ints.tmp1)
+    tmp12 += np.transpose(ints.tmp30, (0, 2, 1, 3))
     del ints.tmp30
-    tmp12 += ints.tmp43.transpose((2, 1, 0, 3)) * 2
+    tmp12 += np.transpose(ints.tmp43, (2, 1, 0, 3)) * 2
     del ints.tmp43
-    tmp12 += ints.tmp54.transpose((2, 0, 1, 3))
+    tmp12 += np.transpose(ints.tmp54, (2, 0, 1, 3))
     del ints.tmp54
-    tmp12 += ints.tmp42.transpose((1, 2, 0, 3)) * -1
+    tmp12 += np.transpose(ints.tmp42, (1, 2, 0, 3)) * -1
     del ints.tmp42
-    tmp12 += ints.tmp45.transpose((2, 1, 0, 3)) * -1
+    tmp12 += np.transpose(ints.tmp45, (2, 1, 0, 3)) * -1
     del ints.tmp45
-    tmp12 += ints.tmp57.transpose((0, 2, 1, 3)) * -1
+    tmp12 += np.transpose(ints.tmp57, (0, 2, 1, 3)) * -1
     del ints.tmp57
-    tmp13 = f.oo.copy()
+    tmp13 = np.copy(f.oo)
     tmp13 += ints.tmp0
-    tmp13 += ints.tmp21.transpose((1, 0)) * 2
-    tmp13 += ints.tmp18.transpose((1, 0)) * -1
-    tmp6 = ints.tmp35.copy()
+    tmp13 += np.transpose(ints.tmp21, (1, 0)) * 2
+    tmp13 += np.transpose(ints.tmp18, (1, 0)) * -1
+    tmp6 = np.copy(ints.tmp35)
     del ints.tmp35
     tmp6 += ints.tmp46 * -1
     del ints.tmp46
-    tmp14 = f.ov.copy()
+    tmp14 = np.copy(f.ov)
     tmp14 += ints.tmp39 * 2
     del ints.tmp39
     tmp14 += ints.tmp55
@@ -1290,41 +1290,41 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp68
     tmp14 += ints.tmp69 * -1
     del ints.tmp69
-    tmp9 = ints.tmp20.copy() * 2
+    tmp9 = np.copy(ints.tmp20) * 2
     del ints.tmp20
-    tmp9 += v.xov.transpose((1, 2, 0))
+    tmp9 += np.transpose(v.xov, (1, 2, 0))
     tmp9 += ints.tmp17 * -1
     del ints.tmp17
-    tmp7 = ints.tmp33.copy()
+    tmp7 = np.copy(ints.tmp33)
     del ints.tmp33
-    tmp7 += ints.tmp40.transpose((2, 0, 1, 3))
+    tmp7 += np.transpose(ints.tmp40, (2, 0, 1, 3))
     del ints.tmp40
     tmp11 = einsum(ints.tmp32, (0, 1, 2, 3), tmp3, (0, 1, 2), (3,)) * 0.5
     del ints.tmp32
-    tmp2 = f.ov.copy() * 0.5
+    tmp2 = np.copy(f.ov) * 0.5
     tmp2 += ints.tmp11
     del ints.tmp11
     tmp2 += ints.tmp9 * -0.5
     del ints.tmp9
-    tmp4 = f.oo.copy()
+    tmp4 = np.copy(f.oo)
     tmp4 += ints.tmp0
     del ints.tmp0
-    tmp4 += ints.tmp21.transpose((1, 0)) * 2
+    tmp4 += np.transpose(ints.tmp21, (1, 0)) * 2
     del ints.tmp21
-    tmp4 += ints.tmp24.transpose((1, 0)) * 2
+    tmp4 += np.transpose(ints.tmp24, (1, 0)) * 2
     del ints.tmp24
-    tmp4 += ints.tmp7.transpose((1, 0)) * 2
+    tmp4 += np.transpose(ints.tmp7, (1, 0)) * 2
     del ints.tmp7
-    tmp4 += ints.tmp18.transpose((1, 0)) * -1
+    tmp4 += np.transpose(ints.tmp18, (1, 0)) * -1
     del ints.tmp18
-    tmp4 += ints.tmp23.transpose((1, 0)) * -1
+    tmp4 += np.transpose(ints.tmp23, (1, 0)) * -1
     del ints.tmp23
-    tmp4 += ints.tmp5.transpose((1, 0)) * -1
+    tmp4 += np.transpose(ints.tmp5, (1, 0)) * -1
     del ints.tmp5
-    tmp0 = r2.copy() * -1
-    tmp0 += r2.transpose((1, 0, 2)) * 2
-    tmp1 = r2.copy()
-    tmp1 += r2.transpose((1, 0, 2)) * -0.5
+    tmp0 = np.copy(r2) * -1
+    tmp0 += np.transpose(r2, (1, 0, 2)) * 2
+    tmp1 = np.copy(r2)
+    tmp1 += np.transpose(r2, (1, 0, 2)) * -0.5
     r2new = einsum(r2, (0, 1, 2), ints.tmp47, (3, 1, 4, 2), (3, 0, 4))
     del ints.tmp47
     r2new += einsum(tmp5, (0, 1, 2, 3), r2, (1, 4, 3), (0, 4, 2)) * -2
@@ -1477,52 +1477,52 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     """
 
     ints = kwargs["ints"]
-    tmp4 = r2.transpose((2, 0, 1)).copy() * -0.5
-    tmp4 += r2.transpose((2, 1, 0))
-    tmp2 = r2.transpose((2, 0, 1)).copy() * 2
-    tmp2 += r2.transpose((2, 1, 0)) * -1
+    tmp4 = np.copy(np.transpose(r2, (2, 0, 1))) * -0.5
+    tmp4 += np.transpose(r2, (2, 1, 0))
+    tmp2 = np.copy(np.transpose(r2, (2, 0, 1))) * 2
+    tmp2 += np.transpose(r2, (2, 1, 0)) * -1
     tmp13 = einsum(t1, (0, 1), f.ov, (0, 2), (2, 1))
     tmp5 = einsum(tmp4, (0, 1, 2), ints.tmp15, (0, 3, 2, 1), (3,)) * 2
     del tmp4
-    tmp1 = f.ov.copy()
+    tmp1 = np.copy(f.ov)
     tmp1 += ints.tmp12 * 2
     del ints.tmp12
     tmp1 += ints.tmp10 * -1
     del ints.tmp10
     tmp10 = einsum(tmp2, (0, 1, 2), v.xov, (3, 0, 1), (2, 3)) * 0.5
-    tmp8 = ints.tmp37.copy() * 0.5
+    tmp8 = np.copy(ints.tmp37) * 0.5
     tmp8 += ints.tmp68
     tmp8 += ints.tmp36 * -0.5
-    tmp12 = ints.tmp1.copy()
-    tmp12 += ints.tmp39.transpose((0, 2, 3, 1))
+    tmp12 = np.copy(ints.tmp1)
+    tmp12 += np.transpose(ints.tmp39, (0, 2, 3, 1))
     del ints.tmp39
-    tmp12 += ints.tmp62.transpose((0, 3, 2, 1)) * 2
+    tmp12 += np.transpose(ints.tmp62, (0, 3, 2, 1)) * 2
     del ints.tmp62
     tmp12 += ints.tmp33 * -1
     del ints.tmp33
-    tmp12 += ints.tmp64.transpose((0, 3, 2, 1)) * -1
+    tmp12 += np.transpose(ints.tmp64, (0, 3, 2, 1)) * -1
     del ints.tmp64
-    tmp12 += ints.tmp65.transpose((0, 3, 2, 1)) * -1
+    tmp12 += np.transpose(ints.tmp65, (0, 3, 2, 1)) * -1
     del ints.tmp65
-    tmp14 = ints.tmp24.transpose((1, 0)).copy() * 2
+    tmp14 = np.copy(np.transpose(ints.tmp24, (1, 0))) * 2
     tmp14 += f.vv * -1
-    tmp14 += ints.tmp21.transpose((1, 0)) * -1
+    tmp14 += np.transpose(ints.tmp21, (1, 0)) * -1
     tmp14 += tmp13
     del tmp13
-    tmp9 = ints.tmp36.copy()
+    tmp9 = np.copy(ints.tmp36)
     del ints.tmp36
     tmp9 += ints.tmp37 * -1
     del ints.tmp37
-    tmp15 = f.oo.copy()
+    tmp15 = np.copy(f.oo)
     tmp15 += ints.tmp46
     del ints.tmp46
-    tmp15 += ints.tmp53.transpose((1, 0)) * 2
+    tmp15 += np.transpose(ints.tmp53, (1, 0)) * 2
     del ints.tmp53
-    tmp15 += ints.tmp51.transpose((1, 0)) * -1
+    tmp15 += np.transpose(ints.tmp51, (1, 0)) * -1
     del ints.tmp51
     tmp7 = einsum(ints.tmp15, (0, 1, 2, 3), r2, (3, 2, 4), (0, 1, 4))
     del ints.tmp15
-    tmp17 = f.ov.copy()
+    tmp17 = np.copy(f.ov)
     tmp17 += ints.tmp45
     del ints.tmp45
     tmp17 += ints.tmp49 * 2
@@ -1541,27 +1541,27 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp58
     tmp17 += ints.tmp60 * -1
     del ints.tmp60
-    tmp11 = ints.tmp23.copy() * 2
+    tmp11 = np.copy(ints.tmp23) * 2
     del ints.tmp23
-    tmp11 += v.xov.transpose((1, 2, 0))
+    tmp11 += np.transpose(v.xov, (1, 2, 0))
     tmp11 += ints.tmp20 * -1
     del ints.tmp20
     tmp16 = einsum(r1, (0,), f.ov, (1, 0), (1,))
     tmp16 += tmp5 * -1
-    tmp6 = tmp5.copy() * -1
+    tmp6 = np.copy(tmp5) * -1
     del tmp5
     tmp6 += einsum(r1, (0,), tmp1, (1, 0), (1,))
-    tmp3 = f.vv.copy()
-    tmp3 += ints.tmp21.transpose((1, 0))
+    tmp3 = np.copy(f.vv)
+    tmp3 += np.transpose(ints.tmp21, (1, 0))
     del ints.tmp21
-    tmp3 += ints.tmp5.transpose((1, 0)) * 2
+    tmp3 += np.transpose(ints.tmp5, (1, 0)) * 2
     del ints.tmp5
-    tmp3 += ints.tmp24.transpose((1, 0)) * -2
+    tmp3 += np.transpose(ints.tmp24, (1, 0)) * -2
     del ints.tmp24
     tmp3 += ints.tmp8 * -1
     del ints.tmp8
-    tmp0 = r2.transpose((2, 0, 1)).copy()
-    tmp0 += r2.transpose((2, 1, 0)) * -0.5
+    tmp0 = np.copy(np.transpose(r2, (2, 0, 1)))
+    tmp0 += np.transpose(r2, (2, 1, 0)) * -0.5
     r2new = einsum(ints.tmp47, (0, 1, 2, 3), r2, (1, 3, 4), (2, 0, 4))
     del ints.tmp47
     r2new += einsum(ints.tmp68, (0, 1, 2, 3), r2, (4, 3, 1), (2, 4, 0))
@@ -1788,46 +1788,46 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     """
 
     ints = kwargs["ints"]
-    tmp0 = r2.copy()
-    tmp0 += r2.transpose((1, 0, 2)) * -0.5
-    tmp9 = ints.tmp35.copy() * 2
+    tmp0 = np.copy(r2)
+    tmp0 += np.transpose(r2, (1, 0, 2)) * -0.5
+    tmp9 = np.copy(ints.tmp35) * 2
     del ints.tmp35
-    tmp9 += v.xov.transpose((1, 2, 0))
+    tmp9 += np.transpose(v.xov, (1, 2, 0))
     tmp9 += ints.tmp32 * -1
     del ints.tmp32
-    tmp12 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp12 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp12 += t2
     tmp10 = einsum(tmp0, (0, 1, 2), tmp9, (0, 2, 3), (1, 3)) * 2
     del tmp9
-    tmp8 = ints.tmp139.copy()
+    tmp8 = np.copy(ints.tmp139)
     tmp8 += ints.tmp141 * -1
     tmp13 = einsum(r2, (0, 1, 2), tmp12, (0, 1, 2, 3), (3,))
     del tmp12
-    tmp14 = f.oo.copy()
-    tmp14 += ints.tmp0.transpose((1, 0))
+    tmp14 = np.copy(f.oo)
+    tmp14 += np.transpose(ints.tmp0, (1, 0))
     tmp14 += ints.tmp36 * 2
     tmp14 += ints.tmp33 * -1
-    tmp7 = ints.tmp139.copy() * 0.5
+    tmp7 = np.copy(ints.tmp139) * 0.5
     del ints.tmp139
     tmp7 += ints.tmp142
     tmp7 += ints.tmp141 * -0.5
     del ints.tmp141
-    tmp11 = ints.tmp163.copy() * 2
+    tmp11 = np.copy(ints.tmp163) * 2
     del ints.tmp163
     tmp11 += f.vv * -1
     tmp11 += ints.tmp161 * -1
     del ints.tmp161
     tmp11 += einsum(f.ov, (0, 1), t1, (0, 2), (2, 1))
-    tmp5 = r2.copy() * 2
-    tmp5 += r2.transpose((1, 0, 2)) * -1
-    tmp2 = r2.copy() * -1
-    tmp2 += r2.transpose((1, 0, 2)) * 2
-    tmp6 = f.oo.copy()
-    tmp6 += ints.tmp0.transpose((1, 0))
+    tmp5 = np.copy(r2) * 2
+    tmp5 += np.transpose(r2, (1, 0, 2)) * -1
+    tmp2 = np.copy(r2) * -1
+    tmp2 += np.transpose(r2, (1, 0, 2)) * 2
+    tmp6 = np.copy(f.oo)
+    tmp6 += np.transpose(ints.tmp0, (1, 0))
     del ints.tmp0
     tmp6 += ints.tmp107 * 2
     del ints.tmp107
-    tmp6 += ints.tmp16.transpose((1, 0)) * 2
+    tmp6 += np.transpose(ints.tmp16, (1, 0)) * 2
     del ints.tmp16
     tmp6 += ints.tmp36 * 2
     del ints.tmp36
@@ -1837,25 +1837,25 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp14
     tmp6 += ints.tmp33 * -1
     del ints.tmp33
-    tmp3 = ints.tmp117.copy()
+    tmp3 = np.copy(ints.tmp117)
     del ints.tmp117
-    tmp3 += ints.tmp46.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(ints.tmp46, (0, 2, 1, 3))
     del ints.tmp46
-    tmp3 += ints.tmp48.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(ints.tmp48, (0, 2, 1, 3))
     del ints.tmp48
-    tmp3 += ints.tmp74.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(ints.tmp74, (0, 2, 1, 3))
     del ints.tmp74
-    tmp3 += ints.tmp91.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(ints.tmp91, (0, 2, 1, 3))
     del ints.tmp91
     tmp3 += ints.tmp30 * -1
     del ints.tmp30
-    tmp3 += ints.tmp50.transpose((0, 2, 1, 3)) * -2
+    tmp3 += np.transpose(ints.tmp50, (0, 2, 1, 3)) * -2
     del ints.tmp50
-    tmp3 += ints.tmp6.transpose((1, 0, 2, 3)) * -1
+    tmp3 += np.transpose(ints.tmp6, (1, 0, 2, 3)) * -1
     del ints.tmp6
-    tmp3 += ints.tmp77.transpose((0, 2, 1, 3)) * -2
+    tmp3 += np.transpose(ints.tmp77, (0, 2, 1, 3)) * -2
     del ints.tmp77
-    tmp4 = ints.tmp111.copy() * 2
+    tmp4 = np.copy(ints.tmp111) * 2
     del ints.tmp111
     tmp4 += ints.tmp123
     del ints.tmp123
@@ -1906,13 +1906,13 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp83
     tmp4 += ints.tmp98 * -1
     del ints.tmp98
-    tmp1 = ints.tmp103.copy()
+    tmp1 = np.copy(ints.tmp103)
     del ints.tmp103
     tmp1 += ints.tmp115
     del ints.tmp115
     tmp1 += ints.tmp134
     del ints.tmp134
-    tmp1 += ints.tmp19.transpose((0, 2, 1, 3))
+    tmp1 += np.transpose(ints.tmp19, (0, 2, 1, 3))
     del ints.tmp19
     tmp1 += ints.tmp44
     del ints.tmp44
@@ -1920,7 +1920,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp86
     tmp1 += ints.tmp93
     del ints.tmp93
-    tmp1 += ints.tmp10.transpose((1, 2, 0, 3)) * -1
+    tmp1 += np.transpose(ints.tmp10, (1, 2, 0, 3)) * -1
     tmp1 += ints.tmp125 * -1
     del ints.tmp125
     tmp1 += ints.tmp28 * -1
@@ -2135,68 +2135,68 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
 
     ints = kwargs["ints"]
     tmp11 = einsum(t1, (0, 1), r2, (2, 1, 3), (3, 0, 2))
-    tmp0 = r2.transpose((2, 0, 1)).copy()
-    tmp0 += r2.transpose((2, 1, 0)) * -0.5
-    tmp22 = ints.tmp37.copy() * 2
+    tmp0 = np.copy(np.transpose(r2, (2, 0, 1)))
+    tmp0 += np.transpose(r2, (2, 1, 0)) * -0.5
+    tmp22 = np.copy(ints.tmp37) * 2
     del ints.tmp37
-    tmp22 += v.xov.transpose((1, 2, 0))
+    tmp22 += np.transpose(v.xov, (1, 2, 0))
     tmp22 += ints.tmp34 * -1
     del ints.tmp34
-    tmp27 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp27 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp27 += t2 * -0.5
     tmp24 = einsum(t1, (0, 1), f.ov, (0, 2), (2, 1))
     tmp12 = einsum(tmp11, (0, 1, 2), t1, (3, 2), (0, 3, 1))
     del tmp11
-    tmp6 = r2.transpose((2, 0, 1)).copy() * -0.5
-    tmp6 += r2.transpose((2, 1, 0))
-    tmp16 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp6 = np.copy(np.transpose(r2, (2, 0, 1))) * -0.5
+    tmp6 += np.transpose(r2, (2, 1, 0))
+    tmp16 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp16 += t2 * -1
     tmp19 = einsum(r2, (0, 1, 2), t2, (3, 4, 0, 1), (2, 3, 4))
-    tmp21 = ints.tmp105.copy()
+    tmp21 = np.copy(ints.tmp105)
     tmp21 += ints.tmp29 * -1
     tmp23 = einsum(tmp22, (0, 1, 2), tmp0, (0, 1, 3), (3, 2)) * 2
     del tmp22
     tmp28 = einsum(tmp27, (0, 1, 2, 3), r2, (3, 2, 0), (1,))
     del tmp27
-    tmp20 = ints.tmp107.copy()
+    tmp20 = np.copy(ints.tmp107)
     tmp20 += ints.tmp29 * 0.5
     tmp20 += ints.tmp105 * -0.5
-    tmp26 = f.oo.copy()
-    tmp26 += ints.tmp10.transpose((1, 0))
+    tmp26 = np.copy(f.oo)
+    tmp26 += np.transpose(ints.tmp10, (1, 0))
     del ints.tmp10
     tmp26 += ints.tmp92 * 2
     del ints.tmp92
     tmp26 += ints.tmp96 * -1
     del ints.tmp96
-    tmp25 = ints.tmp38.copy() * 2
+    tmp25 = np.copy(ints.tmp38) * 2
     tmp25 += f.vv * -1
     tmp25 += ints.tmp35 * -1
-    tmp25 += tmp24.transpose((1, 0))
+    tmp25 += np.transpose(tmp24, (1, 0))
     del tmp24
-    tmp5 = ints.tmp125.transpose((0, 1, 3, 2)).copy()
+    tmp5 = np.copy(np.transpose(ints.tmp125, (0, 1, 3, 2)))
     del ints.tmp125
-    tmp5 += ints.tmp29.transpose((0, 1, 3, 2))
+    tmp5 += np.transpose(ints.tmp29, (0, 1, 3, 2))
     del ints.tmp29
     tmp5 += ints.tmp105 * -1
     del ints.tmp105
-    tmp2 = r2.transpose((2, 0, 1)).copy() * -1
-    tmp2 += r2.transpose((2, 1, 0)) * 2
-    tmp10 = r2.transpose((2, 0, 1)).copy() * 2
-    tmp10 += r2.transpose((2, 1, 0)) * -1
-    tmp8 = ints.tmp102.copy() * 2
+    tmp2 = np.copy(np.transpose(r2, (2, 0, 1))) * -1
+    tmp2 += np.transpose(r2, (2, 1, 0)) * 2
+    tmp10 = np.copy(np.transpose(r2, (2, 0, 1))) * 2
+    tmp10 += np.transpose(r2, (2, 1, 0)) * -1
+    tmp8 = np.copy(ints.tmp102) * 2
     del ints.tmp102
-    tmp8 += ints.tmp127.transpose((0, 1, 3, 2))
+    tmp8 += np.transpose(ints.tmp127, (0, 1, 3, 2))
     del ints.tmp127
     tmp8 += ints.tmp25
     tmp8 += ints.tmp100 * -1
     del ints.tmp100
     tmp8 += ints.tmp107 * -1
-    tmp13 = tmp12.copy() * -0.5
-    tmp13 += tmp12.transpose((0, 2, 1))
-    tmp14 = tmp12.copy() * 2
-    tmp14 += tmp12.transpose((0, 2, 1)) * -1
+    tmp13 = np.copy(tmp12) * -0.5
+    tmp13 += np.transpose(tmp12, (0, 2, 1))
+    tmp14 = np.copy(tmp12) * 2
+    tmp14 += np.transpose(tmp12, (0, 2, 1)) * -1
     del tmp12
-    tmp9 = ints.tmp114.copy() * 2
+    tmp9 = np.copy(ints.tmp114) * 2
     del ints.tmp114
     tmp9 += ints.tmp11
     del ints.tmp11
@@ -2246,27 +2246,27 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp86
     tmp9 += ints.tmp97 * -1
     del ints.tmp97
-    tmp15 = f.vv.copy()
-    tmp15 += ints.tmp16.transpose((1, 0)) * 2
+    tmp15 = np.copy(f.vv)
+    tmp15 += np.transpose(ints.tmp16, (1, 0)) * 2
     del ints.tmp16
     tmp15 += ints.tmp35
     del ints.tmp35
-    tmp15 += ints.tmp19.transpose((1, 0)) * -1
+    tmp15 += np.transpose(ints.tmp19, (1, 0)) * -1
     del ints.tmp19
     tmp15 += ints.tmp38 * -2
     del ints.tmp38
     tmp7 = einsum(tmp6, (0, 1, 2), t1, (3, 1), (0, 3, 2)) * 2
     del tmp6
-    tmp3 = ints.tmp47.copy()
+    tmp3 = np.copy(ints.tmp47)
     del ints.tmp47
     tmp3 += ints.tmp58 * 2
     del ints.tmp58
     tmp3 += ints.tmp56 * -1
     del ints.tmp56
-    tmp3 += ints.tmp63.transpose((0, 1, 3, 2)) * -1
+    tmp3 += np.transpose(ints.tmp63, (0, 1, 3, 2)) * -1
     del ints.tmp63
     tmp4 = einsum(tmp0, (0, 1, 2), t1, (3, 1), (0, 3, 2))
-    tmp18 = f.ov.copy()
+    tmp18 = np.copy(f.ov)
     tmp18 += ints.tmp20 * 2
     del ints.tmp20
     tmp18 += ints.tmp66 * -1
@@ -2274,12 +2274,12 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp17 = einsum(r1, (0,), t1, (1, 0), (1,)) * 0.5
     tmp17 += einsum(r2, (0, 1, 2), tmp16, (2, 3, 1, 0), (3,)) * -0.5
     del tmp16
-    tmp1 = ints.tmp12.copy()
+    tmp1 = np.copy(ints.tmp12)
     tmp1 += ints.tmp31
     del ints.tmp31
-    tmp1 += ints.tmp89.transpose((0, 3, 1, 2))
+    tmp1 += np.transpose(ints.tmp89, (0, 3, 1, 2))
     del ints.tmp89
-    tmp1 += ints.tmp61.transpose((0, 2, 1, 3)) * -1
+    tmp1 += np.transpose(ints.tmp61, (0, 2, 1, 3)) * -1
     del ints.tmp61
     r2new = einsum(r1, (0,), ints.tmp12, (1, 2, 0, 3), (3, 2, 1)) * -1
     del ints.tmp12

--- a/ebcc/codegen/RDFCCD.py
+++ b/ebcc/codegen/RDFCCD.py
@@ -460,7 +460,7 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.vvov = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[0], t2.shape[-1]))
     rdm2.vvvo = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[0]))
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.swapaxes(1, 2)
+    rdm2 = rdm2.transpose(0, 2, 1, 3)
 
     return rdm2
 

--- a/ebcc/codegen/RDFCCD.py
+++ b/ebcc/codegen/RDFCCD.py
@@ -33,7 +33,7 @@ def energy(t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp0 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp0 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp0 += t2 * -1
     tmp1 = einsum(v.xov, (0, 1, 2), tmp0, (1, 3, 4, 2), (3, 4, 0)) * 0.5
     del tmp0
@@ -62,10 +62,10 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     """
 
     tmp3 = einsum(v.xov, (0, 1, 2), t2, (3, 1, 2, 4), (3, 4, 0))
-    tmp12 = v.xov.transpose((1, 2, 0)).copy()
+    tmp12 = np.copy(np.transpose(v.xov, (1, 2, 0)))
     tmp12 += tmp3 * -1
     tmp1 = einsum(v.xov, (0, 1, 2), v.xov, (0, 3, 4), (3, 1, 4, 2))
-    tmp17 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp17 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp17 += t2 * -1
     tmp13 = einsum(v.xov, (0, 1, 2), tmp12, (3, 4, 0), (1, 3, 2, 4))
     del tmp12
@@ -73,9 +73,9 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp8 = einsum(v.xvv, (0, 1, 2), v.xoo, (0, 3, 4), (3, 4, 1, 2))
     tmp18 = einsum(v.xov, (0, 1, 2), tmp17, (1, 3, 4, 2), (3, 4, 0))
     del tmp17
-    tmp14 = tmp8.transpose((1, 0, 3, 2)).copy()
+    tmp14 = np.copy(np.transpose(tmp8, (1, 0, 3, 2)))
     tmp14 += tmp4 * -1
-    tmp14 += tmp13.transpose((1, 0, 3, 2)) * -2
+    tmp14 += np.transpose(tmp13, (1, 0, 3, 2)) * -2
     del tmp13
     tmp21 = einsum(v.xov, (0, 1, 2), tmp18, (3, 2, 0), (1, 3))
     tmp19 = einsum(tmp18, (0, 1, 2), v.xov, (2, 0, 3), (3, 1)) * 0.5
@@ -90,20 +90,20 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     del tmp21
     tmp20 = einsum(t2, (0, 1, 2, 3), tmp19, (2, 4), (0, 1, 3, 4)) * 2
     del tmp19
-    tmp24 = tmp1.transpose((1, 0, 2, 3)).copy() * -1
-    tmp24 += tmp1.transpose((1, 0, 3, 2)) * 2
+    tmp24 = np.copy(np.transpose(tmp1, (1, 0, 2, 3))) * -1
+    tmp24 += np.transpose(tmp1, (1, 0, 3, 2)) * 2
     tmp0 = einsum(v.xoo, (0, 1, 2), v.xoo, (0, 3, 4), (3, 1, 2, 4))
-    tmp16 = tmp11.copy()
+    tmp16 = np.copy(tmp11)
     del tmp11
     tmp16 += tmp15
     del tmp15
-    tmp10 = tmp7.copy()
+    tmp10 = np.copy(tmp7)
     del tmp7
     tmp10 += tmp9 * -1
     del tmp9
-    tmp23 = tmp20.transpose((1, 0, 2, 3)).copy()
+    tmp23 = np.copy(np.transpose(tmp20, (1, 0, 2, 3)))
     del tmp20
-    tmp23 += tmp22.transpose((0, 1, 3, 2))
+    tmp23 += np.transpose(tmp22, (0, 1, 3, 2))
     del tmp22
     tmp2 = einsum(v.xvv, (0, 1, 2), v.xvv, (0, 3, 4), (3, 1, 2, 4))
     tmp6 = einsum(f.oo, (0, 1), t2, (2, 1, 3, 4), (0, 2, 3, 4))
@@ -112,7 +112,7 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp5 = einsum(tmp1, (0, 1, 2, 3), t2, (4, 5, 3, 2), (4, 5, 1, 0))
     t2new = einsum(tmp0, (0, 1, 2, 3), t2, (1, 3, 4, 5), (2, 0, 4, 5))
     del tmp0
-    t2new += tmp1.transpose((1, 0, 3, 2))
+    t2new += np.transpose(tmp1, (1, 0, 3, 2))
     del tmp1
     t2new += einsum(t2, (0, 1, 2, 3), tmp2, (4, 2, 5, 3), (0, 1, 5, 4))
     del tmp2
@@ -122,17 +122,17 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     del tmp4
     t2new += einsum(tmp5, (0, 1, 2, 3), t2, (2, 3, 4, 5), (1, 0, 5, 4))
     del tmp5
-    t2new += tmp6.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp6.transpose((1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp6, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp6, (1, 0, 2, 3)) * -1
     del tmp6
-    t2new += tmp10.transpose((0, 1, 3, 2))
-    t2new += tmp10.transpose((1, 0, 2, 3))
+    t2new += np.transpose(tmp10, (0, 1, 3, 2))
+    t2new += np.transpose(tmp10, (1, 0, 2, 3))
     del tmp10
     t2new += tmp16 * -1
-    t2new += tmp16.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp16, (1, 0, 3, 2)) * -1
     del tmp16
     t2new += tmp23 * -1
-    t2new += tmp23.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp23, (1, 0, 3, 2)) * -1
     del tmp23
     t2new += einsum(t2, (0, 1, 2, 3), tmp25, (4, 1, 5, 3), (4, 0, 5, 2)) * 2
     del tmp25
@@ -160,17 +160,17 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
         Updated L2 residuals.
     """
 
-    tmp18 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp18 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp18 += t2 * -1
-    tmp25 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp25 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp25 += t2
-    tmp29 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp29 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp29 += t2 * -0.5
-    tmp34 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp34 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp34 += t2 * -1
     tmp1 = einsum(v.xov, (0, 1, 2), v.xov, (0, 3, 4), (3, 1, 4, 2))
-    tmp14 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp14 += l2.transpose((2, 3, 0, 1)) * 2
+    tmp14 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp14 += np.transpose(l2, (2, 3, 0, 1)) * 2
     tmp19 = einsum(v.xov, (0, 1, 2), tmp18, (1, 3, 4, 2), (3, 4, 0))
     del tmp18
     tmp26 = einsum(l2, (0, 1, 2, 3), tmp25, (2, 4, 0, 1), (3, 4)) * 2
@@ -184,9 +184,9 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp13 = einsum(t2, (0, 1, 2, 3), l2, (4, 2, 5, 1), (5, 0, 4, 3))
     tmp15 = einsum(t2, (0, 1, 2, 3), tmp14, (1, 4, 3, 5), (0, 4, 2, 5))
     del tmp14
-    tmp21 = l2.transpose((3, 2, 0, 1)).copy() * 2
-    tmp21 += l2.transpose((2, 3, 0, 1)) * -1
-    tmp20 = v.xov.transpose((1, 2, 0)).copy()
+    tmp21 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * 2
+    tmp21 += np.transpose(l2, (2, 3, 0, 1)) * -1
+    tmp20 = np.copy(np.transpose(v.xov, (1, 2, 0)))
     tmp20 += tmp19
     del tmp19
     tmp27 = einsum(tmp26, (0, 1), v.xov, (2, 1, 3), (0, 3, 2)) * 0.5
@@ -196,12 +196,12 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp38 = einsum(v.xov, (0, 1, 2), tmp35, (3, 2, 0), (1, 3))
     tmp36 = einsum(tmp35, (0, 1, 2), v.xov, (2, 0, 3), (3, 1)) * 0.5
     del tmp35
-    tmp9 = tmp7.transpose((1, 0, 3, 2)).copy() * -1
+    tmp9 = np.copy(np.transpose(tmp7, (1, 0, 3, 2))) * -1
     tmp9 += tmp8
     del tmp8
-    tmp16 = tmp13.copy()
+    tmp16 = np.copy(tmp13)
     del tmp13
-    tmp16 += tmp15.transpose((1, 0, 3, 2)) * -1
+    tmp16 += np.transpose(tmp15, (1, 0, 3, 2)) * -1
     del tmp15
     tmp22 = einsum(tmp20, (0, 1, 2), tmp21, (0, 3, 4, 1), (3, 4, 2))
     del tmp20, tmp21
@@ -223,51 +223,51 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp12 = einsum(tmp7, (0, 1, 2, 3), l2, (4, 3, 5, 1), (5, 0, 4, 2))
     del tmp7
     tmp0 = einsum(v.xoo, (0, 1, 2), v.xoo, (0, 3, 4), (3, 1, 2, 4))
-    tmp33 = tmp28.transpose((1, 0, 2, 3)).copy()
+    tmp33 = np.copy(np.transpose(tmp28, (1, 0, 2, 3)))
     del tmp28
-    tmp33 += tmp32.transpose((0, 1, 3, 2))
+    tmp33 += np.transpose(tmp32, (0, 1, 3, 2))
     del tmp32
     tmp3 = einsum(l2, (0, 1, 2, 3), t2, (4, 5, 0, 1), (2, 3, 4, 5))
-    tmp40 = tmp37.transpose((1, 0, 2, 3)).copy()
+    tmp40 = np.copy(np.transpose(tmp37, (1, 0, 2, 3)))
     del tmp37
-    tmp40 += tmp39.transpose((1, 0, 3, 2))
+    tmp40 += np.transpose(tmp39, (1, 0, 3, 2))
     del tmp39
     tmp4 = einsum(tmp1, (0, 1, 2, 3), t2, (4, 5, 2, 3), (4, 5, 0, 1))
     tmp2 = einsum(v.xvv, (0, 1, 2), v.xvv, (0, 3, 4), (3, 1, 2, 4))
-    tmp11 = tmp6.copy()
+    tmp11 = np.copy(tmp6)
     del tmp6
     tmp11 += tmp10
     del tmp10
-    tmp24 = tmp12.copy()
+    tmp24 = np.copy(tmp12)
     del tmp12
-    tmp24 += tmp17.transpose((1, 0, 3, 2)) * -1
+    tmp24 += np.transpose(tmp17, (1, 0, 3, 2)) * -1
     del tmp17
-    tmp24 += tmp23.transpose((1, 0, 3, 2)) * -1
+    tmp24 += np.transpose(tmp23, (1, 0, 3, 2)) * -1
     del tmp23
     tmp5 = einsum(f.oo, (0, 1), l2, (2, 3, 4, 1), (0, 4, 2, 3))
     l2new = einsum(tmp0, (0, 1, 2, 3), l2, (4, 5, 3, 1), (4, 5, 0, 2))
     del tmp0
-    l2new += tmp1.transpose((3, 2, 1, 0))
+    l2new += np.transpose(tmp1, (3, 2, 1, 0))
     l2new += einsum(l2, (0, 1, 2, 3), tmp2, (4, 0, 5, 1), (4, 5, 3, 2))
     del tmp2
     l2new += einsum(tmp3, (0, 1, 2, 3), tmp1, (3, 2, 4, 5), (4, 5, 1, 0))
     del tmp1, tmp3
     l2new += einsum(tmp4, (0, 1, 2, 3), l2, (4, 5, 0, 1), (4, 5, 2, 3))
     del tmp4
-    l2new += tmp5.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp5.transpose((2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp5, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp5, (2, 3, 1, 0)) * -1
     del tmp5
-    l2new += tmp11.transpose((3, 2, 0, 1))
-    l2new += tmp11.transpose((2, 3, 1, 0))
+    l2new += np.transpose(tmp11, (3, 2, 0, 1))
+    l2new += np.transpose(tmp11, (2, 3, 1, 0))
     del tmp11
-    l2new += tmp24.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp24.transpose((3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp24, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp24, (3, 2, 1, 0)) * -1
     del tmp24
-    l2new += tmp33.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp33.transpose((2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp33, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp33, (2, 3, 1, 0)) * -1
     del tmp33
-    l2new += tmp40.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp40.transpose((3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp40, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp40, (3, 2, 1, 0)) * -1
     del tmp40
 
     return {f"l2new": l2new}
@@ -294,10 +294,10 @@ def make_rdm1_f(l2=None, t2=None, **kwargs):
         oo=np.eye(t2.shape[0]),
         vv=np.eye(t2.shape[-1]),
     )
-    tmp0 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp0 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp0 += t2 * -0.5
     rdm1.vv = einsum(tmp0, (0, 1, 2, 3), l2, (4, 2, 0, 1), (4, 3)) * 4
-    rdm1.oo = delta.oo.copy() * 2
+    rdm1.oo = np.copy(delta.oo) * 2
     del delta
     rdm1.oo += einsum(l2, (0, 1, 2, 3), tmp0, (2, 4, 1, 0), (4, 3)) * -4
     del tmp0
@@ -329,27 +329,27 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
         oo=np.eye(t2.shape[0]),
         vv=np.eye(t2.shape[-1]),
     )
-    tmp3 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp3 += l2.transpose((2, 3, 0, 1)) * 2
-    tmp6 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp6 += l2.transpose((2, 3, 0, 1))
-    tmp1 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp3 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp3 += np.transpose(l2, (2, 3, 0, 1)) * 2
+    tmp6 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp6 += np.transpose(l2, (2, 3, 0, 1))
+    tmp1 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp1 += t2 * -0.5
-    tmp13 = l2.transpose((3, 2, 0, 1)).copy() * 2
-    tmp13 += l2.transpose((2, 3, 0, 1)) * -1
+    tmp13 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * 2
+    tmp13 += np.transpose(l2, (2, 3, 0, 1)) * -1
     tmp4 = einsum(t2, (0, 1, 2, 3), tmp3, (1, 4, 3, 5), (0, 4, 2, 5))
     tmp7 = einsum(t2, (0, 1, 2, 3), tmp6, (1, 4, 2, 5), (0, 4, 3, 5))
     tmp2 = einsum(tmp1, (0, 1, 2, 3), l2, (3, 2, 0, 4), (4, 1)) * 2
     del tmp1
     tmp14 = einsum(t2, (0, 1, 2, 3), tmp13, (0, 1, 3, 4), (2, 4)) * 0.5
-    tmp26 = l2.transpose((3, 2, 0, 1)).copy() * 2
-    tmp26 += l2.transpose((2, 3, 0, 1)) * -1
-    tmp22 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp26 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * 2
+    tmp26 += np.transpose(l2, (2, 3, 0, 1)) * -1
+    tmp22 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp22 += t2
-    tmp24 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp24 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp24 += t2 * 2
-    tmp28 = l2.transpose((3, 2, 0, 1)).copy()
-    tmp28 += l2.transpose((2, 3, 0, 1)) * -1
+    tmp28 = np.copy(np.transpose(l2, (3, 2, 0, 1)))
+    tmp28 += np.transpose(l2, (2, 3, 0, 1)) * -1
     tmp5 = einsum(t2, (0, 1, 2, 3), tmp4, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp4
     tmp8 = einsum(t2, (0, 1, 2, 3), tmp7, (4, 1, 5, 2), (0, 4, 3, 5))
@@ -374,75 +374,75 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     del tmp24
     tmp29 = einsum(t2, (0, 1, 2, 3), tmp28, (1, 4, 5, 2), (0, 4, 3, 5))
     del tmp28
-    tmp9 = tmp5.copy() * 2
-    tmp9 += tmp8.transpose((1, 0, 3, 2))
+    tmp9 = np.copy(tmp5) * 2
+    tmp9 += np.transpose(tmp8, (1, 0, 3, 2))
     del tmp8
-    tmp17 = tmp15.transpose((1, 0, 2, 3)).copy()
+    tmp17 = np.copy(np.transpose(tmp15, (1, 0, 2, 3)))
     del tmp15
-    tmp17 += tmp16.transpose((0, 1, 3, 2))
+    tmp17 += np.transpose(tmp16, (0, 1, 3, 2))
     del tmp16
     tmp19 = einsum(tmp18, (0, 1, 2, 3), t2, (4, 0, 2, 5), (4, 1, 5, 3))
     tmp21 = einsum(tmp20, (0, 1, 2, 3), t2, (4, 0, 2, 5), (4, 1, 5, 3))
     tmp12 = einsum(tmp0, (0, 1, 2, 3), t2, (1, 0, 4, 5), (3, 2, 4, 5))
     tmp11 = einsum(t2, (0, 1, 2, 3), tmp10, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp10
-    rdm2.vvvv = tmp32.transpose((1, 0, 2, 3)).copy() * -2
-    rdm2.vvvv += tmp32.transpose((1, 0, 3, 2)) * 4
+    rdm2.vvvv = np.copy(np.transpose(tmp32, (1, 0, 2, 3))) * -2
+    rdm2.vvvv += np.transpose(tmp32, (1, 0, 3, 2)) * 4
     del tmp32
-    rdm2.vvoo = l2.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.vvoo = np.copy(np.transpose(l2, (0, 1, 3, 2))) * -2
     rdm2.vvoo += l2 * 4
-    rdm2.vovo = tmp27.transpose((3, 0, 2, 1)).copy() * -2
-    rdm2.vovo += tmp31.transpose((3, 0, 2, 1)) * -2
+    rdm2.vovo = np.copy(np.transpose(tmp27, (3, 0, 2, 1))) * -2
+    rdm2.vovo += np.transpose(tmp31, (3, 0, 2, 1)) * -2
     del tmp31
     rdm2.vovo += einsum(delta.oo, (0, 1), tmp30, (2, 3), (3, 0, 2, 1)) * 4
-    rdm2.vovo += tmp20.transpose((2, 1, 3, 0)) * -2
-    rdm2.voov = tmp25.transpose((2, 1, 0, 3)).copy() * 2
-    rdm2.voov += tmp23.transpose((2, 1, 0, 3)) * -2
+    rdm2.vovo += np.transpose(tmp20, (2, 1, 3, 0)) * -2
+    rdm2.voov = np.copy(np.transpose(tmp25, (2, 1, 0, 3))) * 2
+    rdm2.voov += np.transpose(tmp23, (2, 1, 0, 3)) * -2
     rdm2.voov += einsum(delta.oo, (0, 1), tmp30, (2, 3), (3, 0, 1, 2)) * -2
     del tmp30
-    rdm2.voov += tmp18.transpose((2, 1, 0, 3)) * -2
-    rdm2.voov += tmp27.transpose((3, 0, 1, 2)) * 2
-    rdm2.ovvo = tmp27.transpose((0, 3, 2, 1)).copy() * 4
+    rdm2.voov += np.transpose(tmp18, (2, 1, 0, 3)) * -2
+    rdm2.voov += np.transpose(tmp27, (3, 0, 1, 2)) * 2
+    rdm2.ovvo = np.copy(np.transpose(tmp27, (0, 3, 2, 1))) * 4
     del tmp27
-    rdm2.ovvo += tmp29.transpose((0, 3, 2, 1)) * -2
+    rdm2.ovvo += np.transpose(tmp29, (0, 3, 2, 1)) * -2
     del tmp29
     rdm2.ovvo += einsum(delta.oo, (0, 1), tmp14, (2, 3), (0, 3, 2, 1)) * -4
-    rdm2.ovvo += tmp18.transpose((1, 2, 3, 0)) * -2
+    rdm2.ovvo += np.transpose(tmp18, (1, 2, 3, 0)) * -2
     del tmp18
-    rdm2.ovov = tmp23.transpose((1, 2, 0, 3)).copy() * 2
+    rdm2.ovov = np.copy(np.transpose(tmp23, (1, 2, 0, 3))) * 2
     del tmp23
-    rdm2.ovov += tmp25.transpose((1, 2, 0, 3)) * -2
+    rdm2.ovov += np.transpose(tmp25, (1, 2, 0, 3)) * -2
     del tmp25
     rdm2.ovov += einsum(delta.oo, (0, 1), tmp14, (2, 3), (0, 3, 1, 2)) * 8
     del tmp14
-    rdm2.ovov += tmp20.transpose((1, 2, 0, 3)) * -2
+    rdm2.ovov += np.transpose(tmp20, (1, 2, 0, 3)) * -2
     del tmp20
-    rdm2.oovv = tmp9.copy() * 2
-    rdm2.oovv += tmp9.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv = np.copy(tmp9) * 2
+    rdm2.oovv += np.transpose(tmp9, (0, 1, 3, 2)) * -2
     del tmp9
     rdm2.oovv += tmp11 * -4
-    rdm2.oovv += tmp11.transpose((0, 1, 3, 2)) * 2
-    rdm2.oovv += tmp11.transpose((1, 0, 2, 3)) * 2
-    rdm2.oovv += tmp11.transpose((1, 0, 3, 2)) * -4
+    rdm2.oovv += np.transpose(tmp11, (0, 1, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp11, (1, 0, 2, 3)) * 2
+    rdm2.oovv += np.transpose(tmp11, (1, 0, 3, 2)) * -4
     del tmp11
     rdm2.oovv += tmp12 * 4
-    rdm2.oovv += tmp12.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(tmp12, (0, 1, 3, 2)) * -2
     del tmp12
     rdm2.oovv += tmp17 * -4
-    rdm2.oovv += tmp17.transpose((0, 1, 3, 2)) * 2
-    rdm2.oovv += tmp17.transpose((1, 0, 2, 3)) * 2
-    rdm2.oovv += tmp17.transpose((1, 0, 3, 2)) * -4
+    rdm2.oovv += np.transpose(tmp17, (0, 1, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp17, (1, 0, 2, 3)) * 2
+    rdm2.oovv += np.transpose(tmp17, (1, 0, 3, 2)) * -4
     del tmp17
-    rdm2.oovv += t2.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(t2, (0, 1, 3, 2)) * -2
     rdm2.oovv += t2 * 4
     rdm2.oovv += tmp19 * 2
     del tmp19
-    rdm2.oovv += tmp21.transpose((0, 1, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp21, (0, 1, 3, 2)) * 2
     del tmp21
-    rdm2.oovv += tmp5.transpose((1, 0, 3, 2)) * 4
+    rdm2.oovv += np.transpose(tmp5, (1, 0, 3, 2)) * 4
     del tmp5
-    rdm2.oooo = tmp0.transpose((2, 3, 1, 0)).copy() * -2
-    rdm2.oooo += tmp0.transpose((3, 2, 1, 0)) * 4
+    rdm2.oooo = np.copy(np.transpose(tmp0, (2, 3, 1, 0))) * -2
+    rdm2.oooo += np.transpose(tmp0, (3, 2, 1, 0)) * 4
     del tmp0
     rdm2.oooo += einsum(delta.oo, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1)) * 4
     rdm2.oooo += einsum(delta.oo, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * -2
@@ -460,7 +460,7 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.vvov = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[0], t2.shape[-1]))
     rdm2.vvvo = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[0]))
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.transpose(0, 2, 1, 3)
+    rdm2 = np.transpose(rdm2, (0, 2, 1, 3))
 
     return rdm2
 
@@ -562,17 +562,17 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     """
 
     ints = kwargs["ints"]
-    tmp0 = r2.copy() * -1
-    tmp0 += r2.transpose((1, 0, 2)) * 2
+    tmp0 = np.copy(r2) * -1
+    tmp0 += np.transpose(r2, (1, 0, 2)) * 2
     tmp8 = einsum(tmp0, (0, 1, 2), ints.tmp15, (1, 0, 2, 3), (3,)) * 0.5
     del ints.tmp15
-    tmp3 = ints.tmp18.copy()
+    tmp3 = np.copy(ints.tmp18)
     tmp3 += ints.tmp31 * -1
-    tmp4 = ints.tmp16.copy()
+    tmp4 = np.copy(ints.tmp16)
     del ints.tmp16
-    tmp4 += ints.tmp25.transpose((2, 0, 1, 3))
+    tmp4 += np.transpose(ints.tmp25, (2, 0, 1, 3))
     del ints.tmp25
-    tmp10 = f.ov.copy()
+    tmp10 = np.copy(f.ov)
     tmp10 += ints.tmp24 * 2
     del ints.tmp24
     tmp10 += ints.tmp38
@@ -585,38 +585,38 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp39
     tmp10 += ints.tmp50 * -1
     del ints.tmp50
-    tmp7 = f.vv.copy()
-    tmp7 += ints.tmp41.transpose((1, 0))
+    tmp7 = np.copy(f.vv)
+    tmp7 += np.transpose(ints.tmp41, (1, 0))
     del ints.tmp41
-    tmp7 += ints.tmp43.transpose((1, 0)) * -2
+    tmp7 += np.transpose(ints.tmp43, (1, 0)) * -2
     del ints.tmp43
-    tmp2 = ints.tmp18.copy() * 0.5
+    tmp2 = np.copy(ints.tmp18) * 0.5
     del ints.tmp18
     tmp2 += ints.tmp32
     tmp2 += ints.tmp31 * -0.5
     del ints.tmp31
-    tmp1 = f.oo.copy()
-    tmp1 += ints.tmp7.transpose((1, 0)) * 2
+    tmp1 = np.copy(f.oo)
+    tmp1 += np.transpose(ints.tmp7, (1, 0)) * 2
     del ints.tmp7
-    tmp1 += ints.tmp4.transpose((1, 0)) * -1
+    tmp1 += np.transpose(ints.tmp4, (1, 0)) * -1
     del ints.tmp4
-    tmp6 = ints.tmp6.copy() * 2
+    tmp6 = np.copy(ints.tmp6) * 2
     del ints.tmp6
-    tmp6 += v.xov.transpose((1, 2, 0))
+    tmp6 += np.transpose(v.xov, (1, 2, 0))
     tmp6 += ints.tmp3 * -1
     del ints.tmp3
-    tmp9 = ints.tmp0.copy()
-    tmp9 += ints.tmp13.transpose((0, 2, 1, 3))
+    tmp9 = np.copy(ints.tmp0)
+    tmp9 += np.transpose(ints.tmp13, (0, 2, 1, 3))
     del ints.tmp13
-    tmp9 += ints.tmp28.transpose((2, 1, 0, 3)) * 2
+    tmp9 += np.transpose(ints.tmp28, (2, 1, 0, 3)) * 2
     del ints.tmp28
-    tmp9 += ints.tmp37.transpose((2, 0, 1, 3))
+    tmp9 += np.transpose(ints.tmp37, (2, 0, 1, 3))
     del ints.tmp37
-    tmp9 += ints.tmp27.transpose((1, 2, 0, 3)) * -1
+    tmp9 += np.transpose(ints.tmp27, (1, 2, 0, 3)) * -1
     del ints.tmp27
-    tmp9 += ints.tmp30.transpose((2, 1, 0, 3)) * -1
+    tmp9 += np.transpose(ints.tmp30, (2, 1, 0, 3)) * -1
     del ints.tmp30
-    tmp9 += ints.tmp40.transpose((0, 2, 1, 3)) * -1
+    tmp9 += np.transpose(ints.tmp40, (0, 2, 1, 3)) * -1
     del ints.tmp40
     tmp5 = einsum(v.xov, (0, 1, 2), tmp0, (3, 1, 2), (3, 0)) * 0.5
     r2new = einsum(r2, (0, 1, 2), ints.tmp32, (3, 1, 4, 2), (3, 0, 4))
@@ -742,39 +742,39 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     """
 
     ints = kwargs["ints"]
-    tmp9 = r2.transpose((2, 0, 1)).copy()
-    tmp9 += r2.transpose((2, 1, 0)) * -0.5
-    tmp1 = r2.transpose((2, 0, 1)).copy() * -1
-    tmp1 += r2.transpose((2, 1, 0)) * 2
-    tmp8 = ints.tmp0.copy()
-    tmp8 += ints.tmp20.transpose((0, 2, 3, 1))
+    tmp9 = np.copy(np.transpose(r2, (2, 0, 1)))
+    tmp9 += np.transpose(r2, (2, 1, 0)) * -0.5
+    tmp1 = np.copy(np.transpose(r2, (2, 0, 1))) * -1
+    tmp1 += np.transpose(r2, (2, 1, 0)) * 2
+    tmp8 = np.copy(ints.tmp0)
+    tmp8 += np.transpose(ints.tmp20, (0, 2, 3, 1))
     del ints.tmp20
-    tmp8 += ints.tmp38.transpose((0, 3, 2, 1)) * 2
+    tmp8 += np.transpose(ints.tmp38, (0, 3, 2, 1)) * 2
     del ints.tmp38
     tmp8 += ints.tmp12 * -1
     del ints.tmp12
-    tmp8 += ints.tmp40.transpose((0, 3, 2, 1)) * -1
+    tmp8 += np.transpose(ints.tmp40, (0, 3, 2, 1)) * -1
     del ints.tmp40
-    tmp8 += ints.tmp41.transpose((0, 3, 2, 1)) * -1
+    tmp8 += np.transpose(ints.tmp41, (0, 3, 2, 1)) * -1
     del ints.tmp41
     tmp3 = einsum(r2, (0, 1, 2), ints.tmp15, (3, 4, 1, 0), (3, 4, 2))
-    tmp4 = ints.tmp18.copy() * 0.5
+    tmp4 = np.copy(ints.tmp18) * 0.5
     tmp4 += ints.tmp44
     tmp4 += ints.tmp16 * -0.5
     tmp10 = einsum(r1, (0,), f.ov, (1, 0), (1,))
     tmp10 += einsum(ints.tmp15, (0, 1, 2, 3), tmp9, (0, 2, 3), (1,)) * -2
     del ints.tmp15, tmp9
-    tmp7 = ints.tmp6.copy() * 2
+    tmp7 = np.copy(ints.tmp6) * 2
     del ints.tmp6
-    tmp7 += v.xov.transpose((1, 2, 0))
+    tmp7 += np.transpose(v.xov, (1, 2, 0))
     tmp7 += ints.tmp3 * -1
     del ints.tmp3
-    tmp2 = f.vv.copy()
-    tmp2 += ints.tmp4.transpose((1, 0))
+    tmp2 = np.copy(f.vv)
+    tmp2 += np.transpose(ints.tmp4, (1, 0))
     del ints.tmp4
-    tmp2 += ints.tmp7.transpose((1, 0)) * -2
+    tmp2 += np.transpose(ints.tmp7, (1, 0)) * -2
     del ints.tmp7
-    tmp12 = f.ov.copy()
+    tmp12 = np.copy(f.ov)
     tmp12 += ints.tmp30 * 2
     del ints.tmp30
     tmp12 += ints.tmp37 * 2
@@ -788,17 +788,17 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp12 += ints.tmp50 * -2
     del ints.tmp50
     tmp6 = einsum(v.xov, (0, 1, 2), tmp1, (1, 3, 2), (3, 0)) * 0.5
-    tmp11 = f.oo.copy()
-    tmp11 += ints.tmp34.transpose((1, 0)) * 2
+    tmp11 = np.copy(f.oo)
+    tmp11 += np.transpose(ints.tmp34, (1, 0)) * 2
     del ints.tmp34
-    tmp11 += ints.tmp32.transpose((1, 0)) * -1
+    tmp11 += np.transpose(ints.tmp32, (1, 0)) * -1
     del ints.tmp32
-    tmp5 = ints.tmp16.copy()
+    tmp5 = np.copy(ints.tmp16)
     del ints.tmp16
     tmp5 += ints.tmp18 * -1
     del ints.tmp18
-    tmp0 = r2.transpose((2, 0, 1)).copy() * -0.5
-    tmp0 += r2.transpose((2, 1, 0))
+    tmp0 = np.copy(np.transpose(r2, (2, 0, 1))) * -0.5
+    tmp0 += np.transpose(r2, (2, 1, 0))
     r2new = einsum(ints.tmp44, (0, 1, 2, 3), r2, (4, 3, 1), (2, 4, 0))
     del ints.tmp44
     r2new += einsum(tmp3, (0, 1, 2), t2, (1, 0, 3, 4), (3, 4, 2))
@@ -928,47 +928,47 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     """
 
     ints = kwargs["ints"]
-    tmp8 = ints.tmp12.copy()
+    tmp8 = np.copy(ints.tmp12)
     del ints.tmp12
-    tmp8 += v.xov.transpose((1, 2, 0)) * 0.5
+    tmp8 += np.transpose(v.xov, (1, 2, 0)) * 0.5
     tmp8 += ints.tmp9 * -0.5
     del ints.tmp9
-    tmp2 = r2.copy() * -1
-    tmp2 += r2.transpose((1, 0, 2)) * 2
-    tmp11 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp2 = np.copy(r2) * -1
+    tmp2 += np.transpose(r2, (1, 0, 2)) * 2
+    tmp11 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp11 += t2
     tmp9 = einsum(tmp2, (0, 1, 2), tmp8, (1, 2, 3), (0, 3)) * 2
     del tmp8
-    tmp10 = f.vv.copy()
+    tmp10 = np.copy(f.vv)
     tmp10 += ints.tmp65
     del ints.tmp65
     tmp10 += ints.tmp67 * -2
     del ints.tmp67
-    tmp7 = ints.tmp41.copy()
-    tmp7 += ints.tmp44.transpose((1, 0, 3, 2)) * -1
+    tmp7 = np.copy(ints.tmp41)
+    tmp7 += np.transpose(ints.tmp44, (1, 0, 3, 2)) * -1
     tmp12 = einsum(tmp11, (0, 1, 2, 3), r2, (0, 1, 2), (3,))
     del tmp11
-    tmp6 = ints.tmp41.copy() * 0.5
+    tmp6 = np.copy(ints.tmp41) * 0.5
     del ints.tmp41
-    tmp6 += ints.tmp45.transpose((1, 0, 3, 2))
-    tmp6 += ints.tmp44.transpose((1, 0, 3, 2)) * -0.5
+    tmp6 += np.transpose(ints.tmp45, (1, 0, 3, 2))
+    tmp6 += np.transpose(ints.tmp44, (1, 0, 3, 2)) * -0.5
     del ints.tmp44
-    tmp5 = f.oo.copy()
+    tmp5 = np.copy(f.oo)
     tmp5 += ints.tmp13 * 2
     del ints.tmp13
     tmp5 += ints.tmp10 * -1
     del ints.tmp10
-    tmp0 = r2.copy()
-    tmp0 += r2.transpose((1, 0, 2)) * -0.5
-    tmp3 = ints.tmp27.copy() * 2
+    tmp0 = np.copy(r2)
+    tmp0 += np.transpose(r2, (1, 0, 2)) * -0.5
+    tmp3 = np.copy(ints.tmp27) * 2
     del ints.tmp27
-    tmp3 += ints.tmp3.transpose((1, 2, 0, 3))
+    tmp3 += np.transpose(ints.tmp3, (1, 2, 0, 3))
     del ints.tmp3
     tmp3 += ints.tmp23 * -1
     del ints.tmp23
     tmp3 += ints.tmp25 * -1
     del ints.tmp25
-    tmp4 = f.ov.copy()
+    tmp4 = np.copy(f.ov)
     tmp4 += ints.tmp15
     del ints.tmp15
     tmp4 += ints.tmp1 * 2
@@ -981,9 +981,9 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp18
     tmp4 += ints.tmp32 * -1
     del ints.tmp32
-    tmp1 = ints.tmp36.copy()
+    tmp1 = np.copy(ints.tmp36)
     del ints.tmp36
-    tmp1 += ints.tmp6.transpose((1, 2, 0, 3))
+    tmp1 += np.transpose(ints.tmp6, (1, 2, 0, 3))
     tmp1 += ints.tmp21 * -1
     del ints.tmp21
     r2new = einsum(ints.tmp6, (0, 1, 2, 3), r1, (1,), (2, 0, 3))
@@ -1112,20 +1112,20 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     """
 
     ints = kwargs["ints"]
-    tmp5 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp5 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp5 += t2
-    tmp11 = ints.tmp13.copy() * 2
+    tmp11 = np.copy(ints.tmp13) * 2
     del ints.tmp13
-    tmp11 += v.xov.transpose((1, 2, 0))
+    tmp11 += np.transpose(v.xov, (1, 2, 0))
     tmp11 += ints.tmp10 * -1
     del ints.tmp10
-    tmp10 = r2.transpose((2, 0, 1)).copy()
-    tmp10 += r2.transpose((2, 1, 0)) * -0.5
+    tmp10 = np.copy(np.transpose(r2, (2, 0, 1)))
+    tmp10 += np.transpose(r2, (2, 1, 0)) * -0.5
     tmp14 = einsum(tmp5, (0, 1, 2, 3), r2, (2, 3, 0), (1,))
-    tmp8 = ints.tmp43.copy() * 0.5
-    tmp8 += ints.tmp51.transpose((1, 0, 3, 2))
-    tmp8 += ints.tmp50.transpose((1, 0, 3, 2)) * -0.5
-    tmp4 = f.vv.copy()
+    tmp8 = np.copy(ints.tmp43) * 0.5
+    tmp8 += np.transpose(ints.tmp51, (1, 0, 3, 2))
+    tmp8 += np.transpose(ints.tmp50, (1, 0, 3, 2)) * -0.5
+    tmp4 = np.copy(f.vv)
     tmp4 += ints.tmp11
     del ints.tmp11
     tmp4 += ints.tmp14 * -2
@@ -1133,24 +1133,24 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp7 = einsum(t2, (0, 1, 2, 3), r2, (2, 3, 4), (4, 0, 1))
     tmp12 = einsum(tmp11, (0, 1, 2), tmp10, (0, 1, 3), (3, 2)) * 2
     del tmp11, tmp10
-    tmp13 = f.oo.copy()
+    tmp13 = np.copy(f.oo)
     tmp13 += ints.tmp47 * 2
     del ints.tmp47
     tmp13 += ints.tmp45 * -1
     del ints.tmp45
-    tmp9 = ints.tmp43.copy()
+    tmp9 = np.copy(ints.tmp43)
     del ints.tmp43
-    tmp9 += ints.tmp50.transpose((1, 0, 3, 2)) * -1
+    tmp9 += np.transpose(ints.tmp50, (1, 0, 3, 2)) * -1
     del ints.tmp50
-    tmp0 = ints.tmp23.copy() * 0.5
+    tmp0 = np.copy(ints.tmp23) * 0.5
     tmp0 += ints.tmp34
-    tmp0 += ints.tmp37.transpose((0, 1, 3, 2))
+    tmp0 += np.transpose(ints.tmp37, (0, 1, 3, 2))
     tmp0 += ints.tmp32 * -0.5
-    tmp0 += ints.tmp39.transpose((0, 1, 3, 2)) * -0.5
-    tmp0 += ints.tmp7.transpose((0, 2, 3, 1)) * -1
-    tmp3 = r2.transpose((2, 0, 1)).copy() * -1
-    tmp3 += r2.transpose((2, 1, 0)) * 2
-    tmp2 = f.ov.copy()
+    tmp0 += np.transpose(ints.tmp39, (0, 1, 3, 2)) * -0.5
+    tmp0 += np.transpose(ints.tmp7, (0, 2, 3, 1)) * -1
+    tmp3 = np.copy(np.transpose(r2, (2, 0, 1))) * -1
+    tmp3 += np.transpose(r2, (2, 1, 0)) * 2
+    tmp2 = np.copy(f.ov)
     tmp2 += ints.tmp17
     del ints.tmp17
     tmp2 += ints.tmp1 * 2
@@ -1163,17 +1163,17 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp20
     tmp2 += ints.tmp29 * -1
     del ints.tmp29
-    tmp1 = ints.tmp23.copy() * 2
+    tmp1 = np.copy(ints.tmp23) * 2
     del ints.tmp23
     tmp1 += ints.tmp34 * 4
     del ints.tmp34
-    tmp1 += ints.tmp37.transpose((0, 1, 3, 2))
+    tmp1 += np.transpose(ints.tmp37, (0, 1, 3, 2))
     del ints.tmp37
     tmp1 += ints.tmp32 * -2
     del ints.tmp32
-    tmp1 += ints.tmp39.transpose((0, 1, 3, 2)) * -2
+    tmp1 += np.transpose(ints.tmp39, (0, 1, 3, 2)) * -2
     del ints.tmp39
-    tmp1 += ints.tmp7.transpose((0, 2, 3, 1)) * -1
+    tmp1 += np.transpose(ints.tmp7, (0, 2, 3, 1)) * -1
     tmp6 = einsum(tmp5, (0, 1, 2, 3), r2, (2, 3, 0), (1,)) * 2
     del tmp5
     r2new = einsum(r1, (0,), ints.tmp7, (1, 2, 0, 3), (3, 2, 1)) * -1

--- a/ebcc/codegen/RDFCCSD.py
+++ b/ebcc/codegen/RDFCCSD.py
@@ -1296,7 +1296,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp7, (2, 3), (3, 0, 2, 1)) * 2
     del delta, tmp7
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.swapaxes(1, 2)
+    rdm2 = rdm2.transpose(0, 2, 1, 3)
 
     return rdm2
 

--- a/ebcc/codegen/RDFCCSD.py
+++ b/ebcc/codegen/RDFCCSD.py
@@ -39,9 +39,9 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
 
     tmp3 = einsum(t1, (0, 1), v.xov, (2, 3, 1), (0, 3, 2))
     tmp0 = einsum(t1, (0, 1), v.xov, (2, 0, 1), (2,))
-    tmp1 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp1 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp1 += t2 * -1
-    tmp4 = f.ov.copy()
+    tmp4 = np.copy(f.ov)
     tmp4 += einsum(tmp3, (0, 1, 2), v.xov, (2, 0, 3), (1, 3)) * -0.5
     del tmp3
     tmp2 = einsum(tmp0, (0,), t1, (1, 2), (1, 2, 0))
@@ -80,28 +80,28 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
 
     tmp2 = einsum(t1, (0, 1), v.xov, (2, 3, 1), (0, 3, 2))
     tmp0 = einsum(t1, (0, 1), v.xov, (2, 0, 1), (2,))
-    tmp37 = t2.copy()
+    tmp37 = np.copy(t2)
     tmp37 += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3))
     tmp9 = einsum(v.xov, (0, 1, 2), tmp2, (1, 3, 0), (3, 2))
     tmp1 = einsum(tmp0, (0,), v.xov, (0, 1, 2), (1, 2))
     tmp32 = einsum(v.xov, (0, 1, 2), v.xoo, (0, 3, 4), (3, 4, 1, 2))
     tmp30 = einsum(tmp2, (0, 1, 2), v.xov, (2, 3, 4), (0, 3, 1, 4))
     tmp18 = einsum(t2, (0, 1, 2, 3), v.xov, (4, 1, 2), (0, 3, 4))
-    tmp5 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp5 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp5 += t2 * -1
     tmp38 = einsum(tmp37, (0, 1, 2, 3), v.xov, (4, 0, 3), (1, 2, 4))
     del tmp37
-    tmp35 = tmp1.copy() * 2
+    tmp35 = np.copy(tmp1) * 2
     tmp35 += tmp9 * -1
-    tmp33 = tmp32.transpose((1, 0, 2, 3)).copy() * -1
-    tmp33 += tmp32.transpose((2, 1, 0, 3)) * 2
-    tmp11 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp33 = np.copy(np.transpose(tmp32, (1, 0, 2, 3))) * -1
+    tmp33 += np.transpose(tmp32, (2, 1, 0, 3)) * 2
+    tmp11 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp11 += t2 * -1
     tmp21 = einsum(t1, (0, 1), v.xvv, (2, 3, 1), (0, 3, 2))
-    tmp57 = tmp30.copy() * 2
-    tmp57 += tmp30.transpose((0, 2, 1, 3)) * -1
+    tmp57 = np.copy(tmp30) * 2
+    tmp57 += np.transpose(tmp30, (0, 2, 1, 3)) * -1
     tmp17 = einsum(v.xov, (0, 1, 2), v.xov, (0, 3, 4), (3, 1, 4, 2))
-    tmp45 = v.xov.transpose((1, 2, 0)).copy()
+    tmp45 = np.copy(np.transpose(v.xov, (1, 2, 0)))
     tmp45 += tmp18 * -1
     tmp72 = einsum(v.xvv, (0, 1, 2), v.xov, (0, 3, 4), (3, 1, 2, 4))
     tmp13 = einsum(v.xov, (0, 1, 2), tmp5, (1, 3, 4, 2), (3, 4, 0))
@@ -130,38 +130,38 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp72
     tmp75 = einsum(v.xov, (0, 1, 2), tmp13, (1, 3, 0), (3, 2)) * 0.5
     tmp77 = einsum(v.xov, (0, 1, 2), tmp13, (3, 2, 0), (3, 1))
-    tmp40 = tmp31.transpose((0, 2, 1, 3)).copy()
+    tmp40 = np.copy(np.transpose(tmp31, (0, 2, 1, 3)))
     del tmp31
-    tmp40 += tmp34.transpose((2, 1, 0, 3)) * -1
+    tmp40 += np.transpose(tmp34, (2, 1, 0, 3)) * -1
     del tmp34
-    tmp40 += tmp36.transpose((2, 0, 1, 3)) * -1
+    tmp40 += np.transpose(tmp36, (2, 0, 1, 3)) * -1
     del tmp36
-    tmp40 += tmp39.transpose((2, 1, 0, 3))
+    tmp40 += np.transpose(tmp39, (2, 1, 0, 3))
     del tmp39
     tmp25 = einsum(tmp2, (0, 1, 2), v.xvv, (2, 3, 4), (0, 1, 3, 4))
-    tmp28 = v.xov.transpose((1, 2, 0)).copy()
+    tmp28 = np.copy(np.transpose(v.xov, (1, 2, 0)))
     tmp28 += tmp6 * -1
     tmp28 += tmp27
     del tmp27
     tmp42 = einsum(tmp35, (0, 1), t1, (2, 1), (0, 2))
     del tmp35
-    tmp53 = tmp51.transpose((1, 0)).copy() * 2
+    tmp53 = np.copy(np.transpose(tmp51, (1, 0))) * 2
     del tmp51
     tmp53 += tmp52 * -1
     del tmp52
-    tmp62 = tmp61.transpose((1, 0)).copy() * -1
+    tmp62 = np.copy(np.transpose(tmp61, (1, 0))) * -1
     del tmp61
-    tmp62 += tmp12.transpose((1, 0)) * 2
-    tmp49 = tmp6.copy()
+    tmp62 += np.transpose(tmp12, (1, 0)) * 2
+    tmp49 = np.copy(tmp6)
     tmp49 += tmp38
     del tmp38
-    tmp59 = tmp55.copy()
+    tmp59 = np.copy(tmp55)
     del tmp55
     tmp59 += tmp56
     del tmp56
-    tmp59 += tmp58.transpose((0, 2, 1, 3)) * -1
+    tmp59 += np.transpose(tmp58, (0, 2, 1, 3)) * -1
     del tmp58
-    tmp47 = tmp23.transpose((1, 0, 3, 2)).copy()
+    tmp47 = np.copy(np.transpose(tmp23, (1, 0, 3, 2)))
     tmp47 += tmp19 * -1
     tmp47 += tmp46 * -2
     del tmp46
@@ -196,8 +196,8 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp59
     tmp48 = einsum(t2, (0, 1, 2, 3), tmp47, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp47
-    tmp89 = tmp17.transpose((1, 0, 2, 3)).copy() * 2
-    tmp89 += tmp17.transpose((1, 0, 3, 2)) * -1
+    tmp89 = np.copy(np.transpose(tmp17, (1, 0, 2, 3))) * 2
+    tmp89 += np.transpose(tmp17, (1, 0, 3, 2)) * -1
     tmp83 = einsum(tmp82, (0, 1, 2, 3), t1, (2, 4), (0, 1, 4, 3))
     del tmp82
     tmp81 = einsum(t2, (0, 1, 2, 3), tmp25, (4, 1, 5, 2), (4, 0, 3, 5))
@@ -209,48 +209,48 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp70 = einsum(tmp69, (0, 1, 2, 3), t2, (1, 3, 4, 5), (0, 2, 4, 5))
     del tmp69
     tmp7 = einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 0.5
-    tmp7 += t2.transpose((0, 1, 3, 2)) * -1
+    tmp7 += np.transpose(t2, (0, 1, 3, 2)) * -1
     tmp7 += t2 * 0.5
-    tmp3 = v.xoo.transpose((1, 2, 0)).copy()
-    tmp3 += tmp2.transpose((1, 0, 2))
-    tmp14 = tmp6.copy() * -1
+    tmp3 = np.copy(np.transpose(v.xoo, (1, 2, 0)))
+    tmp3 += np.transpose(tmp2, (1, 0, 2))
+    tmp14 = np.copy(tmp6) * -1
     tmp14 += einsum(tmp0, (0,), t1, (1, 2), (1, 2, 0)) * 2
     tmp14 += tmp13
     del tmp13
-    tmp15 = f.ov.copy()
+    tmp15 = np.copy(f.ov)
     tmp15 += tmp9 * -1
-    tmp86 = t2.copy()
+    tmp86 = np.copy(t2)
     tmp86 += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3))
-    tmp79 = tmp74.copy()
+    tmp79 = np.copy(tmp74)
     del tmp74
-    tmp79 += tmp76.transpose((1, 0, 3, 2))
+    tmp79 += np.transpose(tmp76, (1, 0, 3, 2))
     del tmp76
-    tmp79 += tmp78.transpose((1, 0, 3, 2))
+    tmp79 += np.transpose(tmp78, (1, 0, 3, 2))
     del tmp78
     tmp88 = einsum(v.xvv, (0, 1, 2), v.xvv, (0, 3, 4), (3, 1, 2, 4))
     tmp88 += einsum(tmp87, (0, 1, 2, 3), t1, (0, 4), (3, 4, 2, 1))
     del tmp87
-    tmp44 = tmp22.copy()
+    tmp44 = np.copy(tmp22)
     del tmp22
     tmp44 += tmp24 * -1
     del tmp24
     tmp44 += tmp26 * -1
     del tmp26
-    tmp44 += tmp29.transpose((1, 0, 2, 3))
+    tmp44 += np.transpose(tmp29, (1, 0, 2, 3))
     del tmp29
-    tmp44 += tmp41.transpose((0, 1, 3, 2))
+    tmp44 += np.transpose(tmp41, (0, 1, 3, 2))
     del tmp41
-    tmp44 += tmp43.transpose((0, 1, 3, 2)) * -1
+    tmp44 += np.transpose(tmp43, (0, 1, 3, 2)) * -1
     del tmp43
-    tmp64 = tmp48.transpose((1, 0, 3, 2)).copy()
+    tmp64 = np.copy(np.transpose(tmp48, (1, 0, 3, 2)))
     del tmp48
     tmp64 += tmp50
     del tmp50
-    tmp64 += tmp54.transpose((1, 0, 3, 2)) * -1
+    tmp64 += np.transpose(tmp54, (1, 0, 3, 2)) * -1
     del tmp54
-    tmp64 += tmp60.transpose((0, 1, 3, 2)) * -1
+    tmp64 += np.transpose(tmp60, (0, 1, 3, 2)) * -1
     del tmp60
-    tmp64 += tmp63.transpose((1, 0, 3, 2))
+    tmp64 += np.transpose(tmp63, (1, 0, 3, 2))
     del tmp63
     tmp90 = einsum(tmp89, (0, 1, 2, 3), t2, (4, 0, 5, 3), (4, 1, 5, 2))
     del tmp89
@@ -259,36 +259,36 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp2
     tmp20 = einsum(tmp17, (0, 1, 2, 3), t2, (4, 5, 3, 2), (4, 5, 1, 0))
     tmp80 = einsum(f.oo, (0, 1), t2, (2, 1, 3, 4), (0, 2, 3, 4))
-    tmp84 = tmp81.copy()
+    tmp84 = np.copy(tmp81)
     del tmp81
     tmp84 += tmp83
     del tmp83
-    tmp71 = tmp66.copy()
+    tmp71 = np.copy(tmp66)
     del tmp66
     tmp71 += tmp68
     del tmp68
     tmp71 += tmp70 * -1
     del tmp70
-    tmp8 = tmp6.copy() * 0.5
+    tmp8 = np.copy(tmp6) * 0.5
     del tmp6
     tmp8 += einsum(tmp0, (0,), t1, (1, 2), (1, 2, 0)) * -1
     del tmp0
     tmp8 += einsum(tmp7, (0, 1, 2, 3), v.xov, (4, 0, 3), (1, 2, 4))
     del tmp7
-    tmp10 = f.ov.copy()
+    tmp10 = np.copy(f.ov)
     tmp10 += tmp1 * 2
     tmp10 += tmp9 * -1
     del tmp9
     tmp4 = einsum(v.xov, (0, 1, 2), tmp3, (3, 4, 0), (4, 1, 3, 2))
     del tmp3
-    tmp16 = f.oo.copy()
-    tmp16 += tmp12.transpose((1, 0)) * 2
+    tmp16 = np.copy(f.oo)
+    tmp16 += np.transpose(tmp12, (1, 0)) * 2
     del tmp12
     tmp16 += einsum(v.xov, (0, 1, 2), tmp14, (3, 2, 0), (1, 3))
     del tmp14
     tmp16 += einsum(tmp15, (0, 1), t1, (2, 1), (0, 2))
     del tmp15
-    t2new = tmp17.transpose((1, 0, 3, 2)).copy()
+    t2new = np.copy(np.transpose(tmp17, (1, 0, 3, 2)))
     del tmp17
     t2new += einsum(tmp18, (0, 1, 2), tmp18, (3, 4, 2), (0, 3, 1, 4))
     del tmp18
@@ -298,23 +298,23 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp20
     t2new += einsum(tmp21, (0, 1, 2), tmp21, (3, 4, 2), (0, 3, 1, 4))
     del tmp21
-    t2new += tmp44.transpose((0, 1, 3, 2))
-    t2new += tmp44.transpose((1, 0, 2, 3))
+    t2new += np.transpose(tmp44, (0, 1, 3, 2))
+    t2new += np.transpose(tmp44, (1, 0, 2, 3))
     del tmp44
     t2new += tmp64 * -1
-    t2new += tmp64.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp64, (1, 0, 3, 2)) * -1
     del tmp64
-    t2new += tmp71.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp71.transpose((1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp71, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp71, (1, 0, 2, 3)) * -1
     del tmp71
     t2new += tmp79 * -1
-    t2new += tmp79.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp79, (1, 0, 3, 2)) * -1
     del tmp79
-    t2new += tmp80.transpose((0, 1, 3, 2)) * -1
-    t2new += tmp80.transpose((1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp80, (0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp80, (1, 0, 2, 3)) * -1
     del tmp80
     t2new += tmp84 * -1
-    t2new += tmp84.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp84, (1, 0, 3, 2)) * -1
     del tmp84
     t2new += einsum(tmp86, (0, 1, 2, 3), tmp85, (0, 4, 1, 5), (4, 5, 3, 2))
     del tmp86, tmp85
@@ -322,7 +322,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp88
     t2new += einsum(t2, (0, 1, 2, 3), tmp90, (4, 1, 5, 3), (4, 0, 5, 2)) * 2
     del tmp90
-    t1new = f.ov.copy()
+    t1new = np.copy(f.ov)
     t1new += einsum(f.vv, (0, 1), t1, (2, 1), (2, 0))
     t1new += tmp1 * 2
     del tmp1
@@ -366,11 +366,11 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
 
     tmp5 = einsum(t1, (0, 1), v.xov, (2, 3, 1), (0, 3, 2))
     tmp13 = einsum(t1, (0, 1), v.xov, (2, 0, 1), (2,))
-    tmp95 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp95 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp95 += t2 * -1
-    tmp20 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp20 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp20 += t2
-    tmp21 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp21 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp21 += t2 * -1
     tmp15 = einsum(v.xov, (0, 1, 2), tmp5, (1, 3, 0), (3, 2))
     tmp14 = einsum(v.xov, (0, 1, 2), tmp13, (0,), (1, 2))
@@ -379,29 +379,29 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp95
     tmp32 = einsum(t1, (0, 1), l2, (2, 1, 3, 4), (3, 4, 0, 2))
     tmp7 = einsum(v.xov, (0, 1, 2), v.xov, (0, 3, 4), (3, 1, 4, 2))
-    tmp35 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp35 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp35 += t2 * -0.5
     tmp51 = einsum(l2, (0, 1, 2, 3), tmp20, (2, 4, 0, 1), (3, 4))
     tmp50 = einsum(l1, (0, 1), t1, (2, 0), (1, 2))
     tmp22 = einsum(tmp21, (0, 1, 2, 3), v.xov, (4, 0, 3), (1, 2, 4))
-    tmp80 = v.xoo.transpose((1, 2, 0)).copy()
-    tmp80 += tmp5.transpose((1, 0, 2))
-    tmp91 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp80 = np.copy(np.transpose(v.xoo, (1, 2, 0)))
+    tmp80 += np.transpose(tmp5, (1, 0, 2))
+    tmp91 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp91 += t2 * 2
-    tmp105 = tmp14.copy() * 2
+    tmp105 = np.copy(tmp14) * 2
     tmp105 += tmp15 * -1
-    tmp98 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp98 += l2.transpose((2, 3, 0, 1)) * 2
-    tmp97 = v.xov.transpose((1, 2, 0)).copy()
+    tmp98 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp98 += np.transpose(l2, (2, 3, 0, 1)) * 2
+    tmp97 = np.copy(np.transpose(v.xov, (1, 2, 0)))
     tmp97 += tmp0
     tmp97 += tmp96
     del tmp96
-    tmp100 = tmp32.copy() * 2
-    tmp100 += tmp32.transpose((1, 0, 2, 3)) * -1
+    tmp100 = np.copy(tmp32) * 2
+    tmp100 += np.transpose(tmp32, (1, 0, 2, 3)) * -1
     tmp9 = einsum(tmp5, (0, 1, 2), tmp5, (3, 4, 2), (3, 0, 4, 1))
     tmp8 = einsum(t2, (0, 1, 2, 3), tmp7, (4, 5, 3, 2), (0, 1, 5, 4))
     tmp36 = einsum(l2, (0, 1, 2, 3), tmp35, (3, 2, 4, 1), (0, 4)) * 2
-    tmp52 = tmp50.copy() * 0.5
+    tmp52 = np.copy(tmp50) * 0.5
     tmp52 += tmp51
     del tmp51
     tmp113 = einsum(tmp22, (0, 1, 2), v.xov, (2, 3, 1), (3, 0)) * 0.5
@@ -418,60 +418,60 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp101 = einsum(v.xoo, (0, 1, 2), tmp100, (3, 1, 2, 4), (3, 4, 0))
     tmp102 = einsum(tmp100, (0, 1, 2, 3), tmp5, (1, 2, 4), (0, 3, 4))
     del tmp100
-    tmp10 = tmp8.copy()
+    tmp10 = np.copy(tmp8)
     tmp10 += tmp9
     tmp3 = einsum(v.xvv, (0, 1, 2), v.xov, (0, 3, 4), (3, 1, 2, 4))
     tmp37 = einsum(v.xov, (0, 1, 2), tmp36, (3, 2), (1, 3, 0)) * 0.5
     del tmp36
     tmp118 = einsum(v.xov, (0, 1, 2), tmp52, (3, 1), (3, 2, 0)) * 2
     tmp77 = einsum(v.xov, (0, 1, 2), tmp5, (3, 4, 0), (3, 1, 4, 2))
-    tmp114 = tmp61.transpose((1, 0)).copy()
-    tmp114 += tmp113.transpose((1, 0))
+    tmp114 = np.copy(np.transpose(tmp61, (1, 0)))
+    tmp114 += np.transpose(tmp113, (1, 0))
     del tmp113
     tmp111 = einsum(tmp22, (0, 1, 2), v.xov, (2, 0, 3), (3, 1)) * 0.5
     tmp75 = einsum(v.xov, (0, 1, 2), v.xoo, (0, 3, 4), (3, 4, 1, 2))
     tmp123 = einsum(tmp0, (0, 1, 2), v.xov, (2, 0, 3), (3, 1))
     tmp69 = einsum(f.ov, (0, 1), t1, (2, 1), (0, 2))
-    tmp82 = tmp79.copy() * -1
+    tmp82 = np.copy(tmp79) * -1
     del tmp79
-    tmp82 += tmp81.transpose((1, 0, 3, 2))
+    tmp82 += np.transpose(tmp81, (1, 0, 3, 2))
     tmp72 = einsum(l1, (0, 1), v.xvv, (2, 3, 0), (1, 3, 2))
     tmp25 = einsum(v.xoo, (0, 1, 2), tmp5, (3, 4, 0), (3, 1, 2, 4))
-    tmp93 = tmp92.transpose((1, 0, 3, 2)).copy()
+    tmp93 = np.copy(np.transpose(tmp92, (1, 0, 3, 2)))
     del tmp92
-    tmp93 += tmp81.transpose((1, 0, 3, 2))
+    tmp93 += np.transpose(tmp81, (1, 0, 3, 2))
     del tmp81
-    tmp107 = tmp62.copy()
+    tmp107 = np.copy(tmp62)
     tmp107 += tmp106 * -1
     del tmp106
     tmp88 = einsum(t2, (0, 1, 2, 3), l2, (4, 3, 1, 5), (5, 0, 4, 2))
     tmp65 = einsum(v.xvv, (0, 1, 2), tmp13, (0,), (1, 2))
     del tmp13
-    tmp103 = tmp99.copy() * -1
+    tmp103 = np.copy(tmp99) * -1
     del tmp99
     tmp103 += tmp101
     del tmp101
     tmp103 += tmp102
     del tmp102
-    tmp18 = v.xoo.transpose((1, 2, 0)).copy()
-    tmp18 += tmp5.transpose((1, 0, 2))
-    tmp16 = tmp14.copy() * 2
+    tmp18 = np.copy(np.transpose(v.xoo, (1, 2, 0)))
+    tmp18 += np.transpose(tmp5, (1, 0, 2))
+    tmp16 = np.copy(tmp14) * 2
     tmp16 += tmp15 * -1
     tmp24 = einsum(v.xoo, (0, 1, 2), v.xoo, (0, 3, 4), (3, 1, 2, 4))
     tmp6 = einsum(tmp0, (0, 1, 2), tmp5, (3, 4, 2), (3, 0, 4, 1))
     tmp11 = einsum(t1, (0, 1), tmp10, (2, 3, 4, 0), (2, 3, 4, 1)) * 2
     del tmp10
     tmp4 = einsum(tmp3, (0, 1, 2, 3), t2, (4, 5, 3, 1), (4, 5, 0, 2))
-    tmp56 = tmp50.copy()
+    tmp56 = np.copy(tmp50)
     tmp56 += einsum(l2, (0, 1, 2, 3), tmp20, (2, 4, 0, 1), (3, 4)) * 2
-    tmp40 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp40 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp40 += t2 * 2
     tmp46 = einsum(l2, (0, 1, 2, 3), t2, (4, 5, 0, 1), (2, 3, 4, 5))
     tmp47 = einsum(t1, (0, 1), tmp32, (2, 3, 4, 1), (3, 2, 4, 0))
-    tmp34 = tmp32.copy()
-    tmp34 += tmp32.transpose((1, 0, 2, 3)) * -0.5
-    tmp44 = tmp32.copy() * -1
-    tmp44 += tmp32.transpose((1, 0, 2, 3)) * 2
+    tmp34 = np.copy(tmp32)
+    tmp34 += np.transpose(tmp32, (1, 0, 2, 3)) * -0.5
+    tmp44 = np.copy(tmp32) * -1
+    tmp44 += np.transpose(tmp32, (1, 0, 2, 3)) * 2
     tmp43 = einsum(l1, (0, 1), t2, (2, 3, 4, 0), (1, 2, 3, 4))
     tmp120 = einsum(v.xov, (0, 1, 2), tmp37, (3, 4, 0), (1, 3, 2, 4)) * 2
     tmp119 = einsum(tmp118, (0, 1, 2), v.xov, (2, 3, 4), (3, 0, 4, 1))
@@ -511,100 +511,100 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp77
     tmp85 = einsum(tmp32, (0, 1, 2, 3), tmp75, (4, 1, 2, 5), (0, 4, 3, 5))
     del tmp75
-    tmp38 = v.xoo.transpose((1, 2, 0)).copy()
+    tmp38 = np.copy(np.transpose(v.xoo, (1, 2, 0)))
     tmp38 += tmp5
-    tmp33 = tmp32.copy() * 2
-    tmp33 += tmp32.transpose((1, 0, 2, 3)) * -1
-    tmp31 = l2.transpose((3, 2, 0, 1)).copy() * -0.5
-    tmp31 += l2.transpose((2, 3, 0, 1))
-    tmp30 = v.xov.transpose((1, 2, 0)).copy()
+    tmp33 = np.copy(tmp32) * 2
+    tmp33 += np.transpose(tmp32, (1, 0, 2, 3)) * -1
+    tmp31 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -0.5
+    tmp31 += np.transpose(l2, (2, 3, 0, 1))
+    tmp30 = np.copy(np.transpose(v.xov, (1, 2, 0)))
     tmp30 += tmp0
     tmp30 += tmp22
     tmp19 = einsum(tmp18, (0, 1, 2), v.xov, (2, 3, 4), (3, 0, 1, 4))
-    tmp23 = v.xov.transpose((1, 2, 0)).copy()
+    tmp23 = np.copy(np.transpose(v.xov, (1, 2, 0)))
     tmp23 += tmp22
     tmp1 = einsum(v.xoo, (0, 1, 2), tmp0, (3, 4, 0), (3, 1, 2, 4))
     tmp2 = einsum(t2, (0, 1, 2, 3), f.ov, (4, 3), (4, 0, 1, 2))
     tmp17 = einsum(t2, (0, 1, 2, 3), tmp16, (4, 2), (0, 1, 4, 3))
     del tmp16
-    tmp26 = tmp24.transpose((3, 2, 1, 0)).copy()
-    tmp26 += tmp25.transpose((1, 0, 3, 2))
-    tmp26 += tmp25.transpose((3, 0, 2, 1)) * -0.5
-    tmp12 = tmp4.copy() * 2
+    tmp26 = np.copy(np.transpose(tmp24, (3, 2, 1, 0)))
+    tmp26 += np.transpose(tmp25, (1, 0, 3, 2))
+    tmp26 += np.transpose(tmp25, (3, 0, 2, 1)) * -0.5
+    tmp12 = np.copy(tmp4) * 2
     del tmp4
     tmp12 += tmp6 * 2
     del tmp6
     tmp12 += tmp11 * -1
     del tmp11
-    tmp57 = l1.transpose((1, 0)).copy()
+    tmp57 = np.copy(np.transpose(l1, (1, 0)))
     tmp57 += t1
     tmp57 += einsum(tmp21, (0, 1, 2, 3), tmp32, (0, 1, 4, 3), (4, 2)) * -1
     tmp57 += einsum(l1, (0, 1), tmp20, (1, 2, 0, 3), (2, 3)) * 2
     tmp57 += einsum(tmp56, (0, 1), t1, (0, 2), (1, 2)) * -1
     del tmp56
-    tmp58 = tmp50.copy()
+    tmp58 = np.copy(tmp50)
     del tmp50
     tmp58 += einsum(l2, (0, 1, 2, 3), tmp40, (2, 4, 0, 1), (4, 3))
     tmp55 = einsum(l1, (0, 1), t1, (1, 2), (0, 2)) * 0.5
     tmp55 += einsum(tmp40, (0, 1, 2, 3), l2, (4, 2, 1, 0), (3, 4)) * 0.5
-    tmp49 = tmp46.transpose((1, 0, 2, 3)).copy() * 2
-    tmp49 += tmp46.transpose((1, 0, 3, 2)) * -1
+    tmp49 = np.copy(np.transpose(tmp46, (1, 0, 2, 3))) * 2
+    tmp49 += np.transpose(tmp46, (1, 0, 3, 2)) * -1
     tmp49 += tmp47 * -1
-    tmp49 += tmp47.transpose((0, 1, 3, 2)) * 2
+    tmp49 += np.transpose(tmp47, (0, 1, 3, 2)) * 2
     tmp41 = einsum(l2, (0, 1, 2, 3), tmp40, (2, 4, 5, 1), (3, 4, 0, 5))
     del tmp40
     tmp41 += einsum(l2, (0, 1, 2, 3), tmp35, (3, 4, 5, 1), (2, 4, 0, 5)) * 2
     del tmp35
-    tmp42 = tmp32.copy() * -0.5
-    tmp42 += tmp32.transpose((1, 0, 2, 3))
-    tmp48 = tmp46.transpose((1, 0, 2, 3)).copy() * -1
-    tmp48 += tmp46.transpose((1, 0, 3, 2)) * 2
+    tmp42 = np.copy(tmp32) * -0.5
+    tmp42 += np.transpose(tmp32, (1, 0, 2, 3))
+    tmp48 = np.copy(np.transpose(tmp46, (1, 0, 2, 3))) * -1
+    tmp48 += np.transpose(tmp46, (1, 0, 3, 2)) * 2
     tmp48 += tmp47 * 2
-    tmp48 += tmp47.transpose((0, 1, 3, 2)) * -1
-    tmp53 = t1.copy() * -0.5
+    tmp48 += np.transpose(tmp47, (0, 1, 3, 2)) * -1
+    tmp53 = np.copy(t1) * -0.5
     tmp53 += einsum(tmp32, (0, 1, 2, 3), tmp20, (0, 1, 3, 4), (2, 4))
     del tmp32
     tmp53 += einsum(l1, (0, 1), tmp21, (1, 2, 3, 0), (2, 3)) * -0.5
     del tmp21
     tmp53 += einsum(tmp52, (0, 1), t1, (0, 2), (1, 2))
-    tmp45 = tmp43.copy() * -1
-    tmp45 += tmp43.transpose((0, 2, 1, 3)) * 0.5
+    tmp45 = np.copy(tmp43) * -1
+    tmp45 += np.transpose(tmp43, (0, 2, 1, 3)) * 0.5
     del tmp43
     tmp45 += einsum(tmp44, (0, 1, 2, 3), t2, (4, 1, 5, 3), (0, 2, 4, 5)) * 0.5
     del tmp44
     tmp45 += einsum(tmp34, (0, 1, 2, 3), t2, (4, 1, 3, 5), (0, 2, 4, 5))
-    tmp63 = f.ov.copy()
+    tmp63 = np.copy(f.ov)
     tmp63 += tmp14 * 2
     tmp63 += tmp15 * -1
-    tmp28 = tmp24.transpose((3, 2, 1, 0)).copy() * 0.5
-    tmp28 += tmp25.transpose((1, 0, 3, 2)) * 0.5
-    tmp28 += tmp25.transpose((3, 0, 2, 1)) * -1
+    tmp28 = np.copy(np.transpose(tmp24, (3, 2, 1, 0))) * 0.5
+    tmp28 += np.transpose(tmp25, (1, 0, 3, 2)) * 0.5
+    tmp28 += np.transpose(tmp25, (3, 0, 2, 1)) * -1
     del tmp25
-    tmp121 = tmp117.copy()
+    tmp121 = np.copy(tmp117)
     del tmp117
-    tmp121 += tmp119.transpose((1, 0, 2, 3))
+    tmp121 += np.transpose(tmp119, (1, 0, 2, 3))
     del tmp119
-    tmp121 += tmp120.transpose((0, 1, 3, 2))
+    tmp121 += np.transpose(tmp120, (0, 1, 3, 2))
     del tmp120
-    tmp116 = tmp112.transpose((1, 0, 2, 3)).copy()
+    tmp116 = np.copy(np.transpose(tmp112, (1, 0, 2, 3)))
     del tmp112
-    tmp116 += tmp115.transpose((0, 1, 3, 2))
+    tmp116 += np.transpose(tmp115, (0, 1, 3, 2))
     del tmp115
     tmp67 = einsum(v.xvv, (0, 1, 2), v.xvv, (0, 3, 4), (3, 1, 2, 4))
-    tmp128 = tmp24.transpose((3, 2, 1, 0)).copy()
+    tmp128 = np.copy(np.transpose(tmp24, (3, 2, 1, 0)))
     del tmp24
-    tmp128 += tmp9.transpose((0, 3, 1, 2))
+    tmp128 += np.transpose(tmp9, (0, 3, 1, 2))
     del tmp9
     tmp126 = einsum(f.oo, (0, 1), l2, (2, 3, 4, 1), (0, 4, 2, 3))
-    tmp125 = tmp122.copy()
+    tmp125 = np.copy(tmp122)
     del tmp122
     tmp125 += tmp124
     del tmp124
-    tmp127 = tmp46.transpose((1, 0, 3, 2)).copy()
+    tmp127 = np.copy(np.transpose(tmp46, (1, 0, 3, 2)))
     del tmp46
     tmp127 += tmp47
     del tmp47
-    tmp84 = tmp68.copy()
+    tmp84 = np.copy(tmp68)
     del tmp68
     tmp84 += tmp70 * -1
     del tmp70
@@ -633,9 +633,9 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp90
     tmp110 += tmp94 * -1
     del tmp94
-    tmp110 += tmp104.transpose((1, 0, 3, 2)) * -1
+    tmp110 += np.transpose(tmp104, (1, 0, 3, 2)) * -1
     del tmp104
-    tmp110 += tmp108.transpose((0, 1, 3, 2))
+    tmp110 += np.transpose(tmp108, (0, 1, 3, 2))
     del tmp108
     tmp110 += tmp109 * -1
     del tmp109
@@ -651,15 +651,15 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp37
     tmp39 += einsum(l1, (0, 1), tmp38, (1, 2, 3), (2, 0, 3)) * 0.5
     del tmp38
-    tmp27 = tmp1.transpose((0, 2, 1, 3)).copy()
-    tmp27 += tmp2.transpose((1, 0, 2, 3))
-    tmp27 += tmp2.transpose((2, 0, 1, 3)) * -2
+    tmp27 = np.copy(np.transpose(tmp1, (0, 2, 1, 3)))
+    tmp27 += np.transpose(tmp2, (1, 0, 2, 3))
+    tmp27 += np.transpose(tmp2, (2, 0, 1, 3)) * -2
     del tmp2
-    tmp27 += tmp12.transpose((0, 2, 1, 3)) * -1
-    tmp27 += tmp12.transpose((1, 2, 0, 3)) * 0.5
+    tmp27 += np.transpose(tmp12, (0, 2, 1, 3)) * -1
+    tmp27 += np.transpose(tmp12, (1, 2, 0, 3)) * 0.5
     del tmp12
-    tmp27 += tmp17.transpose((1, 2, 0, 3))
-    tmp27 += tmp17.transpose((0, 2, 1, 3)) * -2
+    tmp27 += np.transpose(tmp17, (1, 2, 0, 3))
+    tmp27 += np.transpose(tmp17, (0, 2, 1, 3)) * -2
     del tmp17
     tmp27 += einsum(tmp20, (0, 1, 2, 3), tmp19, (4, 0, 5, 2), (5, 4, 1, 3)) * 2
     tmp27 += einsum(tmp23, (0, 1, 2), tmp18, (3, 4, 2), (4, 3, 0, 1)) * -2
@@ -686,8 +686,8 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp54 += einsum(v.xov, (0, 1, 2), tmp53, (3, 2), (3, 1, 0)) * 2
     del tmp53
     tmp54 += einsum(v.xoo, (0, 1, 2), tmp52, (2, 3), (3, 1, 0)) * 2
-    tmp64 = f.oo.copy()
-    tmp64 += tmp61.transpose((1, 0)) * 2
+    tmp64 = np.copy(f.oo)
+    tmp64 += np.transpose(tmp61, (1, 0)) * 2
     del tmp61
     tmp64 += tmp62 * -1
     del tmp62
@@ -695,12 +695,12 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp22
     tmp64 += einsum(t1, (0, 1), tmp63, (2, 1), (0, 2))
     del tmp63
-    tmp60 = f.ov.copy() * 0.5
+    tmp60 = np.copy(f.ov) * 0.5
     tmp60 += tmp14
     del tmp14
     tmp60 += tmp15 * -0.5
     del tmp15
-    tmp29 = tmp1.transpose((0, 2, 1, 3)).copy() * -1
+    tmp29 = np.copy(np.transpose(tmp1, (0, 2, 1, 3))) * -1
     del tmp1
     tmp29 += einsum(tmp20, (0, 1, 2, 3), tmp19, (4, 0, 5, 3), (5, 4, 1, 2))
     del tmp20, tmp19
@@ -708,37 +708,37 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp18, tmp23
     tmp29 += einsum(t1, (0, 1), tmp28, (0, 2, 3, 4), (2, 3, 4, 1)) * -1
     del tmp28
-    tmp66 = f.vv.copy()
-    tmp66 += tmp65.transpose((1, 0)) * 2
+    tmp66 = np.copy(f.vv)
+    tmp66 += np.transpose(tmp65, (1, 0)) * 2
     del tmp65
-    l2new = tmp7.transpose((3, 2, 1, 0)).copy()
+    l2new = np.copy(np.transpose(tmp7, (3, 2, 1, 0)))
     l2new += einsum(l2, (0, 1, 2, 3), tmp8, (2, 3, 4, 5), (0, 1, 4, 5))
     del tmp8
     l2new += einsum(l2, (0, 1, 2, 3), tmp67, (4, 5, 1, 0), (4, 5, 2, 3))
     del tmp67
-    l2new += tmp84.transpose((3, 2, 0, 1))
-    l2new += tmp84.transpose((2, 3, 1, 0))
+    l2new += np.transpose(tmp84, (3, 2, 0, 1))
+    l2new += np.transpose(tmp84, (2, 3, 1, 0))
     del tmp84
-    l2new += tmp110.transpose((2, 3, 0, 1))
-    l2new += tmp110.transpose((3, 2, 1, 0))
+    l2new += np.transpose(tmp110, (2, 3, 0, 1))
+    l2new += np.transpose(tmp110, (3, 2, 1, 0))
     del tmp110
-    l2new += tmp116.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp116.transpose((3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp116, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp116, (3, 2, 1, 0)) * -1
     del tmp116
-    l2new += tmp121.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp121.transpose((2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp121, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp121, (2, 3, 1, 0)) * -1
     del tmp121
-    l2new += tmp125.transpose((2, 3, 0, 1)) * -1
-    l2new += tmp125.transpose((3, 2, 1, 0)) * -1
+    l2new += np.transpose(tmp125, (2, 3, 0, 1)) * -1
+    l2new += np.transpose(tmp125, (3, 2, 1, 0)) * -1
     del tmp125
-    l2new += tmp126.transpose((3, 2, 0, 1)) * -1
-    l2new += tmp126.transpose((2, 3, 1, 0)) * -1
+    l2new += np.transpose(tmp126, (3, 2, 0, 1)) * -1
+    l2new += np.transpose(tmp126, (2, 3, 1, 0)) * -1
     del tmp126
     l2new += einsum(tmp7, (0, 1, 2, 3), tmp127, (4, 5, 0, 1), (3, 2, 5, 4))
     del tmp7, tmp127
     l2new += einsum(tmp128, (0, 1, 2, 3), l2, (4, 5, 2, 0), (4, 5, 1, 3))
     del tmp128
-    l1new = f.ov.transpose((1, 0)).copy()
+    l1new = np.copy(np.transpose(f.ov, (1, 0)))
     l1new += einsum(tmp27, (0, 1, 2, 3), l2, (4, 3, 0, 2), (4, 1))
     del tmp27
     l1new += einsum(l2, (0, 1, 2, 3), tmp29, (3, 4, 2, 1), (0, 4)) * 2
@@ -786,32 +786,32 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     )
     tmp2 = einsum(t1, (0, 1), l2, (2, 1, 3, 4), (3, 4, 0, 2))
     tmp0 = einsum(l1, (0, 1), t1, (2, 0), (1, 2))
-    tmp5 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp5 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp5 += t2
-    tmp7 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp7 += l2.transpose((2, 3, 0, 1)) * 2
-    tmp4 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp7 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp7 += np.transpose(l2, (2, 3, 0, 1)) * 2
+    tmp4 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp4 += t2 * -1
-    tmp3 = tmp2.copy()
-    tmp3 += tmp2.transpose((1, 0, 2, 3)) * -0.5
+    tmp3 = np.copy(tmp2)
+    tmp3 += np.transpose(tmp2, (1, 0, 2, 3)) * -0.5
     del tmp2
-    tmp6 = tmp0.copy() * 0.5
+    tmp6 = np.copy(tmp0) * 0.5
     tmp6 += einsum(l2, (0, 1, 2, 3), tmp5, (2, 4, 0, 1), (3, 4))
     del tmp5
-    tmp1 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp1 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp1 += t2 * -0.5
     rdm1.vv = einsum(l1, (0, 1), t1, (1, 2), (0, 2)) * 2
     rdm1.vv += einsum(tmp7, (0, 1, 2, 3), t2, (0, 1, 2, 4), (3, 4)) * 2
     del tmp7
-    rdm1.vo = l1.copy() * 2
-    rdm1.ov = t1.copy() * 2
+    rdm1.vo = np.copy(l1) * 2
+    rdm1.ov = np.copy(t1) * 2
     rdm1.ov += einsum(tmp3, (0, 1, 2, 3), t2, (0, 1, 3, 4), (2, 4)) * -4
     del tmp3
     rdm1.ov += einsum(l1, (0, 1), tmp4, (1, 2, 3, 0), (2, 3)) * 2
     del tmp4
     rdm1.ov += einsum(tmp6, (0, 1), t1, (0, 2), (1, 2)) * -4
     del tmp6
-    rdm1.oo = tmp0.transpose((1, 0)).copy() * -2
+    rdm1.oo = np.copy(np.transpose(tmp0, (1, 0))) * -2
     del tmp0
     rdm1.oo += delta.oo * 2
     del delta
@@ -848,32 +848,32 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
         vv=np.eye(t2.shape[-1]),
     )
     tmp4 = einsum(t1, (0, 1), l2, (2, 1, 3, 4), (3, 4, 0, 2))
-    tmp9 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp9 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp9 += t2 * -1
-    tmp78 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp78 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp78 += t2 * -1
-    tmp1 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp1 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp1 += t2
-    tmp20 = tmp4.copy() * -1
-    tmp20 += tmp4.transpose((1, 0, 2, 3)) * 2
-    tmp18 = tmp4.copy() * -1
-    tmp18 += tmp4.transpose((1, 0, 2, 3))
+    tmp20 = np.copy(tmp4) * -1
+    tmp20 += np.transpose(tmp4, (1, 0, 2, 3)) * 2
+    tmp18 = np.copy(tmp4) * -1
+    tmp18 += np.transpose(tmp4, (1, 0, 2, 3))
     tmp80 = einsum(tmp9, (0, 1, 2, 3), l2, (4, 3, 5, 0), (1, 5, 2, 4))
     tmp79 = einsum(tmp78, (0, 1, 2, 3), l2, (4, 3, 0, 5), (1, 5, 2, 4))
     del tmp78
     tmp91 = einsum(t1, (0, 1), tmp4, (2, 0, 3, 4), (2, 3, 4, 1))
-    tmp45 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp45 += l2.transpose((2, 3, 0, 1)) * 2
-    tmp62 = l2.transpose((3, 2, 0, 1)).copy() * 2
-    tmp62 += l2.transpose((2, 3, 0, 1)) * -1
-    tmp103 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp103 += l2.transpose((2, 3, 0, 1)) * 2
-    tmp12 = tmp4.copy() * -1
-    tmp12 += tmp4.transpose((1, 0, 2, 3)) * 2
+    tmp45 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp45 += np.transpose(l2, (2, 3, 0, 1)) * 2
+    tmp62 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * 2
+    tmp62 += np.transpose(l2, (2, 3, 0, 1)) * -1
+    tmp103 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp103 += np.transpose(l2, (2, 3, 0, 1)) * 2
+    tmp12 = np.copy(tmp4) * -1
+    tmp12 += np.transpose(tmp4, (1, 0, 2, 3)) * 2
     tmp2 = einsum(l2, (0, 1, 2, 3), tmp1, (2, 4, 0, 1), (3, 4)) * 2
     tmp5 = einsum(tmp4, (0, 1, 2, 3), t1, (4, 3), (0, 1, 4, 2))
-    tmp54 = l2.transpose((3, 2, 0, 1)).copy() * -1
-    tmp54 += l2.transpose((2, 3, 0, 1))
+    tmp54 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * -1
+    tmp54 += np.transpose(l2, (2, 3, 0, 1))
     tmp16 = einsum(l1, (0, 1), t2, (2, 3, 4, 0), (1, 2, 3, 4))
     tmp26 = einsum(tmp4, (0, 1, 2, 3), t2, (4, 1, 3, 5), (0, 2, 4, 5))
     tmp21 = einsum(tmp20, (0, 1, 2, 3), t2, (4, 1, 5, 3), (0, 2, 4, 5))
@@ -885,45 +885,45 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp1
     tmp3 = einsum(t2, (0, 1, 2, 3), l2, (3, 2, 4, 5), (5, 4, 0, 1))
     tmp113 = einsum(l2, (0, 1, 2, 3), t1, (3, 4), (2, 0, 1, 4))
-    tmp107 = tmp91.copy()
-    tmp107 += tmp79.transpose((1, 0, 3, 2))
-    tmp107 += tmp80.transpose((1, 0, 3, 2)) * -1
+    tmp107 = np.copy(tmp91)
+    tmp107 += np.transpose(tmp79, (1, 0, 3, 2))
+    tmp107 += np.transpose(tmp80, (1, 0, 3, 2)) * -1
     tmp67 = einsum(t2, (0, 1, 2, 3), l2, (4, 2, 5, 1), (5, 0, 4, 3))
     tmp52 = einsum(t2, (0, 1, 2, 3), tmp45, (1, 4, 3, 5), (4, 0, 5, 2))
     tmp83 = einsum(l1, (0, 1), t1, (1, 2), (0, 2))
     tmp84 = einsum(t2, (0, 1, 2, 3), tmp62, (0, 1, 3, 4), (4, 2))
     tmp104 = einsum(tmp103, (0, 1, 2, 3), t2, (4, 0, 5, 2), (1, 4, 3, 5))
     del tmp103
-    tmp96 = tmp80.transpose((1, 0, 3, 2)).copy()
-    tmp96 += tmp79.transpose((1, 0, 3, 2)) * -1
+    tmp96 = np.copy(np.transpose(tmp80, (1, 0, 3, 2)))
+    tmp96 += np.transpose(tmp79, (1, 0, 3, 2)) * -1
     tmp13 = einsum(tmp12, (0, 1, 2, 3), t2, (0, 1, 4, 3), (2, 4)) * 0.5
     tmp14 = einsum(tmp2, (0, 1), t1, (0, 2), (1, 2)) * 0.5
     tmp63 = einsum(t2, (0, 1, 2, 3), tmp62, (0, 1, 3, 4), (4, 2)) * 0.5
     del tmp62
     tmp17 = einsum(tmp5, (0, 1, 2, 3), t1, (0, 4), (1, 3, 2, 4))
     tmp55 = einsum(tmp54, (0, 1, 2, 3), t2, (4, 0, 2, 5), (1, 4, 3, 5))
-    tmp74 = tmp16.copy()
+    tmp74 = np.copy(tmp16)
     tmp74 += tmp26 * -1
-    tmp36 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp36 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp36 += t2 * 2
-    tmp71 = tmp25.copy()
+    tmp71 = np.copy(tmp25)
     tmp71 += tmp21 * -1
     tmp46 = einsum(t2, (0, 1, 2, 3), tmp45, (1, 4, 2, 5), (4, 0, 5, 3))
     del tmp45
-    tmp59 = t2.copy()
+    tmp59 = np.copy(t2)
     tmp59 += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3))
     tmp10 = einsum(l1, (0, 1), tmp9, (1, 2, 3, 0), (2, 3))
     del tmp9
     tmp8 = einsum(tmp0, (0, 1), t1, (0, 2), (1, 2))
-    tmp48 = tmp16.copy()
+    tmp48 = np.copy(tmp16)
     tmp48 += tmp19
     tmp48 += tmp21 * -1
-    tmp32 = tmp0.copy() * 0.5
+    tmp32 = np.copy(tmp0) * 0.5
     tmp32 += tmp31
     del tmp31
-    tmp6 = tmp3.transpose((1, 0, 3, 2)).copy()
+    tmp6 = np.copy(np.transpose(tmp3, (1, 0, 3, 2)))
     tmp6 += tmp5
-    tmp29 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp29 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp29 += t2 * -1
     tmp115 = einsum(t1, (0, 1), tmp113, (0, 2, 3, 4), (3, 2, 4, 1))
     tmp114 = einsum(t2, (0, 1, 2, 3), l2, (4, 5, 1, 0), (4, 5, 3, 2))
@@ -931,26 +931,26 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp108 = einsum(tmp107, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     del tmp107
     tmp69 = einsum(t2, (0, 1, 2, 3), l2, (4, 2, 1, 5), (5, 0, 4, 3))
-    tmp111 = tmp67.copy()
+    tmp111 = np.copy(tmp67)
     tmp111 += tmp91
     tmp111 += tmp52 * -1
     tmp99 = einsum(t2, (0, 1, 2, 3), tmp4, (0, 1, 4, 5), (4, 5, 2, 3))
-    tmp85 = tmp83.copy()
+    tmp85 = np.copy(tmp83)
     tmp85 += tmp84
     del tmp84
-    tmp105 = tmp67.copy()
+    tmp105 = np.copy(tmp67)
     tmp105 += tmp91
     tmp105 += tmp104 * -1
     del tmp104
     tmp97 = einsum(tmp96, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     del tmp96
-    tmp87 = l2.transpose((3, 2, 0, 1)).copy() * 2
-    tmp87 += l2.transpose((2, 3, 0, 1)) * -1
-    tmp81 = tmp4.copy()
-    tmp81 += tmp4.transpose((1, 0, 2, 3)) * -1
-    tmp89 = l2.transpose((3, 2, 0, 1)).copy()
-    tmp89 += l2.transpose((2, 3, 0, 1)) * -1
-    tmp15 = tmp13.copy()
+    tmp87 = np.copy(np.transpose(l2, (3, 2, 0, 1))) * 2
+    tmp87 += np.transpose(l2, (2, 3, 0, 1)) * -1
+    tmp81 = np.copy(tmp4)
+    tmp81 += np.transpose(tmp4, (1, 0, 2, 3)) * -1
+    tmp89 = np.copy(np.transpose(l2, (3, 2, 0, 1)))
+    tmp89 += np.transpose(l2, (2, 3, 0, 1)) * -1
+    tmp15 = np.copy(tmp13)
     tmp15 += tmp14
     del tmp14
     tmp64 = einsum(tmp63, (0, 1), t2, (2, 3, 0, 4), (2, 3, 1, 4)) * 2
@@ -972,7 +972,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp60 = einsum(tmp3, (0, 1, 2, 3), tmp59, (0, 1, 4, 5), (2, 3, 4, 5))
     del tmp59
     tmp58 = einsum(tmp5, (0, 1, 2, 3), t2, (0, 1, 4, 5), (3, 2, 5, 4))
-    tmp11 = tmp8.copy()
+    tmp11 = np.copy(tmp8)
     tmp11 += tmp10 * -1
     del tmp10
     tmp49 = einsum(t1, (0, 1), tmp48, (0, 2, 3, 4), (2, 3, 4, 1))
@@ -987,27 +987,27 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp30 = einsum(l1, (0, 1), tmp29, (1, 2, 3, 0), (2, 3))
     del tmp29
     tmp23 = einsum(t1, (0, 1), tmp3, (2, 0, 3, 4), (2, 3, 4, 1))
-    tmp116 = tmp114.transpose((1, 0, 3, 2)).copy()
-    tmp116 += tmp115.transpose((1, 0, 3, 2))
-    tmp94 = tmp83.copy() * 0.5
+    tmp116 = np.copy(np.transpose(tmp114, (1, 0, 3, 2)))
+    tmp116 += np.transpose(tmp115, (1, 0, 3, 2))
+    tmp94 = np.copy(tmp83) * 0.5
     tmp94 += tmp63
-    tmp109 = tmp95.copy()
-    tmp109 += tmp108.transpose((0, 1, 3, 2))
+    tmp109 = np.copy(tmp95)
+    tmp109 += np.transpose(tmp108, (0, 1, 3, 2))
     del tmp108
     tmp102 = einsum(tmp69, (0, 1, 2, 3), t1, (0, 4), (1, 2, 4, 3))
     tmp112 = einsum(tmp111, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     del tmp111
-    tmp110 = tmp99.copy()
+    tmp110 = np.copy(tmp99)
     tmp110 += einsum(t1, (0, 1), tmp85, (2, 3), (0, 2, 1, 3))
     tmp106 = einsum(tmp105, (0, 1, 2, 3), t1, (0, 4), (1, 2, 3, 4))
     del tmp105
-    tmp98 = tmp95.copy()
+    tmp98 = np.copy(tmp95)
     tmp98 += einsum(tmp83, (0, 1), t1, (2, 3), (2, 0, 3, 1))
     del tmp83
-    tmp98 += tmp97.transpose((0, 1, 3, 2)) * -1
+    tmp98 += np.transpose(tmp97, (0, 1, 3, 2)) * -1
     del tmp97
     tmp101 = einsum(tmp91, (0, 1, 2, 3), t1, (0, 4), (1, 2, 4, 3))
-    tmp100 = tmp99.copy()
+    tmp100 = np.copy(tmp99)
     tmp100 += einsum(tmp63, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 2
     del tmp63
     tmp86 = einsum(t1, (0, 1), tmp4, (0, 2, 3, 4), (2, 3, 4, 1))
@@ -1021,173 +1021,173 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp81
     tmp90 = einsum(tmp89, (0, 1, 2, 3), t2, (4, 0, 3, 5), (1, 4, 2, 5))
     del tmp89
-    tmp77 = t1.copy()
+    tmp77 = np.copy(t1)
     tmp77 += tmp8 * -1
-    tmp66 = tmp64.transpose((1, 0, 3, 2)).copy()
+    tmp66 = np.copy(np.transpose(tmp64, (1, 0, 3, 2)))
     del tmp64
-    tmp66 += tmp65.transpose((0, 1, 3, 2))
+    tmp66 += np.transpose(tmp65, (0, 1, 3, 2))
     del tmp65
     tmp66 += einsum(t1, (0, 1), tmp15, (2, 3), (0, 2, 1, 3)) * 2
-    tmp57 = tmp51.copy()
-    tmp57 += tmp53.transpose((1, 0, 3, 2)) * 2
+    tmp57 = np.copy(tmp51)
+    tmp57 += np.transpose(tmp53, (1, 0, 3, 2)) * 2
     tmp57 += tmp56
     del tmp56
-    tmp76 = tmp44.copy()
-    tmp76 += tmp75.transpose((0, 1, 3, 2))
+    tmp76 = np.copy(tmp44)
+    tmp76 += np.transpose(tmp75, (0, 1, 3, 2))
     del tmp75
     tmp70 = einsum(tmp69, (0, 1, 2, 3), t2, (4, 0, 2, 5), (4, 1, 5, 3))
-    tmp73 = tmp47.transpose((1, 0, 3, 2)).copy() * -1
-    tmp73 += tmp72.transpose((0, 1, 3, 2))
+    tmp73 = np.copy(np.transpose(tmp47, (1, 0, 3, 2))) * -1
+    tmp73 += np.transpose(tmp72, (0, 1, 3, 2))
     del tmp72
     tmp73 += einsum(t1, (0, 1), tmp37, (2, 3), (0, 2, 1, 3))
-    tmp61 = tmp58.copy()
-    tmp61 += tmp60.transpose((1, 0, 3, 2))
-    tmp50 = tmp44.copy()
+    tmp61 = np.copy(tmp58)
+    tmp61 += np.transpose(tmp60, (1, 0, 3, 2))
+    tmp50 = np.copy(tmp44)
     del tmp44
-    tmp50 += tmp47.transpose((1, 0, 3, 2)) * -1
+    tmp50 += np.transpose(tmp47, (1, 0, 3, 2)) * -1
     del tmp47
-    tmp50 += tmp49.transpose((0, 1, 3, 2))
+    tmp50 += np.transpose(tmp49, (0, 1, 3, 2))
     del tmp49
     tmp50 += einsum(t1, (0, 1), tmp11, (2, 3), (0, 2, 1, 3)) * -1
     tmp68 = einsum(tmp67, (0, 1, 2, 3), t2, (4, 0, 2, 5), (4, 1, 5, 3))
     tmp39 = einsum(t1, (0, 1), tmp0, (2, 3), (2, 0, 3, 1))
     tmp39 += tmp19
     tmp39 += tmp21 * -1
-    tmp38 = tmp28.copy()
+    tmp38 = np.copy(tmp28)
     tmp38 += tmp33
-    tmp40 = tmp16.copy()
-    tmp40 += tmp27.transpose((0, 2, 1, 3))
+    tmp40 = np.copy(tmp16)
+    tmp40 += np.transpose(tmp27, (0, 2, 1, 3))
     tmp40 += einsum(t1, (0, 1), tmp2, (2, 3), (2, 0, 3, 1))
-    tmp35 = tmp0.copy()
+    tmp35 = np.copy(tmp0)
     tmp35 += tmp2
-    tmp43 = t1.copy() * -0.5
+    tmp43 = np.copy(t1) * -0.5
     tmp43 += tmp13
     del tmp13
     tmp43 += tmp41 * -1
     del tmp41
     tmp43 += tmp42
     del tmp42
-    tmp34 = t1.copy() * -1
+    tmp34 = np.copy(t1) * -1
     tmp34 += tmp28
     del tmp28
     tmp34 += tmp30 * -1
     del tmp30
     tmp34 += tmp33
     del tmp33
-    tmp22 = tmp16.copy()
+    tmp22 = np.copy(tmp16)
     tmp22 += tmp17
     del tmp17
     tmp22 += tmp19
     del tmp19
     tmp22 += tmp21 * -1
-    tmp24 = tmp23.copy()
+    tmp24 = np.copy(tmp23)
     del tmp23
     tmp24 += einsum(t1, (0, 1), tmp2, (2, 3), (2, 0, 3, 1))
-    tmp7 = delta.oo.copy()
+    tmp7 = np.copy(delta.oo)
     tmp7 += tmp0 * -1
-    rdm2.vvvv = tmp116.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.vvvv = np.copy(np.transpose(tmp116, (0, 1, 3, 2))) * -2
     rdm2.vvvv += tmp116 * 2
     del tmp116
-    rdm2.vvvv += tmp114.transpose((1, 0, 3, 2)) * 2
+    rdm2.vvvv += np.transpose(tmp114, (1, 0, 3, 2)) * 2
     del tmp114
-    rdm2.vvvv += tmp115.transpose((1, 0, 3, 2)) * 2
+    rdm2.vvvv += np.transpose(tmp115, (1, 0, 3, 2)) * 2
     del tmp115
-    rdm2.vvvo = tmp113.transpose((1, 2, 3, 0)).copy() * -2
-    rdm2.vvvo += tmp113.transpose((2, 1, 3, 0)) * 4
-    rdm2.vvov = tmp113.transpose((1, 2, 0, 3)).copy() * 4
-    rdm2.vvov += tmp113.transpose((2, 1, 0, 3)) * -2
+    rdm2.vvvo = np.copy(np.transpose(tmp113, (1, 2, 3, 0))) * -2
+    rdm2.vvvo += np.transpose(tmp113, (2, 1, 3, 0)) * 4
+    rdm2.vvov = np.copy(np.transpose(tmp113, (1, 2, 0, 3))) * 4
+    rdm2.vvov += np.transpose(tmp113, (2, 1, 0, 3)) * -2
     del tmp113
-    rdm2.vovv = tmp109.transpose((1, 0, 2, 3)).copy() * -2
-    rdm2.vovv += tmp109.transpose((1, 0, 3, 2)) * 2
+    rdm2.vovv = np.copy(np.transpose(tmp109, (1, 0, 2, 3))) * -2
+    rdm2.vovv += np.transpose(tmp109, (1, 0, 3, 2)) * 2
     del tmp109
-    rdm2.vovv += tmp110.transpose((1, 0, 2, 3)) * -2
-    rdm2.vovv += tmp110.transpose((1, 0, 3, 2)) * 2
+    rdm2.vovv += np.transpose(tmp110, (1, 0, 2, 3)) * -2
+    rdm2.vovv += np.transpose(tmp110, (1, 0, 3, 2)) * 2
     del tmp110
-    rdm2.vovv += tmp95.transpose((1, 0, 3, 2)) * 2
-    rdm2.vovv += tmp102.transpose((1, 0, 3, 2)) * -2
-    rdm2.vovv += tmp99.transpose((1, 0, 2, 3)) * -2
-    rdm2.vovv += tmp112.transpose((1, 0, 3, 2)) * -2
+    rdm2.vovv += np.transpose(tmp95, (1, 0, 3, 2)) * 2
+    rdm2.vovv += np.transpose(tmp102, (1, 0, 3, 2)) * -2
+    rdm2.vovv += np.transpose(tmp99, (1, 0, 2, 3)) * -2
+    rdm2.vovv += np.transpose(tmp112, (1, 0, 3, 2)) * -2
     del tmp112
     rdm2.vovv += einsum(t1, (0, 1), tmp94, (2, 3), (2, 0, 3, 1)) * 4
-    rdm2.ovvv = tmp98.copy() * 2
-    rdm2.ovvv += tmp98.transpose((0, 1, 3, 2)) * -2
+    rdm2.ovvv = np.copy(tmp98) * 2
+    rdm2.ovvv += np.transpose(tmp98, (0, 1, 3, 2)) * -2
     del tmp98
     rdm2.ovvv += tmp100 * 2
-    rdm2.ovvv += tmp100.transpose((0, 1, 3, 2)) * -2
+    rdm2.ovvv += np.transpose(tmp100, (0, 1, 3, 2)) * -2
     del tmp100
     rdm2.ovvv += tmp101 * 2
-    rdm2.ovvv += tmp101.transpose((0, 1, 3, 2)) * -2
+    rdm2.ovvv += np.transpose(tmp101, (0, 1, 3, 2)) * -2
     del tmp101
     rdm2.ovvv += tmp95 * 2
     del tmp95
-    rdm2.ovvv += tmp99.transpose((0, 1, 3, 2)) * -2
+    rdm2.ovvv += np.transpose(tmp99, (0, 1, 3, 2)) * -2
     del tmp99
     rdm2.ovvv += tmp102 * -2
     del tmp102
     rdm2.ovvv += tmp106 * -2
     del tmp106
     rdm2.ovvv += einsum(t1, (0, 1), tmp85, (2, 3), (0, 2, 1, 3)) * 2
-    rdm2.vvoo = l2.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.vvoo = np.copy(np.transpose(l2, (0, 1, 3, 2))) * -2
     rdm2.vvoo += l2 * 4
     rdm2.vovo = einsum(l1, (0, 1), t1, (2, 3), (0, 2, 3, 1)) * -2
-    rdm2.vovo += tmp88.transpose((2, 1, 3, 0)) * -2
-    rdm2.vovo += tmp93.transpose((2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp88, (2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp93, (2, 1, 3, 0)) * -2
     del tmp93
-    rdm2.vovo += tmp92.transpose((2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp92, (2, 1, 3, 0)) * -2
     rdm2.vovo += einsum(delta.oo, (0, 1), tmp94, (2, 3), (2, 0, 3, 1)) * 8
     del tmp94
-    rdm2.vovo += tmp69.transpose((2, 1, 3, 0)) * -2
-    rdm2.vovo += tmp86.transpose((2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp69, (2, 1, 3, 0)) * -2
+    rdm2.vovo += np.transpose(tmp86, (2, 1, 3, 0)) * -2
     rdm2.voov = einsum(l1, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 4
-    rdm2.voov += tmp80.transpose((3, 0, 1, 2)) * 2
-    rdm2.voov += tmp79.transpose((3, 0, 1, 2)) * -2
-    rdm2.voov += tmp92.transpose((2, 1, 0, 3)) * 2
+    rdm2.voov += np.transpose(tmp80, (3, 0, 1, 2)) * 2
+    rdm2.voov += np.transpose(tmp79, (3, 0, 1, 2)) * -2
+    rdm2.voov += np.transpose(tmp92, (2, 1, 0, 3)) * 2
     del tmp92
     rdm2.voov += einsum(delta.oo, (0, 1), tmp85, (2, 3), (2, 0, 1, 3)) * -2
-    rdm2.voov += tmp67.transpose((2, 1, 0, 3)) * -2
-    rdm2.voov += tmp91.transpose((2, 1, 0, 3)) * -2
-    rdm2.voov += tmp88.transpose((2, 1, 0, 3)) * 2
+    rdm2.voov += np.transpose(tmp67, (2, 1, 0, 3)) * -2
+    rdm2.voov += np.transpose(tmp91, (2, 1, 0, 3)) * -2
+    rdm2.voov += np.transpose(tmp88, (2, 1, 0, 3)) * 2
     rdm2.ovvo = einsum(l1, (0, 1), t1, (2, 3), (2, 0, 3, 1)) * 4
-    rdm2.ovvo += tmp88.transpose((1, 2, 3, 0)) * 4
+    rdm2.ovvo += np.transpose(tmp88, (1, 2, 3, 0)) * 4
     del tmp88
-    rdm2.ovvo += tmp90.transpose((1, 2, 3, 0)) * -2
+    rdm2.ovvo += np.transpose(tmp90, (1, 2, 3, 0)) * -2
     del tmp90
-    rdm2.ovvo += tmp82.transpose((1, 2, 3, 0)) * -2
+    rdm2.ovvo += np.transpose(tmp82, (1, 2, 3, 0)) * -2
     rdm2.ovvo += einsum(delta.oo, (0, 1), tmp85, (2, 3), (0, 2, 3, 1)) * -2
-    rdm2.ovvo += tmp67.transpose((1, 2, 3, 0)) * -2
+    rdm2.ovvo += np.transpose(tmp67, (1, 2, 3, 0)) * -2
     del tmp67
-    rdm2.ovvo += tmp91.transpose((1, 2, 3, 0)) * -2
+    rdm2.ovvo += np.transpose(tmp91, (1, 2, 3, 0)) * -2
     del tmp91
     rdm2.ovov = einsum(l1, (0, 1), t1, (2, 3), (2, 0, 1, 3)) * -2
-    rdm2.ovov += tmp79.transpose((0, 3, 1, 2)) * 2
+    rdm2.ovov += np.transpose(tmp79, (0, 3, 1, 2)) * 2
     del tmp79
-    rdm2.ovov += tmp80.transpose((0, 3, 1, 2)) * -2
+    rdm2.ovov += np.transpose(tmp80, (0, 3, 1, 2)) * -2
     del tmp80
-    rdm2.ovov += tmp82.transpose((1, 2, 0, 3)) * 2
+    rdm2.ovov += np.transpose(tmp82, (1, 2, 0, 3)) * 2
     del tmp82
     rdm2.ovov += einsum(delta.oo, (0, 1), tmp85, (2, 3), (0, 2, 1, 3)) * 4
     del tmp85
-    rdm2.ovov += tmp69.transpose((1, 2, 0, 3)) * -2
+    rdm2.ovov += np.transpose(tmp69, (1, 2, 0, 3)) * -2
     del tmp69
-    rdm2.ovov += tmp86.transpose((1, 2, 0, 3)) * -2
+    rdm2.ovov += np.transpose(tmp86, (1, 2, 0, 3)) * -2
     del tmp86
-    rdm2.oovv = tmp50.copy() * 2
-    rdm2.oovv += tmp50.transpose((0, 1, 3, 2)) * -2
-    rdm2.oovv += tmp50.transpose((1, 0, 2, 3)) * -2
-    rdm2.oovv += tmp50.transpose((1, 0, 3, 2)) * 2
+    rdm2.oovv = np.copy(tmp50) * 2
+    rdm2.oovv += np.transpose(tmp50, (0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(tmp50, (1, 0, 2, 3)) * -2
+    rdm2.oovv += np.transpose(tmp50, (1, 0, 3, 2)) * 2
     del tmp50
     rdm2.oovv += tmp57 * 2
-    rdm2.oovv += tmp57.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(tmp57, (0, 1, 3, 2)) * -2
     del tmp57
     rdm2.oovv += tmp61 * 2
-    rdm2.oovv += tmp61.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(tmp61, (0, 1, 3, 2)) * -2
     del tmp61
     rdm2.oovv += tmp66 * -4
-    rdm2.oovv += tmp66.transpose((0, 1, 3, 2)) * 2
-    rdm2.oovv += tmp66.transpose((1, 0, 2, 3)) * 2
-    rdm2.oovv += tmp66.transpose((1, 0, 3, 2)) * -4
+    rdm2.oovv += np.transpose(tmp66, (0, 1, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp66, (1, 0, 2, 3)) * 2
+    rdm2.oovv += np.transpose(tmp66, (1, 0, 3, 2)) * -4
     del tmp66
-    rdm2.oovv += t2.transpose((0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(t2, (0, 1, 3, 2)) * -2
     rdm2.oovv += t2 * 4
     rdm2.oovv += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 3, 1)) * -2
     rdm2.oovv += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 2
@@ -1195,30 +1195,30 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp8
     rdm2.oovv += tmp68 * 2
     del tmp68
-    rdm2.oovv += tmp70.transpose((0, 1, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp70, (0, 1, 3, 2)) * 2
     del tmp70
     rdm2.oovv += tmp58 * 2
     del tmp58
     rdm2.oovv += tmp51 * 2
     del tmp51
     rdm2.oovv += tmp73 * 2
-    rdm2.oovv += tmp73.transpose((1, 0, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp73, (1, 0, 3, 2)) * 2
     del tmp73
-    rdm2.oovv += tmp76.transpose((0, 1, 3, 2)) * -2
-    rdm2.oovv += tmp76.transpose((1, 0, 2, 3)) * -2
+    rdm2.oovv += np.transpose(tmp76, (0, 1, 3, 2)) * -2
+    rdm2.oovv += np.transpose(tmp76, (1, 0, 2, 3)) * -2
     del tmp76
     rdm2.oovv += tmp53 * 4
     del tmp53
-    rdm2.oovv += tmp60.transpose((1, 0, 3, 2)) * 2
+    rdm2.oovv += np.transpose(tmp60, (1, 0, 3, 2)) * 2
     del tmp60
     rdm2.oovv += einsum(tmp77, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 2
     del tmp77
-    rdm2.vooo = tmp4.transpose((3, 2, 0, 1)).copy() * -4
-    rdm2.vooo += tmp4.transpose((3, 2, 1, 0)) * 2
+    rdm2.vooo = np.copy(np.transpose(tmp4, (3, 2, 0, 1))) * -4
+    rdm2.vooo += np.transpose(tmp4, (3, 2, 1, 0)) * 2
     rdm2.vooo += einsum(l1, (0, 1), delta.oo, (2, 3), (0, 2, 1, 3)) * 4
     rdm2.vooo += einsum(l1, (0, 1), delta.oo, (2, 3), (0, 2, 3, 1)) * -2
-    rdm2.ovoo = tmp4.transpose((2, 3, 0, 1)).copy() * 2
-    rdm2.ovoo += tmp4.transpose((2, 3, 1, 0)) * -4
+    rdm2.ovoo = np.copy(np.transpose(tmp4, (2, 3, 0, 1))) * 2
+    rdm2.ovoo += np.transpose(tmp4, (2, 3, 1, 0)) * -4
     del tmp4
     rdm2.ovoo += einsum(l1, (0, 1), delta.oo, (2, 3), (2, 0, 1, 3)) * -2
     rdm2.ovoo += einsum(l1, (0, 1), delta.oo, (2, 3), (2, 0, 3, 1)) * 4
@@ -1230,17 +1230,17 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp38
     rdm2.oovo += einsum(t1, (0, 1), delta.oo, (2, 3), (0, 2, 1, 3)) * 2
     rdm2.oovo += einsum(delta.oo, (0, 1), t1, (2, 3), (0, 2, 3, 1)) * -2
-    rdm2.oovo += tmp39.transpose((1, 2, 3, 0)) * -2
-    rdm2.oovo += tmp39.transpose((2, 1, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp39, (1, 2, 3, 0)) * -2
+    rdm2.oovo += np.transpose(tmp39, (2, 1, 3, 0)) * 2
     del tmp39
-    rdm2.oovo += tmp40.transpose((1, 2, 3, 0)) * -2
-    rdm2.oovo += tmp40.transpose((2, 1, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp40, (1, 2, 3, 0)) * -2
+    rdm2.oovo += np.transpose(tmp40, (2, 1, 3, 0)) * 2
     del tmp40
-    rdm2.oovo += tmp26.transpose((1, 2, 3, 0)) * 2
-    rdm2.oovo += tmp25.transpose((2, 1, 3, 0)) * 2
-    rdm2.oovo += tmp16.transpose((1, 2, 3, 0)) * -2
-    rdm2.oovo += tmp21.transpose((2, 1, 3, 0)) * -2
-    rdm2.oovo += tmp27.transpose((1, 2, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp26, (1, 2, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp25, (2, 1, 3, 0)) * 2
+    rdm2.oovo += np.transpose(tmp16, (1, 2, 3, 0)) * -2
+    rdm2.oovo += np.transpose(tmp21, (2, 1, 3, 0)) * -2
+    rdm2.oovo += np.transpose(tmp27, (1, 2, 3, 0)) * 2
     rdm2.oovo += einsum(tmp43, (0, 1), delta.oo, (2, 3), (0, 2, 1, 3)) * -4
     del tmp43
     rdm2.oovo += einsum(t1, (0, 1), tmp35, (2, 3), (0, 3, 1, 2)) * -2
@@ -1252,23 +1252,23 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp15
     rdm2.ooov += einsum(t1, (0, 1), delta.oo, (2, 3), (0, 2, 3, 1)) * -2
     rdm2.ooov += einsum(delta.oo, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 2
-    rdm2.ooov += tmp22.transpose((1, 2, 0, 3)) * 2
-    rdm2.ooov += tmp22.transpose((2, 1, 0, 3)) * -2
+    rdm2.ooov += np.transpose(tmp22, (1, 2, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp22, (2, 1, 0, 3)) * -2
     del tmp22
-    rdm2.ooov += tmp24.transpose((1, 2, 0, 3)) * 2
-    rdm2.ooov += tmp24.transpose((2, 1, 0, 3)) * -2
+    rdm2.ooov += np.transpose(tmp24, (1, 2, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp24, (2, 1, 0, 3)) * -2
     del tmp24
     rdm2.ooov += einsum(t1, (0, 1), tmp0, (2, 3), (0, 3, 2, 1)) * 2
     rdm2.ooov += einsum(t1, (0, 1), tmp0, (2, 3), (3, 0, 2, 1)) * -2
-    rdm2.ooov += tmp25.transpose((1, 2, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp25, (1, 2, 0, 3)) * 2
     del tmp25
-    rdm2.ooov += tmp26.transpose((2, 1, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp26, (2, 1, 0, 3)) * 2
     del tmp26
-    rdm2.ooov += tmp16.transpose((2, 1, 0, 3)) * -2
+    rdm2.ooov += np.transpose(tmp16, (2, 1, 0, 3)) * -2
     del tmp16
-    rdm2.ooov += tmp21.transpose((1, 2, 0, 3)) * -2
+    rdm2.ooov += np.transpose(tmp21, (1, 2, 0, 3)) * -2
     del tmp21
-    rdm2.ooov += tmp27.transpose((2, 1, 0, 3)) * 2
+    rdm2.ooov += np.transpose(tmp27, (2, 1, 0, 3)) * 2
     del tmp27
     rdm2.ooov += einsum(delta.oo, (0, 1), tmp34, (2, 3), (0, 2, 1, 3)) * -2
     del tmp34
@@ -1286,17 +1286,17 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.oooo += einsum(tmp2, (0, 1), delta.oo, (2, 3), (1, 2, 3, 0)) * 2
     rdm2.oooo += einsum(tmp2, (0, 1), delta.oo, (2, 3), (2, 1, 3, 0)) * -4
     del tmp2
-    rdm2.oooo += tmp6.transpose((3, 2, 0, 1)) * -2
-    rdm2.oooo += tmp6.transpose((2, 3, 0, 1)) * 2
+    rdm2.oooo += np.transpose(tmp6, (3, 2, 0, 1)) * -2
+    rdm2.oooo += np.transpose(tmp6, (2, 3, 0, 1)) * 2
     del tmp6
-    rdm2.oooo += tmp3.transpose((3, 2, 1, 0)) * 2
+    rdm2.oooo += np.transpose(tmp3, (3, 2, 1, 0)) * 2
     del tmp3
-    rdm2.oooo += tmp5.transpose((3, 2, 1, 0)) * 2
+    rdm2.oooo += np.transpose(tmp5, (3, 2, 1, 0)) * 2
     del tmp5
     rdm2.oooo += einsum(delta.oo, (0, 1), tmp7, (2, 3), (3, 0, 2, 1)) * 2
     del delta, tmp7
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.transpose(0, 2, 1, 3)
+    rdm2 = np.transpose(rdm2, (0, 2, 1, 3))
 
     return rdm2
 
@@ -1496,59 +1496,59 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     """
 
     ints = kwargs["ints"]
-    tmp3 = r2.copy() * -1
-    tmp3 += r2.transpose((1, 0, 2)) * 2
-    tmp2 = f.ov.copy() * 0.5
+    tmp3 = np.copy(r2) * -1
+    tmp3 += np.transpose(r2, (1, 0, 2)) * 2
+    tmp2 = np.copy(f.ov) * 0.5
     tmp2 += ints.tmp11
     tmp2 += ints.tmp9 * -0.5
     del ints.tmp9
-    tmp15 = ints.tmp4.copy()
+    tmp15 = np.copy(ints.tmp4)
     del ints.tmp4
-    tmp15 += v.xoo.transpose((1, 2, 0))
+    tmp15 += np.transpose(v.xoo, (1, 2, 0))
     tmp9 = einsum(v.xov, (0, 1, 2), tmp3, (3, 1, 2), (3, 0)) * 0.5
-    tmp14 = ints.tmp14.copy()
-    tmp14 += ints.tmp1.transpose((0, 2, 1, 3))
+    tmp14 = np.copy(ints.tmp14)
+    tmp14 += np.transpose(ints.tmp1, (0, 2, 1, 3))
     tmp17 = einsum(tmp3, (0, 1, 2), ints.tmp37, (1, 0, 2, 3), (3,)) * 0.5
     del ints.tmp37
-    tmp7 = ints.tmp38.copy()
+    tmp7 = np.copy(ints.tmp38)
     del ints.tmp38
-    tmp7 += ints.tmp44.transpose((2, 0, 1, 3))
-    tmp7 += ints.tmp57.transpose((2, 0, 1, 3))
+    tmp7 += np.transpose(ints.tmp44, (2, 0, 1, 3))
+    tmp7 += np.transpose(ints.tmp57, (2, 0, 1, 3))
     del ints.tmp57
-    tmp10 = ints.tmp20.copy() * 2
+    tmp10 = np.copy(ints.tmp20) * 2
     del ints.tmp20
     tmp10 += ints.tmp31
     del ints.tmp31
-    tmp10 += v.xov.transpose((1, 2, 0))
+    tmp10 += np.transpose(v.xov, (1, 2, 0))
     tmp10 += ints.tmp17 * -1
     del ints.tmp17
-    tmp13 = f.oo.copy() * 0.5
+    tmp13 = np.copy(f.oo) * 0.5
     tmp13 += ints.tmp0 * 0.5
-    tmp13 += ints.tmp21.transpose((1, 0))
-    tmp13 += ints.tmp24.transpose((1, 0))
-    tmp13 += ints.tmp7.transpose((1, 0))
-    tmp13 += ints.tmp18.transpose((1, 0)) * -0.5
-    tmp13 += ints.tmp23.transpose((1, 0)) * -0.5
-    tmp13 += ints.tmp5.transpose((1, 0)) * -0.5
-    tmp5 = ints.tmp33.copy() * 0.5
+    tmp13 += np.transpose(ints.tmp21, (1, 0))
+    tmp13 += np.transpose(ints.tmp24, (1, 0))
+    tmp13 += np.transpose(ints.tmp7, (1, 0))
+    tmp13 += np.transpose(ints.tmp18, (1, 0)) * -0.5
+    tmp13 += np.transpose(ints.tmp23, (1, 0)) * -0.5
+    tmp13 += np.transpose(ints.tmp5, (1, 0)) * -0.5
+    tmp5 = np.copy(ints.tmp33) * 0.5
     tmp5 += ints.tmp42 * 0.5
     tmp5 += ints.tmp67
     tmp5 += ints.tmp66 * -0.5
-    tmp8 = ints.tmp110.copy()
+    tmp8 = np.copy(ints.tmp110)
     del ints.tmp110
-    tmp8 += ints.tmp44.transpose((2, 0, 1, 3))
+    tmp8 += np.transpose(ints.tmp44, (2, 0, 1, 3))
     del ints.tmp44
-    tmp11 = ints.tmp32.copy()
+    tmp11 = np.copy(ints.tmp32)
     del ints.tmp32
-    tmp11 += ints.tmp89.transpose((1, 0)) * 2
+    tmp11 += np.transpose(ints.tmp89, (1, 0)) * 2
     del ints.tmp89
     tmp11 += f.vv * -1
-    tmp11 += ints.tmp29.transpose((1, 0)) * -2
+    tmp11 += np.transpose(ints.tmp29, (1, 0)) * -2
     del ints.tmp29
-    tmp11 += ints.tmp87.transpose((1, 0)) * -1
+    tmp11 += np.transpose(ints.tmp87, (1, 0)) * -1
     del ints.tmp87
     tmp11 += einsum(t1, (0, 1), tmp2, (0, 2), (2, 1)) * 2
-    tmp18 = ints.tmp106.copy()
+    tmp18 = np.copy(ints.tmp106)
     del ints.tmp106
     tmp18 += ints.tmp108
     del ints.tmp108
@@ -1604,17 +1604,17 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp14
     tmp16 += einsum(tmp9, (0, 1), tmp15, (2, 3, 1), (0, 3, 2)) * -1
     del tmp15
-    tmp6 = ints.tmp33.copy()
+    tmp6 = np.copy(ints.tmp33)
     del ints.tmp33
     tmp6 += ints.tmp42
     del ints.tmp42
     tmp6 += ints.tmp66 * -1
     del ints.tmp66
-    tmp12 = ints.tmp112.copy()
+    tmp12 = np.copy(ints.tmp112)
     del ints.tmp112
-    tmp12 += ints.tmp120.transpose((1, 0, 2, 3))
+    tmp12 += np.transpose(ints.tmp120, (1, 0, 2, 3))
     del ints.tmp120
-    tmp12 += ints.tmp123.transpose((2, 0, 1, 3))
+    tmp12 += np.transpose(ints.tmp123, (2, 0, 1, 3))
     del ints.tmp123
     tmp12 += ints.tmp40
     del ints.tmp40
@@ -1624,51 +1624,51 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp51
     tmp12 += ints.tmp52
     del ints.tmp52
-    tmp12 += ints.tmp59.transpose((1, 2, 0, 3))
+    tmp12 += np.transpose(ints.tmp59, (1, 2, 0, 3))
     del ints.tmp59
-    tmp12 += ints.tmp62.transpose((1, 0, 2, 3))
+    tmp12 += np.transpose(ints.tmp62, (1, 0, 2, 3))
     del ints.tmp62
-    tmp12 += ints.tmp65.transpose((2, 0, 1, 3))
+    tmp12 += np.transpose(ints.tmp65, (2, 0, 1, 3))
     del ints.tmp65
     tmp12 += ints.tmp86
     del ints.tmp86
-    tmp12 += ints.tmp95.transpose((1, 0, 2, 3))
+    tmp12 += np.transpose(ints.tmp95, (1, 0, 2, 3))
     del ints.tmp95
     tmp12 += ints.tmp109 * -1
     del ints.tmp109
-    tmp12 += ints.tmp114.transpose((2, 0, 1, 3)) * -1
+    tmp12 += np.transpose(ints.tmp114, (2, 0, 1, 3)) * -1
     del ints.tmp114
     tmp12 += ints.tmp14 * -1
-    tmp12 += ints.tmp1.transpose((0, 2, 1, 3)) * -1
+    tmp12 += np.transpose(ints.tmp1, (0, 2, 1, 3)) * -1
     tmp12 += ints.tmp35 * -1
     del ints.tmp35
     tmp12 += ints.tmp48 * -2
     del ints.tmp48
-    tmp12 += ints.tmp63.transpose((2, 0, 1, 3)) * -2
+    tmp12 += np.transpose(ints.tmp63, (2, 0, 1, 3)) * -2
     del ints.tmp63
-    tmp12 += ints.tmp78.transpose((2, 1, 0, 3)) * -1
+    tmp12 += np.transpose(ints.tmp78, (2, 1, 0, 3)) * -1
     del ints.tmp78
-    tmp12 += ints.tmp96.transpose((1, 0, 2, 3)) * -2
+    tmp12 += np.transpose(ints.tmp96, (1, 0, 2, 3)) * -2
     del ints.tmp96
-    tmp1 = r2.copy() * -0.5
-    tmp1 += r2.transpose((1, 0, 2))
-    tmp4 = f.oo.copy()
+    tmp1 = np.copy(r2) * -0.5
+    tmp1 += np.transpose(r2, (1, 0, 2))
+    tmp4 = np.copy(f.oo)
     tmp4 += ints.tmp0
     del ints.tmp0
-    tmp4 += ints.tmp21.transpose((1, 0)) * 2
+    tmp4 += np.transpose(ints.tmp21, (1, 0)) * 2
     del ints.tmp21
-    tmp4 += ints.tmp24.transpose((1, 0)) * 2
+    tmp4 += np.transpose(ints.tmp24, (1, 0)) * 2
     del ints.tmp24
-    tmp4 += ints.tmp7.transpose((1, 0)) * 2
+    tmp4 += np.transpose(ints.tmp7, (1, 0)) * 2
     del ints.tmp7
-    tmp4 += ints.tmp18.transpose((1, 0)) * -1
+    tmp4 += np.transpose(ints.tmp18, (1, 0)) * -1
     del ints.tmp18
-    tmp4 += ints.tmp23.transpose((1, 0)) * -1
+    tmp4 += np.transpose(ints.tmp23, (1, 0)) * -1
     del ints.tmp23
-    tmp4 += ints.tmp5.transpose((1, 0)) * -1
+    tmp4 += np.transpose(ints.tmp5, (1, 0)) * -1
     del ints.tmp5
-    tmp0 = r2.copy() * 2
-    tmp0 += r2.transpose((1, 0, 2)) * -1
+    tmp0 = np.copy(r2) * 2
+    tmp0 += np.transpose(r2, (1, 0, 2)) * -1
     r2new = einsum(ints.tmp67, (0, 1, 2, 3), r2, (4, 1, 3), (0, 4, 2))
     del ints.tmp67
     r2new += einsum(tmp5, (0, 1, 2, 3), r2, (1, 4, 3), (0, 4, 2)) * -2
@@ -1877,38 +1877,38 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     """
 
     ints = kwargs["ints"]
-    tmp15 = f.ov.copy() * 0.5
+    tmp15 = np.copy(f.ov) * 0.5
     tmp15 += ints.tmp12
     tmp15 += ints.tmp10 * -0.5
-    tmp19 = ints.tmp132.copy()
+    tmp19 = np.copy(ints.tmp132)
     del ints.tmp132
     tmp19 += ints.tmp15 * 0.5
-    tmp19 += ints.tmp81.transpose((0, 1, 3, 2)) * 0.5
+    tmp19 += np.transpose(ints.tmp81, (0, 1, 3, 2)) * 0.5
     del ints.tmp81
     tmp19 += ints.tmp123 * -0.5
     tmp19 += ints.tmp136 * -0.5
     del ints.tmp136
     tmp7 = einsum(r2, (0, 1, 2), ints.tmp15, (3, 4, 1, 0), (3, 4, 2))
-    tmp10 = r2.transpose((2, 0, 1)).copy()
+    tmp10 = np.copy(np.transpose(r2, (2, 0, 1)))
     tmp10 += einsum(t1, (0, 1), r1, (2,), (0, 1, 2)) * -1
-    tmp8 = ints.tmp49.copy()
+    tmp8 = np.copy(ints.tmp49)
     del ints.tmp49
-    tmp8 += ints.tmp76.transpose((0, 2, 1, 3))
+    tmp8 += np.transpose(ints.tmp76, (0, 2, 1, 3))
     del ints.tmp76
-    tmp2 = r2.transpose((2, 0, 1)).copy() * -1
-    tmp2 += r2.transpose((2, 1, 0)) * 2
-    tmp13 = ints.tmp9.copy()
+    tmp2 = np.copy(np.transpose(r2, (2, 0, 1))) * -1
+    tmp2 += np.transpose(r2, (2, 1, 0)) * 2
+    tmp13 = np.copy(ints.tmp9)
     del ints.tmp9
-    tmp13 += v.xoo.transpose((1, 2, 0))
+    tmp13 += np.transpose(v.xoo, (1, 2, 0))
     tmp16 = einsum(t1, (0, 1), tmp15, (0, 2), (1, 2)) * 2
     del tmp15
-    tmp4 = r2.transpose((2, 0, 1)).copy()
-    tmp4 += r2.transpose((2, 1, 0)) * -0.5
-    tmp1 = f.ov.copy()
+    tmp4 = np.copy(np.transpose(r2, (2, 0, 1)))
+    tmp4 += np.transpose(r2, (2, 1, 0)) * -0.5
+    tmp1 = np.copy(f.ov)
     tmp1 += ints.tmp12 * 2
     tmp1 += ints.tmp10 * -1
     del ints.tmp10
-    tmp23 = ints.tmp101.copy() * 2
+    tmp23 = np.copy(ints.tmp101) * 2
     del ints.tmp101
     tmp23 += ints.tmp102
     del ints.tmp102
@@ -1959,20 +1959,20 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp92
     tmp23 += ints.tmp94 * -1
     del ints.tmp94
-    tmp21 = f.oo.copy()
-    tmp21 += ints.tmp47.transpose((1, 0)) * 2
+    tmp21 = np.copy(f.oo)
+    tmp21 += np.transpose(ints.tmp47, (1, 0)) * 2
     del ints.tmp47
     tmp21 += ints.tmp63
     del ints.tmp63
-    tmp21 += ints.tmp74.transpose((1, 0)) * 2
+    tmp21 += np.transpose(ints.tmp74, (1, 0)) * 2
     del ints.tmp74
-    tmp21 += ints.tmp84.transpose((1, 0)) * 2
+    tmp21 += np.transpose(ints.tmp84, (1, 0)) * 2
     del ints.tmp84
-    tmp21 += ints.tmp46.transpose((1, 0)) * -1
+    tmp21 += np.transpose(ints.tmp46, (1, 0)) * -1
     del ints.tmp46
-    tmp21 += ints.tmp72.transpose((1, 0)) * -1
+    tmp21 += np.transpose(ints.tmp72, (1, 0)) * -1
     del ints.tmp72
-    tmp21 += ints.tmp83.transpose((1, 0)) * -1
+    tmp21 += np.transpose(ints.tmp83, (1, 0)) * -1
     del ints.tmp83
     tmp20 = einsum(r2, (0, 1, 2), ints.tmp1, (3, 4, 0, 1), (2, 3, 4)) * -1
     tmp20 += einsum(tmp7, (0, 1, 2), t1, (1, 3), (2, 0, 3))
@@ -1980,19 +1980,19 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp20 += einsum(tmp19, (0, 1, 2, 3), r1, (3,), (0, 1, 2)) * 2
     del tmp19
     tmp12 = einsum(v.xov, (0, 1, 2), tmp2, (1, 3, 2), (3, 0)) * 0.5
-    tmp14 = ints.tmp23.copy() * 2
+    tmp14 = np.copy(ints.tmp23) * 2
     del ints.tmp23
     tmp14 += ints.tmp7
     del ints.tmp7
-    tmp14 += v.xov.transpose((1, 2, 0))
+    tmp14 += np.transpose(v.xov, (1, 2, 0))
     tmp14 += ints.tmp20 * -1
     del ints.tmp20
     tmp14 += einsum(t1, (0, 1), tmp13, (2, 0, 3), (2, 1, 3)) * -1
     del tmp13
-    tmp11 = ints.tmp44.copy()
+    tmp11 = np.copy(ints.tmp44)
     tmp11 += ints.tmp68
     tmp11 += ints.tmp39 * -1
-    tmp9 = ints.tmp123.copy()
+    tmp9 = np.copy(ints.tmp123)
     tmp9 += ints.tmp44 * 0.5
     del ints.tmp44
     tmp9 += ints.tmp68 * 0.5
@@ -2002,41 +2002,41 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp9 += einsum(tmp8, (0, 1, 2, 3), t1, (2, 4), (0, 1, 4, 3)) * -0.5
     del tmp8
     tmp6 = einsum(ints.tmp1, (0, 1, 2, 3), r2, (3, 2, 4), (0, 4, 1))
-    tmp18 = ints.tmp117.copy() * 2
+    tmp18 = np.copy(ints.tmp117) * 2
     del ints.tmp117
-    tmp18 += ints.tmp1.transpose((0, 3, 2, 1))
-    tmp18 += ints.tmp51.transpose((0, 1, 3, 2))
+    tmp18 += np.transpose(ints.tmp1, (0, 3, 2, 1))
+    tmp18 += np.transpose(ints.tmp51, (0, 1, 3, 2))
     del ints.tmp51
-    tmp18 += ints.tmp66.transpose((0, 3, 1, 2))
+    tmp18 += np.transpose(ints.tmp66, (0, 3, 1, 2))
     del ints.tmp66
-    tmp18 += ints.tmp77.transpose((0, 2, 3, 1))
+    tmp18 += np.transpose(ints.tmp77, (0, 2, 3, 1))
     del ints.tmp77
     tmp18 += ints.tmp119 * -1
     del ints.tmp119
     tmp18 += ints.tmp120 * -1
     del ints.tmp120
-    tmp18 += ints.tmp36.transpose((0, 3, 2, 1)) * -1
+    tmp18 += np.transpose(ints.tmp36, (0, 3, 2, 1)) * -1
     del ints.tmp36
-    tmp17 = ints.tmp24.transpose((1, 0)).copy() * 2
+    tmp17 = np.copy(np.transpose(ints.tmp24, (1, 0))) * 2
     tmp17 += ints.tmp8
     tmp17 += f.vv * -1
-    tmp17 += ints.tmp21.transpose((1, 0)) * -1
-    tmp17 += ints.tmp5.transpose((1, 0)) * -2
-    tmp17 += tmp16.transpose((1, 0))
+    tmp17 += np.transpose(ints.tmp21, (1, 0)) * -1
+    tmp17 += np.transpose(ints.tmp5, (1, 0)) * -2
+    tmp17 += np.transpose(tmp16, (1, 0))
     del tmp16
     tmp22 = einsum(ints.tmp15, (0, 1, 2, 3), tmp4, (0, 2, 3), (1,)) * -2
     tmp22 += einsum(r1, (0,), tmp1, (1, 0), (1,))
     tmp5 = einsum(ints.tmp15, (0, 1, 2, 3), tmp4, (0, 2, 3), (1,)) * -1
     del ints.tmp15, tmp4
     tmp5 += einsum(r1, (0,), tmp1, (1, 0), (1,)) * 0.5
-    tmp0 = r2.transpose((2, 0, 1)).copy() * -0.5
-    tmp0 += r2.transpose((2, 1, 0))
-    tmp3 = f.vv.copy()
-    tmp3 += ints.tmp21.transpose((1, 0))
+    tmp0 = np.copy(np.transpose(r2, (2, 0, 1))) * -0.5
+    tmp0 += np.transpose(r2, (2, 1, 0))
+    tmp3 = np.copy(f.vv)
+    tmp3 += np.transpose(ints.tmp21, (1, 0))
     del ints.tmp21
-    tmp3 += ints.tmp5.transpose((1, 0)) * 2
+    tmp3 += np.transpose(ints.tmp5, (1, 0)) * 2
     del ints.tmp5
-    tmp3 += ints.tmp24.transpose((1, 0)) * -2
+    tmp3 += np.transpose(ints.tmp24, (1, 0)) * -2
     del ints.tmp24
     tmp3 += ints.tmp8 * -1
     del ints.tmp8
@@ -2275,44 +2275,44 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
 
     ints = kwargs["ints"]
     tmp11 = einsum(r2, (0, 1, 2), t1, (3, 2), (0, 1, 3))
-    tmp20 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp20 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp20 += t2
-    tmp17 = f.ov.copy()
+    tmp17 = np.copy(f.ov)
     tmp17 += ints.tmp22 * 2
     tmp17 += ints.tmp62 * -1
     del ints.tmp62
-    tmp0 = r2.copy() * -0.5
-    tmp0 += r2.transpose((1, 0, 2))
-    tmp13 = ints.tmp25.copy()
+    tmp0 = np.copy(r2) * -0.5
+    tmp0 += np.transpose(r2, (1, 0, 2))
+    tmp13 = np.copy(ints.tmp25)
     del ints.tmp25
     tmp13 += ints.tmp35 * 2
     del ints.tmp35
-    tmp13 += v.xov.transpose((1, 2, 0))
+    tmp13 += np.transpose(v.xov, (1, 2, 0))
     tmp13 += ints.tmp32 * -1
     del ints.tmp32
-    tmp15 = ints.tmp13.copy()
+    tmp15 = np.copy(ints.tmp13)
     del ints.tmp13
-    tmp15 += v.xoo.transpose((1, 2, 0))
-    tmp14 = tmp11.copy() * -1
-    tmp14 += tmp11.transpose((1, 0, 2)) * 2
-    tmp19 = f.oo.copy() * 0.5
-    tmp19 += ints.tmp0.transpose((1, 0)) * 0.5
+    tmp15 += np.transpose(v.xoo, (1, 2, 0))
+    tmp14 = np.copy(tmp11) * -1
+    tmp14 += np.transpose(tmp11, (1, 0, 2)) * 2
+    tmp19 = np.copy(f.oo) * 0.5
+    tmp19 += np.transpose(ints.tmp0, (1, 0)) * 0.5
     tmp19 += ints.tmp107
     tmp19 += ints.tmp16
     tmp19 += ints.tmp36
     tmp19 += ints.tmp106 * -0.5
     tmp19 += ints.tmp14 * -0.5
     tmp19 += ints.tmp33 * -0.5
-    tmp7 = ints.tmp139.copy() * 0.5
+    tmp7 = np.copy(ints.tmp139) * 0.5
     tmp7 += ints.tmp145 * 0.5
     tmp7 += ints.tmp150
     tmp7 += ints.tmp149 * -0.5
-    tmp22 = ints.tmp10.copy()
-    tmp22 += ints.tmp28.transpose((2, 0, 1, 3))
-    tmp10 = ints.tmp102.copy()
+    tmp22 = np.copy(ints.tmp10)
+    tmp22 += np.transpose(ints.tmp28, (2, 0, 1, 3))
+    tmp10 = np.copy(ints.tmp102)
     del ints.tmp102
-    tmp10 += ints.tmp114.transpose((0, 1, 3, 2))
-    tmp8 = ints.tmp139.copy()
+    tmp10 += np.transpose(ints.tmp114, (0, 1, 3, 2))
+    tmp8 = np.copy(ints.tmp139)
     del ints.tmp139
     tmp8 += ints.tmp145
     del ints.tmp145
@@ -2320,7 +2320,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp149
     tmp21 = einsum(r2, (0, 1, 2), tmp20, (1, 0, 3, 2), (3,))
     del tmp20
-    tmp18 = ints.tmp177.transpose((1, 0)).copy()
+    tmp18 = np.copy(np.transpose(ints.tmp177, (1, 0)))
     del ints.tmp177
     tmp18 += ints.tmp180 * 2
     del ints.tmp180
@@ -2334,21 +2334,21 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp13
     tmp16 += einsum(tmp15, (0, 1, 2), tmp14, (3, 0, 1), (3, 2)) * 0.5
     del tmp15, tmp14
-    tmp9 = ints.tmp114.copy()
+    tmp9 = np.copy(ints.tmp114)
     del ints.tmp114
-    tmp9 += ints.tmp133.transpose((0, 1, 3, 2))
+    tmp9 += np.transpose(ints.tmp133, (0, 1, 3, 2))
     del ints.tmp133
-    tmp9 += ints.tmp18.transpose((2, 3, 0, 1))
+    tmp9 += np.transpose(ints.tmp18, (2, 3, 0, 1))
     del ints.tmp18
-    tmp12 = ints.tmp10.copy()
-    tmp12 += ints.tmp28.transpose((0, 2, 1, 3))
-    tmp1 = ints.tmp103.copy()
+    tmp12 = np.copy(ints.tmp10)
+    tmp12 += np.transpose(ints.tmp28, (0, 2, 1, 3))
+    tmp1 = np.copy(ints.tmp103)
     del ints.tmp103
     tmp1 += ints.tmp115
     del ints.tmp115
     tmp1 += ints.tmp134
     del ints.tmp134
-    tmp1 += ints.tmp19.transpose((0, 2, 1, 3))
+    tmp1 += np.transpose(ints.tmp19, (0, 2, 1, 3))
     del ints.tmp19
     tmp1 += ints.tmp44
     del ints.tmp44
@@ -2356,7 +2356,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp86
     tmp1 += ints.tmp93
     del ints.tmp93
-    tmp1 += ints.tmp10.transpose((1, 2, 0, 3)) * -1
+    tmp1 += np.transpose(ints.tmp10, (1, 2, 0, 3)) * -1
     del ints.tmp10
     tmp1 += ints.tmp125 * -1
     del ints.tmp125
@@ -2366,11 +2366,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp59
     tmp1 += ints.tmp88 * -2
     del ints.tmp88
-    tmp2 = r2.copy() * 2
-    tmp2 += r2.transpose((1, 0, 2)) * -1
-    tmp5 = r2.copy() * -1
-    tmp5 += r2.transpose((1, 0, 2)) * 2
-    tmp4 = ints.tmp111.copy() * 2
+    tmp2 = np.copy(r2) * 2
+    tmp2 += np.transpose(r2, (1, 0, 2)) * -1
+    tmp5 = np.copy(r2) * -1
+    tmp5 += np.transpose(r2, (1, 0, 2)) * 2
+    tmp4 = np.copy(ints.tmp111) * 2
     del ints.tmp111
     tmp4 += ints.tmp123
     del ints.tmp123
@@ -2421,30 +2421,30 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp83
     tmp4 += ints.tmp98 * -1
     del ints.tmp98
-    tmp3 = ints.tmp117.copy()
+    tmp3 = np.copy(ints.tmp117)
     del ints.tmp117
-    tmp3 += ints.tmp46.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(ints.tmp46, (0, 2, 1, 3))
     del ints.tmp46
-    tmp3 += ints.tmp48.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(ints.tmp48, (0, 2, 1, 3))
     del ints.tmp48
-    tmp3 += ints.tmp74.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(ints.tmp74, (0, 2, 1, 3))
     del ints.tmp74
-    tmp3 += ints.tmp91.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(ints.tmp91, (0, 2, 1, 3))
     del ints.tmp91
     tmp3 += ints.tmp30 * -1
     del ints.tmp30
-    tmp3 += ints.tmp50.transpose((0, 2, 1, 3)) * -2
+    tmp3 += np.transpose(ints.tmp50, (0, 2, 1, 3)) * -2
     del ints.tmp50
-    tmp3 += ints.tmp6.transpose((1, 0, 2, 3)) * -1
+    tmp3 += np.transpose(ints.tmp6, (1, 0, 2, 3)) * -1
     del ints.tmp6
-    tmp3 += ints.tmp77.transpose((0, 2, 1, 3)) * -2
+    tmp3 += np.transpose(ints.tmp77, (0, 2, 1, 3)) * -2
     del ints.tmp77
-    tmp6 = f.oo.copy()
-    tmp6 += ints.tmp0.transpose((1, 0))
+    tmp6 = np.copy(f.oo)
+    tmp6 += np.transpose(ints.tmp0, (1, 0))
     del ints.tmp0
     tmp6 += ints.tmp107 * 2
     del ints.tmp107
-    tmp6 += ints.tmp16.transpose((1, 0)) * 2
+    tmp6 += np.transpose(ints.tmp16, (1, 0)) * 2
     del ints.tmp16
     tmp6 += ints.tmp36 * 2
     del ints.tmp36
@@ -2663,47 +2663,47 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     """
 
     ints = kwargs["ints"]
-    tmp17 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp17 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp17 += t2 * -1
-    tmp26 = ints.tmp65.copy()
+    tmp26 = np.copy(ints.tmp65)
     del ints.tmp65
-    tmp26 += v.xoo.transpose((1, 2, 0))
+    tmp26 += np.transpose(v.xoo, (1, 2, 0))
     tmp11 = einsum(r2, (0, 1, 2), t1, (3, 1), (2, 3, 0))
-    tmp20 = f.ov.copy()
+    tmp20 = np.copy(f.ov)
     tmp20 += ints.tmp20 * 2
     tmp20 += ints.tmp66 * -1
     del ints.tmp66
     tmp16 = einsum(r1, (0,), t1, (1, 0), (1,))
     tmp18 = einsum(tmp17, (0, 1, 2, 3), r2, (3, 2, 0), (1,))
     del tmp17
-    tmp22 = ints.tmp40.copy()
-    tmp22 += ints.tmp82.transpose((0, 2, 1, 3))
-    tmp0 = r2.transpose((2, 0, 1)).copy() * -0.5
-    tmp0 += r2.transpose((2, 1, 0))
-    tmp27 = ints.tmp18.copy()
+    tmp22 = np.copy(ints.tmp40)
+    tmp22 += np.transpose(ints.tmp82, (0, 2, 1, 3))
+    tmp0 = np.copy(np.transpose(r2, (2, 0, 1))) * -0.5
+    tmp0 += np.transpose(r2, (2, 1, 0))
+    tmp27 = np.copy(ints.tmp18)
     del ints.tmp18
     tmp27 += ints.tmp37 * 2
     del ints.tmp37
-    tmp27 += v.xov.transpose((1, 2, 0))
+    tmp27 += np.transpose(v.xov, (1, 2, 0))
     tmp27 += ints.tmp34 * -1
     del ints.tmp34
     tmp27 += einsum(tmp26, (0, 1, 2), t1, (1, 3), (0, 3, 2)) * -1
     del tmp26
     tmp12 = einsum(tmp11, (0, 1, 2), t1, (3, 2), (0, 3, 1))
     tmp29 = einsum(tmp20, (0, 1), t1, (0, 2), (2, 1))
-    tmp6 = r2.transpose((2, 0, 1)).copy()
-    tmp6 += r2.transpose((2, 1, 0)) * -0.5
-    tmp19 = tmp16.copy()
+    tmp6 = np.copy(np.transpose(r2, (2, 0, 1)))
+    tmp6 += np.transpose(r2, (2, 1, 0)) * -0.5
+    tmp19 = np.copy(tmp16)
     del tmp16
     tmp19 += tmp18 * -1
     del tmp18
-    tmp23 = ints.tmp107.copy()
+    tmp23 = np.copy(ints.tmp107)
     tmp23 += ints.tmp125 * 0.5
     tmp23 += ints.tmp29 * 0.5
     tmp23 += ints.tmp105 * -0.5
     tmp23 += einsum(tmp22, (0, 1, 2, 3), t1, (2, 4), (0, 1, 4, 3)) * -0.5
-    tmp31 = f.oo.copy()
-    tmp31 += ints.tmp10.transpose((1, 0))
+    tmp31 = np.copy(f.oo)
+    tmp31 += np.transpose(ints.tmp10, (1, 0))
     del ints.tmp10
     tmp31 += ints.tmp113 * 2
     del ints.tmp113
@@ -2721,62 +2721,62 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp27
     tmp25 = einsum(r2, (0, 1, 2), t2, (3, 4, 0, 1), (2, 3, 4))
     tmp25 += tmp12
-    tmp30 = ints.tmp19.transpose((1, 0)).copy()
+    tmp30 = np.copy(np.transpose(ints.tmp19, (1, 0)))
     tmp30 += ints.tmp38 * 2
     tmp30 += f.vv * -1
     tmp30 += ints.tmp16 * -2
     tmp30 += ints.tmp35 * -1
     tmp30 += tmp29
     del tmp29
-    tmp24 = ints.tmp105.copy()
+    tmp24 = np.copy(ints.tmp105)
     tmp24 += ints.tmp125 * -1
     tmp24 += ints.tmp29 * -1
     tmp24 += einsum(tmp22, (0, 1, 2, 3), t1, (2, 4), (0, 1, 4, 3))
     del tmp22
     tmp21 = einsum(r2, (0, 1, 2), t1, (3, 0), (2, 3, 1))
-    tmp14 = tmp12.copy() * 2
-    tmp14 += tmp12.transpose((0, 2, 1)) * -1
-    tmp1 = ints.tmp12.copy()
+    tmp14 = np.copy(tmp12) * 2
+    tmp14 += np.transpose(tmp12, (0, 2, 1)) * -1
+    tmp1 = np.copy(ints.tmp12)
     tmp1 += ints.tmp31
     del ints.tmp31
-    tmp1 += ints.tmp89.transpose((0, 3, 1, 2))
+    tmp1 += np.transpose(ints.tmp89, (0, 3, 1, 2))
     del ints.tmp89
-    tmp1 += ints.tmp61.transpose((0, 2, 1, 3)) * -1
+    tmp1 += np.transpose(ints.tmp61, (0, 2, 1, 3)) * -1
     del ints.tmp61
-    tmp8 = ints.tmp102.copy() * 2
+    tmp8 = np.copy(ints.tmp102) * 2
     del ints.tmp102
-    tmp8 += ints.tmp127.transpose((0, 1, 3, 2))
+    tmp8 += np.transpose(ints.tmp127, (0, 1, 3, 2))
     del ints.tmp127
     tmp8 += ints.tmp25
     tmp8 += ints.tmp100 * -1
     del ints.tmp100
     tmp8 += ints.tmp107 * -1
-    tmp2 = r2.transpose((2, 0, 1)).copy() * 2
-    tmp2 += r2.transpose((2, 1, 0)) * -1
+    tmp2 = np.copy(np.transpose(r2, (2, 0, 1))) * 2
+    tmp2 += np.transpose(r2, (2, 1, 0)) * -1
     tmp7 = einsum(tmp6, (0, 1, 2), t1, (3, 2), (0, 3, 1)) * 2
     del tmp6
-    tmp13 = tmp12.copy() * -0.5
-    tmp13 += tmp12.transpose((0, 2, 1))
+    tmp13 = np.copy(tmp12) * -0.5
+    tmp13 += np.transpose(tmp12, (0, 2, 1))
     del tmp12
-    tmp5 = ints.tmp125.transpose((0, 1, 3, 2)).copy()
+    tmp5 = np.copy(np.transpose(ints.tmp125, (0, 1, 3, 2)))
     del ints.tmp125
-    tmp5 += ints.tmp29.transpose((0, 1, 3, 2))
+    tmp5 += np.transpose(ints.tmp29, (0, 1, 3, 2))
     del ints.tmp29
     tmp5 += ints.tmp105 * -1
     del ints.tmp105
     tmp4 = einsum(tmp0, (0, 1, 2), t1, (3, 2), (0, 3, 1))
-    tmp10 = r2.transpose((2, 0, 1)).copy() * -1
-    tmp10 += r2.transpose((2, 1, 0)) * 2
-    tmp15 = f.vv.copy()
-    tmp15 += ints.tmp16.transpose((1, 0)) * 2
+    tmp10 = np.copy(np.transpose(r2, (2, 0, 1))) * -1
+    tmp10 += np.transpose(r2, (2, 1, 0)) * 2
+    tmp15 = np.copy(f.vv)
+    tmp15 += np.transpose(ints.tmp16, (1, 0)) * 2
     del ints.tmp16
     tmp15 += ints.tmp35
     del ints.tmp35
-    tmp15 += ints.tmp19.transpose((1, 0)) * -1
+    tmp15 += np.transpose(ints.tmp19, (1, 0)) * -1
     del ints.tmp19
     tmp15 += ints.tmp38 * -2
     del ints.tmp38
-    tmp9 = ints.tmp114.copy() * 2
+    tmp9 = np.copy(ints.tmp114) * 2
     del ints.tmp114
     tmp9 += ints.tmp11
     del ints.tmp11
@@ -2827,13 +2827,13 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp86
     tmp9 += ints.tmp97 * -1
     del ints.tmp97
-    tmp3 = ints.tmp47.copy()
+    tmp3 = np.copy(ints.tmp47)
     del ints.tmp47
     tmp3 += ints.tmp58 * 2
     del ints.tmp58
     tmp3 += ints.tmp56 * -1
     del ints.tmp56
-    tmp3 += ints.tmp63.transpose((0, 1, 3, 2)) * -1
+    tmp3 += np.transpose(ints.tmp63, (0, 1, 3, 2)) * -1
     del ints.tmp63
     r2new = einsum(r2, (0, 1, 2), ints.tmp163, (3, 4, 0, 1), (4, 3, 2))
     del ints.tmp163

--- a/ebcc/codegen/RDFDCD.py
+++ b/ebcc/codegen/RDFDCD.py
@@ -33,7 +33,7 @@ def energy(t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp0 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp0 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp0 += t2 * -1
     tmp1 = einsum(v.xov, (0, 1, 2), tmp0, (1, 3, 4, 2), (3, 4, 0)) * 0.5
     del tmp0
@@ -61,9 +61,9 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
         Updated T2 residuals.
     """
 
-    tmp15 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp15 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp15 += t2 * -1
-    tmp7 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp7 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp7 += t2 * -1
     tmp16 = einsum(v.xov, (0, 1, 2), tmp15, (1, 3, 4, 2), (3, 4, 0))
     del tmp15
@@ -90,36 +90,36 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp14 = einsum(tmp3, (0, 1, 2), tmp2, (3, 4, 2), (0, 3, 1, 4))
     del tmp3, tmp2
     tmp4 = einsum(f.oo, (0, 1), t2, (2, 1, 3, 4), (0, 2, 3, 4))
-    t2new += tmp4.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp4.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp4, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp4, (0, 1, 3, 2)) * -1
     del tmp4
     tmp1 = einsum(v.xvv, (0, 1, 2), v.xvv, (0, 3, 4), (3, 1, 2, 4))
     t2new += einsum(tmp1, (0, 1, 2, 3), t2, (4, 5, 3, 1), (4, 5, 0, 2))
     del tmp1
-    tmp10 = tmp6.copy()
+    tmp10 = np.copy(tmp6)
     del tmp6
-    tmp10 += tmp9.transpose((1, 0, 3, 2)) * -1
+    tmp10 += np.transpose(tmp9, (1, 0, 3, 2)) * -1
     del tmp9
-    t2new += tmp10.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp10, (1, 0, 3, 2)) * -1
     t2new += tmp10 * -1
     del tmp10
     tmp0 = einsum(v.xoo, (0, 1, 2), v.xoo, (0, 3, 4), (1, 3, 4, 2))
     t2new += einsum(t2, (0, 1, 2, 3), tmp0, (4, 0, 5, 1), (5, 4, 2, 3))
     del tmp0
-    tmp13 = tmp11.copy()
+    tmp13 = np.copy(tmp11)
     del tmp11
     tmp13 += tmp12 * -1
     del tmp12
-    t2new += tmp13.transpose((1, 0, 2, 3))
-    t2new += tmp13.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp13, (1, 0, 2, 3))
+    t2new += np.transpose(tmp13, (0, 1, 3, 2))
     del tmp13
-    tmp21 = tmp14.copy() * 2
+    tmp21 = np.copy(tmp14) * 2
     del tmp14
-    tmp21 += tmp18.transpose((1, 0, 2, 3))
+    tmp21 += np.transpose(tmp18, (1, 0, 2, 3))
     del tmp18
-    tmp21 += tmp20.transpose((0, 1, 3, 2))
+    tmp21 += np.transpose(tmp20, (0, 1, 3, 2))
     del tmp20
-    t2new += tmp21.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp21, (1, 0, 3, 2)) * -1
     t2new += tmp21 * -1
     del tmp21
     t2new += einsum(v.xov, (0, 1, 2), v.xov, (0, 3, 4), (3, 1, 4, 2))

--- a/ebcc/codegen/RDFDCSD.py
+++ b/ebcc/codegen/RDFDCSD.py
@@ -39,9 +39,9 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
 
     tmp3 = einsum(t1, (0, 1), v.xov, (2, 3, 1), (0, 3, 2))
     tmp0 = einsum(t1, (0, 1), v.xov, (2, 0, 1), (2,))
-    tmp1 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp1 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp1 += t2 * -1
-    tmp4 = f.ov.copy() * 2
+    tmp4 = np.copy(f.ov) * 2
     tmp4 += einsum(tmp3, (0, 1, 2), v.xov, (2, 0, 3), (1, 3)) * -1
     del tmp3
     e_cc = einsum(tmp4, (0, 1), t1, (0, 1), ())
@@ -83,28 +83,28 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp29 = einsum(tmp2, (0, 1, 2), v.xov, (2, 3, 4), (0, 3, 1, 4))
     tmp9 = einsum(tmp2, (0, 1, 2), v.xov, (2, 0, 3), (1, 3))
     tmp1 = einsum(v.xov, (0, 1, 2), tmp0, (0,), (1, 2))
-    t1new = tmp1.copy() * 2
+    t1new = np.copy(tmp1) * 2
     tmp31 = einsum(v.xoo, (0, 1, 2), v.xov, (0, 3, 4), (1, 2, 3, 4))
-    tmp36 = t2.copy()
+    tmp36 = np.copy(t2)
     tmp36 += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3))
-    tmp5 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp5 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp5 += t2 * -1
     tmp19 = einsum(t2, (0, 1, 2, 3), v.xov, (4, 1, 2), (0, 3, 4))
     t2new = einsum(tmp19, (0, 1, 2), tmp19, (3, 4, 2), (0, 3, 1, 4))
-    tmp55 = tmp29.copy() * 2
-    tmp55 += tmp29.transpose((0, 2, 1, 3)) * -1
+    tmp55 = np.copy(tmp29) * 2
+    tmp55 += np.transpose(tmp29, (0, 2, 1, 3)) * -1
     tmp45 = einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3))
-    tmp45 += t2.transpose((0, 1, 3, 2)) * -2
+    tmp45 += np.transpose(t2, (0, 1, 3, 2)) * -2
     tmp45 += t2
     tmp18 = einsum(v.xvv, (0, 1, 2), t1, (3, 2), (3, 1, 0))
     t2new += einsum(tmp18, (0, 1, 2), tmp18, (3, 4, 2), (3, 0, 4, 1))
-    tmp34 = tmp1.copy() * 2
+    tmp34 = np.copy(tmp1) * 2
     tmp34 += tmp9 * -1
-    tmp32 = tmp31.transpose((1, 0, 2, 3)).copy() * 2
-    tmp32 += tmp31.transpose((1, 2, 0, 3)) * -1
+    tmp32 = np.copy(np.transpose(tmp31, (1, 0, 2, 3))) * 2
+    tmp32 += np.transpose(tmp31, (1, 2, 0, 3)) * -1
     tmp37 = einsum(v.xov, (0, 1, 2), tmp36, (1, 3, 4, 2), (3, 4, 0))
     del tmp36
-    tmp11 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp11 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp11 += t2 * -1
     tmp13 = einsum(v.xov, (0, 1, 2), tmp5, (1, 3, 4, 2), (3, 4, 0))
     tmp70 = einsum(v.xvv, (0, 1, 2), v.xov, (0, 3, 4), (3, 1, 2, 4))
@@ -138,37 +138,37 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp70
     tmp74 = einsum(v.xov, (0, 1, 2), tmp13, (1, 3, 0), (3, 2)) * 0.5
     tmp17 = einsum(v.xov, (0, 1, 2), v.xov, (0, 3, 4), (3, 1, 4, 2))
-    t2new += tmp17.transpose((1, 0, 3, 2))
+    t2new += np.transpose(tmp17, (1, 0, 3, 2))
     tmp80 = einsum(tmp2, (0, 1, 2), tmp18, (3, 4, 2), (0, 3, 1, 4))
     tmp24 = einsum(v.xvv, (0, 1, 2), tmp2, (3, 4, 0), (3, 4, 1, 2))
     tmp22 = einsum(v.xvv, (0, 1, 2), v.xoo, (0, 3, 4), (3, 4, 1, 2))
-    tmp57 = tmp53.copy()
+    tmp57 = np.copy(tmp53)
     del tmp53
     tmp57 += tmp54
     del tmp54
-    tmp57 += tmp56.transpose((0, 2, 1, 3)) * -1
+    tmp57 += np.transpose(tmp56, (0, 2, 1, 3)) * -1
     del tmp56
-    tmp47 = tmp6.copy()
+    tmp47 = np.copy(tmp6)
     tmp47 += tmp46
     del tmp46
-    tmp51 = tmp49.transpose((1, 0)).copy() * 2
+    tmp51 = np.copy(np.transpose(tmp49, (1, 0))) * 2
     del tmp49
     tmp51 += tmp50 * -1
     del tmp50
-    tmp60 = tmp59.transpose((1, 0)).copy() * -1
+    tmp60 = np.copy(np.transpose(tmp59, (1, 0))) * -1
     del tmp59
-    tmp60 += tmp12.transpose((1, 0)) * 2
+    tmp60 += np.transpose(tmp12, (1, 0)) * 2
     tmp41 = einsum(tmp34, (0, 1), t1, (2, 1), (0, 2))
     del tmp34
-    tmp39 = tmp30.transpose((0, 2, 1, 3)).copy()
+    tmp39 = np.copy(np.transpose(tmp30, (0, 2, 1, 3)))
     del tmp30
-    tmp39 += tmp33.transpose((2, 1, 0, 3)) * -1
+    tmp39 += np.transpose(tmp33, (2, 1, 0, 3)) * -1
     del tmp33
-    tmp39 += tmp35.transpose((2, 0, 1, 3)) * -1
+    tmp39 += np.transpose(tmp35, (2, 0, 1, 3)) * -1
     del tmp35
-    tmp39 += tmp38.transpose((0, 2, 1, 3))
+    tmp39 += np.transpose(tmp38, (0, 2, 1, 3))
     del tmp38
-    tmp27 = v.xov.transpose((1, 2, 0)).copy()
+    tmp27 = np.copy(np.transpose(v.xov, (1, 2, 0)))
     tmp27 += tmp6 * -1
     tmp27 += tmp26
     del tmp26
@@ -211,38 +211,38 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp24
     tmp28 = einsum(tmp27, (0, 1, 2), tmp18, (3, 4, 2), (3, 0, 4, 1))
     del tmp18, tmp27
-    tmp3 = v.xoo.transpose((1, 2, 0)).copy()
-    tmp3 += tmp2.transpose((1, 0, 2))
+    tmp3 = np.copy(np.transpose(v.xoo, (1, 2, 0)))
+    tmp3 += np.transpose(tmp2, (1, 0, 2))
     tmp7 = einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3)) * 0.5
-    tmp7 += t2.transpose((0, 1, 3, 2)) * -1
+    tmp7 += np.transpose(t2, (0, 1, 3, 2)) * -1
     tmp7 += t2 * 0.5
-    tmp14 = tmp6.copy() * -1
+    tmp14 = np.copy(tmp6) * -1
     tmp14 += einsum(t1, (0, 1), tmp0, (2,), (0, 1, 2)) * 2
     tmp14 += tmp13
     del tmp13
-    tmp15 = f.ov.copy()
+    tmp15 = np.copy(f.ov)
     tmp15 += tmp9 * -1
-    tmp69 = tmp64.copy()
+    tmp69 = np.copy(tmp64)
     del tmp64
     tmp69 += tmp66
     del tmp66
     tmp69 += tmp68 * -1
     del tmp68
-    t2new += tmp69.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp69.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp69, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp69, (0, 1, 3, 2)) * -1
     del tmp69
     tmp84 = einsum(v.xoo, (0, 1, 2), v.xoo, (0, 3, 4), (1, 3, 4, 2))
     tmp84 += einsum(tmp2, (0, 1, 2), tmp2, (3, 4, 2), (1, 3, 4, 0))
     del tmp2
-    tmp78 = tmp72.copy()
+    tmp78 = np.copy(tmp72)
     del tmp72
     tmp78 += tmp73 * 2
     del tmp73
-    tmp78 += tmp75.transpose((1, 0, 3, 2))
+    tmp78 += np.transpose(tmp75, (1, 0, 3, 2))
     del tmp75
-    tmp78 += tmp77.transpose((1, 0, 3, 2))
+    tmp78 += np.transpose(tmp77, (1, 0, 3, 2))
     del tmp77
-    t2new += tmp78.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp78, (1, 0, 3, 2)) * -1
     t2new += tmp78 * -1
     del tmp78
     tmp87 = einsum(v.xvv, (0, 1, 2), v.xvv, (0, 3, 4), (1, 3, 4, 2))
@@ -250,61 +250,61 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp86
     t2new += einsum(tmp87, (0, 1, 2, 3), t2, (4, 5, 2, 0), (4, 5, 1, 3))
     del tmp87
-    tmp85 = t2.copy()
+    tmp85 = np.copy(t2)
     tmp85 += einsum(t1, (0, 1), t1, (2, 3), (0, 2, 1, 3))
     t2new += einsum(tmp85, (0, 1, 2, 3), tmp84, (0, 4, 1, 5), (4, 5, 3, 2))
     del tmp85, tmp84
-    tmp82 = tmp79.copy()
+    tmp82 = np.copy(tmp79)
     del tmp79
     tmp82 += tmp81
     del tmp81
-    t2new += tmp82.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp82, (1, 0, 3, 2)) * -1
     t2new += tmp82 * -1
     del tmp82
-    tmp62 = tmp44.copy()
+    tmp62 = np.copy(tmp44)
     del tmp44
     tmp62 += tmp48
     del tmp48
-    tmp62 += tmp52.transpose((1, 0, 3, 2)) * -1
+    tmp62 += np.transpose(tmp52, (1, 0, 3, 2)) * -1
     del tmp52
-    tmp62 += tmp58.transpose((0, 1, 3, 2)) * -1
+    tmp62 += np.transpose(tmp58, (0, 1, 3, 2)) * -1
     del tmp58
-    tmp62 += tmp61.transpose((1, 0, 3, 2))
+    tmp62 += np.transpose(tmp61, (1, 0, 3, 2))
     del tmp61
-    t2new += tmp62.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp62, (1, 0, 3, 2)) * -1
     t2new += tmp62 * -1
     del tmp62
-    tmp43 = tmp21.copy()
+    tmp43 = np.copy(tmp21)
     del tmp21
     tmp43 += tmp23 * -1
     del tmp23
     tmp43 += tmp25 * -1
     del tmp25
-    tmp43 += tmp28.transpose((0, 1, 3, 2))
+    tmp43 += np.transpose(tmp28, (0, 1, 3, 2))
     del tmp28
-    tmp43 += tmp40.transpose((0, 1, 3, 2))
+    tmp43 += np.transpose(tmp40, (0, 1, 3, 2))
     del tmp40
-    tmp43 += tmp42.transpose((0, 1, 3, 2)) * -1
+    tmp43 += np.transpose(tmp42, (0, 1, 3, 2)) * -1
     del tmp42
-    t2new += tmp43.transpose((1, 0, 2, 3))
-    t2new += tmp43.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp43, (1, 0, 2, 3))
+    t2new += np.transpose(tmp43, (0, 1, 3, 2))
     del tmp43
     tmp83 = einsum(f.oo, (0, 1), t2, (2, 1, 3, 4), (0, 2, 3, 4))
-    t2new += tmp83.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp83.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp83, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp83, (0, 1, 3, 2)) * -1
     del tmp83
     tmp4 = einsum(tmp3, (0, 1, 2), v.xov, (2, 3, 4), (1, 3, 0, 4))
     del tmp3
     t1new += einsum(tmp4, (0, 1, 2, 3), tmp5, (1, 2, 4, 3), (0, 4)) * -1
     del tmp5, tmp4
-    tmp10 = f.ov.copy()
+    tmp10 = np.copy(f.ov)
     tmp10 += tmp1 * 2
     del tmp1
     tmp10 += tmp9 * -1
     del tmp9
     t1new += einsum(tmp11, (0, 1, 2, 3), tmp10, (0, 3), (1, 2))
     del tmp11, tmp10
-    tmp8 = tmp6.copy()
+    tmp8 = np.copy(tmp6)
     del tmp6
     tmp8 += einsum(t1, (0, 1), tmp0, (2,), (0, 1, 2)) * -2
     del tmp0
@@ -312,8 +312,8 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp7
     t1new += einsum(v.xvv, (0, 1, 2), tmp8, (3, 2, 0), (3, 1)) * -1
     del tmp8
-    tmp16 = f.oo.copy() * 0.5
-    tmp16 += tmp12.transpose((1, 0))
+    tmp16 = np.copy(f.oo) * 0.5
+    tmp16 += np.transpose(tmp12, (1, 0))
     del tmp12
     tmp16 += einsum(tmp14, (0, 1, 2), v.xov, (2, 3, 1), (3, 0)) * 0.5
     del tmp14

--- a/ebcc/codegen/RDFQCISD.py
+++ b/ebcc/codegen/RDFQCISD.py
@@ -33,7 +33,7 @@ def energy(t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp0 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp0 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp0 += t2 * -1
     tmp1 = einsum(tmp0, (0, 1, 2, 3), v.xov, (4, 0, 3), (1, 2, 4)) * 0.5
     del tmp0
@@ -67,12 +67,12 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
 
     tmp16 = einsum(v.xov, (0, 1, 2), t2, (3, 1, 2, 4), (3, 4, 0))
     t2new = einsum(tmp16, (0, 1, 2), tmp16, (3, 4, 2), (0, 3, 1, 4))
-    tmp11 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp11 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp11 += t2 * -1
-    tmp19 = v.xov.transpose((1, 2, 0)).copy()
+    tmp19 = np.copy(np.transpose(v.xov, (1, 2, 0)))
     tmp19 += tmp16 * -1
     tmp15 = einsum(v.xov, (0, 1, 2), v.xov, (0, 3, 4), (1, 3, 2, 4))
-    t2new += tmp15.transpose((1, 0, 3, 2))
+    t2new += np.transpose(tmp15, (1, 0, 3, 2))
     tmp32 = einsum(v.xov, (0, 1, 2), tmp11, (1, 3, 4, 2), (3, 4, 0))
     tmp18 = einsum(v.xoo, (0, 1, 2), v.xvv, (0, 3, 4), (1, 2, 3, 4))
     tmp20 = einsum(v.xov, (0, 1, 2), tmp19, (3, 4, 0), (3, 1, 4, 2))
@@ -84,12 +84,12 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp35 = einsum(tmp32, (0, 1, 2), v.xov, (2, 3, 1), (0, 3))
     tmp33 = einsum(tmp32, (0, 1, 2), v.xov, (2, 0, 3), (1, 3)) * 0.5
     del tmp32
-    tmp21 = tmp18.transpose((1, 0, 3, 2)).copy()
+    tmp21 = np.copy(np.transpose(tmp18, (1, 0, 3, 2)))
     tmp21 += tmp17 * -1
     del tmp17
     tmp21 += tmp20 * -2
     del tmp20
-    tmp23 = tmp6.copy()
+    tmp23 = np.copy(tmp6)
     tmp23 += tmp16
     del tmp16
     tmp2 = einsum(t1, (0, 1), v.xov, (2, 3, 1), (0, 3, 2))
@@ -107,36 +107,36 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp21
     tmp24 = einsum(v.xov, (0, 1, 2), tmp23, (3, 4, 0), (3, 1, 4, 2))
     del tmp23
-    tmp39 = tmp15.transpose((1, 0, 2, 3)).copy() * 2
-    tmp39 += tmp15.transpose((1, 0, 3, 2)) * -1
-    tmp7 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp39 = np.copy(np.transpose(tmp15, (1, 0, 2, 3))) * 2
+    tmp39 += np.transpose(tmp15, (1, 0, 3, 2)) * -1
+    tmp7 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp7 += t2 * -0.5
-    tmp3 = v.xoo.transpose((1, 2, 0)).copy()
-    tmp3 += tmp2.transpose((1, 0, 2))
+    tmp3 = np.copy(np.transpose(v.xoo, (1, 2, 0)))
+    tmp3 += np.transpose(tmp2, (1, 0, 2))
     tmp1 = einsum(v.xov, (0, 1, 2), tmp0, (0,), (1, 2))
     del tmp0
-    t1new = tmp1.copy() * 2
+    t1new = np.copy(tmp1) * 2
     tmp12 = einsum(v.xov, (0, 1, 2), tmp11, (1, 3, 4, 2), (3, 4, 0)) * 0.5
     del tmp11
-    tmp31 = tmp27.copy()
+    tmp31 = np.copy(tmp27)
     del tmp27
     tmp31 += tmp29
     del tmp29
     tmp31 += tmp30 * -1
     del tmp30
-    t2new += tmp31.transpose((1, 0, 2, 3))
-    t2new += tmp31.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp31, (1, 0, 2, 3))
+    t2new += np.transpose(tmp31, (0, 1, 3, 2))
     del tmp31
-    tmp37 = tmp34.transpose((1, 0, 3, 2)).copy()
+    tmp37 = np.copy(np.transpose(tmp34, (1, 0, 3, 2)))
     del tmp34
-    tmp37 += tmp36.transpose((1, 0, 3, 2))
+    tmp37 += np.transpose(tmp36, (1, 0, 3, 2))
     del tmp36
-    t2new += tmp37.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp37, (1, 0, 3, 2)) * -1
     t2new += tmp37 * -1
     del tmp37
     tmp26 = einsum(f.oo, (0, 1), t2, (2, 1, 3, 4), (0, 2, 3, 4))
-    t2new += tmp26.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp26.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp26, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp26, (0, 1, 3, 2)) * -1
     del tmp26
     tmp38 = einsum(v.xoo, (0, 1, 2), v.xoo, (0, 3, 4), (1, 3, 4, 2))
     tmp38 += einsum(t2, (0, 1, 2, 3), tmp15, (4, 5, 3, 2), (4, 0, 5, 1))
@@ -146,18 +146,18 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp14 = einsum(v.xvv, (0, 1, 2), v.xvv, (0, 3, 4), (3, 1, 2, 4))
     t2new += einsum(tmp14, (0, 1, 2, 3), t2, (4, 5, 3, 1), (4, 5, 0, 2))
     del tmp14
-    tmp25 = tmp22.transpose((1, 0, 3, 2)).copy()
+    tmp25 = np.copy(np.transpose(tmp22, (1, 0, 3, 2)))
     del tmp22
     tmp25 += tmp24
     del tmp24
-    t2new += tmp25.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp25, (1, 0, 3, 2)) * -1
     t2new += tmp25 * -1
     del tmp25
     tmp40 = einsum(tmp39, (0, 1, 2, 3), t2, (4, 0, 5, 3), (4, 1, 5, 2))
     del tmp39
     t2new += einsum(t2, (0, 1, 2, 3), tmp40, (4, 1, 5, 3), (4, 0, 5, 2)) * 2
     del tmp40
-    tmp8 = tmp6.copy()
+    tmp8 = np.copy(tmp6)
     del tmp6
     tmp8 += einsum(v.xov, (0, 1, 2), tmp7, (1, 3, 4, 2), (3, 4, 0)) * -2
     del tmp7
@@ -165,21 +165,21 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp8
     tmp4 = einsum(v.xov, (0, 1, 2), tmp3, (3, 4, 0), (4, 1, 3, 2))
     del tmp3
-    tmp9 = f.ov.copy()
+    tmp9 = np.copy(f.ov)
     tmp9 += tmp1 * 2
     del tmp1
     tmp9 += einsum(v.xov, (0, 1, 2), tmp2, (1, 3, 0), (3, 2)) * -1
     del tmp2
-    tmp10 = t2.transpose((0, 1, 3, 2)).copy() * 2
+    tmp10 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * 2
     tmp10 += t2 * -1
     t1new += einsum(tmp10, (0, 1, 2, 3), tmp9, (0, 3), (1, 2))
     del tmp10, tmp9
-    tmp13 = f.oo.copy()
+    tmp13 = np.copy(f.oo)
     tmp13 += einsum(tmp12, (0, 1, 2), v.xov, (2, 3, 1), (3, 0)) * 2
     del tmp12
     t1new += einsum(tmp13, (0, 1), t1, (0, 2), (1, 2)) * -1
     del tmp13
-    tmp5 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp5 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp5 += t2 * 2
     t1new += einsum(tmp5, (0, 1, 2, 3), tmp4, (4, 0, 1, 2), (4, 3)) * -1
     del tmp5, tmp4

--- a/ebcc/codegen/RMP2.py
+++ b/ebcc/codegen/RMP2.py
@@ -113,8 +113,9 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.vvvv = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[-1]))
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
     rdm2 = rdm2.swapaxes(1, 2)
+    rdm1 = make_rdm1_f(t2=t2, l2=l2)
     nocc = t2.shape[0]
-    rdm1[np.diag_indices(nocc)] -= 1
+    rdm1[np.diag_indices(nocc)] -= 2
     for i in range(nocc):
         rdm2[i, i, :, :] += rdm1.T * 2
         rdm2[:, :, i, i] += rdm1.T * 2

--- a/ebcc/codegen/RMP2.py
+++ b/ebcc/codegen/RMP2.py
@@ -113,7 +113,7 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.vvvo = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[0]))
     rdm2.vvvv = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[-1]))
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.swapaxes(1, 2)
+    rdm2 = rdm2.transpose(0, 2, 1, 3)
     rdm1 = make_rdm1_f(t2=t2, l2=l2)
     delta = np.diag(np.concatenate([np.ones(t2.shape[0]), np.zeros(t2.shape[-1])]))
     rdm1 -= delta * 2

--- a/ebcc/codegen/RMP2.py
+++ b/ebcc/codegen/RMP2.py
@@ -60,13 +60,13 @@ def make_rdm1_f(l2=None, t2=None, **kwargs):
         oo=np.eye(t2.shape[0]),
         vv=np.eye(t2.shape[-1]),
     )
-    tmp1 = t2.transpose((0, 1, 3, 2)).copy()
+    tmp1 = np.copy(np.transpose(t2, (0, 1, 3, 2)))
     tmp1 += t2 * -0.5
-    tmp0 = t2.transpose((0, 1, 3, 2)).copy() * -0.5
+    tmp0 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.5
     tmp0 += t2
     rdm1.vv = einsum(tmp1, (0, 1, 2, 3), l2, (4, 2, 0, 1), (4, 3)) * 4
     del tmp1
-    rdm1.oo = delta.oo.copy() * 2
+    rdm1.oo = np.copy(delta.oo) * 2
     del delta
     rdm1.oo += einsum(l2, (0, 1, 2, 3), tmp0, (2, 4, 0, 1), (4, 3)) * -4
     del tmp0
@@ -94,9 +94,9 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     """
 
     rdm2 = Namespace()
-    rdm2.vvoo = l2.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.vvoo = np.copy(np.transpose(l2, (0, 1, 3, 2))) * -2
     rdm2.vvoo += l2 * 4
-    rdm2.oovv = t2.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.oovv = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -2
     rdm2.oovv += t2 * 4
     rdm2.oooo = np.zeros((t2.shape[0], t2.shape[0], t2.shape[0], t2.shape[0]))
     rdm2.ooov = np.zeros((t2.shape[0], t2.shape[0], t2.shape[0], t2.shape[-1]))
@@ -113,7 +113,7 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.vvvo = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[0]))
     rdm2.vvvv = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[-1]))
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
-    rdm2 = rdm2.transpose(0, 2, 1, 3)
+    rdm2 = np.transpose(rdm2, (0, 2, 1, 3))
     rdm1 = make_rdm1_f(t2=t2, l2=l2)
     delta = np.diag(np.concatenate([np.ones(t2.shape[0]), np.zeros(t2.shape[-1])]))
     rdm1 -= delta * 2
@@ -172,16 +172,16 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, v=None, **kwargs):
     """
 
     ints = kwargs["ints"]
-    tmp1 = ints.tmp4.copy() * 2
+    tmp1 = np.copy(ints.tmp4) * 2
     del ints.tmp4
     tmp1 += ints.tmp2 * -1
     del ints.tmp2
-    tmp2 = f.oo.copy() * 2
+    tmp2 = np.copy(f.oo) * 2
     tmp2 += tmp1
-    tmp2 += tmp1.transpose((1, 0))
+    tmp2 += np.transpose(tmp1, (1, 0))
     del tmp1
-    tmp0 = v.ooov.copy() * -0.5
-    tmp0 += v.ovoo.transpose((0, 2, 3, 1))
+    tmp0 = np.copy(v.ooov) * -0.5
+    tmp0 += np.transpose(v.ovoo, (0, 2, 3, 1))
     r2new = einsum(f.vv, (0, 1), r2, (2, 3, 1), (2, 3, 0))
     r2new += einsum(v.ovoo, (0, 1, 2, 3), r1, (3,), (0, 2, 1))
     r2new += einsum(r2, (0, 1, 2), f.oo, (3, 0), (3, 1, 2)) * -1
@@ -239,16 +239,16 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, v=None, **kwargs):
     """
 
     ints = kwargs["ints"]
-    tmp1 = ints.tmp4.copy()
+    tmp1 = np.copy(ints.tmp4)
     del ints.tmp4
     tmp1 += ints.tmp2 * -0.5
     del ints.tmp2
-    tmp2 = f.vv.copy()
+    tmp2 = np.copy(f.vv)
     tmp2 += tmp1 * -1
-    tmp2 += tmp1.transpose((1, 0)) * -1
+    tmp2 += np.transpose(tmp1, (1, 0)) * -1
     del tmp1
-    tmp0 = v.ovvv.copy() * 2
-    tmp0 += v.ovvv.transpose((0, 2, 1, 3)) * -1
+    tmp0 = np.copy(v.ovvv) * 2
+    tmp0 += np.transpose(v.ovvv, (0, 2, 1, 3)) * -1
     r2new = einsum(r2, (0, 1, 2), f.vv, (3, 0), (3, 1, 2))
     r2new += einsum(r2, (0, 1, 2), f.vv, (3, 1), (0, 3, 2))
     r2new += einsum(r1, (0,), v.ovvv, (1, 2, 3, 0), (2, 3, 1)) * -1

--- a/ebcc/codegen/RMP2.py
+++ b/ebcc/codegen/RMP2.py
@@ -113,9 +113,8 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.vvvv = np.zeros((t2.shape[-1], t2.shape[-1], t2.shape[-1], t2.shape[-1]))
     rdm2 = pack_2e(rdm2.oooo, rdm2.ooov, rdm2.oovo, rdm2.ovoo, rdm2.vooo, rdm2.oovv, rdm2.ovov, rdm2.ovvo, rdm2.voov, rdm2.vovo, rdm2.vvoo, rdm2.ovvv, rdm2.vovv, rdm2.vvov, rdm2.vvvo, rdm2.vvvv)
     rdm2 = rdm2.swapaxes(1, 2)
-    rdm1 = make_rdm1_f(t2=t2, l2=l2)
     nocc = t2.shape[0]
-    rdm1[np.diag_indices(nocc)] -= 2
+    rdm1[np.diag_indices(nocc)] -= 1
     for i in range(nocc):
         rdm2[i, i, :, :] += rdm1.T * 2
         rdm2[:, :, i, i] += rdm1.T * 2

--- a/ebcc/codegen/RMP3.py
+++ b/ebcc/codegen/RMP3.py
@@ -36,23 +36,23 @@ def energy(t2=None, v=None, **kwargs):
     tmp3 = einsum(t2, (0, 1, 2, 3), v.vvvv, (4, 2, 5, 3), (0, 1, 4, 5))
     tmp0 = einsum(t2, (0, 1, 2, 3), v.oovv, (4, 1, 5, 2), (0, 4, 3, 5))
     e_mp = einsum(t2, (0, 1, 2, 3), tmp0, (0, 1, 3, 2), ()) * -4
-    tmp1 = t2.transpose((0, 1, 3, 2)).copy() * -0.25
+    tmp1 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -0.25
     tmp1 += t2
-    tmp6 = tmp5.transpose((3, 1, 2, 0)).copy() * -0.5
-    tmp6 += tmp5.transpose((3, 2, 1, 0))
+    tmp6 = np.copy(np.transpose(tmp5, (3, 1, 2, 0))) * -0.5
+    tmp6 += np.transpose(tmp5, (3, 2, 1, 0))
     del tmp5
     e_mp += einsum(tmp6, (0, 1, 2, 3), v.oooo, (0, 1, 2, 3), ()) * 2
     del tmp6
-    tmp4 = v.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp4 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3)))
     tmp4 += einsum(v.oovv, (0, 1, 2, 3), t2, (4, 1, 5, 3), (0, 4, 5, 2)) * 4
-    tmp4 += tmp0.transpose((0, 1, 3, 2)) * -4
+    tmp4 += np.transpose(tmp0, (0, 1, 3, 2)) * -4
     del tmp0
-    tmp4 += tmp3.transpose((1, 0, 2, 3)) * -2
-    tmp4 += tmp3.transpose((1, 0, 3, 2))
+    tmp4 += np.transpose(tmp3, (1, 0, 2, 3)) * -2
+    tmp4 += np.transpose(tmp3, (1, 0, 3, 2))
     del tmp3
     e_mp += einsum(tmp4, (0, 1, 2, 3), t2, (0, 1, 3, 2), ()) * -1
     del tmp4
-    tmp2 = t2.copy()
+    tmp2 = np.copy(t2)
     tmp2 += einsum(t2, (0, 1, 2, 3), t2, (4, 1, 5, 3), (4, 0, 5, 2)) * 4
     tmp2 += einsum(t2, (0, 1, 2, 3), tmp1, (1, 4, 2, 5), (0, 4, 3, 5)) * -4
     del tmp1

--- a/ebcc/codegen/RQCISD.py
+++ b/ebcc/codegen/RQCISD.py
@@ -61,17 +61,17 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
         Updated T2 residuals.
     """
 
-    tmp18 = v.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp18 += v.ovov.transpose((0, 2, 1, 3)) * -0.5
-    tmp14 = v.ovov.transpose((0, 2, 3, 1)).copy() * 2
-    tmp14 += v.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp18 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1)))
+    tmp18 += np.transpose(v.ovov, (0, 2, 1, 3)) * -0.5
+    tmp14 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * 2
+    tmp14 += np.transpose(v.ovov, (0, 2, 1, 3)) * -1
     tmp21 = einsum(t2, (0, 1, 2, 3), tmp18, (1, 4, 2, 3), (0, 4)) * 2
     tmp19 = einsum(t2, (0, 1, 2, 3), tmp18, (0, 1, 4, 2), (3, 4))
     del tmp18
     tmp15 = einsum(t2, (0, 1, 2, 3), tmp14, (1, 4, 5, 3), (0, 4, 2, 5))
     del tmp14
     tmp9 = einsum(t2, (0, 1, 2, 3), v.ovov, (4, 5, 1, 2), (0, 4, 3, 5))
-    t2new = tmp9.transpose((1, 0, 3, 2)).copy() * -1
+    t2new = np.copy(np.transpose(tmp9, (1, 0, 3, 2))) * -1
     tmp22 = einsum(t2, (0, 1, 2, 3), tmp21, (4, 1), (0, 4, 3, 2))
     del tmp21
     tmp20 = einsum(tmp19, (0, 1), t2, (2, 3, 1, 4), (2, 3, 4, 0)) * 2
@@ -81,77 +81,77 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp11 = einsum(v.ovvv, (0, 1, 2, 3), t1, (4, 3), (4, 0, 1, 2))
     tmp10 = einsum(f.vv, (0, 1), t2, (2, 3, 4, 1), (2, 3, 0, 4))
     tmp1 = einsum(v.ovov, (0, 1, 2, 3), t1, (4, 3), (4, 0, 2, 1))
-    tmp3 = v.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp3 += v.ovov.transpose((0, 2, 1, 3)) * 2
-    tmp7 = v.ovov.transpose((0, 2, 3, 1)).copy() * 2
-    tmp7 += v.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp27 = v.ovov.transpose((0, 2, 1, 3)).copy() * -1
+    tmp3 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * -1
+    tmp3 += np.transpose(v.ovov, (0, 2, 1, 3)) * 2
+    tmp7 = np.copy(np.transpose(v.ovov, (0, 2, 3, 1))) * 2
+    tmp7 += np.transpose(v.ovov, (0, 2, 1, 3)) * -1
+    tmp27 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * -1
     tmp27 += tmp9
     del tmp9
     t2new += einsum(t2, (0, 1, 2, 3), tmp27, (4, 1, 5, 2), (0, 4, 3, 5))
     del tmp27
-    tmp25 = v.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp25 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 2
     tmp25 += v.oovv * -1
     tmp25 += tmp15 * 2
     del tmp15
     t2new += einsum(tmp25, (0, 1, 2, 3), t2, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp25
-    tmp23 = tmp20.transpose((1, 0, 2, 3)).copy()
+    tmp23 = np.copy(np.transpose(tmp20, (1, 0, 2, 3)))
     del tmp20
-    tmp23 += tmp22.transpose((0, 1, 3, 2))
+    tmp23 += np.transpose(tmp22, (0, 1, 3, 2))
     del tmp22
-    t2new += tmp23.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp23, (1, 0, 3, 2)) * -1
     t2new += tmp23 * -1
     del tmp23
-    tmp17 = tmp13.copy()
+    tmp17 = np.copy(tmp13)
     del tmp13
-    tmp17 += tmp16.transpose((1, 0, 3, 2))
+    tmp17 += np.transpose(tmp16, (1, 0, 3, 2))
     del tmp16
-    t2new += tmp17.transpose((1, 0, 3, 2)) * -1
+    t2new += np.transpose(tmp17, (1, 0, 3, 2)) * -1
     t2new += tmp17 * -1
     del tmp17
-    tmp26 = v.oooo.copy()
+    tmp26 = np.copy(v.oooo)
     tmp26 += einsum(t2, (0, 1, 2, 3), v.ovov, (4, 2, 5, 3), (4, 0, 5, 1))
     t2new += einsum(tmp26, (0, 1, 2, 3), t2, (0, 2, 4, 5), (1, 3, 4, 5))
     del tmp26
-    tmp12 = tmp10.copy()
+    tmp12 = np.copy(tmp10)
     del tmp10
     tmp12 += tmp11
     del tmp11
-    t2new += tmp12.transpose((1, 0, 2, 3))
-    t2new += tmp12.transpose((0, 1, 3, 2))
+    t2new += np.transpose(tmp12, (1, 0, 2, 3))
+    t2new += np.transpose(tmp12, (0, 1, 3, 2))
     del tmp12
-    tmp28 = v.oovv.copy() * -1
+    tmp28 = np.copy(v.oovv) * -1
     tmp28 += einsum(v.ovov, (0, 1, 2, 3), t2, (4, 2, 1, 5), (4, 0, 5, 3))
     t2new += einsum(t2, (0, 1, 2, 3), tmp28, (4, 1, 5, 2), (4, 0, 3, 5))
     del tmp28
     tmp24 = einsum(t2, (0, 1, 2, 3), f.oo, (4, 1), (4, 0, 2, 3))
-    t2new += tmp24.transpose((1, 0, 2, 3)) * -1
-    t2new += tmp24.transpose((0, 1, 3, 2)) * -1
+    t2new += np.transpose(tmp24, (1, 0, 2, 3)) * -1
+    t2new += np.transpose(tmp24, (0, 1, 3, 2)) * -1
     del tmp24
-    tmp6 = v.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp6 = np.copy(np.transpose(v.ovov, (0, 2, 1, 3))) * 2
     tmp6 += v.oovv * -1
     t1new = einsum(tmp6, (0, 1, 2, 3), t1, (0, 2), (1, 3))
     del tmp6
-    tmp0 = v.ovvv.copy() * -0.5
-    tmp0 += v.ovvv.transpose((0, 2, 1, 3))
+    tmp0 = np.copy(v.ovvv) * -0.5
+    tmp0 += np.transpose(v.ovvv, (0, 2, 1, 3))
     t1new += einsum(tmp0, (0, 1, 2, 3), t2, (4, 0, 1, 2), (4, 3)) * 2
     del tmp0
-    tmp5 = t2.transpose((0, 1, 3, 2)).copy() * -1
+    tmp5 = np.copy(np.transpose(t2, (0, 1, 3, 2))) * -1
     tmp5 += t2 * 2
-    tmp2 = v.ooov.copy()
-    tmp2 += v.ooov.transpose((0, 2, 1, 3)) * -0.5
+    tmp2 = np.copy(v.ooov)
+    tmp2 += np.transpose(v.ooov, (0, 2, 1, 3)) * -0.5
     tmp2 += tmp1 * -0.5
-    tmp2 += tmp1.transpose((0, 2, 1, 3))
+    tmp2 += np.transpose(tmp1, (0, 2, 1, 3))
     del tmp1
     t1new += einsum(tmp2, (0, 1, 2, 3), t2, (2, 1, 3, 4), (0, 4)) * -2
     del tmp2
-    tmp4 = f.ov.copy()
+    tmp4 = np.copy(f.ov)
     tmp4 += einsum(tmp3, (0, 1, 2, 3), t1, (0, 2), (1, 3))
     del tmp3
     t1new += einsum(tmp5, (0, 1, 2, 3), tmp4, (0, 2), (1, 3))
     del tmp5, tmp4
-    tmp8 = f.oo.copy()
+    tmp8 = np.copy(f.oo)
     tmp8 += einsum(tmp7, (0, 1, 2, 3), t2, (4, 0, 2, 3), (1, 4))
     del tmp7
     t1new += einsum(t1, (0, 1), tmp8, (0, 2), (2, 1)) * -1
@@ -161,7 +161,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new += einsum(v.oovv, (0, 1, 2, 3), t2, (4, 1, 3, 5), (4, 0, 2, 5)) * -1
     t2new += einsum(v.ovov, (0, 1, 2, 3), t2, (4, 2, 5, 3), (0, 4, 1, 5)) * 2
     t2new += einsum(t2, (0, 1, 2, 3), v.vvvv, (4, 2, 5, 3), (0, 1, 4, 5))
-    t2new += v.ovov.transpose((0, 2, 1, 3))
+    t2new += np.transpose(v.ovov, (0, 2, 1, 3))
 
     return {f"t1new": t1new, f"t2new": t2new}
 

--- a/ebcc/codegen/UCC2.py
+++ b/ebcc/codegen/UCC2.py
@@ -37,14 +37,14 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp2 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp2 += v.aaaa.ovov.transpose((0, 2, 1, 3))
-    tmp0 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp0 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp3 = f.aa.ov.copy() * 2
+    tmp2 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1))) * -1
+    tmp2 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
+    tmp0 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp0 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
+    tmp3 = np.copy(f.aa.ov) * 2
     tmp3 += einsum(t1.aa, (0, 1), tmp2, (0, 2, 3, 1), (2, 3)) * -1
     del tmp2
-    tmp1 = f.bb.ov.copy() * 2
+    tmp1 = np.copy(f.bb.ov) * 2
     tmp1 += einsum(t1.aa, (0, 1), v.aabb.ovov, (0, 1, 2, 3), (2, 3)) * 2
     tmp1 += einsum(t1.bb, (0, 1), tmp0, (0, 2, 1, 3), (2, 3)) * -1
     del tmp0
@@ -85,10 +85,10 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new = Namespace()
     tmp17 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t1.bb, (4, 3), (4, 0, 2, 1))
     tmp2 = einsum(v.aaaa.ovov, (0, 1, 2, 3), t1.aa, (4, 3), (4, 0, 2, 1))
-    tmp11 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp11 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp5 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp5 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp11 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp11 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
+    tmp5 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1))) * -1
+    tmp5 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp74 = einsum(t1.bb, (0, 1), tmp17, (2, 3, 4, 1), (2, 0, 4, 3))
     tmp72 = einsum(v.bbbb.ovvv, (0, 1, 2, 3), t1.bb, (4, 3), (4, 0, 1, 2))
     tmp68 = einsum(t1.bb, (0, 1), v.bbbb.ooov, (2, 3, 4, 1), (0, 2, 3, 4))
@@ -127,19 +127,19 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp41
     tmp29 = einsum(t1.aa, (0, 1), v.aaaa.oovv, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp23 = einsum(v.aaaa.oooo, (0, 1, 2, 3), t1.aa, (3, 4), (0, 1, 2, 4))
-    tmp13 = f.bb.ov.copy()
+    tmp13 = np.copy(f.bb.ov)
     tmp13 += tmp10
     tmp13 += tmp12 * -1
     del tmp12
-    tmp21 = v.bbbb.ooov.copy() * -1
-    tmp21 += v.bbbb.ooov.transpose((0, 2, 1, 3))
-    tmp14 = v.aaaa.ooov.copy()
-    tmp14 += v.aaaa.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp7 = f.aa.ov.copy()
+    tmp21 = np.copy(v.bbbb.ooov) * -1
+    tmp21 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3))
+    tmp14 = np.copy(v.aaaa.ooov)
+    tmp14 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1)) * -1
+    tmp7 = np.copy(f.aa.ov)
     tmp7 += tmp1
     tmp7 += tmp6 * -1
     del tmp6
-    tmp48 = f.bb.vv.copy()
+    tmp48 = np.copy(f.bb.vv)
     tmp48 += tmp47 * -1
     tmp63 = einsum(f.bb.oo, (0, 1), t2.bbbb, (2, 1, 3, 4), (0, 2, 3, 4))
     tmp73 = einsum(t1.bb, (0, 1), v.bbbb.ooov, (2, 0, 3, 4), (2, 3, 1, 4))
@@ -147,7 +147,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp75
     tmp66 = einsum(t1.bb, (0, 1), tmp65, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp65
-    tmp64 = f.bb.vv.copy()
+    tmp64 = np.copy(f.bb.vv)
     tmp64 += tmp47 * -1
     del tmp47
     tmp67 = einsum(tmp51, (0, 1), t2.bbbb, (2, 0, 3, 4), (1, 2, 3, 4))
@@ -172,10 +172,10 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp46 = einsum(t1.bb, (0, 1), v.aabb.oooo, (2, 3, 4, 0), (2, 3, 4, 1))
     tmp50 = einsum(t1.bb, (0, 1), tmp49, (2, 3, 4, 0), (3, 2, 4, 1))
     del tmp49
-    tmp27 = f.aa.vv.copy()
+    tmp27 = np.copy(f.aa.vv)
     tmp27 += tmp26 * -1
     tmp0 = einsum(t1.aa, (0, 1), v.aabb.ovov, (2, 1, 3, 4), (0, 2, 3, 4))
-    tmp55 = v.aabb.vvov.transpose((2, 0, 1, 3)).copy()
+    tmp55 = np.copy(np.transpose(v.aabb.vvov, (2, 0, 1, 3)))
     tmp55 += einsum(v.aabb.vvvv, (0, 1, 2, 3), t1.bb, (4, 3), (4, 0, 1, 2))
     tmp35 = einsum(tmp34, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3))
     del tmp34
@@ -187,7 +187,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp38 = einsum(v.aaaa.ooov, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3))
     tmp45 = einsum(tmp44, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
     del tmp44
-    tmp28 = f.aa.vv.copy()
+    tmp28 = np.copy(f.aa.vv)
     tmp28 += tmp26 * -1
     del tmp26
     tmp43 = einsum(tmp42, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
@@ -196,79 +196,79 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp29
     tmp24 = einsum(t1.aa, (0, 1), tmp23, (2, 0, 3, 4), (3, 2, 4, 1))
     del tmp23
-    tmp3 = t2.abab.copy()
+    tmp3 = np.copy(t2.abab)
     tmp3 += einsum(t1.aa, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3))
     tmp19 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (0, 4, 1, 3), (2, 4))
     tmp19 += einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.ovov, (4, 2, 1, 3), (4, 0)) * 2
     tmp19 += einsum(t1.bb, (0, 1), tmp13, (2, 1), (2, 0))
-    tmp22 = f.bb.oo.copy()
+    tmp22 = np.copy(f.bb.oo)
     tmp22 += einsum(t1.aa, (0, 1), v.aabb.ovoo, (0, 1, 2, 3), (2, 3))
     tmp22 += einsum(tmp21, (0, 1, 2, 3), t1.bb, (2, 3), (1, 0)) * -1
     del tmp21
-    tmp18 = t2.bbbb.copy() * 2
+    tmp18 = np.copy(t2.bbbb) * 2
     tmp18 += einsum(t1.bb, (0, 1), t1.bb, (2, 3), (2, 0, 3, 1))
-    tmp20 = f.bb.vv.copy()
+    tmp20 = np.copy(f.bb.vv)
     tmp20 += einsum(v.bbbb.ovvv, (0, 1, 2, 3), t1.bb, (0, 1), (2, 3))
-    tmp15 = f.aa.oo.copy()
+    tmp15 = np.copy(f.aa.oo)
     tmp15 += einsum(t1.bb, (0, 1), v.aabb.ooov, (2, 3, 0, 1), (2, 3))
     tmp15 += einsum(tmp14, (0, 1, 2, 3), t1.aa, (0, 3), (2, 1)) * -1
     del tmp14
-    tmp9 = f.aa.vv.copy()
+    tmp9 = np.copy(f.aa.vv)
     tmp9 += einsum(v.aaaa.ovvv, (0, 1, 2, 3), t1.aa, (0, 1), (2, 3))
     tmp8 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 3, 1, 2), (4, 0)) * -1
     tmp8 += einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (4, 2, 1, 3), (0, 4)) * 0.5
     tmp8 += einsum(t1.aa, (0, 1), tmp7, (2, 1), (2, 0)) * 0.5
-    tmp4 = t2.aaaa.copy() * 2
+    tmp4 = np.copy(t2.aaaa) * 2
     tmp4 += einsum(t1.aa, (0, 1), t1.aa, (2, 3), (0, 2, 1, 3))
-    t2new.bbbb = tmp62.copy()
-    t2new.bbbb += tmp63.transpose((1, 0, 3, 2)) * 2
-    t2new.bbbb += tmp62.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb = np.copy(tmp62)
+    t2new.bbbb += np.transpose(tmp63, (1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp62, (0, 1, 3, 2)) * -1
     del tmp62
-    t2new.bbbb += tmp63.transpose((0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp63, (0, 1, 3, 2)) * -2
     del tmp63
     t2new.bbbb += einsum(tmp64, (0, 1), t2.bbbb, (2, 3, 4, 0), (2, 3, 1, 4)) * -2
     del tmp64
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), tmp48, (3, 4), (0, 1, 2, 4)) * 2
-    t2new.bbbb += tmp66.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp67.transpose((1, 0, 3, 2)) * 2
-    t2new.bbbb += tmp70.transpose((1, 0, 2, 3))
-    t2new.bbbb += tmp70.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp66.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp67.transpose((0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp66, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp67, (1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp70, (1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp70, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp66, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp67, (0, 1, 3, 2)) * -2
     del tmp67
-    t2new.bbbb += tmp66.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp66, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp70 * -1
-    t2new.bbbb += tmp70.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp70, (0, 1, 3, 2))
     del tmp70
     t2new.bbbb += tmp66
     del tmp66
-    t2new.bbbb += tmp71.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += v.bbbb.ovov.transpose((0, 2, 1, 3))
-    t2new.bbbb += tmp72.transpose((1, 0, 2, 3))
-    t2new.bbbb += tmp71.transpose((0, 1, 3, 2))
-    t2new.bbbb += v.bbbb.ovov.transpose((0, 2, 3, 1)) * -1
+    t2new.bbbb += np.transpose(tmp71, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
+    t2new.bbbb += np.transpose(tmp72, (1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp71, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(v.bbbb.ovov, (0, 2, 3, 1)) * -1
     t2new.bbbb += tmp72 * -1
-    t2new.bbbb += tmp73.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp73.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp73, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp73, (1, 0, 3, 2)) * -1
     t2new.bbbb += tmp73 * -1
-    t2new.bbbb += tmp73.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp73, (1, 0, 2, 3))
     del tmp73
-    t2new.bbbb += tmp72.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp72, (0, 1, 3, 2))
     t2new.bbbb += tmp76
-    t2new.bbbb += tmp76.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp76, (0, 1, 3, 2)) * -1
     del tmp76
     t2new.bbbb += tmp78
-    t2new.bbbb += tmp78.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp78, (0, 1, 3, 2)) * -1
     del tmp78
-    t2new.bbbb += tmp80.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp80.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp72.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp80, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp80, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp72, (1, 0, 3, 2)) * -1
     del tmp72
     t2new.bbbb += tmp71 * -1
-    t2new.bbbb += tmp71.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp71, (1, 0, 2, 3))
     del tmp71
     t2new.bbbb += tmp80 * -1
-    t2new.bbbb += tmp80.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp80, (1, 0, 2, 3))
     del tmp80
     t2new.abab = einsum(f.bb.oo, (0, 1), t2.abab, (2, 1, 3, 4), (2, 0, 3, 4)) * -1
     t2new.abab += einsum(t1.aa, (0, 1), tmp46, (2, 0, 3, 4), (2, 3, 1, 4))
@@ -286,7 +286,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new.abab += einsum(t1.bb, (0, 1), tmp53, (2, 0, 3, 4), (2, 3, 4, 1)) * -1
     del tmp53
     t2new.abab += einsum(t1.bb, (0, 1), tmp16, (2, 3, 0, 4), (2, 3, 4, 1)) * -1
-    t2new.abab += v.aabb.ovov.transpose((0, 2, 1, 3))
+    t2new.abab += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     t2new.abab += tmp54
     del tmp54
     t2new.abab += einsum(t1.bb, (0, 1), v.aabb.ovoo, (2, 3, 4, 0), (2, 4, 3, 1)) * -1
@@ -300,56 +300,56 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp59
     t2new.abab += einsum(t1.aa, (0, 1), tmp60, (2, 0, 3, 4), (2, 3, 1, 4)) * -1
     del tmp60
-    t2new.aaaa = tmp24.copy()
-    t2new.aaaa += tmp25.transpose((1, 0, 3, 2)) * 2
-    t2new.aaaa += tmp24.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa = np.copy(tmp24)
+    t2new.aaaa += np.transpose(tmp25, (1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp24, (0, 1, 3, 2)) * -1
     del tmp24
-    t2new.aaaa += tmp25.transpose((0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp25, (0, 1, 3, 2)) * -2
     del tmp25
     t2new.aaaa += einsum(tmp27, (0, 1), t2.aaaa, (2, 3, 4, 0), (2, 3, 1, 4)) * -2
     del tmp27
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp28, (3, 4), (0, 1, 2, 4)) * 2
     del tmp28
-    t2new.aaaa += tmp30.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp32.transpose((1, 0, 3, 2)) * 2
-    t2new.aaaa += tmp35.transpose((1, 0, 2, 3))
-    t2new.aaaa += tmp35.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp30.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp32.transpose((0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp30, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp32, (1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp35, (1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp35, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp30, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp32, (0, 1, 3, 2)) * -2
     del tmp32
-    t2new.aaaa += tmp30.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp30, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp35 * -1
-    t2new.aaaa += tmp35.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp35, (0, 1, 3, 2))
     del tmp35
     t2new.aaaa += tmp30
     del tmp30
-    t2new.aaaa += tmp36.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += v.aaaa.ovov.transpose((0, 2, 1, 3))
-    t2new.aaaa += tmp37.transpose((1, 0, 2, 3))
-    t2new.aaaa += tmp36.transpose((0, 1, 3, 2))
-    t2new.aaaa += v.aaaa.ovov.transpose((0, 2, 3, 1)) * -1
+    t2new.aaaa += np.transpose(tmp36, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
+    t2new.aaaa += np.transpose(tmp37, (1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp36, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(v.aaaa.ovov, (0, 2, 3, 1)) * -1
     t2new.aaaa += tmp37 * -1
-    t2new.aaaa += tmp38.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp38.transpose((1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp38, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp38, (1, 0, 3, 2)) * -1
     t2new.aaaa += tmp38 * -1
-    t2new.aaaa += tmp38.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp38, (1, 0, 2, 3))
     del tmp38
-    t2new.aaaa += tmp37.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp37, (0, 1, 3, 2))
     t2new.aaaa += tmp40
-    t2new.aaaa += tmp40.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp40, (0, 1, 3, 2)) * -1
     del tmp40
     t2new.aaaa += tmp43
-    t2new.aaaa += tmp43.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp43, (0, 1, 3, 2)) * -1
     del tmp43
-    t2new.aaaa += tmp45.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp45.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp37.transpose((1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp45, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp45, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp37, (1, 0, 3, 2)) * -1
     del tmp37
     t2new.aaaa += tmp36 * -1
-    t2new.aaaa += tmp36.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp36, (1, 0, 2, 3))
     del tmp36
     t2new.aaaa += tmp45 * -1
-    t2new.aaaa += tmp45.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp45, (1, 0, 2, 3))
     del tmp45
     t1new.bb = einsum(tmp16, (0, 1, 2, 3), t2.abab, (0, 2, 3, 4), (1, 4)) * -1
     del tmp16
@@ -373,7 +373,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t1new.bb += einsum(t2.bbbb, (0, 1, 2, 3), tmp13, (1, 3), (0, 2)) * 2
     t1new.bb += einsum(t1.bb, (0, 1), tmp22, (0, 2), (2, 1)) * -1
     del tmp22
-    t1new.aa = f.aa.ov.copy()
+    t1new.aa = np.copy(f.aa.ov)
     t1new.aa += einsum(t2.abab, (0, 1, 2, 3), tmp0, (4, 0, 1, 3), (4, 2)) * -1
     del tmp0
     t1new.aa += einsum(v.aaaa.ovov, (0, 1, 2, 3), t1.aa, (2, 3), (0, 1))
@@ -430,38 +430,38 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
 
     l1new = Namespace()
     l2new = Namespace()
-    tmp90 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp90 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp153 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp153 += v.aaaa.ovov.transpose((0, 2, 1, 3))
-    tmp7 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp7 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp90 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp90 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
+    tmp153 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1))) * -1
+    tmp153 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
+    tmp7 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1))) * -1
+    tmp7 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp2 = einsum(v.aabb.ovov, (0, 1, 2, 3), t1.bb, (4, 3), (0, 4, 2, 1))
-    tmp188 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp188 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp207 = v.bbbb.ovvv.copy() * -1
-    tmp207 += v.bbbb.ovvv.transpose((0, 2, 1, 3))
-    tmp176 = v.bbbb.ovvv.copy()
-    tmp176 += v.bbbb.ovvv.transpose((0, 2, 1, 3)) * -1
+    tmp188 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp188 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
+    tmp207 = np.copy(v.bbbb.ovvv) * -1
+    tmp207 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3))
+    tmp176 = np.copy(v.bbbb.ovvv)
+    tmp176 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3)) * -1
     tmp89 = einsum(t1.aa, (0, 1), v.aabb.ovov, (0, 1, 2, 3), (2, 3))
     tmp91 = einsum(t1.bb, (0, 1), tmp90, (0, 2, 1, 3), (2, 3))
     del tmp90
     tmp154 = einsum(t1.aa, (0, 1), tmp153, (0, 2, 3, 1), (2, 3))
     del tmp153
     tmp6 = einsum(v.aabb.ovov, (0, 1, 2, 3), t1.bb, (2, 3), (0, 1))
-    tmp145 = v.aaaa.ovvv.copy() * -1
-    tmp145 += v.aaaa.ovvv.transpose((0, 2, 1, 3))
+    tmp145 = np.copy(v.aaaa.ovvv) * -1
+    tmp145 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3))
     tmp8 = einsum(tmp7, (0, 1, 2, 3), t1.aa, (0, 3), (1, 2))
     del tmp7
-    tmp164 = v.aaaa.ovvv.copy()
-    tmp164 += v.aaaa.ovvv.transpose((0, 2, 1, 3)) * -1
+    tmp164 = np.copy(v.aaaa.ovvv)
+    tmp164 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3)) * -1
     tmp41 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 4, 0, 1), (3, 4))
     tmp42 = einsum(t2.bbbb, (0, 1, 2, 3), l2.bbbb, (2, 3, 4, 1), (4, 0))
     tmp40 = einsum(t1.bb, (0, 1), l1.bb, (1, 2), (2, 0))
     tmp38 = einsum(l2.bbbb, (0, 1, 2, 3), t1.bb, (4, 1), (2, 3, 4, 0))
     tmp36 = einsum(t1.bb, (0, 1), l2.abab, (2, 1, 3, 4), (3, 4, 0, 2))
     tmp87 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t1.bb, (4, 3), (4, 0, 2, 1))
-    tmp14 = v.aabb.ovoo.transpose((0, 2, 3, 1)).copy()
+    tmp14 = np.copy(np.transpose(v.aabb.ovoo, (0, 2, 3, 1)))
     tmp14 += tmp2
     tmp52 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (2, 3, 4, 1), (4, 0))
     tmp51 = einsum(l1.aa, (0, 1), t1.aa, (2, 0), (1, 2))
@@ -474,36 +474,36 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp207
     tmp186 = einsum(tmp176, (0, 1, 2, 3), t1.bb, (0, 2), (1, 3))
     tmp130 = einsum(t1.aa, (0, 1), v.aabb.ovvv, (0, 1, 2, 3), (2, 3))
-    tmp109 = v.bbbb.ooov.copy()
-    tmp109 += v.bbbb.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp92 = f.bb.ov.copy()
+    tmp109 = np.copy(v.bbbb.ooov)
+    tmp109 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1)) * -1
+    tmp92 = np.copy(f.bb.ov)
     tmp92 += tmp89
     tmp92 += tmp91 * -1
     del tmp91
-    tmp118 = v.bbbb.ovvv.copy()
-    tmp118 += v.bbbb.ovvv.transpose((0, 2, 1, 3)) * -1
+    tmp118 = np.copy(v.bbbb.ovvv)
+    tmp118 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3)) * -1
     tmp178 = einsum(t1.aa, (0, 1), v.aabb.vvov, (2, 1, 3, 4), (0, 3, 2, 4))
-    tmp155 = f.aa.ov.copy()
+    tmp155 = np.copy(f.aa.ov)
     tmp155 += tmp6
     tmp155 += tmp154 * -1
     del tmp154
-    tmp151 = v.aaaa.ooov.copy()
-    tmp151 += v.aaaa.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp84 = v.aaaa.ovvv.copy()
-    tmp84 += v.aaaa.ovvv.transpose((0, 2, 1, 3)) * -1
+    tmp151 = np.copy(v.aaaa.ooov)
+    tmp151 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1)) * -1
+    tmp84 = np.copy(v.aaaa.ovvv)
+    tmp84 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3)) * -1
     tmp146 = einsum(t1.aa, (0, 1), tmp145, (2, 3, 1, 4), (2, 0, 3, 4))
     del tmp145
     tmp10 = einsum(v.aabb.ovvv, (0, 1, 2, 3), t1.bb, (4, 3), (0, 4, 1, 2))
-    tmp59 = v.aaaa.ooov.copy()
-    tmp59 += v.aaaa.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp9 = f.aa.ov.copy()
+    tmp59 = np.copy(v.aaaa.ooov)
+    tmp59 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1)) * -1
+    tmp9 = np.copy(f.aa.ov)
     tmp9 += tmp6
     tmp9 += tmp8 * -1
     del tmp8
     tmp165 = einsum(tmp164, (0, 1, 2, 3), t1.aa, (0, 2), (1, 3))
     del tmp164
     tmp83 = einsum(t1.bb, (0, 1), v.aabb.vvov, (2, 3, 0, 1), (2, 3))
-    tmp43 = tmp40.copy()
+    tmp43 = np.copy(tmp40)
     tmp43 += tmp41
     del tmp41
     tmp43 += tmp42 * 2
@@ -520,7 +520,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp15 = einsum(t1.aa, (0, 1), tmp14, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp93 = einsum(t1.bb, (0, 1), v.aabb.vvov, (2, 3, 4, 1), (0, 4, 2, 3))
     tmp4 = einsum(t1.aa, (0, 1), v.aabb.ovov, (2, 1, 3, 4), (0, 2, 3, 4))
-    tmp54 = tmp51.copy() * 0.5
+    tmp54 = np.copy(tmp51) * 0.5
     tmp54 += tmp52
     tmp54 += tmp53 * 0.5
     tmp49 = einsum(l2.abab, (0, 1, 2, 3), t1.aa, (4, 0), (2, 4, 3, 1))
@@ -528,30 +528,30 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp22 = einsum(t1.aa, (0, 1), v.aaaa.ooov, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp65 = einsum(tmp47, (0, 1, 2, 3), t1.aa, (4, 3), (0, 1, 4, 2))
     tmp64 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (2, 3, 4, 5), (4, 5, 0, 1))
-    tmp190 = f.bb.ov.copy()
+    tmp190 = np.copy(f.bb.ov)
     tmp190 += tmp89
     tmp190 += tmp189 * -1
     del tmp189
     tmp108 = einsum(t1.aa, (0, 1), v.aabb.ovoo, (0, 1, 2, 3), (2, 3))
-    tmp212 = v.bbbb.ooov.copy()
-    tmp212 += v.bbbb.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp209 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
+    tmp212 = np.copy(v.bbbb.ooov)
+    tmp212 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1)) * -1
+    tmp209 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
     tmp209 += v.bbbb.oovv * -1
-    tmp209 += tmp208.transpose((1, 0, 2, 3)) * -1
+    tmp209 += np.transpose(tmp208, (1, 0, 2, 3)) * -1
     del tmp208
-    tmp219 = f.bb.vv.copy()
-    tmp219 += tmp130.transpose((1, 0))
+    tmp219 = np.copy(f.bb.vv)
+    tmp219 += np.transpose(tmp130, (1, 0))
     tmp219 += tmp186 * -1
-    tmp203 = v.bbbb.ovvv.copy() * -1
-    tmp203 += v.bbbb.ovvv.transpose((0, 2, 1, 3))
+    tmp203 = np.copy(v.bbbb.ovvv) * -1
+    tmp203 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3))
     tmp110 = einsum(t1.bb, (0, 1), tmp109, (0, 2, 3, 1), (2, 3))
     del tmp109
     tmp111 = einsum(tmp92, (0, 1), t1.bb, (2, 1), (2, 0))
     tmp131 = einsum(tmp118, (0, 1, 2, 3), t1.bb, (0, 2), (1, 3))
     tmp180 = einsum(t1.bb, (0, 1), v.bbbb.ovov, (2, 3, 0, 1), (2, 3))
-    tmp179 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp179 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp179 += tmp178
-    tmp196 = v.bbbb.ooov.transpose((0, 2, 1, 3)).copy()
+    tmp196 = np.copy(np.transpose(v.bbbb.ooov, (0, 2, 1, 3)))
     tmp196 += tmp87
     tmp156 = einsum(t1.aa, (0, 1), tmp155, (2, 1), (2, 0))
     tmp152 = einsum(tmp151, (0, 1, 2, 3), t1.aa, (0, 3), (1, 2))
@@ -560,67 +560,67 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp85 = einsum(tmp84, (0, 1, 2, 3), t1.aa, (0, 2), (1, 3))
     del tmp84
     tmp143 = einsum(v.aaaa.ovov, (0, 1, 2, 3), t1.aa, (2, 3), (0, 1))
-    tmp3 = v.aabb.ovoo.transpose((0, 2, 3, 1)).copy()
-    tmp3 += tmp2.transpose((0, 2, 1, 3))
-    tmp147 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy()
+    tmp3 = np.copy(np.transpose(v.aabb.ovoo, (0, 2, 3, 1)))
+    tmp3 += np.transpose(tmp2, (0, 2, 1, 3))
+    tmp147 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1)))
     tmp147 += v.aaaa.oovv * -1
-    tmp147 += tmp146.transpose((1, 0, 2, 3)) * -1
-    tmp134 = v.aaaa.ooov.transpose((0, 2, 1, 3)).copy()
+    tmp147 += np.transpose(tmp146, (1, 0, 2, 3)) * -1
+    tmp134 = np.copy(np.transpose(v.aaaa.ooov, (0, 2, 1, 3)))
     tmp134 += tmp0
-    tmp149 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp149 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp149 += tmp10
     tmp60 = einsum(tmp59, (0, 1, 2, 3), t1.aa, (0, 3), (1, 2))
     del tmp59
     tmp61 = einsum(t1.aa, (0, 1), tmp9, (2, 1), (0, 2))
-    tmp166 = f.aa.vv.copy()
-    tmp166 += tmp83.transpose((1, 0))
+    tmp166 = np.copy(f.aa.vv)
+    tmp166 += np.transpose(tmp83, (1, 0))
     tmp166 += tmp165 * -1
     del tmp165
-    tmp29 = v.aaaa.ovvv.copy() * -1
-    tmp29 += v.aaaa.ovvv.transpose((0, 2, 1, 3))
+    tmp29 = np.copy(v.aaaa.ovvv) * -1
+    tmp29 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3))
     tmp35 = einsum(t2.bbbb, (0, 1, 2, 3), l1.bb, (3, 1), (0, 2))
     tmp39 = einsum(t2.bbbb, (0, 1, 2, 3), tmp38, (1, 0, 4, 3), (4, 2))
     tmp106 = einsum(t1.bb, (0, 1), tmp43, (0, 2), (2, 1)) * 0.5
     tmp37 = einsum(tmp36, (0, 1, 2, 3), t2.abab, (0, 1, 3, 4), (2, 4))
     tmp34 = einsum(l1.aa, (0, 1), t2.abab, (1, 2, 0, 3), (2, 3))
     tmp123 = einsum(t2.abab, (0, 1, 2, 3), tmp36, (0, 4, 5, 2), (4, 5, 1, 3))
-    tmp125 = tmp115.transpose((1, 0, 3, 2)).copy()
-    tmp125 += tmp116.transpose((0, 1, 3, 2)) * -1
+    tmp125 = np.copy(np.transpose(tmp115, (1, 0, 3, 2)))
+    tmp125 += np.transpose(tmp116, (0, 1, 3, 2)) * -1
     tmp124 = einsum(t2.bbbb, (0, 1, 2, 3), tmp38, (4, 1, 5, 3), (4, 5, 0, 2)) * -1
-    tmp70 = tmp68.copy()
+    tmp70 = np.copy(tmp68)
     tmp70 += tmp69
-    tmp96 = v.bbbb.ooov.copy()
-    tmp96 += v.bbbb.ooov.transpose((0, 2, 1, 3)) * -1
+    tmp96 = np.copy(v.bbbb.ooov)
+    tmp96 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3)) * -1
     tmp96 += tmp87 * -1
-    tmp96 += tmp87.transpose((0, 2, 1, 3))
-    tmp101 = v.bbbb.oooo.copy()
+    tmp96 += np.transpose(tmp87, (0, 2, 1, 3))
+    tmp101 = np.copy(v.bbbb.oooo)
     tmp101 += einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.ovov, (4, 2, 5, 3), (4, 0, 5, 1))
-    tmp101 += tmp99.transpose((2, 1, 3, 0)) * -1
-    tmp101 += tmp100.transpose((2, 0, 3, 1)) * -1
-    tmp101 += tmp100.transpose((3, 0, 2, 1))
-    tmp98 = v.bbbb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp101 += np.transpose(tmp99, (2, 1, 3, 0)) * -1
+    tmp101 += np.transpose(tmp100, (2, 0, 3, 1)) * -1
+    tmp101 += np.transpose(tmp100, (3, 0, 2, 1))
+    tmp98 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 1, 3)))
     tmp98 += v.bbbb.oovv * -1
-    tmp98 += tmp97.transpose((0, 1, 3, 2))
+    tmp98 += np.transpose(tmp97, (0, 1, 3, 2))
     tmp25 = einsum(l1.aa, (0, 1), t1.aa, (1, 2), (0, 2))
     tmp26 = einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (2, 3, 4, 1), (0, 4))
     tmp27 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 3, 4, 1), (0, 4))
     tmp32 = einsum(t2.bbbb, (0, 1, 2, 3), l2.bbbb, (4, 3, 0, 1), (4, 2))
     tmp31 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 3, 0, 4), (1, 4))
     tmp30 = einsum(t1.bb, (0, 1), l1.bb, (2, 0), (2, 1))
-    tmp16 = v.aabb.oooo.copy()
-    tmp16 += tmp12.transpose((1, 0, 3, 2))
-    tmp16 += tmp13.transpose((1, 0, 3, 2))
+    tmp16 = np.copy(v.aabb.oooo)
+    tmp16 += np.transpose(tmp12, (1, 0, 3, 2))
+    tmp16 += np.transpose(tmp13, (1, 0, 3, 2))
     del tmp13
-    tmp16 += tmp15.transpose((1, 0, 3, 2))
+    tmp16 += np.transpose(tmp15, (1, 0, 3, 2))
     del tmp15
-    tmp94 = v.aabb.vvoo.transpose((2, 3, 0, 1)).copy()
-    tmp94 += tmp93.transpose((1, 0, 3, 2))
-    tmp5 = v.aabb.ooov.copy()
-    tmp5 += tmp4.transpose((1, 0, 2, 3))
-    tmp88 = v.bbbb.ooov.copy() * -1
-    tmp88 += v.bbbb.ovoo.transpose((0, 2, 3, 1))
-    tmp88 += tmp87.transpose((1, 0, 2, 3))
-    tmp88 += tmp87.transpose((2, 0, 1, 3)) * -1
+    tmp94 = np.copy(np.transpose(v.aabb.vvoo, (2, 3, 0, 1)))
+    tmp94 += np.transpose(tmp93, (1, 0, 3, 2))
+    tmp5 = np.copy(v.aabb.ooov)
+    tmp5 += np.transpose(tmp4, (1, 0, 2, 3))
+    tmp88 = np.copy(v.bbbb.ooov) * -1
+    tmp88 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1))
+    tmp88 += np.transpose(tmp87, (1, 0, 2, 3))
+    tmp88 += np.transpose(tmp87, (2, 0, 1, 3)) * -1
     tmp48 = einsum(t2.aaaa, (0, 1, 2, 3), tmp47, (1, 0, 4, 3), (4, 2))
     tmp55 = einsum(tmp54, (0, 1), t1.aa, (0, 2), (1, 2)) * 2
     tmp46 = einsum(t2.abab, (0, 1, 2, 3), l1.bb, (3, 1), (0, 2))
@@ -628,32 +628,32 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp50 = einsum(t2.abab, (0, 1, 2, 3), tmp49, (0, 4, 1, 3), (4, 2))
     tmp77 = einsum(tmp49, (0, 1, 2, 3), t2.abab, (4, 2, 5, 3), (0, 1, 4, 5))
     tmp76 = einsum(t2.aaaa, (0, 1, 2, 3), tmp47, (4, 1, 5, 3), (4, 5, 0, 2)) * -1
-    tmp23 = v.aaaa.oooo.copy()
+    tmp23 = np.copy(v.aaaa.oooo)
     tmp23 += einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 3, 5, 2), (4, 0, 5, 1)) * -1
-    tmp23 += tmp21.transpose((3, 1, 2, 0))
-    tmp23 += tmp22.transpose((2, 1, 3, 0))
-    tmp23 += tmp22.transpose((3, 2, 1, 0)) * -1
-    tmp18 = v.aaaa.ooov.copy()
-    tmp18 += v.aaaa.ooov.transpose((0, 2, 1, 3)) * -1
+    tmp23 += np.transpose(tmp21, (3, 1, 2, 0))
+    tmp23 += np.transpose(tmp22, (2, 1, 3, 0))
+    tmp23 += np.transpose(tmp22, (3, 2, 1, 0)) * -1
+    tmp18 = np.copy(v.aaaa.ooov)
+    tmp18 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3)) * -1
     tmp18 += tmp0 * -1
-    tmp18 += tmp0.transpose((0, 2, 1, 3))
-    tmp20 = v.aaaa.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp18 += np.transpose(tmp0, (0, 2, 1, 3))
+    tmp20 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 1, 3)))
     tmp20 += v.aaaa.oovv * -1
     tmp20 += einsum(v.aaaa.ovvv, (0, 1, 2, 3), t1.aa, (4, 3), (4, 0, 2, 1))
-    tmp19 = v.aabb.ooov.copy()
+    tmp19 = np.copy(v.aabb.ooov)
     tmp19 += tmp4
-    tmp11 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp11 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp11 += tmp10
     del tmp10
-    tmp1 = v.aaaa.ooov.copy() * -1
-    tmp1 += v.aaaa.ovoo.transpose((0, 2, 3, 1))
-    tmp1 += tmp0.transpose((1, 0, 2, 3))
-    tmp1 += tmp0.transpose((2, 0, 1, 3)) * -1
-    tmp78 = tmp64.transpose((1, 0, 3, 2)).copy()
-    tmp78 += tmp65.transpose((0, 1, 3, 2)) * -1
+    tmp1 = np.copy(v.aaaa.ooov) * -1
+    tmp1 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1))
+    tmp1 += np.transpose(tmp0, (1, 0, 2, 3))
+    tmp1 += np.transpose(tmp0, (2, 0, 1, 3)) * -1
+    tmp78 = np.copy(np.transpose(tmp64, (1, 0, 3, 2)))
+    tmp78 += np.transpose(tmp65, (0, 1, 3, 2)) * -1
     tmp218 = einsum(tmp190, (0, 1), tmp38, (2, 3, 0, 4), (2, 3, 1, 4))
-    tmp213 = f.bb.oo.copy()
-    tmp213 += tmp108.transpose((1, 0))
+    tmp213 = np.copy(f.bb.oo)
+    tmp213 += np.transpose(tmp108, (1, 0))
     tmp213 += einsum(tmp212, (0, 1, 2, 3), t1.bb, (0, 3), (1, 2)) * -1
     del tmp212
     tmp213 += einsum(t1.bb, (0, 1), tmp190, (2, 1), (0, 2))
@@ -663,87 +663,87 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp194 = einsum(t1.bb, (0, 1), v.bbbb.ovov, (2, 1, 0, 3), (2, 3))
     tmp220 = einsum(l2.bbbb, (0, 1, 2, 3), tmp219, (4, 1), (2, 3, 4, 0)) * -1
     del tmp219
-    tmp205 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp205 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp205 += tmp178
     del tmp178
-    tmp204 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
+    tmp204 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
     tmp204 += v.bbbb.oovv * -1
     tmp204 += einsum(tmp203, (0, 1, 2, 3), t1.bb, (4, 2), (4, 0, 1, 3)) * -1
     del tmp203
     tmp199 = einsum(tmp49, (0, 1, 2, 3), v.aabb.ooov, (1, 0, 4, 5), (2, 4, 3, 5))
     tmp198 = einsum(tmp38, (0, 1, 2, 3), v.bbbb.ovoo, (4, 5, 2, 0), (1, 4, 3, 5)) * -1
-    tmp183 = f.bb.oo.copy()
-    tmp183 += tmp108.transpose((1, 0))
+    tmp183 = np.copy(f.bb.oo)
+    tmp183 += np.transpose(tmp108, (1, 0))
     tmp183 += tmp110 * -1
     tmp183 += tmp111
-    tmp217 = f.bb.vv.copy()
-    tmp217 += tmp130.transpose((1, 0))
+    tmp217 = np.copy(f.bb.vv)
+    tmp217 += np.transpose(tmp130, (1, 0))
     tmp217 += tmp131 * -1
     tmp221 = einsum(tmp100, (0, 1, 2, 3), l2.bbbb, (4, 5, 0, 1), (2, 3, 4, 5))
     del tmp100
-    tmp223 = v.bbbb.ooov.copy()
-    tmp223 += tmp87.transpose((0, 2, 1, 3))
+    tmp223 = np.copy(v.bbbb.ooov)
+    tmp223 += np.transpose(tmp87, (0, 2, 1, 3))
     tmp226 = einsum(tmp38, (0, 1, 2, 3), v.bbbb.ooov, (4, 0, 2, 5), (1, 4, 3, 5)) * -1
     tmp201 = einsum(v.bbbb.ovvv, (0, 1, 2, 3), l1.bb, (3, 4), (4, 0, 1, 2))
     tmp216 = einsum(tmp38, (0, 1, 2, 3), v.bbbb.ovvv, (2, 4, 5, 3), (1, 0, 4, 5))
-    tmp181 = f.bb.ov.copy()
+    tmp181 = np.copy(f.bb.ov)
     tmp181 += tmp89
     tmp181 += tmp180
     tmp200 = einsum(tmp38, (0, 1, 2, 3), tmp87, (0, 4, 2, 5), (1, 4, 3, 5)) * -1
     tmp215 = einsum(l2.bbbb, (0, 1, 2, 3), v.bbbb.vvvv, (4, 0, 5, 1), (2, 3, 4, 5))
     tmp214 = einsum(v.bbbb.ovov, (0, 1, 2, 3), tmp116, (4, 5, 2, 0), (4, 5, 3, 1))
     tmp202 = einsum(tmp4, (0, 1, 2, 3), tmp49, (0, 1, 4, 5), (4, 2, 5, 3))
-    tmp195 = v.bbbb.ooov.copy()
-    tmp195 += tmp87.transpose((0, 2, 1, 3))
+    tmp195 = np.copy(v.bbbb.ooov)
+    tmp195 += np.transpose(tmp87, (0, 2, 1, 3))
     tmp211 = einsum(tmp179, (0, 1, 2, 3), l2.abab, (2, 4, 0, 5), (1, 5, 3, 4))
     tmp224 = einsum(tmp40, (0, 1), v.bbbb.ovov, (2, 3, 1, 4), (0, 2, 3, 4))
-    tmp206 = f.bb.ov.copy()
+    tmp206 = np.copy(f.bb.ov)
     tmp206 += tmp89
     del tmp89
     tmp206 += tmp180
     del tmp180
-    tmp222 = v.bbbb.oooo.copy()
-    tmp222 += tmp99.transpose((0, 2, 3, 1))
+    tmp222 = np.copy(v.bbbb.oooo)
+    tmp222 += np.transpose(tmp99, (0, 2, 3, 1))
     del tmp99
     tmp197 = einsum(tmp196, (0, 1, 2, 3), l1.bb, (4, 0), (1, 2, 3, 4))
     del tmp196
-    tmp177 = v.bbbb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp177 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 1, 3)))
     tmp177 += v.bbbb.oovv * -1
     tmp177 += einsum(tmp176, (0, 1, 2, 3), t1.bb, (4, 1), (4, 0, 3, 2)) * -1
     del tmp176
-    tmp182 = v.aabb.vvoo.transpose((2, 3, 0, 1)).copy()
-    tmp182 += tmp93.transpose((0, 1, 3, 2))
+    tmp182 = np.copy(np.transpose(v.aabb.vvoo, (2, 3, 0, 1)))
+    tmp182 += np.transpose(tmp93, (0, 1, 3, 2))
     del tmp93
-    tmp157 = f.aa.oo.copy()
-    tmp157 += tmp58.transpose((1, 0))
+    tmp157 = np.copy(f.aa.oo)
+    tmp157 += np.transpose(tmp58, (1, 0))
     tmp157 += tmp152 * -1
     del tmp152
-    tmp157 += tmp156.transpose((1, 0))
+    tmp157 += np.transpose(tmp156, (1, 0))
     del tmp156
-    tmp86 = f.aa.vv.copy()
-    tmp86 += tmp83.transpose((1, 0))
-    tmp86 += tmp85.transpose((1, 0)) * -1
+    tmp86 = np.copy(f.aa.vv)
+    tmp86 += np.transpose(tmp83, (1, 0))
+    tmp86 += np.transpose(tmp85, (1, 0)) * -1
     tmp185 = einsum(tmp69, (0, 1, 2, 3), v.aabb.ovov, (1, 4, 3, 5), (0, 2, 4, 5))
     tmp171 = einsum(v.aaaa.ovov, (0, 1, 2, 3), t1.aa, (2, 1), (0, 3))
-    tmp193 = v.aabb.oovv.copy()
+    tmp193 = np.copy(v.aabb.oovv)
     tmp193 += einsum(t1.aa, (0, 1), v.aabb.ovvv, (2, 1, 3, 4), (0, 2, 3, 4))
-    tmp187 = f.bb.vv.copy()
-    tmp187 += tmp130.transpose((1, 0))
-    tmp187 += tmp186.transpose((1, 0)) * -1
+    tmp187 = np.copy(f.bb.vv)
+    tmp187 += np.transpose(tmp130, (1, 0))
+    tmp187 += np.transpose(tmp186, (1, 0)) * -1
     del tmp186
-    tmp158 = f.aa.ov.copy()
+    tmp158 = np.copy(f.aa.ov)
     tmp158 += tmp143
     tmp158 += tmp6
     tmp184 = einsum(v.aabb.vvvv, (0, 1, 2, 3), l2.abab, (1, 3, 4, 5), (4, 5, 0, 2))
-    tmp191 = v.aabb.ooov.copy()
+    tmp191 = np.copy(v.aabb.ooov)
     tmp191 += tmp4
-    tmp192 = v.aabb.oooo.copy()
-    tmp192 += tmp12.transpose((1, 0, 2, 3))
+    tmp192 = np.copy(v.aabb.oooo)
+    tmp192 += np.transpose(tmp12, (1, 0, 2, 3))
     del tmp12
     tmp192 += einsum(t1.aa, (0, 1), tmp3, (2, 3, 4, 1), (0, 2, 4, 3))
-    tmp175 = v.aaaa.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp175 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 1, 3)))
     tmp175 += v.aaaa.oovv * -1
-    tmp175 += tmp146.transpose((1, 0, 3, 2)) * -1
+    tmp175 += np.transpose(tmp146, (1, 0, 3, 2)) * -1
     del tmp146
     tmp138 = einsum(tmp2, (0, 1, 2, 3), tmp36, (4, 1, 2, 5), (4, 0, 5, 3))
     tmp168 = einsum(tmp22, (0, 1, 2, 3), l2.aaaa, (4, 5, 0, 1), (2, 3, 4, 5))
@@ -752,31 +752,31 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp147
     tmp135 = einsum(tmp134, (0, 1, 2, 3), l1.aa, (4, 0), (1, 2, 3, 4))
     del tmp134
-    tmp169 = v.aaaa.oooo.copy()
-    tmp169 += tmp21.transpose((0, 3, 1, 2)) * -1
+    tmp169 = np.copy(v.aaaa.oooo)
+    tmp169 += np.transpose(tmp21, (0, 3, 1, 2)) * -1
     del tmp21
     tmp136 = einsum(tmp0, (0, 1, 2, 3), tmp47, (0, 4, 2, 5), (4, 1, 5, 3)) * -1
-    tmp133 = v.aaaa.ooov.copy()
-    tmp133 += tmp0.transpose((0, 2, 1, 3))
+    tmp133 = np.copy(v.aaaa.ooov)
+    tmp133 += np.transpose(tmp0, (0, 2, 1, 3))
     tmp137 = einsum(v.aaaa.ovvv, (0, 1, 2, 3), l1.aa, (3, 4), (4, 0, 1, 2))
-    tmp144 = f.aa.ov.copy()
+    tmp144 = np.copy(f.aa.ov)
     tmp144 += tmp143
     del tmp143
     tmp144 += tmp6
     del tmp6
     tmp140 = einsum(tmp47, (0, 1, 2, 3), v.aaaa.ovoo, (4, 5, 2, 0), (1, 4, 3, 5)) * -1
-    tmp170 = v.aaaa.ooov.copy()
-    tmp170 += tmp0.transpose((0, 2, 1, 3))
+    tmp170 = np.copy(v.aaaa.ooov)
+    tmp170 += np.transpose(tmp0, (0, 2, 1, 3))
     tmp174 = einsum(tmp47, (0, 1, 2, 3), v.aaaa.ooov, (4, 0, 2, 5), (1, 4, 3, 5)) * -1
     tmp139 = einsum(tmp36, (0, 1, 2, 3), v.aabb.ovoo, (4, 5, 2, 1), (0, 4, 3, 5))
     tmp150 = einsum(l2.abab, (0, 1, 2, 3), tmp149, (4, 3, 5, 1), (4, 2, 5, 0))
-    tmp142 = f.aa.oo.copy()
-    tmp142 += tmp58.transpose((1, 0))
+    tmp142 = np.copy(f.aa.oo)
+    tmp142 += np.transpose(tmp58, (1, 0))
     tmp142 += tmp60 * -1
     tmp142 += tmp61
     tmp172 = einsum(tmp51, (0, 1), v.aaaa.ovov, (2, 3, 1, 4), (0, 2, 3, 4))
-    tmp162 = f.aa.vv.copy()
-    tmp162 += tmp83.transpose((1, 0))
+    tmp162 = np.copy(f.aa.vv)
+    tmp162 += np.transpose(tmp83, (1, 0))
     del tmp83
     tmp162 += tmp85 * -1
     del tmp85
@@ -787,18 +787,18 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp166
     tmp163 = einsum(tmp47, (0, 1, 2, 3), tmp155, (2, 4), (0, 1, 4, 3))
     tmp161 = einsum(tmp47, (0, 1, 2, 3), v.aaaa.ovvv, (2, 4, 5, 3), (1, 0, 4, 5))
-    tmp141 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy()
+    tmp141 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1)))
     tmp141 += v.aaaa.oovv * -1
     tmp141 += einsum(tmp29, (0, 1, 2, 3), t1.aa, (4, 2), (4, 0, 1, 3)) * -1
-    tmp129 = t1.bb.copy() * -0.5
+    tmp129 = np.copy(t1.bb) * -0.5
     tmp129 += tmp34 * -0.5
     tmp129 += tmp35 * -1
     tmp129 += tmp37 * 0.5
     tmp129 += tmp39
     tmp129 += tmp106
-    tmp126 = tmp38.transpose((1, 0, 2, 3)).copy() * -2
-    tmp126 += tmp123.transpose((2, 0, 1, 3))
-    tmp126 += tmp124.transpose((2, 0, 1, 3)) * 4
+    tmp126 = np.copy(np.transpose(tmp38, (1, 0, 2, 3))) * -2
+    tmp126 += np.transpose(tmp123, (2, 0, 1, 3))
+    tmp126 += np.transpose(tmp124, (2, 0, 1, 3)) * 4
     tmp126 += einsum(tmp125, (0, 1, 2, 3), t1.bb, (0, 4), (3, 1, 2, 4)) * 2
     del tmp125
     tmp120 = einsum(t2.abab, (0, 1, 2, 3), l1.bb, (3, 4), (0, 4, 1, 2)) * 0.5
@@ -808,16 +808,16 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp120 += einsum(t2.abab, (0, 1, 2, 3), tmp38, (4, 1, 5, 3), (0, 4, 5, 2)) * -1
     tmp120 += einsum(t1.aa, (0, 1), tmp70, (0, 2, 3, 4), (2, 3, 4, 1)) * -0.5
     tmp127 = einsum(t2.bbbb, (0, 1, 2, 3), l1.bb, (3, 4), (4, 0, 1, 2)) * 2
-    tmp127 += tmp123.transpose((0, 2, 1, 3))
+    tmp127 += np.transpose(tmp123, (0, 2, 1, 3))
     del tmp123
-    tmp127 += tmp124.transpose((0, 2, 1, 3)) * 4
+    tmp127 += np.transpose(tmp124, (0, 2, 1, 3)) * 4
     del tmp124
-    tmp132 = f.bb.vv.copy()
-    tmp132 += tmp130.transpose((1, 0))
+    tmp132 = np.copy(f.bb.vv)
+    tmp132 += np.transpose(tmp130, (1, 0))
     del tmp130
-    tmp132 += tmp131.transpose((1, 0)) * -1
+    tmp132 += np.transpose(tmp131, (1, 0)) * -1
     del tmp131
-    tmp102 = v.bbbb.ooov.copy() * -1
+    tmp102 = np.copy(v.bbbb.ooov) * -1
     tmp102 += einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.ovvv, (4, 3, 5, 2), (4, 0, 1, 5))
     tmp102 += einsum(t2.bbbb, (0, 1, 2, 3), tmp96, (4, 5, 1, 3), (5, 0, 4, 2)) * 2
     del tmp96
@@ -827,19 +827,19 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp98
     tmp102 += einsum(t1.bb, (0, 1), tmp101, (0, 2, 3, 4), (3, 4, 2, 1))
     del tmp101
-    tmp105 = tmp25.copy()
+    tmp105 = np.copy(tmp25)
     tmp105 += tmp26 * 2
     tmp105 += tmp27
-    tmp121 = l2.bbbb.transpose((2, 3, 0, 1)).copy() * -1
+    tmp121 = np.copy(np.transpose(l2.bbbb, (2, 3, 0, 1))) * -1
     tmp121 += einsum(t1.bb, (0, 1), tmp38, (0, 2, 3, 4), (2, 3, 4, 1)) * -1
-    tmp117 = l2.abab.transpose((2, 3, 0, 1)).copy()
+    tmp117 = np.copy(np.transpose(l2.abab, (2, 3, 0, 1)))
     tmp117 += einsum(t2.aaaa, (0, 1, 2, 3), l2.abab, (3, 4, 1, 5), (0, 5, 2, 4)) * 2
     tmp117 += einsum(tmp49, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3)) * -1
     tmp117 += einsum(l2.bbbb, (0, 1, 2, 3), t2.abab, (4, 3, 5, 1), (4, 2, 5, 0)) * 2
-    tmp103 = tmp30.copy() * 0.5
+    tmp103 = np.copy(tmp30) * 0.5
     tmp103 += tmp31 * 0.5
     tmp103 += tmp32
-    tmp95 = v.aabb.ovoo.transpose((0, 2, 3, 1)).copy()
+    tmp95 = np.copy(np.transpose(v.aabb.ovoo, (0, 2, 3, 1)))
     tmp95 += tmp2
     tmp95 += einsum(t2.abab, (0, 1, 2, 3), v.aabb.vvov, (4, 2, 5, 3), (0, 1, 5, 4))
     tmp95 += einsum(t2.abab, (0, 1, 2, 3), tmp88, (1, 4, 5, 3), (0, 4, 5, 2))
@@ -850,7 +850,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp95 += einsum(t1.aa, (0, 1), tmp94, (2, 3, 1, 4), (0, 3, 2, 4))
     del tmp94
     tmp95 += einsum(tmp16, (0, 1, 2, 3), t1.aa, (0, 4), (1, 3, 2, 4)) * -1
-    tmp56 = l1.aa.transpose((1, 0)).copy() * -1
+    tmp56 = np.copy(np.transpose(l1.aa, (1, 0))) * -1
     tmp56 += t1.aa * -1
     tmp56 += tmp45 * -2
     tmp56 += tmp46 * -1
@@ -858,8 +858,8 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp56 += tmp50
     tmp56 += tmp55
     tmp113 = einsum(v.bbbb.vvvv, (0, 1, 2, 3), t1.bb, (4, 3), (4, 0, 1, 2))
-    tmp112 = f.bb.oo.copy()
-    tmp112 += tmp108.transpose((1, 0))
+    tmp112 = np.copy(f.bb.oo)
+    tmp112 += np.transpose(tmp108, (1, 0))
     del tmp108
     tmp112 += einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (0, 4, 1, 3), (4, 2))
     tmp112 += einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.ovov, (4, 2, 1, 3), (0, 4)) * 2
@@ -870,7 +870,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp119 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 4, 0, 5), (3, 4, 1, 5))
     tmp119 += einsum(l2.bbbb, (0, 1, 2, 3), t2.bbbb, (4, 3, 5, 1), (2, 4, 0, 5)) * 4
     tmp114 = einsum(t1.aa, (0, 1), v.aabb.vvvv, (2, 1, 3, 4), (0, 2, 3, 4))
-    tmp107 = l1.bb.transpose((1, 0)).copy() * -0.5
+    tmp107 = np.copy(np.transpose(l1.bb, (1, 0))) * -0.5
     tmp107 += t1.bb * -0.5
     tmp107 += tmp34 * -0.5
     tmp107 += tmp35 * -1
@@ -878,13 +878,13 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp107 += tmp39
     tmp107 += tmp106
     del tmp106
-    tmp104 = v.bbbb.ovvv.copy()
-    tmp104 += v.bbbb.ovvv.transpose((0, 2, 3, 1)) * -1
+    tmp104 = np.copy(v.bbbb.ovvv)
+    tmp104 += np.transpose(v.bbbb.ovvv, (0, 2, 3, 1)) * -1
     tmp122 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 4, 5, 1), (3, 4, 0, 5))
     tmp122 += einsum(t1.aa, (0, 1), tmp36, (0, 2, 3, 4), (2, 3, 1, 4))
-    tmp128 = tmp68.copy()
-    tmp128 += tmp69.transpose((1, 0, 2, 3))
-    tmp44 = l1.bb.transpose((1, 0)).copy() * -1
+    tmp128 = np.copy(tmp68)
+    tmp128 += np.transpose(tmp69, (1, 0, 2, 3))
+    tmp44 = np.copy(np.transpose(l1.bb, (1, 0))) * -1
     tmp44 += t1.bb * -1
     tmp44 += tmp34 * -1
     del tmp34
@@ -896,9 +896,9 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp39
     tmp44 += einsum(t1.bb, (0, 1), tmp43, (0, 2), (2, 1))
     tmp63 = einsum(v.aabb.vvvv, (0, 1, 2, 3), t1.bb, (4, 3), (4, 0, 1, 2))
-    tmp73 = v.aaaa.ovvv.copy()
+    tmp73 = np.copy(v.aaaa.ovvv)
     tmp73 += einsum(t1.aa, (0, 1), v.aaaa.vvvv, (2, 3, 4, 1), (0, 2, 4, 3)) * -1
-    tmp33 = tmp30.copy()
+    tmp33 = np.copy(tmp30)
     del tmp30
     tmp33 += tmp31
     del tmp31
@@ -906,20 +906,20 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp32
     tmp67 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (4, 3, 5, 1), (5, 0, 4, 2))
     tmp67 += einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 3, 5, 1), (2, 4, 0, 5)) * 0.25
-    tmp28 = tmp25.copy() * 0.5
+    tmp28 = np.copy(tmp25) * 0.5
     del tmp25
     tmp28 += tmp26
     del tmp26
     tmp28 += tmp27 * 0.5
     del tmp27
-    tmp81 = tmp68.copy()
+    tmp81 = np.copy(tmp68)
     del tmp68
-    tmp81 += tmp69.transpose((0, 1, 3, 2))
+    tmp81 += np.transpose(tmp69, (0, 1, 3, 2))
     del tmp69
     tmp80 = einsum(l1.aa, (0, 1), t2.aaaa, (2, 3, 4, 0), (1, 2, 3, 4))
-    tmp80 += tmp76.transpose((0, 2, 1, 3)) * 2
-    tmp80 += tmp77.transpose((0, 2, 1, 3)) * 0.5
-    tmp24 = v.aaaa.ooov.transpose((0, 2, 1, 3)).copy() * 0.5
+    tmp80 += np.transpose(tmp76, (0, 2, 1, 3)) * 2
+    tmp80 += np.transpose(tmp77, (0, 2, 1, 3)) * 0.5
+    tmp24 = np.copy(np.transpose(v.aaaa.ooov, (0, 2, 1, 3))) * 0.5
     tmp24 += einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovvv, (4, 2, 5, 3), (4, 0, 1, 5)) * -0.5
     tmp24 += einsum(t2.aaaa, (0, 1, 2, 3), tmp18, (4, 5, 1, 3), (5, 0, 4, 2))
     del tmp18
@@ -931,11 +931,11 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp24 += einsum(tmp23, (0, 1, 2, 3), t1.aa, (0, 4), (2, 1, 3, 4)) * -0.5
     del tmp23
     tmp74 = einsum(t1.aa, (0, 1), tmp47, (2, 0, 3, 4), (2, 3, 4, 1))
-    tmp66 = l2.abab.transpose((2, 3, 0, 1)).copy()
+    tmp66 = np.copy(np.transpose(l2.abab, (2, 3, 0, 1)))
     tmp66 += einsum(t2.abab, (0, 1, 2, 3), l2.aaaa, (4, 2, 5, 0), (5, 1, 4, 3)) * 2
     tmp66 += einsum(l2.abab, (0, 1, 2, 3), t2.bbbb, (4, 3, 5, 1), (2, 4, 0, 5)) * 2
     tmp66 += einsum(t1.bb, (0, 1), tmp36, (2, 0, 3, 4), (2, 3, 4, 1)) * -1
-    tmp82 = t1.aa.copy() * -1
+    tmp82 = np.copy(t1.aa) * -1
     tmp82 += tmp45 * -2
     del tmp45
     tmp82 += tmp46 * -1
@@ -946,12 +946,12 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp50
     tmp82 += tmp55
     del tmp55
-    tmp57 = tmp51.copy()
+    tmp57 = np.copy(tmp51)
     tmp57 += tmp52 * 2
     del tmp52
     tmp57 += tmp53
     del tmp53
-    tmp17 = v.aabb.ooov.copy()
+    tmp17 = np.copy(v.aabb.ooov)
     tmp17 += einsum(v.aabb.oovv, (0, 1, 2, 3), t1.bb, (4, 3), (0, 1, 4, 2))
     tmp17 += einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovvv, (4, 2, 5, 3), (0, 4, 1, 5))
     tmp17 += einsum(t2.abab, (0, 1, 2, 3), tmp1, (0, 4, 5, 2), (4, 5, 1, 3))
@@ -964,17 +964,17 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp17 += einsum(t1.aa, (0, 1), tmp11, (2, 3, 1, 4), (0, 2, 3, 4))
     tmp17 += einsum(t1.bb, (0, 1), tmp16, (2, 3, 0, 4), (3, 2, 4, 1)) * -1
     del tmp16
-    tmp79 = tmp47.transpose((1, 0, 2, 3)).copy() * -1
-    tmp79 += tmp76.transpose((2, 0, 1, 3)) * 2
+    tmp79 = np.copy(np.transpose(tmp47, (1, 0, 2, 3))) * -1
+    tmp79 += np.transpose(tmp76, (2, 0, 1, 3)) * 2
     del tmp76
-    tmp79 += tmp77.transpose((2, 0, 1, 3)) * 0.5
+    tmp79 += np.transpose(tmp77, (2, 0, 1, 3)) * 0.5
     del tmp77
     tmp79 += einsum(t1.aa, (0, 1), tmp78, (0, 2, 3, 4), (4, 2, 3, 1))
     del tmp78
     tmp72 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 3, 0, 5), (2, 4, 1, 5))
     tmp72 += einsum(tmp49, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 4, 3))
-    tmp62 = f.aa.oo.copy()
-    tmp62 += tmp58.transpose((1, 0))
+    tmp62 = np.copy(f.aa.oo)
+    tmp62 += np.transpose(tmp58, (1, 0))
     del tmp58
     tmp62 += einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 2, 1, 3), (0, 4)) * 2
     tmp62 += einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (4, 2, 1, 3), (0, 4))
@@ -982,8 +982,8 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp60
     tmp62 += tmp61
     del tmp61
-    tmp75 = v.aaaa.ovvv.copy() * -1
-    tmp75 += v.aaaa.ovvv.transpose((0, 2, 3, 1))
+    tmp75 = np.copy(v.aaaa.ovvv) * -1
+    tmp75 += np.transpose(v.aaaa.ovvv, (0, 2, 3, 1))
     tmp71 = einsum(l1.aa, (0, 1), t2.abab, (2, 3, 0, 4), (1, 2, 3, 4))
     tmp71 += tmp49
     tmp71 += einsum(tmp47, (0, 1, 2, 3), t2.abab, (1, 4, 3, 5), (0, 2, 4, 5)) * -2
@@ -991,16 +991,16 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp71 += einsum(tmp36, (0, 1, 2, 3), t2.abab, (4, 1, 3, 5), (0, 4, 2, 5)) * -1
     tmp71 += einsum(t1.bb, (0, 1), tmp70, (2, 3, 0, 4), (2, 3, 4, 1)) * -1
     del tmp70
-    l2new.bbbb = v.bbbb.ovov.transpose((1, 3, 0, 2)).copy()
+    l2new.bbbb = np.copy(np.transpose(v.bbbb.ovov, (1, 3, 0, 2)))
     l2new.bbbb += einsum(tmp195, (0, 1, 2, 3), l1.bb, (4, 0), (3, 4, 2, 1)) * -1
     del tmp195
-    l2new.bbbb += v.bbbb.ovov.transpose((3, 1, 0, 2)) * -1
-    l2new.bbbb += tmp197.transpose((3, 2, 0, 1))
-    l2new.bbbb += tmp198.transpose((3, 2, 0, 1)) * 2
-    l2new.bbbb += tmp199.transpose((3, 2, 0, 1))
-    l2new.bbbb += tmp200.transpose((3, 2, 0, 1)) * 2
-    l2new.bbbb += tmp201.transpose((2, 3, 0, 1)) * -1
-    l2new.bbbb += tmp202.transpose((3, 2, 0, 1))
+    l2new.bbbb += np.transpose(v.bbbb.ovov, (3, 1, 0, 2)) * -1
+    l2new.bbbb += np.transpose(tmp197, (3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp198, (3, 2, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp199, (3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp200, (3, 2, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp201, (2, 3, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp202, (3, 2, 0, 1))
     l2new.bbbb += einsum(l2.bbbb, (0, 1, 2, 3), tmp204, (3, 4, 5, 1), (5, 0, 2, 4)) * -2
     del tmp204
     l2new.bbbb += einsum(l2.abab, (0, 1, 2, 3), tmp205, (2, 4, 0, 5), (5, 1, 3, 4)) * -1
@@ -1008,83 +1008,83 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.bbbb += einsum(l2.bbbb, (0, 1, 2, 3), tmp183, (3, 4), (0, 1, 2, 4)) * -2
     l2new.bbbb += einsum(tmp206, (0, 1), l1.bb, (2, 3), (1, 2, 3, 0)) * -1
     del tmp206
-    l2new.bbbb += tmp198.transpose((3, 2, 1, 0)) * -2
-    l2new.bbbb += tmp199.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += tmp200.transpose((3, 2, 1, 0)) * -2
-    l2new.bbbb += tmp201.transpose((2, 3, 1, 0))
-    l2new.bbbb += tmp202.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += tmp210.transpose((2, 3, 0, 1)) * 2
-    l2new.bbbb += tmp211.transpose((2, 3, 0, 1))
+    l2new.bbbb += np.transpose(tmp198, (3, 2, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp199, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp200, (3, 2, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp201, (2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp202, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp210, (2, 3, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp211, (2, 3, 0, 1))
     l2new.bbbb += einsum(l2.bbbb, (0, 1, 2, 3), tmp213, (3, 4), (0, 1, 4, 2)) * 2
     del tmp213
     l2new.bbbb += einsum(tmp181, (0, 1), l1.bb, (2, 3), (1, 2, 0, 3))
-    l2new.bbbb += tmp198.transpose((2, 3, 0, 1)) * -2
-    l2new.bbbb += tmp199.transpose((2, 3, 0, 1)) * -1
-    l2new.bbbb += tmp200.transpose((2, 3, 0, 1)) * -2
-    l2new.bbbb += tmp201.transpose((3, 2, 0, 1))
-    l2new.bbbb += tmp202.transpose((2, 3, 0, 1)) * -1
-    l2new.bbbb += tmp210.transpose((3, 2, 1, 0)) * 2
-    l2new.bbbb += tmp211.transpose((3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp198, (2, 3, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp199, (2, 3, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp200, (2, 3, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp201, (3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp202, (2, 3, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp210, (3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp211, (3, 2, 1, 0))
     l2new.bbbb += einsum(tmp181, (0, 1), l1.bb, (2, 3), (2, 1, 3, 0))
-    l2new.bbbb += tmp198.transpose((2, 3, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp198, (2, 3, 1, 0)) * 2
     del tmp198
-    l2new.bbbb += tmp199.transpose((2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp199, (2, 3, 1, 0))
     del tmp199
-    l2new.bbbb += tmp200.transpose((2, 3, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp200, (2, 3, 1, 0)) * 2
     del tmp200
-    l2new.bbbb += tmp201.transpose((3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp201, (3, 2, 1, 0)) * -1
     del tmp201
-    l2new.bbbb += tmp202.transpose((2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp202, (2, 3, 1, 0))
     del tmp202
-    l2new.bbbb += tmp210.transpose((3, 2, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp210, (3, 2, 0, 1)) * -2
     del tmp210
-    l2new.bbbb += tmp211.transpose((3, 2, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp211, (3, 2, 0, 1)) * -1
     del tmp211
     l2new.bbbb += einsum(tmp181, (0, 1), l1.bb, (2, 3), (2, 1, 0, 3)) * -1
-    l2new.bbbb += tmp214.transpose((3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp214, (3, 2, 1, 0)) * 2
     del tmp214
-    l2new.bbbb += tmp215.transpose((3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp215, (3, 2, 1, 0)) * 2
     del tmp215
-    l2new.bbbb += tmp216.transpose((2, 3, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp216, (2, 3, 1, 0)) * 2
     l2new.bbbb += einsum(l2.bbbb, (0, 1, 2, 3), tmp217, (4, 1), (4, 0, 2, 3)) * -1
     del tmp217
-    l2new.bbbb += tmp218.transpose((2, 3, 1, 0)) * -2
-    l2new.bbbb += tmp220.transpose((2, 3, 1, 0)) * -1
-    l2new.bbbb += tmp216.transpose((3, 2, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp218, (2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp220, (2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp216, (3, 2, 1, 0)) * -2
     del tmp216
-    l2new.bbbb += tmp220.transpose((3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp220, (3, 2, 1, 0)) * 2
     del tmp220
-    l2new.bbbb += tmp218.transpose((3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp218, (3, 2, 1, 0)) * 2
     del tmp218
-    l2new.bbbb += tmp221.transpose((2, 3, 0, 1)) * -2
-    l2new.bbbb += tmp221.transpose((2, 3, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp221, (2, 3, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp221, (2, 3, 1, 0)) * 2
     del tmp221
     l2new.bbbb += einsum(l2.bbbb, (0, 1, 2, 3), tmp222, (2, 4, 5, 3), (0, 1, 5, 4)) * -2
     del tmp222
     l2new.bbbb += einsum(tmp223, (0, 1, 2, 3), l1.bb, (4, 0), (3, 4, 1, 2))
     del tmp223
-    l2new.bbbb += tmp197.transpose((3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp197, (3, 2, 1, 0)) * -1
     del tmp197
     l2new.bbbb += einsum(tmp194, (0, 1), l1.bb, (2, 3), (1, 2, 3, 0))
-    l2new.bbbb += tmp224.transpose((3, 2, 0, 1)) * -1
-    l2new.bbbb += tmp225.transpose((3, 2, 0, 1)) * -2
-    l2new.bbbb += tmp226.transpose((3, 2, 0, 1)) * -2
-    l2new.bbbb += tmp224.transpose((2, 3, 0, 1))
+    l2new.bbbb += np.transpose(tmp224, (3, 2, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp225, (3, 2, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp226, (3, 2, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp224, (2, 3, 0, 1))
     l2new.bbbb += einsum(tmp194, (0, 1), l1.bb, (2, 3), (2, 1, 3, 0)) * -1
-    l2new.bbbb += tmp225.transpose((2, 3, 0, 1)) * 2
-    l2new.bbbb += tmp226.transpose((2, 3, 0, 1)) * 2
-    l2new.bbbb += tmp224.transpose((3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp225, (2, 3, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp226, (2, 3, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp224, (3, 2, 1, 0))
     l2new.bbbb += einsum(tmp194, (0, 1), l1.bb, (2, 3), (1, 2, 0, 3)) * -1
-    l2new.bbbb += tmp225.transpose((3, 2, 1, 0)) * 2
-    l2new.bbbb += tmp226.transpose((3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp225, (3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp226, (3, 2, 1, 0)) * 2
     l2new.bbbb += einsum(tmp194, (0, 1), l1.bb, (2, 3), (2, 1, 0, 3))
-    l2new.bbbb += tmp224.transpose((2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp224, (2, 3, 1, 0)) * -1
     del tmp224
-    l2new.bbbb += tmp225.transpose((2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp225, (2, 3, 1, 0)) * -2
     del tmp225
-    l2new.bbbb += tmp226.transpose((2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp226, (2, 3, 1, 0)) * -2
     del tmp226
-    l2new.abab = v.aabb.ovov.transpose((1, 3, 0, 2)).copy()
+    l2new.abab = np.copy(np.transpose(v.aabb.ovov, (1, 3, 0, 2)))
     l2new.abab += einsum(tmp14, (0, 1, 2, 3), l1.bb, (4, 1), (3, 4, 0, 2)) * -1
     l2new.abab += einsum(tmp38, (0, 1, 2, 3), tmp2, (4, 1, 2, 5), (5, 3, 4, 0)) * -2
     del tmp2
@@ -1115,9 +1115,9 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.abab += einsum(l2.abab, (0, 1, 2, 3), tmp183, (3, 4), (0, 1, 2, 4)) * -1
     del tmp183
     l2new.abab += einsum(tmp49, (0, 1, 2, 3), v.aabb.ovvv, (1, 4, 5, 3), (4, 5, 0, 2)) * -1
-    l2new.abab += tmp184.transpose((2, 3, 0, 1))
+    l2new.abab += np.transpose(tmp184, (2, 3, 0, 1))
     del tmp184
-    l2new.abab += tmp185.transpose((2, 3, 0, 1))
+    l2new.abab += np.transpose(tmp185, (2, 3, 0, 1))
     del tmp185
     l2new.abab += einsum(tmp86, (0, 1), l2.abab, (0, 2, 3, 4), (1, 2, 3, 4))
     l2new.abab += einsum(tmp49, (0, 1, 2, 3), tmp155, (1, 4), (4, 3, 0, 2)) * -1
@@ -1149,16 +1149,16 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.abab += einsum(v.bbbb.ooov, (0, 1, 2, 3), tmp36, (4, 1, 2, 5), (5, 3, 4, 0))
     l2new.abab += einsum(tmp36, (0, 1, 2, 3), tmp87, (1, 2, 4, 5), (3, 5, 0, 4))
     del tmp87
-    l2new.aaaa = v.aaaa.ovov.transpose((1, 3, 0, 2)).copy()
+    l2new.aaaa = np.copy(np.transpose(v.aaaa.ovov, (1, 3, 0, 2)))
     l2new.aaaa += einsum(tmp133, (0, 1, 2, 3), l1.aa, (4, 0), (3, 4, 2, 1)) * -1
     del tmp133
-    l2new.aaaa += v.aaaa.ovov.transpose((3, 1, 0, 2)) * -1
-    l2new.aaaa += tmp135.transpose((3, 2, 0, 1))
-    l2new.aaaa += tmp136.transpose((3, 2, 0, 1)) * 2
-    l2new.aaaa += tmp137.transpose((2, 3, 0, 1)) * -1
-    l2new.aaaa += tmp138.transpose((3, 2, 0, 1))
-    l2new.aaaa += tmp139.transpose((3, 2, 0, 1))
-    l2new.aaaa += tmp140.transpose((3, 2, 0, 1)) * 2
+    l2new.aaaa += np.transpose(v.aaaa.ovov, (3, 1, 0, 2)) * -1
+    l2new.aaaa += np.transpose(tmp135, (3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp136, (3, 2, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp137, (2, 3, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp138, (3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp139, (3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp140, (3, 2, 0, 1)) * 2
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp141, (3, 4, 5, 1), (5, 0, 2, 4)) * -2
     del tmp141
     l2new.aaaa += einsum(tmp11, (0, 1, 2, 3), l2.abab, (4, 3, 5, 1), (2, 4, 5, 0)) * -1
@@ -1167,85 +1167,85 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp142
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp144, (2, 3), (3, 0, 1, 2)) * -1
     del tmp144
-    l2new.aaaa += tmp136.transpose((3, 2, 1, 0)) * -2
-    l2new.aaaa += tmp137.transpose((2, 3, 1, 0))
-    l2new.aaaa += tmp138.transpose((3, 2, 1, 0)) * -1
-    l2new.aaaa += tmp139.transpose((3, 2, 1, 0)) * -1
-    l2new.aaaa += tmp140.transpose((3, 2, 1, 0)) * -2
-    l2new.aaaa += tmp148.transpose((2, 3, 0, 1)) * 2
-    l2new.aaaa += tmp150.transpose((2, 3, 0, 1))
+    l2new.aaaa += np.transpose(tmp136, (3, 2, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp137, (2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp138, (3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp139, (3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp140, (3, 2, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp148, (2, 3, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp150, (2, 3, 0, 1))
     l2new.aaaa += einsum(tmp157, (0, 1), l2.aaaa, (2, 3, 4, 0), (2, 3, 1, 4)) * 2
     del tmp157
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp158, (2, 3), (3, 0, 2, 1))
-    l2new.aaaa += tmp136.transpose((2, 3, 0, 1)) * -2
-    l2new.aaaa += tmp137.transpose((3, 2, 0, 1))
-    l2new.aaaa += tmp138.transpose((2, 3, 0, 1)) * -1
-    l2new.aaaa += tmp139.transpose((2, 3, 0, 1)) * -1
-    l2new.aaaa += tmp140.transpose((2, 3, 0, 1)) * -2
-    l2new.aaaa += tmp148.transpose((3, 2, 1, 0)) * 2
-    l2new.aaaa += tmp150.transpose((3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp136, (2, 3, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp137, (3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp138, (2, 3, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp139, (2, 3, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp140, (2, 3, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp148, (3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp150, (3, 2, 1, 0))
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp158, (2, 3), (0, 3, 1, 2))
-    l2new.aaaa += tmp136.transpose((2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp136, (2, 3, 1, 0)) * 2
     del tmp136
-    l2new.aaaa += tmp137.transpose((3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp137, (3, 2, 1, 0)) * -1
     del tmp137
-    l2new.aaaa += tmp138.transpose((2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp138, (2, 3, 1, 0))
     del tmp138
-    l2new.aaaa += tmp139.transpose((2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp139, (2, 3, 1, 0))
     del tmp139
-    l2new.aaaa += tmp140.transpose((2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp140, (2, 3, 1, 0)) * 2
     del tmp140
-    l2new.aaaa += tmp148.transpose((3, 2, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp148, (3, 2, 0, 1)) * -2
     del tmp148
-    l2new.aaaa += tmp150.transpose((3, 2, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp150, (3, 2, 0, 1)) * -1
     del tmp150
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp158, (2, 3), (0, 3, 2, 1)) * -1
     del tmp158
-    l2new.aaaa += tmp159.transpose((3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp159, (3, 2, 1, 0)) * 2
     del tmp159
-    l2new.aaaa += tmp160.transpose((3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp160, (3, 2, 1, 0)) * 2
     del tmp160
-    l2new.aaaa += tmp161.transpose((2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp161, (2, 3, 1, 0)) * 2
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp162, (4, 1), (4, 0, 2, 3)) * -1
     del tmp162
-    l2new.aaaa += tmp163.transpose((2, 3, 1, 0)) * -2
-    l2new.aaaa += tmp167.transpose((2, 3, 1, 0)) * -1
-    l2new.aaaa += tmp161.transpose((3, 2, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp163, (2, 3, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp167, (2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp161, (3, 2, 1, 0)) * -2
     del tmp161
-    l2new.aaaa += tmp167.transpose((3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp167, (3, 2, 1, 0)) * 2
     del tmp167
-    l2new.aaaa += tmp163.transpose((3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp163, (3, 2, 1, 0)) * 2
     del tmp163
-    l2new.aaaa += tmp168.transpose((2, 3, 0, 1)) * -2
-    l2new.aaaa += tmp168.transpose((2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp168, (2, 3, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp168, (2, 3, 1, 0)) * 2
     del tmp168
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp169, (2, 4, 3, 5), (0, 1, 4, 5)) * 2
     del tmp169
     l2new.aaaa += einsum(tmp170, (0, 1, 2, 3), l1.aa, (4, 0), (3, 4, 1, 2))
     del tmp170
-    l2new.aaaa += tmp135.transpose((3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp135, (3, 2, 1, 0)) * -1
     del tmp135
     l2new.aaaa += einsum(tmp171, (0, 1), l1.aa, (2, 3), (1, 2, 3, 0))
-    l2new.aaaa += tmp172.transpose((3, 2, 0, 1)) * -1
-    l2new.aaaa += tmp173.transpose((3, 2, 0, 1)) * -2
-    l2new.aaaa += tmp174.transpose((3, 2, 0, 1)) * -2
-    l2new.aaaa += tmp172.transpose((2, 3, 0, 1))
+    l2new.aaaa += np.transpose(tmp172, (3, 2, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp173, (3, 2, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp174, (3, 2, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp172, (2, 3, 0, 1))
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp171, (2, 3), (0, 3, 1, 2)) * -1
-    l2new.aaaa += tmp173.transpose((2, 3, 0, 1)) * 2
-    l2new.aaaa += tmp174.transpose((2, 3, 0, 1)) * 2
-    l2new.aaaa += tmp172.transpose((3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp173, (2, 3, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp174, (2, 3, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp172, (3, 2, 1, 0))
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp171, (2, 3), (3, 0, 2, 1)) * -1
-    l2new.aaaa += tmp173.transpose((3, 2, 1, 0)) * 2
-    l2new.aaaa += tmp174.transpose((3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp173, (3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp174, (3, 2, 1, 0)) * 2
     l2new.aaaa += einsum(tmp171, (0, 1), l1.aa, (2, 3), (2, 1, 0, 3))
     del tmp171
-    l2new.aaaa += tmp172.transpose((2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp172, (2, 3, 1, 0)) * -1
     del tmp172
-    l2new.aaaa += tmp173.transpose((2, 3, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp173, (2, 3, 1, 0)) * -2
     del tmp173
-    l2new.aaaa += tmp174.transpose((2, 3, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp174, (2, 3, 1, 0)) * -2
     del tmp174
-    l1new.bb = f.bb.ov.transpose((1, 0)).copy()
+    l1new.bb = np.copy(np.transpose(f.bb.ov, (1, 0)))
     l1new.bb += einsum(v.bbbb.oovv, (0, 1, 2, 3), l1.bb, (3, 1), (2, 0)) * -1
     l1new.bb += einsum(l2.abab, (0, 1, 2, 3), tmp95, (2, 3, 4, 0), (1, 4)) * -1
     del tmp95
@@ -1300,7 +1300,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp132
     l1new.bb += einsum(tmp92, (0, 1), tmp43, (2, 0), (1, 2)) * -1
     del tmp92
-    l1new.aa = f.aa.ov.transpose((1, 0)).copy()
+    l1new.aa = np.copy(np.transpose(f.aa.ov, (1, 0)))
     l1new.aa += einsum(l1.aa, (0, 1), v.aaaa.oovv, (2, 1, 3, 0), (3, 2)) * -1
     l1new.aa += einsum(l2.abab, (0, 1, 2, 3), tmp17, (2, 4, 3, 1), (0, 4)) * -1
     del tmp17
@@ -1392,13 +1392,13 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp0 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 3, 0, 1), (2, 4))
     tmp1 = einsum(l1.aa, (0, 1), t1.aa, (2, 0), (1, 2))
     tmp9 = einsum(t1.bb, (0, 1), l2.abab, (2, 1, 3, 4), (3, 4, 0, 2))
-    tmp11 = tmp3.copy() * 0.5
+    tmp11 = np.copy(tmp3) * 0.5
     tmp11 += tmp5 * 0.5
     tmp11 += tmp4
     tmp10 = einsum(l2.bbbb, (0, 1, 2, 3), t1.bb, (4, 1), (2, 3, 4, 0))
     tmp6 = einsum(t1.aa, (0, 1), l2.aaaa, (2, 1, 3, 4), (3, 4, 0, 2))
     tmp7 = einsum(l2.abab, (0, 1, 2, 3), t1.aa, (4, 0), (2, 4, 3, 1))
-    tmp8 = tmp1.copy()
+    tmp8 = np.copy(tmp1)
     tmp8 += tmp2 * 2
     tmp8 += tmp0
     rdm1.bb.vv = einsum(t1.bb, (0, 1), l1.bb, (2, 0), (2, 1))
@@ -1407,8 +1407,8 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm1.aa.vv = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (4, 3, 0, 1), (4, 2)) * 2
     rdm1.aa.vv += einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 3, 4, 1), (0, 4))
     rdm1.aa.vv += einsum(l1.aa, (0, 1), t1.aa, (1, 2), (0, 2))
-    rdm1.bb.vo = l1.bb.copy()
-    rdm1.aa.vo = l1.aa.copy()
+    rdm1.bb.vo = np.copy(l1.bb)
+    rdm1.aa.vo = np.copy(l1.aa)
     rdm1.bb.ov = einsum(t2.bbbb, (0, 1, 2, 3), l1.bb, (3, 1), (0, 2)) * 2
     rdm1.bb.ov += einsum(l1.aa, (0, 1), t2.abab, (1, 2, 0, 3), (2, 3))
     rdm1.bb.ov += t1.bb
@@ -1418,7 +1418,7 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp10
     rdm1.bb.ov += einsum(t1.bb, (0, 1), tmp11, (0, 2), (2, 1)) * -2
     del tmp11
-    rdm1.aa.ov = t1.aa.copy()
+    rdm1.aa.ov = np.copy(t1.aa)
     rdm1.aa.ov += einsum(l1.aa, (0, 1), t2.aaaa, (2, 1, 3, 0), (2, 3)) * 2
     rdm1.aa.ov += einsum(t2.abab, (0, 1, 2, 3), l1.bb, (3, 1), (0, 2))
     rdm1.aa.ov += einsum(t2.aaaa, (0, 1, 2, 3), tmp6, (1, 0, 4, 3), (4, 2)) * -2
@@ -1427,20 +1427,20 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp7
     rdm1.aa.ov += einsum(tmp8, (0, 1), t1.aa, (0, 2), (1, 2)) * -1
     del tmp8
-    rdm1.bb.oo = tmp3.transpose((1, 0)).copy() * -1
+    rdm1.bb.oo = np.copy(np.transpose(tmp3, (1, 0))) * -1
     del tmp3
     rdm1.bb.oo += delta.bb.oo
-    rdm1.bb.oo += tmp4.transpose((1, 0)) * -2
+    rdm1.bb.oo += np.transpose(tmp4, (1, 0)) * -2
     del tmp4
-    rdm1.bb.oo += tmp5.transpose((1, 0)) * -1
+    rdm1.bb.oo += np.transpose(tmp5, (1, 0)) * -1
     del tmp5
-    rdm1.aa.oo = tmp0.transpose((1, 0)).copy() * -1
+    rdm1.aa.oo = np.copy(np.transpose(tmp0, (1, 0))) * -1
     del tmp0
-    rdm1.aa.oo += tmp1.transpose((1, 0)) * -1
+    rdm1.aa.oo += np.transpose(tmp1, (1, 0)) * -1
     del tmp1
     rdm1.aa.oo += delta.aa.oo
     del delta
-    rdm1.aa.oo += tmp2.transpose((1, 0)) * -2
+    rdm1.aa.oo += np.transpose(tmp2, (1, 0)) * -2
     del tmp2
     rdm1.aa = np.block([[rdm1.aa.oo, rdm1.aa.ov], [rdm1.aa.vo, rdm1.aa.vv]])
     rdm1.bb = np.block([[rdm1.bb.oo, rdm1.bb.ov], [rdm1.bb.vo, rdm1.bb.vv]])
@@ -1490,7 +1490,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp90 = einsum(l2.bbbb, (0, 1, 2, 3), t2.bbbb, (4, 3, 5, 1), (2, 4, 0, 5))
     tmp66 = einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (4, 3, 5, 1), (2, 4, 0, 5))
     tmp83 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 3, 5, 1), (2, 4, 0, 5))
-    tmp40 = tmp8.copy()
+    tmp40 = np.copy(tmp8)
     tmp40 += tmp9
     tmp40 += tmp10 * 2
     tmp52 = einsum(t2.bbbb, (0, 1, 2, 3), tmp17, (4, 1, 5, 3), (4, 5, 0, 2)) * -1
@@ -1505,20 +1505,20 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp7 = einsum(tmp6, (0, 1, 2, 3), t1.aa, (4, 3), (0, 1, 4, 2))
     tmp31 = einsum(tmp25, (0, 1, 2, 3), t2.abab, (4, 2, 5, 3), (0, 1, 4, 5))
     tmp30 = einsum(tmp6, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (0, 2, 4, 5)) * -1
-    tmp27 = tmp0.copy() * 0.5
+    tmp27 = np.copy(tmp0) * 0.5
     tmp27 += tmp1
     tmp27 += tmp2 * 0.5
     tmp109 = einsum(t1.bb, (0, 1), tmp17, (2, 0, 3, 4), (2, 3, 4, 1))
     tmp80 = einsum(t2.bbbb, (0, 1, 2, 3), l2.bbbb, (4, 3, 0, 1), (4, 2))
     tmp107 = einsum(t1.bb, (0, 1), l1.bb, (2, 0), (2, 1))
     tmp79 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 3, 0, 4), (1, 4))
-    tmp123 = tmp94.copy()
+    tmp123 = np.copy(tmp94)
     tmp123 += tmp90 * 4
     tmp104 = einsum(l1.aa, (0, 1), t1.aa, (1, 2), (0, 2))
     tmp92 = einsum(t2.abab, (0, 1, 2, 3), l2.aaaa, (4, 2, 5, 0), (5, 1, 4, 3))
     tmp112 = einsum(l2.abab, (0, 1, 2, 3), t2.bbbb, (4, 3, 5, 1), (2, 4, 0, 5))
     tmp106 = einsum(t1.aa, (0, 1), tmp6, (2, 0, 3, 4), (2, 3, 4, 1))
-    tmp84 = tmp66.copy() * 4
+    tmp84 = np.copy(tmp66) * 4
     tmp84 += tmp83
     tmp70 = einsum(t2.aaaa, (0, 1, 2, 3), l2.abab, (3, 4, 1, 5), (0, 5, 2, 4))
     tmp68 = einsum(l2.bbbb, (0, 1, 2, 3), t2.abab, (4, 3, 5, 1), (4, 2, 5, 0))
@@ -1528,14 +1528,14 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp39 = einsum(tmp17, (0, 1, 2, 3), t2.bbbb, (1, 0, 4, 3), (2, 4))
     tmp41 = einsum(t1.bb, (0, 1), tmp40, (0, 2), (2, 1))
     tmp50 = einsum(t1.bb, (0, 1), tmp40, (0, 2), (2, 1)) * 0.5
-    tmp102 = tmp53.copy()
+    tmp102 = np.copy(tmp53)
     tmp102 += tmp52 * 4
-    tmp54 = tmp16.transpose((1, 0, 3, 2)).copy()
-    tmp54 += tmp18.transpose((0, 1, 3, 2)) * -1
+    tmp54 = np.copy(np.transpose(tmp16, (1, 0, 3, 2)))
+    tmp54 += np.transpose(tmp18, (0, 1, 3, 2)) * -1
     tmp49 = einsum(t2.bbbb, (0, 1, 2, 3), l1.bb, (3, 4), (4, 0, 1, 2))
     tmp26 = einsum(t2.abab, (0, 1, 2, 3), tmp25, (0, 4, 1, 3), (4, 2))
     tmp24 = einsum(t2.aaaa, (0, 1, 2, 3), tmp6, (1, 0, 4, 3), (4, 2))
-    tmp45 = tmp12.copy()
+    tmp45 = np.copy(tmp12)
     tmp45 += tmp14
     tmp59 = einsum(tmp13, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 3), (4, 1, 2, 5))
     tmp58 = einsum(t2.abab, (0, 1, 2, 3), tmp17, (4, 1, 5, 3), (0, 4, 5, 2)) * -1
@@ -1543,12 +1543,12 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp19 = einsum(l1.aa, (0, 1), t2.aaaa, (2, 1, 3, 0), (2, 3))
     tmp44 = einsum(t2.bbbb, (0, 1, 2, 3), tmp25, (4, 5, 1, 3), (4, 5, 0, 2))
     tmp43 = einsum(tmp6, (0, 1, 2, 3), t2.abab, (1, 4, 3, 5), (0, 2, 4, 5)) * -1
-    tmp64 = tmp62.copy() * 2
+    tmp64 = np.copy(tmp62) * 2
     tmp64 += tmp63
-    tmp32 = tmp5.transpose((1, 0, 3, 2)).copy()
-    tmp32 += tmp7.transpose((0, 1, 3, 2)) * -1
+    tmp32 = np.copy(np.transpose(tmp5, (1, 0, 3, 2)))
+    tmp32 += np.transpose(tmp7, (0, 1, 3, 2)) * -1
     tmp23 = einsum(l1.aa, (0, 1), t2.aaaa, (2, 3, 4, 0), (1, 2, 3, 4))
-    tmp77 = tmp30.copy() * 4
+    tmp77 = np.copy(tmp30) * 4
     tmp77 += tmp31
     tmp28 = einsum(tmp27, (0, 1), t1.aa, (0, 2), (1, 2)) * 2
     tmp130 = einsum(l2.bbbb, (0, 1, 2, 3), t1.bb, (3, 4), (2, 0, 1, 4))
@@ -1558,49 +1558,49 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp128 = einsum(t1.aa, (0, 1), l2.aaaa, (2, 3, 4, 0), (4, 2, 3, 1))
     tmp126 = einsum(tmp109, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 3, 4)) * -1
     tmp120 = einsum(l1.bb, (0, 1), t2.bbbb, (2, 1, 3, 4), (2, 0, 3, 4))
-    tmp108 = tmp107.copy()
+    tmp108 = np.copy(tmp107)
     tmp108 += tmp79
     tmp108 += tmp80 * 2
     tmp125 = einsum(t2.bbbb, (0, 1, 2, 3), tmp17, (1, 0, 4, 5), (4, 5, 2, 3)) * -1
     tmp124 = einsum(t1.bb, (0, 1), tmp123, (0, 2, 3, 4), (2, 1, 3, 4))
     del tmp123
-    tmp105 = tmp104.copy()
+    tmp105 = np.copy(tmp104)
     tmp105 += tmp62 * 2
     tmp105 += tmp63
     tmp114 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 4, 5, 1), (3, 4, 0, 5))
-    tmp127 = tmp92.copy()
+    tmp127 = np.copy(tmp92)
     tmp127 += tmp112
     tmp113 = einsum(t1.bb, (0, 1), tmp13, (2, 0, 3, 4), (2, 3, 4, 1))
     tmp115 = einsum(l1.aa, (0, 1), t2.aaaa, (2, 1, 3, 4), (2, 0, 3, 4))
     tmp119 = einsum(t1.aa, (0, 1), tmp106, (0, 2, 3, 4), (2, 3, 4, 1)) * -1
     tmp117 = einsum(tmp84, (0, 1, 2, 3), t1.aa, (0, 4), (1, 4, 2, 3))
     tmp118 = einsum(t2.aaaa, (0, 1, 2, 3), tmp6, (1, 0, 4, 5), (4, 5, 2, 3)) * -1
-    tmp122 = tmp94.copy() * 0.25
+    tmp122 = np.copy(tmp94) * 0.25
     tmp122 += tmp90
-    tmp121 = tmp107.copy() * 0.5
+    tmp121 = np.copy(tmp107) * 0.5
     del tmp107
     tmp121 += tmp79 * 0.5
     tmp121 += tmp80
     tmp111 = einsum(t1.aa, (0, 1), tmp25, (0, 2, 3, 4), (2, 3, 1, 4))
-    tmp82 = tmp70.copy()
+    tmp82 = np.copy(tmp70)
     tmp82 += tmp68
     tmp86 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 3, 0, 5), (2, 4, 1, 5))
-    tmp116 = tmp66.copy() * 4
+    tmp116 = np.copy(tmp66) * 4
     tmp116 += tmp83
-    tmp110 = tmp104.copy() * 0.5
+    tmp110 = np.copy(tmp104) * 0.5
     del tmp104
     tmp110 += tmp62
     tmp110 += tmp63 * 0.5
     tmp93 = einsum(t2.abab, (0, 1, 2, 3), tmp92, (0, 4, 2, 5), (4, 1, 5, 3))
-    tmp36 = t1.bb.copy()
+    tmp36 = np.copy(t1.bb)
     tmp36 += tmp34
     tmp36 += tmp35 * 2
-    tmp42 = tmp38.copy()
+    tmp42 = np.copy(tmp38)
     tmp42 += tmp39 * 2
     tmp42 += tmp41
     del tmp41
     tmp95 = einsum(t2.bbbb, (0, 1, 2, 3), tmp94, (1, 4, 3, 5), (4, 0, 5, 2))
-    tmp51 = tmp38.copy() * 0.5
+    tmp51 = np.copy(tmp38) * 0.5
     del tmp38
     tmp51 += tmp39
     del tmp39
@@ -1610,43 +1610,43 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp102
     tmp100 = einsum(t2.bbbb, (0, 1, 2, 3), tmp54, (0, 1, 4, 5), (4, 5, 2, 3))
     tmp97 = einsum(t1.bb, (0, 1), tmp49, (0, 2, 3, 4), (2, 3, 1, 4))
-    tmp61 = t1.bb.copy() * 0.5
+    tmp61 = np.copy(t1.bb) * 0.5
     tmp61 += tmp34 * 0.5
     tmp61 += tmp35
     tmp91 = einsum(t2.bbbb, (0, 1, 2, 3), tmp90, (1, 4, 3, 5), (4, 0, 5, 2))
-    tmp81 = tmp79.copy()
+    tmp81 = np.copy(tmp79)
     tmp81 += tmp80 * 2
-    tmp96 = tmp34.copy()
+    tmp96 = np.copy(tmp34)
     tmp96 += tmp35 * 2
     tmp99 = einsum(t2.bbbb, (0, 1, 2, 3), tmp40, (1, 4), (0, 4, 2, 3)) * -1
-    tmp98 = tmp79.copy() * 0.5
+    tmp98 = np.copy(tmp79) * 0.5
     del tmp79
     tmp98 += tmp80
     del tmp80
     tmp101 = einsum(tmp54, (0, 1, 2, 3), t1.bb, (0, 4), (1, 3, 2, 4))
-    tmp87 = tmp24.copy()
+    tmp87 = np.copy(tmp24)
     tmp87 += tmp26 * 0.5
     tmp87 += einsum(tmp27, (0, 1), t1.aa, (0, 2), (1, 2))
-    tmp15 = tmp8.copy() * 0.5
+    tmp15 = np.copy(tmp8) * 0.5
     tmp15 += tmp9 * 0.5
     tmp15 += tmp10
     tmp60 = einsum(t2.abab, (0, 1, 2, 3), tmp25, (0, 4, 5, 3), (4, 5, 1, 2))
     tmp46 = einsum(t1.bb, (0, 1), tmp45, (2, 3, 0, 4), (2, 3, 4, 1))
-    tmp4 = tmp0.copy()
+    tmp4 = np.copy(tmp0)
     tmp4 += tmp1 * 2
     tmp4 += tmp2
     tmp47 = einsum(tmp13, (0, 1, 2, 3), t2.abab, (4, 1, 3, 5), (0, 4, 2, 5))
-    tmp89 = tmp59.copy()
+    tmp89 = np.copy(tmp59)
     tmp89 += tmp58
     tmp57 = einsum(t2.abab, (0, 1, 2, 3), l1.bb, (3, 4), (0, 4, 1, 2))
     tmp37 = einsum(l1.aa, (0, 1), t2.abab, (2, 3, 0, 4), (1, 2, 3, 4))
-    tmp72 = tmp19.copy() * 2
+    tmp72 = np.copy(tmp19) * 2
     tmp72 += tmp20
-    tmp85 = tmp62.copy()
+    tmp85 = np.copy(tmp62)
     del tmp62
     tmp85 += tmp63 * 0.5
     del tmp63
-    tmp88 = tmp43.copy()
+    tmp88 = np.copy(tmp43)
     tmp88 += tmp44
     tmp65 = einsum(t2.aaaa, (0, 1, 2, 3), tmp64, (3, 4), (0, 1, 4, 2)) * -2
     del tmp64
@@ -1657,72 +1657,72 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp78 = einsum(tmp77, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3))
     del tmp77
     tmp74 = einsum(t2.aaaa, (0, 1, 2, 3), tmp27, (1, 4), (4, 0, 2, 3)) * -2
-    tmp56 = t1.aa.copy()
+    tmp56 = np.copy(t1.aa)
     tmp56 += tmp19 * 2
     tmp56 += tmp20
     tmp75 = einsum(t2.aaaa, (0, 1, 2, 3), tmp32, (0, 1, 4, 5), (4, 5, 2, 3))
     tmp71 = einsum(t2.abab, (0, 1, 2, 3), tmp70, (4, 1, 5, 3), (4, 0, 5, 2))
-    tmp29 = tmp24.copy() * 2
+    tmp29 = np.copy(tmp24) * 2
     del tmp24
     tmp29 += tmp26
     del tmp26
     tmp29 += tmp28
     del tmp28
-    tmp22 = t1.aa.copy()
+    tmp22 = np.copy(t1.aa)
     tmp22 += tmp19 * 2
     tmp22 += tmp20
     tmp55 = einsum(tmp54, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 3, 4)) * 2
     del tmp54
     tmp33 = einsum(tmp32, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 3, 4)) * 2
     del tmp32
-    tmp48 = t1.bb.copy()
+    tmp48 = np.copy(t1.bb)
     tmp48 += tmp34
     del tmp34
     tmp48 += tmp35 * 2
     del tmp35
-    tmp21 = t1.aa.copy() * 0.5
+    tmp21 = np.copy(t1.aa) * 0.5
     tmp21 += tmp19
     del tmp19
     tmp21 += tmp20 * 0.5
     del tmp20
-    tmp11 = delta.bb.oo.copy() * -1
+    tmp11 = np.copy(delta.bb.oo) * -1
     tmp11 += tmp8
     del tmp8
     tmp11 += tmp9
     del tmp9
     tmp11 += tmp10 * 2
     del tmp10
-    tmp3 = delta.aa.oo.copy() * -0.5
+    tmp3 = np.copy(delta.aa.oo) * -0.5
     tmp3 += tmp0 * 0.5
     del tmp0
     tmp3 += tmp1
     del tmp1
     tmp3 += tmp2 * 0.5
     del tmp2
-    rdm2.bbbb.vvvv = tmp132.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.bbbb.vvvv = np.copy(np.transpose(tmp132, (1, 0, 3, 2))) * 2
     del tmp132
     rdm2.bbbb.vvvv += einsum(tmp130, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 4, 3)) * 2
     rdm2.abab.vvvv = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 3, 4, 5), (0, 1, 4, 5))
     rdm2.abab.vvvv += einsum(t1.aa, (0, 1), tmp129, (0, 2, 3, 4), (2, 3, 1, 4))
-    rdm2.aaaa.vvvv = tmp131.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.aaaa.vvvv = np.copy(np.transpose(tmp131, (1, 0, 3, 2))) * 2
     del tmp131
     rdm2.aaaa.vvvv += einsum(tmp128, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3)) * 2
-    rdm2.bbbb.vvvo = tmp130.transpose((2, 1, 3, 0)).copy() * 2
+    rdm2.bbbb.vvvo = np.copy(np.transpose(tmp130, (2, 1, 3, 0))) * 2
     rdm2.abab.vvvo = einsum(l2.abab, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
-    rdm2.aaaa.vvvo = tmp128.transpose((2, 1, 3, 0)).copy() * 2
-    rdm2.bbbb.vvov = tmp130.transpose((2, 1, 0, 3)).copy() * -2
+    rdm2.aaaa.vvvo = np.copy(np.transpose(tmp128, (2, 1, 3, 0))) * 2
+    rdm2.bbbb.vvov = np.copy(np.transpose(tmp130, (2, 1, 0, 3))) * -2
     del tmp130
-    rdm2.abab.vvov = tmp129.transpose((1, 2, 0, 3)).copy()
+    rdm2.abab.vvov = np.copy(np.transpose(tmp129, (1, 2, 0, 3)))
     del tmp129
-    rdm2.aaaa.vvov = tmp128.transpose((2, 1, 0, 3)).copy() * -2
+    rdm2.aaaa.vvov = np.copy(np.transpose(tmp128, (2, 1, 0, 3))) * -2
     del tmp128
-    rdm2.bbbb.vovv = tmp120.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.bbbb.vovv = np.copy(np.transpose(tmp120, (1, 0, 3, 2))) * 2
     rdm2.bbbb.vovv += einsum(tmp108, (0, 1), t1.bb, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.bbbb.vovv += einsum(tmp108, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3))
-    rdm2.bbbb.vovv += tmp124.transpose((2, 0, 1, 3))
-    rdm2.bbbb.vovv += tmp124.transpose((2, 0, 3, 1)) * -1
-    rdm2.bbbb.vovv += tmp125.transpose((1, 0, 3, 2)) * 2
-    rdm2.bbbb.vovv += tmp126.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.vovv += np.transpose(tmp124, (2, 0, 1, 3))
+    rdm2.bbbb.vovv += np.transpose(tmp124, (2, 0, 3, 1)) * -1
+    rdm2.bbbb.vovv += np.transpose(tmp125, (1, 0, 3, 2)) * 2
+    rdm2.bbbb.vovv += np.transpose(tmp126, (1, 0, 3, 2)) * 2
     rdm2.abab.vovv = einsum(l1.aa, (0, 1), t2.abab, (1, 2, 3, 4), (0, 2, 3, 4))
     rdm2.abab.vovv += einsum(tmp105, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3))
     rdm2.abab.vovv += einsum(t1.aa, (0, 1), tmp127, (0, 2, 3, 4), (3, 2, 1, 4)) * 2
@@ -1730,25 +1730,25 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.abab.vovv += einsum(t1.bb, (0, 1), tmp114, (0, 2, 3, 4), (3, 2, 4, 1)) * -1
     rdm2.abab.vovv += einsum(tmp13, (0, 1, 2, 3), t2.abab, (0, 1, 4, 5), (3, 2, 4, 5)) * -1
     rdm2.abab.vovv += einsum(tmp113, (0, 1, 2, 3), t1.aa, (0, 4), (2, 1, 4, 3)) * -1
-    rdm2.aaaa.vovv = tmp115.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.aaaa.vovv = np.copy(np.transpose(tmp115, (1, 0, 3, 2))) * 2
     rdm2.aaaa.vovv += einsum(t1.aa, (0, 1), tmp105, (2, 3), (2, 0, 1, 3)) * -1
     rdm2.aaaa.vovv += einsum(tmp105, (0, 1), t1.aa, (2, 3), (0, 2, 1, 3))
-    rdm2.aaaa.vovv += tmp117.transpose((2, 0, 1, 3))
-    rdm2.aaaa.vovv += tmp117.transpose((2, 0, 3, 1)) * -1
-    rdm2.aaaa.vovv += tmp118.transpose((1, 0, 3, 2)) * 2
-    rdm2.aaaa.vovv += tmp119.transpose((1, 0, 3, 2)) * 2
-    rdm2.bbbb.ovvv = tmp120.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.aaaa.vovv += np.transpose(tmp117, (2, 0, 1, 3))
+    rdm2.aaaa.vovv += np.transpose(tmp117, (2, 0, 3, 1)) * -1
+    rdm2.aaaa.vovv += np.transpose(tmp118, (1, 0, 3, 2)) * 2
+    rdm2.aaaa.vovv += np.transpose(tmp119, (1, 0, 3, 2)) * 2
+    rdm2.bbbb.ovvv = np.copy(np.transpose(tmp120, (0, 1, 3, 2))) * -2
     del tmp120
     rdm2.bbbb.ovvv += einsum(tmp108, (0, 1), t1.bb, (2, 3), (2, 0, 3, 1))
     rdm2.bbbb.ovvv += einsum(tmp121, (0, 1), t1.bb, (2, 3), (2, 0, 1, 3)) * -2
     del tmp121
     rdm2.bbbb.ovvv += einsum(t1.bb, (0, 1), tmp122, (0, 2, 3, 4), (2, 3, 1, 4)) * -4
     del tmp122
-    rdm2.bbbb.ovvv += tmp124.transpose((0, 2, 3, 1))
+    rdm2.bbbb.ovvv += np.transpose(tmp124, (0, 2, 3, 1))
     del tmp124
-    rdm2.bbbb.ovvv += tmp125.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.ovvv += np.transpose(tmp125, (0, 1, 3, 2)) * -2
     del tmp125
-    rdm2.bbbb.ovvv += tmp126.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.ovvv += np.transpose(tmp126, (0, 1, 3, 2)) * -2
     del tmp126
     rdm2.abab.ovvv = einsum(t2.abab, (0, 1, 2, 3), l1.bb, (4, 1), (0, 4, 2, 3))
     rdm2.abab.ovvv += einsum(t1.aa, (0, 1), tmp108, (2, 3), (0, 2, 1, 3))
@@ -1756,104 +1756,104 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.abab.ovvv += einsum(tmp82, (0, 1, 2, 3), t1.bb, (1, 4), (0, 3, 2, 4)) * 2
     rdm2.abab.ovvv += einsum(t2.abab, (0, 1, 2, 3), tmp25, (0, 4, 1, 5), (4, 5, 2, 3)) * -1
     rdm2.abab.ovvv += einsum(t1.bb, (0, 1), tmp111, (2, 0, 3, 4), (2, 4, 3, 1)) * -1
-    rdm2.aaaa.ovvv = tmp115.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.aaaa.ovvv = np.copy(np.transpose(tmp115, (0, 1, 3, 2))) * -2
     del tmp115
     rdm2.aaaa.ovvv += einsum(t1.aa, (0, 1), tmp105, (2, 3), (0, 2, 1, 3))
     rdm2.aaaa.ovvv += einsum(tmp105, (0, 1), t1.aa, (2, 3), (2, 0, 1, 3)) * -1
     rdm2.aaaa.ovvv += einsum(tmp116, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3)) * -1
     del tmp116
-    rdm2.aaaa.ovvv += tmp117.transpose((0, 2, 3, 1))
+    rdm2.aaaa.ovvv += np.transpose(tmp117, (0, 2, 3, 1))
     del tmp117
-    rdm2.aaaa.ovvv += tmp118.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.ovvv += np.transpose(tmp118, (0, 1, 3, 2)) * -2
     del tmp118
-    rdm2.aaaa.ovvv += tmp119.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.ovvv += np.transpose(tmp119, (0, 1, 3, 2)) * -2
     del tmp119
-    rdm2.bbbb.vvoo = l2.bbbb.copy() * 2
-    rdm2.abab.vvoo = l2.abab.copy()
-    rdm2.aaaa.vvoo = l2.aaaa.copy() * 2
+    rdm2.bbbb.vvoo = np.copy(l2.bbbb) * 2
+    rdm2.abab.vvoo = np.copy(l2.abab)
+    rdm2.aaaa.vvoo = np.copy(l2.aaaa) * 2
     rdm2.bbbb.vovo = einsum(tmp108, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3))
-    rdm2.bbbb.vovo += tmp90.transpose((2, 1, 3, 0)) * -4
-    rdm2.bbbb.vovo += tmp94.transpose((2, 1, 3, 0)) * -1
+    rdm2.bbbb.vovo += np.transpose(tmp90, (2, 1, 3, 0)) * -4
+    rdm2.bbbb.vovo += np.transpose(tmp94, (2, 1, 3, 0)) * -1
     rdm2.bbbb.vovo += einsum(l1.bb, (0, 1), t1.bb, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.bbbb.vovo += tmp109.transpose((2, 1, 3, 0)) * 2
+    rdm2.bbbb.vovo += np.transpose(tmp109, (2, 1, 3, 0)) * 2
     rdm2.abab.vovo = einsum(tmp105, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3))
-    rdm2.abab.vovo += tmp114.transpose((2, 1, 3, 0)) * -1
+    rdm2.abab.vovo += np.transpose(tmp114, (2, 1, 3, 0)) * -1
     del tmp114
     rdm2.abab.vovo += einsum(tmp13, (0, 1, 2, 3), t1.aa, (0, 4), (3, 2, 4, 1)) * -1
     rdm2.aaaa.vovo = einsum(delta.aa.oo, (0, 1), tmp110, (2, 3), (2, 0, 3, 1)) * 2
-    rdm2.aaaa.vovo += tmp66.transpose((2, 1, 3, 0)) * -4
+    rdm2.aaaa.vovo += np.transpose(tmp66, (2, 1, 3, 0)) * -4
     rdm2.aaaa.vovo += einsum(l1.aa, (0, 1), t1.aa, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.aaaa.vovo += tmp83.transpose((2, 1, 3, 0)) * -1
-    rdm2.aaaa.vovo += tmp106.transpose((2, 1, 3, 0)) * 2
+    rdm2.aaaa.vovo += np.transpose(tmp83, (2, 1, 3, 0)) * -1
+    rdm2.aaaa.vovo += np.transpose(tmp106, (2, 1, 3, 0)) * 2
     rdm2.bbbb.voov = einsum(tmp108, (0, 1), delta.bb.oo, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.bbbb.voov += tmp90.transpose((2, 1, 0, 3)) * 4
-    rdm2.bbbb.voov += tmp94.transpose((2, 1, 0, 3))
+    rdm2.bbbb.voov += np.transpose(tmp90, (2, 1, 0, 3)) * 4
+    rdm2.bbbb.voov += np.transpose(tmp94, (2, 1, 0, 3))
     rdm2.bbbb.voov += einsum(l1.bb, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3))
-    rdm2.bbbb.voov += tmp109.transpose((2, 1, 0, 3)) * -2
-    rdm2.abab.voov = tmp112.transpose((2, 1, 0, 3)).copy() * 2
+    rdm2.bbbb.voov += np.transpose(tmp109, (2, 1, 0, 3)) * -2
+    rdm2.abab.voov = np.copy(np.transpose(tmp112, (2, 1, 0, 3))) * 2
     del tmp112
     rdm2.abab.voov += einsum(l1.aa, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3))
-    rdm2.abab.voov += tmp92.transpose((2, 1, 0, 3)) * 2
+    rdm2.abab.voov += np.transpose(tmp92, (2, 1, 0, 3)) * 2
     del tmp92
-    rdm2.abab.voov += tmp113.transpose((2, 1, 0, 3)) * -1
+    rdm2.abab.voov += np.transpose(tmp113, (2, 1, 0, 3)) * -1
     del tmp113
     rdm2.aaaa.voov = einsum(tmp105, (0, 1), delta.aa.oo, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.aaaa.voov += tmp66.transpose((2, 1, 0, 3)) * 4
+    rdm2.aaaa.voov += np.transpose(tmp66, (2, 1, 0, 3)) * 4
     rdm2.aaaa.voov += einsum(l1.aa, (0, 1), t1.aa, (2, 3), (0, 2, 1, 3))
-    rdm2.aaaa.voov += tmp83.transpose((2, 1, 0, 3))
-    rdm2.aaaa.voov += tmp106.transpose((2, 1, 0, 3)) * -2
+    rdm2.aaaa.voov += np.transpose(tmp83, (2, 1, 0, 3))
+    rdm2.aaaa.voov += np.transpose(tmp106, (2, 1, 0, 3)) * -2
     rdm2.bbbb.ovvo = einsum(tmp108, (0, 1), delta.bb.oo, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.bbbb.ovvo += tmp90.transpose((1, 2, 3, 0)) * 4
-    rdm2.bbbb.ovvo += tmp94.transpose((1, 2, 3, 0))
+    rdm2.bbbb.ovvo += np.transpose(tmp90, (1, 2, 3, 0)) * 4
+    rdm2.bbbb.ovvo += np.transpose(tmp94, (1, 2, 3, 0))
     rdm2.bbbb.ovvo += einsum(l1.bb, (0, 1), t1.bb, (2, 3), (2, 0, 3, 1))
-    rdm2.bbbb.ovvo += tmp109.transpose((1, 2, 3, 0)) * -2
-    rdm2.abab.ovvo = tmp68.transpose((0, 3, 2, 1)).copy() * 2
+    rdm2.bbbb.ovvo += np.transpose(tmp109, (1, 2, 3, 0)) * -2
+    rdm2.abab.ovvo = np.copy(np.transpose(tmp68, (0, 3, 2, 1))) * 2
     del tmp68
     rdm2.abab.ovvo += einsum(t1.aa, (0, 1), l1.bb, (2, 3), (0, 2, 1, 3))
-    rdm2.abab.ovvo += tmp70.transpose((0, 3, 2, 1)) * 2
+    rdm2.abab.ovvo += np.transpose(tmp70, (0, 3, 2, 1)) * 2
     del tmp70
-    rdm2.abab.ovvo += tmp111.transpose((0, 3, 2, 1)) * -1
+    rdm2.abab.ovvo += np.transpose(tmp111, (0, 3, 2, 1)) * -1
     del tmp111
     rdm2.aaaa.ovvo = einsum(delta.aa.oo, (0, 1), tmp110, (2, 3), (0, 2, 3, 1)) * -2
     del tmp110
-    rdm2.aaaa.ovvo += tmp66.transpose((1, 2, 3, 0)) * 4
+    rdm2.aaaa.ovvo += np.transpose(tmp66, (1, 2, 3, 0)) * 4
     rdm2.aaaa.ovvo += einsum(l1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
-    rdm2.aaaa.ovvo += tmp83.transpose((1, 2, 3, 0))
-    rdm2.aaaa.ovvo += tmp106.transpose((1, 2, 3, 0)) * -2
+    rdm2.aaaa.ovvo += np.transpose(tmp83, (1, 2, 3, 0))
+    rdm2.aaaa.ovvo += np.transpose(tmp106, (1, 2, 3, 0)) * -2
     rdm2.bbbb.ovov = einsum(tmp108, (0, 1), delta.bb.oo, (2, 3), (2, 0, 3, 1))
-    rdm2.bbbb.ovov += tmp90.transpose((1, 2, 0, 3)) * -4
+    rdm2.bbbb.ovov += np.transpose(tmp90, (1, 2, 0, 3)) * -4
     del tmp90
-    rdm2.bbbb.ovov += tmp94.transpose((1, 2, 0, 3)) * -1
+    rdm2.bbbb.ovov += np.transpose(tmp94, (1, 2, 0, 3)) * -1
     del tmp94
     rdm2.bbbb.ovov += einsum(l1.bb, (0, 1), t1.bb, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.bbbb.ovov += tmp109.transpose((1, 2, 0, 3)) * 2
+    rdm2.bbbb.ovov += np.transpose(tmp109, (1, 2, 0, 3)) * 2
     del tmp109
     rdm2.abab.ovov = einsum(tmp108, (0, 1), delta.aa.oo, (2, 3), (2, 0, 3, 1))
     del tmp108
-    rdm2.abab.ovov += tmp86.transpose((1, 2, 0, 3)) * -1
+    rdm2.abab.ovov += np.transpose(tmp86, (1, 2, 0, 3)) * -1
     rdm2.abab.ovov += einsum(tmp25, (0, 1, 2, 3), t1.bb, (2, 4), (1, 3, 0, 4)) * -1
     rdm2.aaaa.ovov = einsum(tmp105, (0, 1), delta.aa.oo, (2, 3), (2, 0, 3, 1))
     del tmp105
-    rdm2.aaaa.ovov += tmp66.transpose((1, 2, 0, 3)) * -4
+    rdm2.aaaa.ovov += np.transpose(tmp66, (1, 2, 0, 3)) * -4
     del tmp66
     rdm2.aaaa.ovov += einsum(l1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.aaaa.ovov += tmp83.transpose((1, 2, 0, 3)) * -1
+    rdm2.aaaa.ovov += np.transpose(tmp83, (1, 2, 0, 3)) * -1
     del tmp83
-    rdm2.aaaa.ovov += tmp106.transpose((1, 2, 0, 3)) * 2
+    rdm2.aaaa.ovov += np.transpose(tmp106, (1, 2, 0, 3)) * 2
     del tmp106
-    rdm2.bbbb.oovv = t2.bbbb.copy() * 2
+    rdm2.bbbb.oovv = np.copy(t2.bbbb) * 2
     rdm2.bbbb.oovv += einsum(tmp81, (0, 1), t2.bbbb, (2, 3, 4, 0), (2, 3, 4, 1)) * -2
-    rdm2.bbbb.oovv += tmp91.transpose((0, 1, 3, 2)) * -8
-    rdm2.bbbb.oovv += tmp93.transpose((0, 1, 3, 2)) * -2
-    rdm2.bbbb.oovv += tmp95.transpose((0, 1, 3, 2)) * -2
-    rdm2.bbbb.oovv += tmp95.transpose((1, 0, 2, 3)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp91, (0, 1, 3, 2)) * -8
+    rdm2.bbbb.oovv += np.transpose(tmp93, (0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp95, (0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp95, (1, 0, 2, 3)) * -2
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp61, (2, 3), (2, 0, 1, 3)) * -2
     rdm2.bbbb.oovv += tmp91 * 8
     del tmp91
-    rdm2.bbbb.oovv += tmp93.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp93, (1, 0, 3, 2)) * 2
     del tmp93
     rdm2.bbbb.oovv += tmp95 * 2
-    rdm2.bbbb.oovv += tmp95.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp95, (1, 0, 3, 2)) * 2
     del tmp95
     rdm2.bbbb.oovv += einsum(tmp36, (0, 1), t1.bb, (2, 3), (2, 0, 3, 1))
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp96, (2, 3), (2, 0, 3, 1))
@@ -1862,25 +1862,25 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.bbbb.oovv += tmp97 * 2
     rdm2.bbbb.oovv += einsum(tmp98, (0, 1), t2.bbbb, (2, 3, 4, 0), (2, 3, 1, 4)) * 4
     del tmp98
-    rdm2.bbbb.oovv += tmp97.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp97, (0, 1, 3, 2)) * -2
     del tmp97
-    rdm2.bbbb.oovv += tmp99.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp99, (0, 1, 3, 2)) * -2
     rdm2.bbbb.oovv += einsum(tmp42, (0, 1), t1.bb, (2, 3), (2, 0, 3, 1)) * -1
     rdm2.bbbb.oovv += einsum(tmp51, (0, 1), t1.bb, (2, 3), (2, 0, 1, 3)) * 2
-    rdm2.bbbb.oovv += tmp99.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp99, (1, 0, 3, 2)) * 2
     del tmp99
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp42, (2, 3), (2, 0, 1, 3))
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp51, (2, 3), (2, 0, 3, 1)) * -2
-    rdm2.bbbb.oovv += tmp100.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp100, (1, 0, 3, 2)) * 2
     del tmp100
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp101, (0, 2, 3, 4), (2, 3, 1, 4)) * 2
     del tmp101
-    rdm2.bbbb.oovv += tmp103.transpose((1, 0, 2, 3))
+    rdm2.bbbb.oovv += np.transpose(tmp103, (1, 0, 2, 3))
     rdm2.bbbb.oovv += tmp103 * -1
-    rdm2.bbbb.oovv += tmp103.transpose((1, 0, 3, 2)) * -1
-    rdm2.bbbb.oovv += tmp103.transpose((0, 1, 3, 2))
+    rdm2.bbbb.oovv += np.transpose(tmp103, (1, 0, 3, 2)) * -1
+    rdm2.bbbb.oovv += np.transpose(tmp103, (0, 1, 3, 2))
     del tmp103
-    rdm2.abab.oovv = t2.abab.copy()
+    rdm2.abab.oovv = np.copy(t2.abab)
     rdm2.abab.oovv += einsum(t2.abab, (0, 1, 2, 3), tmp81, (3, 4), (0, 1, 2, 4)) * -1
     del tmp81
     rdm2.abab.oovv += einsum(tmp82, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (0, 4, 2, 5)) * 4
@@ -1908,173 +1908,173 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.abab.oovv += einsum(t1.bb, (0, 1), tmp89, (2, 0, 3, 4), (2, 3, 4, 1)) * -2
     del tmp89
     rdm2.abab.oovv += einsum(t1.bb, (0, 1), tmp60, (2, 0, 3, 4), (2, 3, 4, 1))
-    rdm2.aaaa.oovv = t2.aaaa.copy() * 2
-    rdm2.aaaa.oovv += tmp65.transpose((1, 0, 3, 2)) * -1
-    rdm2.aaaa.oovv += tmp67.transpose((0, 1, 3, 2)) * -8
-    rdm2.aaaa.oovv += tmp69.transpose((0, 1, 3, 2)) * -2
-    rdm2.aaaa.oovv += tmp71.transpose((0, 1, 3, 2)) * -2
-    rdm2.aaaa.oovv += tmp71.transpose((1, 0, 2, 3)) * -2
+    rdm2.aaaa.oovv = np.copy(t2.aaaa) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp65, (1, 0, 3, 2)) * -1
+    rdm2.aaaa.oovv += np.transpose(tmp67, (0, 1, 3, 2)) * -8
+    rdm2.aaaa.oovv += np.transpose(tmp69, (0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp71, (0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp71, (1, 0, 2, 3)) * -2
     rdm2.aaaa.oovv += einsum(tmp56, (0, 1), t1.aa, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.aaaa.oovv += tmp67 * 8
     del tmp67
     rdm2.aaaa.oovv += tmp69 * 2
     del tmp69
     rdm2.aaaa.oovv += tmp71 * 2
-    rdm2.aaaa.oovv += tmp71.transpose((1, 0, 3, 2)) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp71, (1, 0, 3, 2)) * 2
     del tmp71
     rdm2.aaaa.oovv += einsum(t1.aa, (0, 1), tmp22, (2, 3), (0, 2, 1, 3))
     rdm2.aaaa.oovv += einsum(tmp72, (0, 1), t1.aa, (2, 3), (0, 2, 1, 3))
     rdm2.aaaa.oovv += einsum(tmp72, (0, 1), t1.aa, (2, 3), (2, 0, 1, 3)) * -1
     del tmp72
     rdm2.aaaa.oovv += tmp73 * 2
-    rdm2.aaaa.oovv += tmp65.transpose((1, 0, 2, 3))
+    rdm2.aaaa.oovv += np.transpose(tmp65, (1, 0, 2, 3))
     del tmp65
-    rdm2.aaaa.oovv += tmp73.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp73, (0, 1, 3, 2)) * -2
     del tmp73
-    rdm2.aaaa.oovv += tmp74.transpose((1, 0, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp74, (1, 0, 3, 2)) * -2
     rdm2.aaaa.oovv += einsum(t1.aa, (0, 1), tmp29, (2, 3), (0, 2, 1, 3)) * -1
     rdm2.aaaa.oovv += einsum(t1.aa, (0, 1), tmp29, (2, 3), (0, 2, 3, 1))
-    rdm2.aaaa.oovv += tmp74.transpose((0, 1, 3, 2)) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp74, (0, 1, 3, 2)) * 2
     del tmp74
     rdm2.aaaa.oovv += einsum(tmp29, (0, 1), t1.aa, (2, 3), (0, 2, 3, 1))
     rdm2.aaaa.oovv += einsum(t1.aa, (0, 1), tmp29, (2, 3), (2, 0, 3, 1)) * -1
-    rdm2.aaaa.oovv += tmp75.transpose((1, 0, 3, 2)) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp75, (1, 0, 3, 2)) * 2
     del tmp75
     rdm2.aaaa.oovv += einsum(tmp76, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3)) * 2
     del tmp76
-    rdm2.aaaa.oovv += tmp78.transpose((1, 0, 2, 3))
+    rdm2.aaaa.oovv += np.transpose(tmp78, (1, 0, 2, 3))
     rdm2.aaaa.oovv += tmp78 * -1
-    rdm2.aaaa.oovv += tmp78.transpose((1, 0, 3, 2)) * -1
-    rdm2.aaaa.oovv += tmp78.transpose((0, 1, 3, 2))
+    rdm2.aaaa.oovv += np.transpose(tmp78, (1, 0, 3, 2)) * -1
+    rdm2.aaaa.oovv += np.transpose(tmp78, (0, 1, 3, 2))
     del tmp78
     rdm2.bbbb.vooo = einsum(delta.bb.oo, (0, 1), l1.bb, (2, 3), (2, 0, 3, 1))
     rdm2.bbbb.vooo += einsum(delta.bb.oo, (0, 1), l1.bb, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.bbbb.vooo += tmp17.transpose((3, 2, 1, 0)) * 2
+    rdm2.bbbb.vooo += np.transpose(tmp17, (3, 2, 1, 0)) * 2
     rdm2.abab.vooo = einsum(l1.aa, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3))
-    rdm2.abab.vooo += tmp13.transpose((3, 2, 0, 1)) * -1
+    rdm2.abab.vooo += np.transpose(tmp13, (3, 2, 0, 1)) * -1
     del tmp13
     rdm2.aaaa.vooo = einsum(delta.aa.oo, (0, 1), l1.aa, (2, 3), (2, 0, 3, 1))
     rdm2.aaaa.vooo += einsum(delta.aa.oo, (0, 1), l1.aa, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.aaaa.vooo += tmp6.transpose((3, 2, 1, 0)) * 2
+    rdm2.aaaa.vooo += np.transpose(tmp6, (3, 2, 1, 0)) * 2
     rdm2.bbbb.ovoo = einsum(delta.bb.oo, (0, 1), l1.bb, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.bbbb.ovoo += einsum(delta.bb.oo, (0, 1), l1.bb, (2, 3), (0, 2, 1, 3))
-    rdm2.bbbb.ovoo += tmp17.transpose((2, 3, 1, 0)) * -2
+    rdm2.bbbb.ovoo += np.transpose(tmp17, (2, 3, 1, 0)) * -2
     del tmp17
     rdm2.abab.ovoo = einsum(delta.aa.oo, (0, 1), l1.bb, (2, 3), (0, 2, 1, 3))
-    rdm2.abab.ovoo += tmp25.transpose((1, 3, 0, 2)) * -1
+    rdm2.abab.ovoo += np.transpose(tmp25, (1, 3, 0, 2)) * -1
     del tmp25
     rdm2.aaaa.ovoo = einsum(delta.aa.oo, (0, 1), l1.aa, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.aaaa.ovoo += einsum(delta.aa.oo, (0, 1), l1.aa, (2, 3), (0, 2, 1, 3))
-    rdm2.aaaa.ovoo += tmp6.transpose((2, 3, 1, 0)) * -2
+    rdm2.aaaa.ovoo += np.transpose(tmp6, (2, 3, 1, 0)) * -2
     del tmp6
     rdm2.bbbb.oovo = einsum(tmp61, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3)) * 2
     del tmp61
     rdm2.bbbb.oovo += einsum(delta.bb.oo, (0, 1), tmp36, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.bbbb.oovo += tmp49.transpose((2, 1, 3, 0)) * 2
+    rdm2.bbbb.oovo += np.transpose(tmp49, (2, 1, 3, 0)) * 2
     rdm2.bbbb.oovo += einsum(delta.bb.oo, (0, 1), tmp42, (2, 3), (2, 0, 3, 1)) * -1
     rdm2.bbbb.oovo += einsum(delta.bb.oo, (0, 1), tmp51, (2, 3), (0, 2, 3, 1)) * 2
-    rdm2.bbbb.oovo += tmp52.transpose((1, 2, 3, 0)) * 4
-    rdm2.bbbb.oovo += tmp53.transpose((1, 2, 3, 0))
+    rdm2.bbbb.oovo += np.transpose(tmp52, (1, 2, 3, 0)) * 4
+    rdm2.bbbb.oovo += np.transpose(tmp53, (1, 2, 3, 0))
     rdm2.bbbb.oovo += einsum(t1.bb, (0, 1), tmp15, (2, 3), (3, 0, 1, 2)) * 2
-    rdm2.bbbb.oovo += tmp52.transpose((2, 1, 3, 0)) * -4
-    rdm2.bbbb.oovo += tmp53.transpose((2, 1, 3, 0)) * -1
+    rdm2.bbbb.oovo += np.transpose(tmp52, (2, 1, 3, 0)) * -4
+    rdm2.bbbb.oovo += np.transpose(tmp53, (2, 1, 3, 0)) * -1
     rdm2.bbbb.oovo += einsum(t1.bb, (0, 1), tmp15, (2, 3), (0, 3, 1, 2)) * -2
-    rdm2.bbbb.oovo += tmp55.transpose((2, 1, 3, 0)) * -1
+    rdm2.bbbb.oovo += np.transpose(tmp55, (2, 1, 3, 0)) * -1
     rdm2.abab.oovo = einsum(tmp56, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3))
-    rdm2.abab.oovo += tmp57.transpose((0, 2, 3, 1)) * -1
+    rdm2.abab.oovo += np.transpose(tmp57, (0, 2, 3, 1)) * -1
     del tmp57
     rdm2.abab.oovo += einsum(delta.bb.oo, (0, 1), tmp29, (2, 3), (2, 0, 3, 1)) * -1
-    rdm2.abab.oovo += tmp58.transpose((0, 2, 3, 1)) * -2
+    rdm2.abab.oovo += np.transpose(tmp58, (0, 2, 3, 1)) * -2
     del tmp58
-    rdm2.abab.oovo += tmp59.transpose((0, 2, 3, 1)) * -2
+    rdm2.abab.oovo += np.transpose(tmp59, (0, 2, 3, 1)) * -2
     del tmp59
     rdm2.abab.oovo += einsum(t1.aa, (0, 1), tmp40, (2, 3), (0, 3, 1, 2)) * -1
     rdm2.abab.oovo += einsum(tmp45, (0, 1, 2, 3), t1.aa, (0, 4), (1, 3, 4, 2))
     del tmp45
-    rdm2.abab.oovo += tmp60.transpose((0, 2, 3, 1))
+    rdm2.abab.oovo += np.transpose(tmp60, (0, 2, 3, 1))
     del tmp60
     rdm2.aaaa.oovo = einsum(tmp56, (0, 1), delta.aa.oo, (2, 3), (0, 2, 1, 3))
     del tmp56
     rdm2.aaaa.oovo += einsum(delta.aa.oo, (0, 1), tmp22, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.aaaa.oovo += tmp23.transpose((2, 1, 3, 0)) * 2
+    rdm2.aaaa.oovo += np.transpose(tmp23, (2, 1, 3, 0)) * 2
     rdm2.aaaa.oovo += einsum(delta.aa.oo, (0, 1), tmp29, (2, 3), (2, 0, 3, 1)) * -1
     rdm2.aaaa.oovo += einsum(delta.aa.oo, (0, 1), tmp29, (2, 3), (0, 2, 3, 1))
-    rdm2.aaaa.oovo += tmp31.transpose((1, 2, 3, 0))
-    rdm2.aaaa.oovo += tmp30.transpose((1, 2, 3, 0)) * 4
+    rdm2.aaaa.oovo += np.transpose(tmp31, (1, 2, 3, 0))
+    rdm2.aaaa.oovo += np.transpose(tmp30, (1, 2, 3, 0)) * 4
     rdm2.aaaa.oovo += einsum(tmp4, (0, 1), t1.aa, (2, 3), (1, 2, 3, 0))
-    rdm2.aaaa.oovo += tmp30.transpose((2, 1, 3, 0)) * -4
-    rdm2.aaaa.oovo += tmp31.transpose((2, 1, 3, 0)) * -1
+    rdm2.aaaa.oovo += np.transpose(tmp30, (2, 1, 3, 0)) * -4
+    rdm2.aaaa.oovo += np.transpose(tmp31, (2, 1, 3, 0)) * -1
     rdm2.aaaa.oovo += einsum(t1.aa, (0, 1), tmp27, (2, 3), (0, 3, 1, 2)) * -2
     del tmp27
-    rdm2.aaaa.oovo += tmp33.transpose((2, 1, 3, 0)) * -1
+    rdm2.aaaa.oovo += np.transpose(tmp33, (2, 1, 3, 0)) * -1
     rdm2.bbbb.ooov = einsum(delta.bb.oo, (0, 1), tmp48, (2, 3), (2, 0, 1, 3)) * -1
     del tmp48
     rdm2.bbbb.ooov += einsum(delta.bb.oo, (0, 1), tmp36, (2, 3), (0, 2, 1, 3))
-    rdm2.bbbb.ooov += tmp49.transpose((2, 1, 0, 3)) * -2
+    rdm2.bbbb.ooov += np.transpose(tmp49, (2, 1, 0, 3)) * -2
     del tmp49
     rdm2.bbbb.ooov += einsum(delta.bb.oo, (0, 1), tmp42, (2, 3), (2, 0, 1, 3))
     rdm2.bbbb.ooov += einsum(delta.bb.oo, (0, 1), tmp51, (2, 3), (0, 2, 1, 3)) * -2
     del tmp51
-    rdm2.bbbb.ooov += tmp52.transpose((1, 2, 0, 3)) * -4
-    rdm2.bbbb.ooov += tmp53.transpose((1, 2, 0, 3)) * -1
+    rdm2.bbbb.ooov += np.transpose(tmp52, (1, 2, 0, 3)) * -4
+    rdm2.bbbb.ooov += np.transpose(tmp53, (1, 2, 0, 3)) * -1
     rdm2.bbbb.ooov += einsum(t1.bb, (0, 1), tmp40, (2, 3), (3, 0, 2, 1)) * -1
-    rdm2.bbbb.ooov += tmp52.transpose((2, 1, 0, 3)) * 4
+    rdm2.bbbb.ooov += np.transpose(tmp52, (2, 1, 0, 3)) * 4
     del tmp52
-    rdm2.bbbb.ooov += tmp53.transpose((2, 1, 0, 3))
+    rdm2.bbbb.ooov += np.transpose(tmp53, (2, 1, 0, 3))
     del tmp53
     rdm2.bbbb.ooov += einsum(t1.bb, (0, 1), tmp40, (2, 3), (0, 3, 2, 1))
     del tmp40
-    rdm2.bbbb.ooov += tmp55.transpose((2, 1, 0, 3))
+    rdm2.bbbb.ooov += np.transpose(tmp55, (2, 1, 0, 3))
     del tmp55
     rdm2.abab.ooov = einsum(delta.aa.oo, (0, 1), tmp36, (2, 3), (0, 2, 1, 3))
     del tmp36
-    rdm2.abab.ooov += tmp37.transpose((1, 2, 0, 3)) * -1
+    rdm2.abab.ooov += np.transpose(tmp37, (1, 2, 0, 3)) * -1
     del tmp37
     rdm2.abab.ooov += einsum(tmp42, (0, 1), delta.aa.oo, (2, 3), (2, 0, 3, 1)) * -1
     del tmp42
-    rdm2.abab.ooov += tmp43.transpose((1, 2, 0, 3)) * -2
+    rdm2.abab.ooov += np.transpose(tmp43, (1, 2, 0, 3)) * -2
     del tmp43
-    rdm2.abab.ooov += tmp44.transpose((1, 2, 0, 3)) * -2
+    rdm2.abab.ooov += np.transpose(tmp44, (1, 2, 0, 3)) * -2
     del tmp44
     rdm2.abab.ooov += einsum(tmp4, (0, 1), t1.bb, (2, 3), (1, 2, 0, 3)) * -1
-    rdm2.abab.ooov += tmp46.transpose((1, 2, 0, 3))
+    rdm2.abab.ooov += np.transpose(tmp46, (1, 2, 0, 3))
     del tmp46
-    rdm2.abab.ooov += tmp47.transpose((1, 2, 0, 3))
+    rdm2.abab.ooov += np.transpose(tmp47, (1, 2, 0, 3))
     del tmp47
     rdm2.aaaa.ooov = einsum(delta.aa.oo, (0, 1), tmp21, (2, 3), (2, 0, 1, 3)) * -2
     del tmp21
     rdm2.aaaa.ooov += einsum(delta.aa.oo, (0, 1), tmp22, (2, 3), (0, 2, 1, 3))
     del tmp22
-    rdm2.aaaa.ooov += tmp23.transpose((2, 1, 0, 3)) * -2
+    rdm2.aaaa.ooov += np.transpose(tmp23, (2, 1, 0, 3)) * -2
     del tmp23
     rdm2.aaaa.ooov += einsum(delta.aa.oo, (0, 1), tmp29, (2, 3), (2, 0, 1, 3))
     rdm2.aaaa.ooov += einsum(delta.aa.oo, (0, 1), tmp29, (2, 3), (0, 2, 1, 3)) * -1
     del tmp29
-    rdm2.aaaa.ooov += tmp30.transpose((1, 2, 0, 3)) * -4
-    rdm2.aaaa.ooov += tmp31.transpose((1, 2, 0, 3)) * -1
+    rdm2.aaaa.ooov += np.transpose(tmp30, (1, 2, 0, 3)) * -4
+    rdm2.aaaa.ooov += np.transpose(tmp31, (1, 2, 0, 3)) * -1
     rdm2.aaaa.ooov += einsum(tmp4, (0, 1), t1.aa, (2, 3), (1, 2, 0, 3)) * -1
-    rdm2.aaaa.ooov += tmp31.transpose((2, 1, 0, 3))
+    rdm2.aaaa.ooov += np.transpose(tmp31, (2, 1, 0, 3))
     del tmp31
-    rdm2.aaaa.ooov += tmp30.transpose((2, 1, 0, 3)) * 4
+    rdm2.aaaa.ooov += np.transpose(tmp30, (2, 1, 0, 3)) * 4
     del tmp30
     rdm2.aaaa.ooov += einsum(t1.aa, (0, 1), tmp4, (2, 3), (0, 3, 2, 1))
-    rdm2.aaaa.ooov += tmp33.transpose((2, 1, 0, 3))
+    rdm2.aaaa.ooov += np.transpose(tmp33, (2, 1, 0, 3))
     del tmp33
     rdm2.bbbb.oooo = einsum(delta.bb.oo, (0, 1), tmp11, (2, 3), (0, 3, 1, 2)) * -1
     rdm2.bbbb.oooo += einsum(tmp11, (0, 1), delta.bb.oo, (2, 3), (1, 2, 3, 0))
     rdm2.bbbb.oooo += einsum(delta.bb.oo, (0, 1), tmp15, (2, 3), (3, 0, 2, 1)) * -2
     rdm2.bbbb.oooo += einsum(delta.bb.oo, (0, 1), tmp15, (2, 3), (0, 3, 2, 1)) * 2
     del tmp15
-    rdm2.bbbb.oooo += tmp16.transpose((3, 2, 1, 0)) * 2
+    rdm2.bbbb.oooo += np.transpose(tmp16, (3, 2, 1, 0)) * 2
     del tmp16
-    rdm2.bbbb.oooo += tmp18.transpose((2, 3, 1, 0)) * -2
+    rdm2.bbbb.oooo += np.transpose(tmp18, (2, 3, 1, 0)) * -2
     del tmp18
     rdm2.abab.oooo = einsum(tmp11, (0, 1), delta.aa.oo, (2, 3), (2, 1, 3, 0)) * -1
     del tmp11
     rdm2.abab.oooo += einsum(tmp4, (0, 1), delta.bb.oo, (2, 3), (1, 2, 0, 3)) * -1
-    rdm2.abab.oooo += tmp12.transpose((1, 3, 0, 2))
+    rdm2.abab.oooo += np.transpose(tmp12, (1, 3, 0, 2))
     del tmp12
-    rdm2.abab.oooo += tmp14.transpose((1, 3, 0, 2))
+    rdm2.abab.oooo += np.transpose(tmp14, (1, 3, 0, 2))
     del tmp14
     rdm2.aaaa.oooo = einsum(delta.aa.oo, (0, 1), tmp3, (2, 3), (0, 3, 1, 2)) * -2
     rdm2.aaaa.oooo += einsum(delta.aa.oo, (0, 1), tmp3, (2, 3), (3, 0, 1, 2)) * 2
@@ -2082,17 +2082,17 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.aaaa.oooo += einsum(tmp4, (0, 1), delta.aa.oo, (2, 3), (1, 2, 0, 3)) * -1
     rdm2.aaaa.oooo += einsum(delta.aa.oo, (0, 1), tmp4, (2, 3), (0, 3, 2, 1))
     del delta, tmp4
-    rdm2.aaaa.oooo += tmp5.transpose((3, 2, 1, 0)) * 2
+    rdm2.aaaa.oooo += np.transpose(tmp5, (3, 2, 1, 0)) * 2
     del tmp5
-    rdm2.aaaa.oooo += tmp7.transpose((2, 3, 1, 0)) * -2
+    rdm2.aaaa.oooo += np.transpose(tmp7, (2, 3, 1, 0)) * -2
     del tmp7
     rdm2.aaaa = pack_2e(rdm2.aaaa.oooo, rdm2.aaaa.ooov, rdm2.aaaa.oovo, rdm2.aaaa.ovoo, rdm2.aaaa.vooo, rdm2.aaaa.oovv, rdm2.aaaa.ovov, rdm2.aaaa.ovvo, rdm2.aaaa.voov, rdm2.aaaa.vovo, rdm2.aaaa.vvoo, rdm2.aaaa.ovvv, rdm2.aaaa.vovv, rdm2.aaaa.vvov, rdm2.aaaa.vvvo, rdm2.aaaa.vvvv)
     rdm2.abab = pack_2e(rdm2.abab.oooo, rdm2.abab.ooov, rdm2.abab.oovo, rdm2.abab.ovoo, rdm2.abab.vooo, rdm2.abab.oovv, rdm2.abab.ovov, rdm2.abab.ovvo, rdm2.abab.voov, rdm2.abab.vovo, rdm2.abab.vvoo, rdm2.abab.ovvv, rdm2.abab.vovv, rdm2.abab.vvov, rdm2.abab.vvvo, rdm2.abab.vvvv)
     rdm2.bbbb = pack_2e(rdm2.bbbb.oooo, rdm2.bbbb.ooov, rdm2.bbbb.oovo, rdm2.bbbb.ovoo, rdm2.bbbb.vooo, rdm2.bbbb.oovv, rdm2.bbbb.ovov, rdm2.bbbb.ovvo, rdm2.bbbb.voov, rdm2.bbbb.vovo, rdm2.bbbb.vvoo, rdm2.bbbb.ovvv, rdm2.bbbb.vovv, rdm2.bbbb.vvov, rdm2.bbbb.vvvo, rdm2.bbbb.vvvv)
     rdm2 = Namespace(
-        aaaa=rdm2.aaaa.transpose(0, 2, 1, 3),
-        aabb=rdm2.abab.transpose(0, 2, 1, 3),
-        bbbb=rdm2.bbbb.transpose(0, 2, 1, 3),
+        aaaa=np.transpose(rdm2.aaaa, (0, 2, 1, 3)),
+        aabb=np.transpose(rdm2.abab, (0, 2, 1, 3)),
+        bbbb=np.transpose(rdm2.bbbb, (0, 2, 1, 3)),
     )
 
     return rdm2
@@ -2327,33 +2327,33 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     ints = kwargs["ints"]
     r1new = Namespace()
     r2new = Namespace()
-    tmp56 = ints.tmp147.copy()
+    tmp56 = np.copy(ints.tmp147)
     tmp56 += ints.tmp151 * 0.5
-    tmp58 = ints.tmp41.copy() * 2
+    tmp58 = np.copy(ints.tmp41) * 2
     tmp58 += ints.tmp43
-    tmp60 = ints.tmp184.copy()
+    tmp60 = np.copy(ints.tmp184)
     del ints.tmp184
-    tmp60 += v.bbbb.ooov.transpose((0, 2, 1, 3)) * 0.5
-    tmp65 = ints.tmp143.copy()
+    tmp60 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3)) * 0.5
+    tmp65 = np.copy(ints.tmp143)
     tmp65 += ints.tmp149 * 2
-    tmp67 = f.bb.oo.copy()
+    tmp67 = np.copy(f.bb.oo)
     tmp67 += ints.tmp28
-    tmp69 = ints.tmp188.copy()
+    tmp69 = np.copy(ints.tmp188)
     del ints.tmp188
     tmp69 += ints.tmp186 * 2
     del ints.tmp186
-    tmp22 = ints.tmp20.copy() * 2
+    tmp22 = np.copy(ints.tmp20) * 2
     tmp22 += ints.tmp22
-    tmp24 = ints.tmp67.copy()
+    tmp24 = np.copy(ints.tmp67)
     del ints.tmp67
-    tmp24 += v.aaaa.ooov.transpose((0, 2, 1, 3)) * 0.5
-    tmp20 = ints.tmp83.copy()
+    tmp24 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3)) * 0.5
+    tmp20 = np.copy(ints.tmp83)
     tmp20 += ints.tmp87 * 2
-    tmp18 = ints.tmp79.copy()
+    tmp18 = np.copy(ints.tmp79)
     tmp18 += ints.tmp85 * 0.5
-    tmp12 = f.aa.oo.copy()
+    tmp12 = np.copy(f.aa.oo)
     tmp12 += ints.tmp1
-    tmp14 = ints.tmp71.copy()
+    tmp14 = np.copy(ints.tmp71)
     del ints.tmp71
     tmp14 += ints.tmp69 * 2
     del ints.tmp69
@@ -2397,7 +2397,7 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp14
     tmp11 = einsum(r2.bab, (0, 1, 2), v.aabb.ovov, (3, 4, 0, 2), (1, 3, 4)) * -1
     tmp10 = einsum(ints.tmp81, (0, 1, 2, 3), r2.bab, (1, 4, 3), (0, 4, 2)) * -1
-    tmp52 = ints.tmp152.copy()
+    tmp52 = np.copy(ints.tmp152)
     del ints.tmp152
     tmp52 += ints.tmp155 * 2
     del ints.tmp155
@@ -2416,128 +2416,128 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp165
     tmp52 += ints.tmp167 * -1
     del ints.tmp167
-    tmp73 = tmp39.copy() * -0.5
+    tmp73 = np.copy(tmp39) * -0.5
     tmp73 += tmp40
-    tmp74 = ints.tmp176.copy()
+    tmp74 = np.copy(ints.tmp176)
     del ints.tmp176
-    tmp74 += ints.tmp198.transpose((1, 2, 0, 3)) * -1
+    tmp74 += np.transpose(ints.tmp198, (1, 2, 0, 3)) * -1
     del ints.tmp198
-    tmp72 = ints.tmp178.copy()
+    tmp72 = np.copy(ints.tmp178)
     del ints.tmp178
-    tmp72 += v.bbbb.oooo.transpose((0, 2, 1, 3))
-    tmp62 = tmp53.copy()
+    tmp72 += np.transpose(v.bbbb.oooo, (0, 2, 1, 3))
+    tmp62 = np.copy(tmp53)
     del tmp53
     tmp62 += tmp54
     del tmp54
     tmp62 += tmp55 * 2
     del tmp55
-    tmp62 += tmp57.transpose((1, 0, 2)) * -1
+    tmp62 += np.transpose(tmp57, (1, 0, 2)) * -1
     del tmp57
-    tmp62 += tmp59.transpose((1, 0, 2))
+    tmp62 += np.transpose(tmp59, (1, 0, 2))
     del tmp59
     tmp62 += tmp61
     del tmp61
-    tmp71 = tmp63.copy() * 4
+    tmp71 = np.copy(tmp63) * 4
     del tmp63
     tmp71 += tmp64 * 2
     del tmp64
-    tmp71 += tmp66.transpose((1, 0, 2))
+    tmp71 += np.transpose(tmp66, (1, 0, 2))
     del tmp66
-    tmp71 += tmp68.transpose((1, 0, 2)) * -2
+    tmp71 += np.transpose(tmp68, (1, 0, 2)) * -2
     del tmp68
     tmp71 += tmp70
     del tmp70
-    tmp50 = ints.tmp158.transpose((1, 0)).copy() * 2
+    tmp50 = np.copy(np.transpose(ints.tmp158, (1, 0))) * 2
     del ints.tmp158
-    tmp50 += ints.tmp160.transpose((1, 0))
+    tmp50 += np.transpose(ints.tmp160, (1, 0))
     del ints.tmp160
     tmp50 += f.bb.vv * -1
     tmp50 += tmp49
     del tmp49
-    tmp44 = f.aa.oo.copy()
+    tmp44 = np.copy(f.aa.oo)
     tmp44 += ints.tmp1
-    tmp44 += ints.tmp20.transpose((1, 0)) * 2
-    tmp44 += ints.tmp22.transpose((1, 0))
-    tmp32 = tmp30.copy() * 2
+    tmp44 += np.transpose(ints.tmp20, (1, 0)) * 2
+    tmp44 += np.transpose(ints.tmp22, (1, 0))
+    tmp32 = np.copy(tmp30) * 2
     del tmp30
     tmp32 += tmp31
     del tmp31
-    tmp48 = ints.tmp104.copy()
+    tmp48 = np.copy(ints.tmp104)
     tmp48 += v.aabb.oooo
-    tmp47 = ints.tmp162.copy()
+    tmp47 = np.copy(ints.tmp162)
     del ints.tmp162
     tmp47 += v.aabb.oovv * -1
-    tmp51 = ints.tmp131.copy()
+    tmp51 = np.copy(ints.tmp131)
     del ints.tmp131
     tmp51 += ints.tmp138
     del ints.tmp138
     tmp51 += ints.tmp139 * 2
     del ints.tmp139
-    tmp51 += ints.tmp154.transpose((1, 0, 2, 3))
+    tmp51 += np.transpose(ints.tmp154, (1, 0, 2, 3))
     del ints.tmp154
     tmp51 += v.aabb.ooov
     tmp51 += ints.tmp137 * -1
     del ints.tmp137
     tmp51 += ints.tmp157 * -1
     del ints.tmp157
-    tmp46 = ints.tmp143.copy()
+    tmp46 = np.copy(ints.tmp143)
     del ints.tmp143
     tmp46 += ints.tmp149 * 2
     del ints.tmp149
-    tmp46 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp46 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp46 += ints.tmp141 * -1
     del ints.tmp141
-    tmp45 = ints.tmp147.copy() * 2
+    tmp45 = np.copy(ints.tmp147) * 2
     del ints.tmp147
     tmp45 += ints.tmp151
     del ints.tmp151
-    tmp45 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp45 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp45 += ints.tmp145 * -2
     del ints.tmp145
     tmp45 += v.bbbb.oovv * -1
-    tmp43 = f.bb.oo.copy()
+    tmp43 = np.copy(f.bb.oo)
     tmp43 += ints.tmp28
-    tmp43 += ints.tmp41.transpose((1, 0)) * 2
-    tmp43 += ints.tmp43.transpose((1, 0))
-    tmp41 = tmp39.copy() * -1
+    tmp43 += np.transpose(ints.tmp41, (1, 0)) * 2
+    tmp43 += np.transpose(ints.tmp43, (1, 0))
+    tmp41 = np.copy(tmp39) * -1
     del tmp39
     tmp41 += tmp40 * 2
     del tmp40
-    tmp36 = ints.tmp83.copy()
+    tmp36 = np.copy(ints.tmp83)
     del ints.tmp83
     tmp36 += ints.tmp87 * 2
     del ints.tmp87
-    tmp36 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp36 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp36 += ints.tmp81 * -1
     del ints.tmp81
-    tmp35 = ints.tmp79.copy() * 2
+    tmp35 = np.copy(ints.tmp79) * 2
     del ints.tmp79
     tmp35 += ints.tmp85
     del ints.tmp85
-    tmp35 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp35 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp35 += ints.tmp77 * -2
     del ints.tmp77
     tmp35 += v.aaaa.oovv * -1
-    tmp42 = ints.tmp102.copy()
+    tmp42 = np.copy(ints.tmp102)
     del ints.tmp102
     tmp42 += ints.tmp108
     del ints.tmp108
     tmp42 += ints.tmp109 * 2
     del ints.tmp109
-    tmp42 += ints.tmp117.transpose((0, 2, 1, 3))
+    tmp42 += np.transpose(ints.tmp117, (0, 2, 1, 3))
     del ints.tmp117
-    tmp42 += v.aabb.ovoo.transpose((0, 2, 3, 1))
+    tmp42 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
     tmp42 += ints.tmp107 * -1
     del ints.tmp107
     tmp42 += ints.tmp118 * -1
     del ints.tmp118
-    tmp37 = ints.tmp121.copy()
+    tmp37 = np.copy(ints.tmp121)
     del ints.tmp121
-    tmp37 += v.aabb.vvoo.transpose((2, 3, 0, 1)) * -1
-    tmp38 = ints.tmp104.copy()
+    tmp37 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1)) * -1
+    tmp38 = np.copy(ints.tmp104)
     del ints.tmp104
     tmp38 += v.aabb.oooo
-    tmp34 = ints.tmp52.copy() * 2
+    tmp34 = np.copy(ints.tmp52) * 2
     del ints.tmp52
     tmp34 += ints.tmp59
     del ints.tmp59
@@ -2556,31 +2556,31 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp62
     tmp34 += ints.tmp63 * -1
     del ints.tmp63
-    tmp29 = ints.tmp73.transpose((1, 0)).copy() * 2
+    tmp29 = np.copy(np.transpose(ints.tmp73, (1, 0))) * 2
     del ints.tmp73
-    tmp29 += ints.tmp75.transpose((1, 0))
+    tmp29 += np.transpose(ints.tmp75, (1, 0))
     del ints.tmp75
     tmp29 += f.aa.vv * -1
     tmp29 += tmp28
     del tmp28
-    tmp26 = tmp17.copy() * 2
+    tmp26 = np.copy(tmp17) * 2
     del tmp17
-    tmp26 += tmp19.transpose((1, 0, 2)) * -1
+    tmp26 += np.transpose(tmp19, (1, 0, 2)) * -1
     del tmp19
-    tmp26 += tmp21.transpose((1, 0, 2))
+    tmp26 += np.transpose(tmp21, (1, 0, 2))
     del tmp21
-    tmp26 += tmp23.transpose((1, 0, 2))
+    tmp26 += np.transpose(tmp23, (1, 0, 2))
     del tmp23
     tmp26 += tmp25
     del tmp25
-    tmp33 = ints.tmp54.copy()
+    tmp33 = np.copy(ints.tmp54)
     del ints.tmp54
-    tmp33 += ints.tmp89.transpose((1, 2, 0, 3)) * -1
+    tmp33 += np.transpose(ints.tmp89, (1, 2, 0, 3)) * -1
     del ints.tmp89
-    tmp27 = ints.tmp56.copy()
+    tmp27 = np.copy(ints.tmp56)
     del ints.tmp56
-    tmp27 += v.aaaa.oooo.transpose((0, 2, 1, 3))
-    tmp16 = tmp8.copy() * 4
+    tmp27 += np.transpose(v.aaaa.oooo, (0, 2, 1, 3))
+    tmp16 = np.copy(tmp8) * 4
     del tmp8
     tmp16 += tmp9 * 2
     del tmp9
@@ -2588,79 +2588,79 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp10
     tmp16 += tmp11
     del tmp11
-    tmp16 += tmp13.transpose((1, 0, 2)) * -2
+    tmp16 += np.transpose(tmp13, (1, 0, 2)) * -2
     del tmp13
     tmp16 += tmp15
     del tmp15
-    tmp6 = ints.tmp37.copy()
+    tmp6 = np.copy(ints.tmp37)
     del ints.tmp37
     tmp6 += v.bbbb.ooov * -1
-    tmp7 = f.bb.oo.copy()
+    tmp7 = np.copy(f.bb.oo)
     tmp7 += ints.tmp28
     del ints.tmp28
-    tmp7 += ints.tmp32.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp32, (1, 0))
     del ints.tmp32
-    tmp7 += ints.tmp33.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp33, (1, 0))
     del ints.tmp33
-    tmp7 += ints.tmp41.transpose((1, 0)) * 2
+    tmp7 += np.transpose(ints.tmp41, (1, 0)) * 2
     del ints.tmp41
-    tmp7 += ints.tmp43.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp43, (1, 0))
     del ints.tmp43
-    tmp7 += ints.tmp46.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp46, (1, 0))
     del ints.tmp46
-    tmp7 += ints.tmp47.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp47, (1, 0))
     del ints.tmp47
-    tmp7 += ints.tmp31.transpose((1, 0)) * -1
+    tmp7 += np.transpose(ints.tmp31, (1, 0)) * -1
     del ints.tmp31
-    tmp7 += ints.tmp45.transpose((1, 0)) * -1
+    tmp7 += np.transpose(ints.tmp45, (1, 0)) * -1
     del ints.tmp45
-    tmp2 = f.bb.ov.copy()
+    tmp2 = np.copy(f.bb.ov)
     tmp2 += ints.tmp12
     del ints.tmp12
     tmp2 += ints.tmp15
     del ints.tmp15
     tmp2 += ints.tmp11 * -1
     del ints.tmp11
-    tmp5 = ints.tmp39.copy()
+    tmp5 = np.copy(ints.tmp39)
     del ints.tmp39
-    tmp5 += v.aabb.ovoo.transpose((0, 2, 3, 1))
-    tmp3 = f.aa.ov.copy()
+    tmp5 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
+    tmp3 = np.copy(f.aa.ov)
     tmp3 += ints.tmp13
     del ints.tmp13
     tmp3 += ints.tmp9
     del ints.tmp9
     tmp3 += ints.tmp7 * -1
     del ints.tmp7
-    tmp4 = f.aa.oo.copy()
+    tmp4 = np.copy(f.aa.oo)
     tmp4 += ints.tmp1
     del ints.tmp1
-    tmp4 += ints.tmp20.transpose((1, 0)) * 2
+    tmp4 += np.transpose(ints.tmp20, (1, 0)) * 2
     del ints.tmp20
-    tmp4 += ints.tmp22.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp22, (1, 0))
     del ints.tmp22
-    tmp4 += ints.tmp25.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp25, (1, 0))
     del ints.tmp25
-    tmp4 += ints.tmp26.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp26, (1, 0))
     del ints.tmp26
-    tmp4 += ints.tmp5.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp5, (1, 0))
     del ints.tmp5
-    tmp4 += ints.tmp6.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp6, (1, 0))
     del ints.tmp6
-    tmp4 += ints.tmp24.transpose((1, 0)) * -1
+    tmp4 += np.transpose(ints.tmp24, (1, 0)) * -1
     del ints.tmp24
-    tmp4 += ints.tmp4.transpose((1, 0)) * -1
+    tmp4 += np.transpose(ints.tmp4, (1, 0)) * -1
     del ints.tmp4
-    tmp0 = ints.tmp18.copy()
+    tmp0 = np.copy(ints.tmp18)
     del ints.tmp18
     tmp0 += v.aabb.ooov
-    tmp1 = ints.tmp16.copy()
+    tmp1 = np.copy(ints.tmp16)
     del ints.tmp16
     tmp1 += v.aaaa.ooov * -1
-    r2new.bbb = tmp62.copy() * -1
-    r2new.bbb += tmp62.transpose((1, 0, 2))
+    r2new.bbb = np.copy(tmp62) * -1
+    r2new.bbb += np.transpose(tmp62, (1, 0, 2))
     del tmp62
     r2new.bbb += tmp71
-    r2new.bbb += tmp71.transpose((1, 0, 2)) * -1
+    r2new.bbb += np.transpose(tmp71, (1, 0, 2)) * -1
     del tmp71
     r2new.bbb += einsum(tmp72, (0, 1, 2, 3), r2.bbb, (3, 2, 4), (0, 1, 4)) * -2
     del tmp72
@@ -2706,11 +2706,11 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r2new.aba += einsum(r2.aba, (0, 1, 2), tmp44, (0, 3), (3, 1, 2)) * -1
     del tmp44
     r2new.aba += einsum(r1.b, (0,), tmp34, (1, 2), (1, 0, 2))
-    r2new.aaa = tmp16.copy()
-    r2new.aaa += tmp16.transpose((1, 0, 2)) * -1
+    r2new.aaa = np.copy(tmp16)
+    r2new.aaa += np.transpose(tmp16, (1, 0, 2)) * -1
     del tmp16
     r2new.aaa += tmp26 * -1
-    r2new.aaa += tmp26.transpose((1, 0, 2))
+    r2new.aaa += np.transpose(tmp26, (1, 0, 2))
     del tmp26
     r2new.aaa += einsum(tmp27, (0, 1, 2, 3), r2.aaa, (2, 3, 4), (0, 1, 4)) * 2
     del tmp27
@@ -2941,30 +2941,30 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r1new = Namespace()
     r2new = Namespace()
     tmp56 = einsum(r2.bbb, (0, 1, 2), f.bb.ov, (3, 1), (3, 2, 0))
-    tmp62 = ints.tmp176.copy()
+    tmp62 = np.copy(ints.tmp176)
     del ints.tmp176
     tmp62 += ints.tmp180 * 0.5
     del ints.tmp180
     tmp62 += v.bbbb.ovvv * 0.5
-    tmp58 = ints.tmp166.copy() * 2
+    tmp58 = np.copy(ints.tmp166) * 2
     tmp58 += ints.tmp170
-    tmp60 = ints.tmp41.transpose((1, 0)).copy()
-    tmp60 += ints.tmp43.transpose((1, 0)) * 0.5
+    tmp60 = np.copy(np.transpose(ints.tmp41, (1, 0)))
+    tmp60 += np.transpose(ints.tmp43, (1, 0)) * 0.5
     tmp60 += f.bb.vv * -0.5
-    tmp68 = ints.tmp162.copy()
+    tmp68 = np.copy(ints.tmp162)
     tmp68 += ints.tmp168 * 2
-    tmp16 = ints.tmp69.copy() * 0.5
+    tmp16 = np.copy(ints.tmp69) * 0.5
     tmp16 += ints.tmp73
-    tmp14 = ints.tmp65.copy() * 2
+    tmp14 = np.copy(ints.tmp65) * 2
     tmp14 += ints.tmp71
     tmp12 = einsum(f.aa.ov, (0, 1), r2.aaa, (2, 1, 3), (0, 3, 2))
-    tmp20 = ints.tmp55.copy()
+    tmp20 = np.copy(ints.tmp55)
     del ints.tmp55
     tmp20 += ints.tmp59 * 0.5
     del ints.tmp59
     tmp20 += v.aaaa.ovvv * 0.5
-    tmp18 = ints.tmp20.transpose((1, 0)).copy()
-    tmp18 += ints.tmp22.transpose((1, 0)) * 0.5
+    tmp18 = np.copy(np.transpose(ints.tmp20, (1, 0)))
+    tmp18 += np.transpose(ints.tmp22, (1, 0)) * 0.5
     tmp18 += f.aa.vv * -0.5
     tmp57 = einsum(t1.bb, (0, 1), tmp56, (0, 2, 3), (2, 3, 1))
     del tmp56
@@ -3008,14 +3008,14 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp19 = einsum(r2.aaa, (0, 1, 2), tmp18, (1, 3), (2, 0, 3)) * -4
     del tmp18
     tmp11 = einsum(r2.aaa, (0, 1, 2), v.aaaa.oovv, (3, 2, 4, 1), (3, 0, 4))
-    tmp1 = f.bb.ov.copy()
+    tmp1 = np.copy(f.bb.ov)
     tmp1 += ints.tmp12
     del ints.tmp12
     tmp1 += ints.tmp15
     del ints.tmp15
     tmp1 += ints.tmp11 * -1
     del ints.tmp11
-    tmp0 = f.aa.ov.copy()
+    tmp0 = np.copy(f.aa.ov)
     tmp0 += ints.tmp13
     del ints.tmp13
     tmp0 += ints.tmp9
@@ -3023,7 +3023,7 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp0 += ints.tmp7 * -1
     del ints.tmp7
     tmp52 = einsum(r2.bbb, (0, 1, 2), v.bbbb.ovov, (3, 1, 4, 0), (2, 3, 4)) * -1
-    tmp64 = tmp53.copy()
+    tmp64 = np.copy(tmp53)
     del tmp53
     tmp64 += tmp54
     del tmp54
@@ -3031,13 +3031,13 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp55
     tmp64 += tmp57 * 2
     del tmp57
-    tmp64 += tmp59.transpose((0, 2, 1)) * -1
+    tmp64 += np.transpose(tmp59, (0, 2, 1)) * -1
     del tmp59
-    tmp64 += tmp61.transpose((0, 2, 1))
+    tmp64 += np.transpose(tmp61, (0, 2, 1))
     del tmp61
     tmp64 += tmp63
     del tmp63
-    tmp51 = ints.tmp141.copy() * 2
+    tmp51 = np.copy(ints.tmp141) * 2
     del ints.tmp141
     tmp51 += ints.tmp147
     del ints.tmp147
@@ -3056,78 +3056,78 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp152
     tmp51 += ints.tmp153 * -2
     del ints.tmp153
-    tmp71 = tmp42.copy()
+    tmp71 = np.copy(tmp42)
     tmp71 += tmp7 * -1
     tmp71 += tmp8 * 2
-    tmp70 = tmp65.copy() * 2
+    tmp70 = np.copy(tmp65) * 2
     del tmp65
     tmp70 += tmp66 * 4
     del tmp66
     tmp70 += tmp67 * 2
     del tmp67
-    tmp70 += tmp69.transpose((0, 2, 1))
+    tmp70 += np.transpose(tmp69, (0, 2, 1))
     del tmp69
-    tmp50 = f.bb.oo.copy()
+    tmp50 = np.copy(f.bb.oo)
     tmp50 += ints.tmp139
     del ints.tmp139
-    tmp50 += ints.tmp143.transpose((1, 0)) * 2
+    tmp50 += np.transpose(ints.tmp143, (1, 0)) * 2
     del ints.tmp143
-    tmp50 += ints.tmp145.transpose((1, 0))
+    tmp50 += np.transpose(ints.tmp145, (1, 0))
     del ints.tmp145
     tmp44 = einsum(v.aabb.ovov, (0, 1, 2, 3), r2.bab, (3, 1, 4), (0, 4, 2)) * -1
-    tmp41 = ints.tmp20.transpose((1, 0)).copy() * 2
-    tmp41 += ints.tmp22.transpose((1, 0))
+    tmp41 = np.copy(np.transpose(ints.tmp20, (1, 0))) * 2
+    tmp41 += np.transpose(ints.tmp22, (1, 0))
     tmp41 += f.aa.vv * -1
     tmp41 += tmp40
     del tmp40
-    tmp48 = ints.tmp132.copy()
+    tmp48 = np.copy(ints.tmp132)
     del ints.tmp132
     tmp48 += ints.tmp154
     del ints.tmp154
     tmp48 += ints.tmp156 * 2
     del ints.tmp156
-    tmp48 += v.aabb.vvov.transpose((2, 0, 1, 3))
+    tmp48 += np.transpose(v.aabb.vvov, (2, 0, 1, 3))
     tmp48 += ints.tmp128 * -1
     del ints.tmp128
-    tmp48 += ints.tmp155.transpose((0, 2, 1, 3)) * -1
+    tmp48 += np.transpose(ints.tmp155, (0, 2, 1, 3)) * -1
     del ints.tmp155
-    tmp31 = tmp30.copy() * 0.5
+    tmp31 = np.copy(tmp30) * 0.5
     del tmp30
     tmp31 += tmp3
     tmp31 += tmp4 * 0.5
-    tmp47 = ints.tmp131.copy()
+    tmp47 = np.copy(ints.tmp131)
     del ints.tmp131
-    tmp47 += v.aabb.vvoo.transpose((2, 3, 0, 1)) * -1
-    tmp49 = ints.tmp41.transpose((1, 0)).copy()
-    tmp49 += ints.tmp43.transpose((1, 0)) * 0.5
+    tmp47 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1)) * -1
+    tmp49 = np.copy(np.transpose(ints.tmp41, (1, 0)))
+    tmp49 += np.transpose(ints.tmp43, (1, 0)) * 0.5
     tmp49 += f.bb.vv * -0.5
     tmp49 += tmp38 * 0.5
-    tmp46 = ints.tmp162.copy()
+    tmp46 = np.copy(ints.tmp162)
     del ints.tmp162
     tmp46 += ints.tmp168 * 2
     del ints.tmp168
-    tmp46 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp46 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp46 += ints.tmp160 * -1
     del ints.tmp160
-    tmp45 = ints.tmp166.copy() * 2
+    tmp45 = np.copy(ints.tmp166) * 2
     del ints.tmp166
     tmp45 += ints.tmp170
     del ints.tmp170
-    tmp45 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp45 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp45 += ints.tmp164 * -2
     del ints.tmp164
     tmp45 += v.bbbb.oovv * -1
-    tmp36 = ints.tmp104.copy()
+    tmp36 = np.copy(ints.tmp104)
     del ints.tmp104
     tmp36 += v.aabb.oovv * -1
-    tmp35 = ints.tmp69.copy()
+    tmp35 = np.copy(ints.tmp69)
     del ints.tmp69
     tmp35 += ints.tmp73 * 2
     del ints.tmp73
-    tmp35 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp35 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp35 += ints.tmp67 * -1
     del ints.tmp67
-    tmp37 = ints.tmp105.copy()
+    tmp37 = np.copy(ints.tmp105)
     del ints.tmp105
     tmp37 += ints.tmp115
     del ints.tmp115
@@ -3136,10 +3136,10 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp37 += v.aabb.ovvv
     tmp37 += ints.tmp101 * -1
     del ints.tmp101
-    tmp37 += ints.tmp116.transpose((0, 1, 3, 2)) * -1
+    tmp37 += np.transpose(ints.tmp116, (0, 1, 3, 2)) * -1
     del ints.tmp116
     tmp33 = einsum(r2.aba, (0, 1, 2), v.aabb.ovov, (3, 0, 4, 1), (2, 3, 4))
-    tmp32 = ints.tmp76.copy()
+    tmp32 = np.copy(ints.tmp76)
     del ints.tmp76
     tmp32 += ints.tmp79 * 2
     del ints.tmp79
@@ -3158,31 +3158,31 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp88
     tmp32 += ints.tmp94 * -1
     del ints.tmp94
-    tmp34 = ints.tmp65.copy() * 2
+    tmp34 = np.copy(ints.tmp65) * 2
     del ints.tmp65
     tmp34 += ints.tmp71
     del ints.tmp71
-    tmp34 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp34 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp34 += ints.tmp63 * -2
     del ints.tmp63
     tmp34 += v.aaaa.oovv * -1
-    tmp39 = ints.tmp41.transpose((1, 0)).copy() * 2
-    tmp39 += ints.tmp43.transpose((1, 0))
+    tmp39 = np.copy(np.transpose(ints.tmp41, (1, 0))) * 2
+    tmp39 += np.transpose(ints.tmp43, (1, 0))
     tmp39 += f.bb.vv * -1
     tmp39 += tmp38
     del tmp38
-    tmp43 = tmp42.copy() * 0.5
+    tmp43 = np.copy(tmp42) * 0.5
     del tmp42
     tmp43 += tmp7 * -0.5
     tmp43 += tmp8
-    tmp29 = f.aa.oo.copy()
+    tmp29 = np.copy(f.aa.oo)
     tmp29 += ints.tmp89
     del ints.tmp89
-    tmp29 += ints.tmp95.transpose((1, 0)) * 2
+    tmp29 += np.transpose(ints.tmp95, (1, 0)) * 2
     del ints.tmp95
-    tmp29 += ints.tmp97.transpose((1, 0))
+    tmp29 += np.transpose(ints.tmp97, (1, 0))
     del ints.tmp97
-    tmp28 = tmp23.copy() * 2
+    tmp28 = np.copy(tmp23) * 2
     del tmp23
     tmp28 += tmp24 * 4
     del tmp24
@@ -3192,47 +3192,47 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp26
     tmp28 += tmp27
     del tmp27
-    tmp22 = tmp11.copy() * 2
+    tmp22 = np.copy(tmp11) * 2
     del tmp11
     tmp22 += tmp13 * 2
     del tmp13
-    tmp22 += tmp15.transpose((0, 2, 1)) * -1
+    tmp22 += np.transpose(tmp15, (0, 2, 1)) * -1
     del tmp15
-    tmp22 += tmp17.transpose((0, 2, 1))
+    tmp22 += np.transpose(tmp17, (0, 2, 1))
     del tmp17
-    tmp22 += tmp19.transpose((0, 2, 1))
+    tmp22 += np.transpose(tmp19, (0, 2, 1))
     del tmp19
     tmp22 += tmp21
     del tmp21
     tmp10 = einsum(r2.aaa, (0, 1, 2), v.aaaa.ovov, (3, 0, 4, 1), (2, 3, 4))
-    tmp9 = tmp7.copy() * -1
+    tmp9 = np.copy(tmp7) * -1
     del tmp7
     tmp9 += tmp8 * 2
     del tmp8
     tmp9 += einsum(tmp1, (0, 1), r1.b, (1,), (0,))
-    tmp6 = ints.tmp32.copy()
+    tmp6 = np.copy(ints.tmp32)
     del ints.tmp32
-    tmp6 += ints.tmp41.transpose((1, 0)) * 2
+    tmp6 += np.transpose(ints.tmp41, (1, 0)) * 2
     del ints.tmp41
-    tmp6 += ints.tmp43.transpose((1, 0))
+    tmp6 += np.transpose(ints.tmp43, (1, 0))
     del ints.tmp43
     tmp6 += f.bb.vv * -1
-    tmp6 += ints.tmp31.transpose((1, 0)) * -1
+    tmp6 += np.transpose(ints.tmp31, (1, 0)) * -1
     del ints.tmp31
-    tmp6 += ints.tmp33.transpose((1, 0)) * -1
+    tmp6 += np.transpose(ints.tmp33, (1, 0)) * -1
     del ints.tmp33
-    tmp2 = ints.tmp20.transpose((1, 0)).copy() * 2
+    tmp2 = np.copy(np.transpose(ints.tmp20, (1, 0))) * 2
     del ints.tmp20
-    tmp2 += ints.tmp22.transpose((1, 0))
+    tmp2 += np.transpose(ints.tmp22, (1, 0))
     del ints.tmp22
     tmp2 += ints.tmp5
     del ints.tmp5
     tmp2 += f.aa.vv * -1
-    tmp2 += ints.tmp4.transpose((1, 0)) * -1
+    tmp2 += np.transpose(ints.tmp4, (1, 0)) * -1
     del ints.tmp4
-    tmp2 += ints.tmp6.transpose((1, 0)) * -1
+    tmp2 += np.transpose(ints.tmp6, (1, 0)) * -1
     del ints.tmp6
-    tmp5 = tmp3.copy() * 2
+    tmp5 = np.copy(tmp3) * 2
     del tmp3
     tmp5 += tmp4
     del tmp4
@@ -3242,11 +3242,11 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r2new.bbb += einsum(r2.bbb, (0, 1, 2), v.bbbb.vvvv, (3, 0, 4, 1), (3, 4, 2)) * 2
     r2new.bbb += einsum(r1.b, (0,), ints.tmp193, (1, 2, 3, 0), (3, 2, 1)) * 2
     del ints.tmp193
-    r2new.bbb += tmp64.transpose((1, 2, 0)) * -1
-    r2new.bbb += tmp64.transpose((2, 1, 0))
+    r2new.bbb += np.transpose(tmp64, (1, 2, 0)) * -1
+    r2new.bbb += np.transpose(tmp64, (2, 1, 0))
     del tmp64
-    r2new.bbb += tmp70.transpose((1, 2, 0))
-    r2new.bbb += tmp70.transpose((2, 1, 0)) * -1
+    r2new.bbb += np.transpose(tmp70, (1, 2, 0))
+    r2new.bbb += np.transpose(tmp70, (2, 1, 0)) * -1
     del tmp70
     r2new.bbb += einsum(r2.bbb, (0, 1, 2), tmp50, (2, 3), (0, 1, 3)) * -2
     r2new.bbb += einsum(tmp71, (0,), t2.bbbb, (1, 0, 2, 3), (2, 3, 1)) * 2
@@ -3296,11 +3296,11 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp81
     r2new.aaa += einsum(tmp10, (0, 1, 2), t2.aaaa, (2, 1, 3, 4), (3, 4, 0)) * -2
     del tmp10
-    r2new.aaa += tmp22.transpose((1, 2, 0)) * -1
-    r2new.aaa += tmp22.transpose((2, 1, 0))
+    r2new.aaa += np.transpose(tmp22, (1, 2, 0)) * -1
+    r2new.aaa += np.transpose(tmp22, (2, 1, 0))
     del tmp22
-    r2new.aaa += tmp28.transpose((1, 2, 0))
-    r2new.aaa += tmp28.transpose((2, 1, 0)) * -1
+    r2new.aaa += np.transpose(tmp28, (1, 2, 0))
+    r2new.aaa += np.transpose(tmp28, (2, 1, 0)) * -1
     del tmp28
     r2new.aaa += einsum(r2.aaa, (0, 1, 2), tmp29, (2, 3), (0, 1, 3)) * -2
     del tmp29
@@ -3784,24 +3784,24 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     r2new = Namespace()
     tmp35 = einsum(t2.abab, (0, 1, 2, 3), r2.aba, (0, 1, 2), (3,))
     tmp36 = einsum(t2.bbbb, (0, 1, 2, 3), r2.bbb, (0, 1, 3), (2,))
-    tmp51 = ints.tmp398.copy()
+    tmp51 = np.copy(ints.tmp398)
     tmp51 += ints.tmp402 * 0.5
-    tmp55 = ints.tmp140.copy() * 2
+    tmp55 = np.copy(ints.tmp140) * 2
     tmp55 += ints.tmp143
-    tmp53 = tmp35.copy() * -0.5
+    tmp53 = np.copy(tmp35) * -0.5
     tmp53 += tmp36
-    tmp62 = f.bb.oo.copy()
-    tmp62 += ints.tmp21.transpose((1, 0))
-    tmp60 = ints.tmp396.copy()
+    tmp62 = np.copy(f.bb.oo)
+    tmp62 += np.transpose(ints.tmp21, (1, 0))
+    tmp60 = np.copy(ints.tmp396)
     tmp60 += ints.tmp400 * 2
-    tmp25 = f.aa.oo.copy()
-    tmp25 += ints.tmp1.transpose((1, 0))
+    tmp25 = np.copy(f.aa.oo)
+    tmp25 += np.transpose(ints.tmp1, (1, 0))
     tmp23 = einsum(r2.bab, (0, 1, 2), t2.abab, (1, 0, 3, 2), (3,)) * -1
-    tmp16 = ints.tmp47.copy() * 2
+    tmp16 = np.copy(ints.tmp47) * 2
     tmp16 += ints.tmp49
-    tmp12 = ints.tmp345.copy()
+    tmp12 = np.copy(ints.tmp345)
     tmp12 += ints.tmp349 * 0.5
-    tmp14 = ints.tmp347.copy()
+    tmp14 = np.copy(ints.tmp347)
     tmp14 += ints.tmp351 * 2
     tmp10 = einsum(t2.aaaa, (0, 1, 2, 3), r2.aaa, (0, 1, 3), (2,))
     tmp48 = einsum(ints.tmp392, (0, 1, 2, 3), r2.aba, (0, 4, 2), (1, 4, 3))
@@ -3838,9 +3838,9 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp15 = einsum(tmp14, (0, 1, 2, 3), r2.bab, (1, 4, 3), (4, 0, 2)) * -1
     del tmp14
     tmp11 = einsum(tmp10, (0,), v.aaaa.ovov, (1, 2, 3, 0), (1, 3, 2)) * -1
-    tmp65 = ints.tmp306.copy()
+    tmp65 = np.copy(ints.tmp306)
     del ints.tmp306
-    tmp65 += v.bbbb.oooo.transpose((0, 2, 1, 3))
+    tmp65 += np.transpose(v.bbbb.oooo, (0, 2, 1, 3))
     tmp57 = einsum(f.bb.ov, (0, 1), r1.b, (2,), (0, 2, 1))
     tmp57 += tmp47
     del tmp47
@@ -3850,92 +3850,92 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp49
     tmp57 += tmp50 * 2
     del tmp50
-    tmp57 += tmp52.transpose((1, 0, 2)) * -1
+    tmp57 += np.transpose(tmp52, (1, 0, 2)) * -1
     del tmp52
-    tmp57 += tmp54.transpose((1, 0, 2)) * -1
+    tmp57 += np.transpose(tmp54, (1, 0, 2)) * -1
     del tmp54
-    tmp57 += tmp56.transpose((1, 0, 2))
+    tmp57 += np.transpose(tmp56, (1, 0, 2))
     del tmp56
-    tmp64 = tmp58.copy() * 4
+    tmp64 = np.copy(tmp58) * 4
     del tmp58
     tmp64 += tmp59 * 2
     del tmp59
-    tmp64 += tmp61.transpose((1, 0, 2))
+    tmp64 += np.transpose(tmp61, (1, 0, 2))
     del tmp61
-    tmp64 += tmp63.transpose((1, 0, 2)) * -2
+    tmp64 += np.transpose(tmp63, (1, 0, 2)) * -2
     del tmp63
-    tmp45 = ints.tmp412.copy() * 2
+    tmp45 = np.copy(ints.tmp412) * 2
     del ints.tmp412
     tmp45 += ints.tmp414
     del ints.tmp414
     tmp45 += f.bb.vv * -1
-    tmp45 += tmp44.transpose((1, 0))
+    tmp45 += np.transpose(tmp44, (1, 0))
     del tmp44
-    tmp41 = ints.tmp396.copy()
+    tmp41 = np.copy(ints.tmp396)
     del ints.tmp396
     tmp41 += ints.tmp400 * 2
     del ints.tmp400
-    tmp41 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp41 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp41 += ints.tmp392 * -1
     del ints.tmp392
-    tmp39 = f.aa.oo.copy()
-    tmp39 += ints.tmp1.transpose((1, 0))
+    tmp39 = np.copy(f.aa.oo)
+    tmp39 += np.transpose(ints.tmp1, (1, 0))
     tmp39 += ints.tmp47 * 2
     tmp39 += ints.tmp49
-    tmp40 = ints.tmp398.copy() * 2
+    tmp40 = np.copy(ints.tmp398) * 2
     del ints.tmp398
     tmp40 += ints.tmp402
     del ints.tmp402
-    tmp40 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp40 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp40 += ints.tmp394 * -2
     del ints.tmp394
     tmp40 += v.bbbb.oovv * -1
-    tmp42 = ints.tmp416.copy()
+    tmp42 = np.copy(ints.tmp416)
     del ints.tmp416
     tmp42 += v.aabb.oovv * -1
-    tmp38 = f.bb.oo.copy()
+    tmp38 = np.copy(f.bb.oo)
     tmp38 += ints.tmp140 * 2
     tmp38 += ints.tmp143
-    tmp38 += ints.tmp21.transpose((1, 0))
-    tmp46 = tmp10.copy() * 2
+    tmp38 += np.transpose(ints.tmp21, (1, 0))
+    tmp46 = np.copy(tmp10) * 2
     del tmp10
     tmp46 += tmp23
     del tmp23
-    tmp43 = ints.tmp151.copy()
+    tmp43 = np.copy(ints.tmp151)
     tmp43 += v.aabb.oooo
-    tmp32 = ints.tmp347.copy()
+    tmp32 = np.copy(ints.tmp347)
     del ints.tmp347
     tmp32 += ints.tmp351 * 2
     del ints.tmp351
-    tmp32 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp32 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp32 += ints.tmp343 * -1
     del ints.tmp343
-    tmp31 = ints.tmp345.copy() * 2
+    tmp31 = np.copy(ints.tmp345) * 2
     del ints.tmp345
     tmp31 += ints.tmp349
     del ints.tmp349
-    tmp31 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp31 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp31 += ints.tmp341 * -2
     del ints.tmp341
     tmp31 += v.aaaa.oovv * -1
-    tmp37 = tmp35.copy() * -1
+    tmp37 = np.copy(tmp35) * -1
     del tmp35
     tmp37 += tmp36 * 2
     del tmp36
-    tmp33 = ints.tmp390.copy()
+    tmp33 = np.copy(ints.tmp390)
     del ints.tmp390
-    tmp33 += v.aabb.vvoo.transpose((2, 3, 0, 1)) * -1
-    tmp34 = ints.tmp151.copy()
+    tmp33 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1)) * -1
+    tmp34 = np.copy(ints.tmp151)
     del ints.tmp151
     tmp34 += v.aabb.oooo
-    tmp30 = ints.tmp367.copy() * 2
+    tmp30 = np.copy(ints.tmp367) * 2
     del ints.tmp367
     tmp30 += ints.tmp369
     del ints.tmp369
     tmp30 += f.aa.vv * -1
-    tmp30 += tmp29.transpose((1, 0))
+    tmp30 += np.transpose(tmp29, (1, 0))
     del tmp29
-    tmp27 = tmp19.copy() * 4
+    tmp27 = np.copy(tmp19) * 4
     del tmp19
     tmp27 += tmp20 * 2
     del tmp20
@@ -3945,7 +3945,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp22
     tmp27 += tmp24
     del tmp24
-    tmp27 += tmp26.transpose((1, 0, 2)) * -2
+    tmp27 += np.transpose(tmp26, (1, 0, 2)) * -2
     del tmp26
     tmp18 = einsum(f.aa.ov, (0, 1), r1.a, (2,), (0, 2, 1))
     tmp18 += tmp8
@@ -3954,24 +3954,24 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp9
     tmp18 += tmp11 * 2
     del tmp11
-    tmp18 += tmp13.transpose((1, 0, 2)) * -1
+    tmp18 += np.transpose(tmp13, (1, 0, 2)) * -1
     del tmp13
-    tmp18 += tmp15.transpose((1, 0, 2))
+    tmp18 += np.transpose(tmp15, (1, 0, 2))
     del tmp15
-    tmp18 += tmp17.transpose((1, 0, 2))
+    tmp18 += np.transpose(tmp17, (1, 0, 2))
     del tmp17
-    tmp28 = ints.tmp148.copy()
+    tmp28 = np.copy(ints.tmp148)
     del ints.tmp148
-    tmp28 += v.aaaa.oooo.transpose((0, 2, 1, 3))
-    tmp6 = ints.tmp225.transpose((1, 2, 0, 3)).copy()
+    tmp28 += np.transpose(v.aaaa.oooo, (0, 2, 1, 3))
+    tmp6 = np.copy(np.transpose(ints.tmp225, (1, 2, 0, 3)))
     del ints.tmp225
-    tmp6 += ints.tmp230.transpose((1, 2, 0, 3))
+    tmp6 += np.transpose(ints.tmp230, (1, 2, 0, 3))
     del ints.tmp230
-    tmp6 += ints.tmp238.transpose((0, 2, 1, 3))
+    tmp6 += np.transpose(ints.tmp238, (0, 2, 1, 3))
     del ints.tmp238
-    tmp6 += ints.tmp251.transpose((0, 2, 1, 3)) * 2
+    tmp6 += np.transpose(ints.tmp251, (0, 2, 1, 3)) * 2
     del ints.tmp251
-    tmp6 += ints.tmp256.transpose((0, 2, 1, 3))
+    tmp6 += np.transpose(ints.tmp256, (0, 2, 1, 3))
     del ints.tmp256
     tmp6 += ints.tmp281
     del ints.tmp281
@@ -3997,31 +3997,31 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp292
     tmp6 += ints.tmp299 * -1
     del ints.tmp299
-    tmp6 += ints.tmp317.transpose((0, 2, 1, 3)) * -1
+    tmp6 += np.transpose(ints.tmp317, (0, 2, 1, 3)) * -1
     del ints.tmp317
     tmp6 += ints.tmp325 * -1
     del ints.tmp325
-    tmp6 += v.bbbb.ooov.transpose((0, 2, 1, 3)) * -1
-    tmp7 = f.bb.oo.copy()
+    tmp6 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3)) * -1
+    tmp7 = np.copy(f.bb.oo)
     tmp7 += ints.tmp140 * 2
     del ints.tmp140
     tmp7 += ints.tmp143
     del ints.tmp143
-    tmp7 += ints.tmp163.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp163, (1, 0))
     del ints.tmp163
-    tmp7 += ints.tmp167.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp167, (1, 0))
     del ints.tmp167
     tmp7 += ints.tmp205
     del ints.tmp205
     tmp7 += ints.tmp209
     del ints.tmp209
-    tmp7 += ints.tmp21.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp21, (1, 0))
     del ints.tmp21
     tmp7 += ints.tmp161 * -1
     del ints.tmp161
     tmp7 += ints.tmp203 * -1
     del ints.tmp203
-    tmp2 = ints.tmp120.copy()
+    tmp2 = np.copy(ints.tmp120)
     del ints.tmp120
     tmp2 += ints.tmp125 * 0.5
     del ints.tmp125
@@ -4084,15 +4084,15 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp88
     tmp2 += ints.tmp96 * -1
     del ints.tmp96
-    tmp5 = ints.tmp124.copy()
+    tmp5 = np.copy(ints.tmp124)
     del ints.tmp124
-    tmp5 += ints.tmp223.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp223, (0, 2, 1, 3))
     del ints.tmp223
-    tmp5 += ints.tmp240.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp240, (0, 2, 1, 3))
     del ints.tmp240
-    tmp5 += ints.tmp250.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp250, (0, 2, 1, 3))
     del ints.tmp250
-    tmp5 += ints.tmp254.transpose((0, 2, 1, 3)) * 2
+    tmp5 += np.transpose(ints.tmp254, (0, 2, 1, 3)) * 2
     del ints.tmp254
     tmp5 += ints.tmp264
     del ints.tmp264
@@ -4106,8 +4106,8 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp297
     tmp5 += ints.tmp328
     del ints.tmp328
-    tmp5 += v.aabb.ovoo.transpose((0, 2, 3, 1))
-    tmp5 += ints.tmp232.transpose((0, 2, 1, 3)) * -1
+    tmp5 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
+    tmp5 += np.transpose(ints.tmp232, (0, 2, 1, 3)) * -1
     del ints.tmp232
     tmp5 += ints.tmp247 * -1
     del ints.tmp247
@@ -4123,11 +4123,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp309
     tmp5 += ints.tmp319 * -1
     del ints.tmp319
-    tmp5 += ints.tmp320.transpose((0, 2, 1, 3)) * -1
+    tmp5 += np.transpose(ints.tmp320, (0, 2, 1, 3)) * -1
     del ints.tmp320
     tmp5 += ints.tmp336 * -1
     del ints.tmp336
-    tmp3 = ints.tmp117.copy()
+    tmp3 = np.copy(ints.tmp117)
     del ints.tmp117
     tmp3 += ints.tmp122 * 0.5
     del ints.tmp122
@@ -4190,16 +4190,16 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp94
     tmp3 += ints.tmp98 * -1
     del ints.tmp98
-    tmp4 = f.aa.oo.copy()
+    tmp4 = np.copy(f.aa.oo)
     tmp4 += ints.tmp155
     del ints.tmp155
     tmp4 += ints.tmp156
     del ints.tmp156
-    tmp4 += ints.tmp1.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp1, (1, 0))
     del ints.tmp1
-    tmp4 += ints.tmp26.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp26, (1, 0))
     del ints.tmp26
-    tmp4 += ints.tmp27.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp27, (1, 0))
     del ints.tmp27
     tmp4 += ints.tmp47 * 2
     del ints.tmp47
@@ -4209,7 +4209,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp154
     tmp4 += ints.tmp25 * -1
     del ints.tmp25
-    tmp0 = ints.tmp111.copy()
+    tmp0 = np.copy(ints.tmp111)
     del ints.tmp111
     tmp0 += ints.tmp115
     del ints.tmp115
@@ -4217,17 +4217,17 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp129
     tmp0 += ints.tmp135 * 2
     del ints.tmp135
-    tmp0 += ints.tmp17.transpose((1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp17, (1, 0, 2, 3))
     del ints.tmp17
     tmp0 += ints.tmp197
     del ints.tmp197
     tmp0 += ints.tmp45
     del ints.tmp45
-    tmp0 += ints.tmp46.transpose((1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp46, (1, 0, 2, 3))
     del ints.tmp46
-    tmp0 += ints.tmp64.transpose((1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp64, (1, 0, 2, 3))
     del ints.tmp64
-    tmp0 += ints.tmp68.transpose((1, 0, 2, 3)) * 2
+    tmp0 += np.transpose(ints.tmp68, (1, 0, 2, 3)) * 2
     del ints.tmp68
     tmp0 += ints.tmp80
     del ints.tmp80
@@ -4242,17 +4242,17 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp152
     tmp0 += ints.tmp175 * -1
     del ints.tmp175
-    tmp0 += ints.tmp177.transpose((1, 0, 2, 3)) * -1
+    tmp0 += np.transpose(ints.tmp177, (1, 0, 2, 3)) * -1
     del ints.tmp177
     tmp0 += ints.tmp215 * -1
     del ints.tmp215
-    tmp0 += ints.tmp30.transpose((1, 0, 2, 3)) * -1
+    tmp0 += np.transpose(ints.tmp30, (1, 0, 2, 3)) * -1
     del ints.tmp30
     tmp0 += ints.tmp61 * -1
     del ints.tmp61
     tmp0 += ints.tmp65 * -1
     del ints.tmp65
-    tmp1 = ints.tmp109.copy()
+    tmp1 = np.copy(ints.tmp109)
     del ints.tmp109
     tmp1 += ints.tmp113
     del ints.tmp113
@@ -4260,19 +4260,19 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp130
     tmp1 += ints.tmp149
     del ints.tmp149
-    tmp1 += ints.tmp15.transpose((1, 2, 0, 3))
+    tmp1 += np.transpose(ints.tmp15, (1, 2, 0, 3))
     del ints.tmp15
     tmp1 += ints.tmp170
     del ints.tmp170
     tmp1 += ints.tmp212
     del ints.tmp212
-    tmp1 += ints.tmp28.transpose((1, 2, 0, 3))
+    tmp1 += np.transpose(ints.tmp28, (1, 2, 0, 3))
     del ints.tmp28
-    tmp1 += ints.tmp43.transpose((0, 2, 1, 3))
+    tmp1 += np.transpose(ints.tmp43, (0, 2, 1, 3))
     del ints.tmp43
-    tmp1 += ints.tmp62.transpose((0, 2, 1, 3)) * 2
+    tmp1 += np.transpose(ints.tmp62, (0, 2, 1, 3)) * 2
     del ints.tmp62
-    tmp1 += ints.tmp66.transpose((0, 2, 1, 3))
+    tmp1 += np.transpose(ints.tmp66, (0, 2, 1, 3))
     del ints.tmp66
     tmp1 += ints.tmp105 * -1
     del ints.tmp105
@@ -4280,7 +4280,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp127
     tmp1 += ints.tmp133 * -1
     del ints.tmp133
-    tmp1 += ints.tmp172.transpose((0, 2, 1, 3)) * -1
+    tmp1 += np.transpose(ints.tmp172, (0, 2, 1, 3)) * -1
     del ints.tmp172
     tmp1 += ints.tmp194 * -1
     del ints.tmp194
@@ -4290,12 +4290,12 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp59
     tmp1 += ints.tmp78 * -1
     del ints.tmp78
-    tmp1 += v.aaaa.ooov.transpose((0, 2, 1, 3)) * -1
-    r2new.bbb = tmp57.copy() * -1
-    r2new.bbb += tmp57.transpose((1, 0, 2))
+    tmp1 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3)) * -1
+    r2new.bbb = np.copy(tmp57) * -1
+    r2new.bbb += np.transpose(tmp57, (1, 0, 2))
     del tmp57
     r2new.bbb += tmp64
-    r2new.bbb += tmp64.transpose((1, 0, 2)) * -1
+    r2new.bbb += np.transpose(tmp64, (1, 0, 2)) * -1
     del tmp64
     r2new.bbb += einsum(tmp65, (0, 1, 2, 3), r2.bbb, (1, 0, 4), (2, 3, 4)) * -2
     del tmp65
@@ -4333,11 +4333,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp38
     r2new.aba += einsum(r2.aba, (0, 1, 2), tmp39, (0, 3), (3, 1, 2)) * -1
     del tmp39
-    r2new.aaa = tmp18.copy() * -1
-    r2new.aaa += tmp18.transpose((1, 0, 2))
+    r2new.aaa = np.copy(tmp18) * -1
+    r2new.aaa += np.transpose(tmp18, (1, 0, 2))
     del tmp18
     r2new.aaa += tmp27
-    r2new.aaa += tmp27.transpose((1, 0, 2)) * -1
+    r2new.aaa += np.transpose(tmp27, (1, 0, 2)) * -1
     del tmp27
     r2new.aaa += einsum(tmp28, (0, 1, 2, 3), r2.aaa, (0, 1, 4), (2, 3, 4)) * 2
     del tmp28
@@ -4706,25 +4706,25 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     r2new = Namespace()
     tmp32 = einsum(t2.abab, (0, 1, 2, 3), r2.aba, (2, 3, 0), (1,))
     tmp33 = einsum(r2.bbb, (0, 1, 2), t2.bbbb, (3, 2, 0, 1), (3,))
-    tmp76 = ints.tmp285.copy() * 2
+    tmp76 = np.copy(ints.tmp285) * 2
     tmp76 += ints.tmp292
-    tmp78 = ints.tmp230.copy()
+    tmp78 = np.copy(ints.tmp230)
     tmp78 += ints.tmp232 * 0.5
     tmp78 += f.bb.vv * -0.5
-    tmp80 = tmp32.copy() * -0.5
+    tmp80 = np.copy(tmp32) * -0.5
     tmp80 += tmp33
-    tmp86 = ints.tmp284.copy()
+    tmp86 = np.copy(ints.tmp284)
     tmp86 += ints.tmp290 * 2
     tmp21 = einsum(r2.bbb, (0, 1, 2), t1.bb, (3, 1), (2, 3, 0))
     tmp16 = einsum(t2.abab, (0, 1, 2, 3), r2.bab, (3, 2, 1), (0,)) * -1
     tmp2 = einsum(r2.aaa, (0, 1, 2), t1.aa, (3, 1), (2, 3, 0))
-    tmp40 = ints.tmp139.copy() * 2
+    tmp40 = np.copy(ints.tmp139) * 2
     tmp40 += ints.tmp145
     tmp15 = einsum(r2.aaa, (0, 1, 2), t2.aaaa, (3, 2, 0, 1), (3,))
-    tmp44 = ints.tmp47.copy()
+    tmp44 = np.copy(ints.tmp47)
     tmp44 += ints.tmp49 * 0.5
     tmp44 += f.aa.vv * -0.5
-    tmp42 = ints.tmp141.copy() * 0.5
+    tmp42 = np.copy(ints.tmp141) * 0.5
     tmp42 += ints.tmp147
     tmp77 = einsum(tmp76, (0, 1, 2, 3), r2.bbb, (4, 2, 0), (1, 4, 3)) * -2
     del tmp76
@@ -4760,12 +4760,12 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp42
     tmp25 = einsum(t1.aa, (0, 1), r2.aba, (1, 2, 3), (3, 0, 2))
     tmp6 = einsum(t1.bb, (0, 1), r2.bab, (1, 2, 3), (3, 0, 2)) * -1
-    tmp69 = f.bb.oo.copy()
+    tmp69 = np.copy(f.bb.oo)
     tmp69 += ints.tmp130 * 2
     del ints.tmp130
     tmp69 += ints.tmp133
     del ints.tmp133
-    tmp69 += ints.tmp22.transpose((1, 0))
+    tmp69 += np.transpose(ints.tmp22, (1, 0))
     del ints.tmp22
     tmp82 = einsum(r1.b, (0,), f.bb.ov, (1, 2), (1, 2, 0))
     tmp82 += tmp72
@@ -4776,72 +4776,72 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp74
     tmp82 += tmp75 * 2
     del tmp75
-    tmp82 += tmp77.transpose((0, 2, 1)) * -1
+    tmp82 += np.transpose(tmp77, (0, 2, 1)) * -1
     del tmp77
-    tmp82 += tmp79.transpose((0, 2, 1))
+    tmp82 += np.transpose(tmp79, (0, 2, 1))
     del tmp79
-    tmp82 += tmp81.transpose((0, 2, 1)) * -1
+    tmp82 += np.transpose(tmp81, (0, 2, 1)) * -1
     del tmp81
     tmp71 = einsum(t2.bbbb, (0, 1, 2, 3), r2.bbb, (2, 3, 4), (4, 0, 1))
-    tmp88 = tmp83.copy() * 4
+    tmp88 = np.copy(tmp83) * 4
     del tmp83
     tmp88 += tmp84 * 2
     del tmp84
     tmp88 += tmp85 * 2
     del tmp85
-    tmp88 += tmp87.transpose((0, 2, 1))
+    tmp88 += np.transpose(tmp87, (0, 2, 1))
     del tmp87
-    tmp65 = ints.tmp285.copy() * 2
+    tmp65 = np.copy(ints.tmp285) * 2
     tmp65 += ints.tmp292
-    tmp65 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp65 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp65 += ints.tmp288 * -2
     tmp65 += v.bbbb.oovv * -1
-    tmp66 = ints.tmp284.copy()
+    tmp66 = np.copy(ints.tmp284)
     tmp66 += ints.tmp290 * 2
-    tmp66 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp66 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp66 += ints.tmp287 * -1
     tmp64 = einsum(t2.abab, (0, 1, 2, 3), r2.bab, (3, 2, 4), (0, 4, 1)) * -1
-    tmp68 = ints.tmp230.copy()
+    tmp68 = np.copy(ints.tmp230)
     tmp68 += ints.tmp232 * 0.5
     tmp68 += f.bb.vv * -0.5
-    tmp68 += tmp59.transpose((1, 0)) * 0.5
-    tmp67 = ints.tmp149.copy()
-    tmp67 += v.aabb.vvoo.transpose((2, 3, 0, 1)) * -1
-    tmp62 = ints.tmp47.copy() * 2
+    tmp68 += np.transpose(tmp59, (1, 0)) * 0.5
+    tmp67 = np.copy(ints.tmp149)
+    tmp67 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1)) * -1
+    tmp62 = np.copy(ints.tmp47) * 2
     tmp62 += ints.tmp49
     tmp62 += f.aa.vv * -1
-    tmp62 += tmp61.transpose((1, 0))
+    tmp62 += np.transpose(tmp61, (1, 0))
     del tmp61
-    tmp70 = tmp15.copy()
+    tmp70 = np.copy(tmp15)
     tmp70 += tmp16 * 0.5
-    tmp60 = ints.tmp230.copy() * 2
+    tmp60 = np.copy(ints.tmp230) * 2
     tmp60 += ints.tmp232
     tmp60 += f.bb.vv * -1
-    tmp60 += tmp59.transpose((1, 0))
+    tmp60 += np.transpose(tmp59, (1, 0))
     del tmp59
-    tmp56 = ints.tmp139.copy() * 2
+    tmp56 = np.copy(ints.tmp139) * 2
     tmp56 += ints.tmp145
-    tmp56 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp56 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp56 += ints.tmp142 * -2
     tmp56 += v.aaaa.oovv * -1
     tmp55 = einsum(t2.abab, (0, 1, 2, 3), r2.aba, (2, 3, 4), (4, 0, 1))
-    tmp57 = ints.tmp141.copy()
+    tmp57 = np.copy(ints.tmp141)
     tmp57 += ints.tmp147 * 2
-    tmp57 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp57 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp57 += ints.tmp144 * -1
-    tmp58 = ints.tmp294.copy()
+    tmp58 = np.copy(ints.tmp294)
     tmp58 += v.aabb.oovv * -1
-    tmp63 = tmp32.copy() * -1
+    tmp63 = np.copy(tmp32) * -1
     tmp63 += tmp33 * 2
-    tmp54 = f.aa.oo.copy()
+    tmp54 = np.copy(f.aa.oo)
     tmp54 += ints.tmp127 * 2
     del ints.tmp127
     tmp54 += ints.tmp136
     del ints.tmp136
-    tmp54 += ints.tmp19.transpose((1, 0))
+    tmp54 += np.transpose(ints.tmp19, (1, 0))
     del ints.tmp19
     tmp36 = einsum(r2.aaa, (0, 1, 2), t2.aaaa, (3, 4, 0, 1), (2, 3, 4))
-    tmp53 = tmp47.copy() * 4
+    tmp53 = np.copy(tmp47) * 4
     del tmp47
     tmp53 += tmp48 * 2
     del tmp48
@@ -4860,32 +4860,32 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp38
     tmp46 += tmp39 * 2
     del tmp39
-    tmp46 += tmp41.transpose((0, 2, 1)) * -1
+    tmp46 += np.transpose(tmp41, (0, 2, 1)) * -1
     del tmp41
-    tmp46 += tmp43.transpose((0, 2, 1))
+    tmp46 += np.transpose(tmp43, (0, 2, 1))
     del tmp43
-    tmp46 += tmp45.transpose((0, 2, 1))
+    tmp46 += np.transpose(tmp45, (0, 2, 1))
     del tmp45
-    tmp28 = ints.tmp117.copy()
+    tmp28 = np.copy(ints.tmp117)
     del ints.tmp117
     tmp28 += v.aabb.ooov
     tmp29 = einsum(t1.bb, (0, 1), tmp21, (2, 3, 1), (2, 3, 0)) * -1
-    tmp19 = ints.tmp228.copy()
+    tmp19 = np.copy(ints.tmp228)
     del ints.tmp228
-    tmp19 += ints.tmp240.transpose((0, 1, 3, 2))
+    tmp19 += np.transpose(ints.tmp240, (0, 1, 3, 2))
     del ints.tmp240
     tmp19 += ints.tmp246
     del ints.tmp246
     tmp19 += ints.tmp252 * 2
     del ints.tmp252
-    tmp19 += ints.tmp278.transpose((0, 1, 3, 2))
+    tmp19 += np.transpose(ints.tmp278, (0, 1, 3, 2))
     del ints.tmp278
     tmp19 += v.aabb.ovvv
     tmp19 += ints.tmp249 * -1
     del ints.tmp249
-    tmp19 += ints.tmp256.transpose((0, 1, 3, 2)) * -1
+    tmp19 += np.transpose(ints.tmp256, (0, 1, 3, 2)) * -1
     del ints.tmp256
-    tmp35 = f.bb.ov.copy()
+    tmp35 = np.copy(f.bb.ov)
     tmp35 += ints.tmp33
     tmp35 += ints.tmp35
     tmp35 += ints.tmp89 * -1
@@ -4896,28 +4896,28 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp32
     tmp34 += tmp33 * 2
     del tmp33
-    tmp24 = ints.tmp284.copy()
+    tmp24 = np.copy(ints.tmp284)
     del ints.tmp284
     tmp24 += ints.tmp290 * 2
     del ints.tmp290
     tmp24 += ints.tmp310
     del ints.tmp310
-    tmp24 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp24 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp24 += ints.tmp287 * -1
     del ints.tmp287
-    tmp22 = ints.tmp285.copy() * 2
+    tmp22 = np.copy(ints.tmp285) * 2
     del ints.tmp285
     tmp22 += ints.tmp292
     del ints.tmp292
-    tmp22 += ints.tmp307.transpose((0, 1, 3, 2))
+    tmp22 += np.transpose(ints.tmp307, (0, 1, 3, 2))
     del ints.tmp307
-    tmp22 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp22 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp22 += ints.tmp288 * -2
     del ints.tmp288
-    tmp22 += ints.tmp305.transpose((0, 1, 3, 2)) * -1
+    tmp22 += np.transpose(ints.tmp305, (0, 1, 3, 2)) * -1
     del ints.tmp305
     tmp22 += v.bbbb.oovv * -1
-    tmp9 = ints.tmp115.copy() * 2
+    tmp9 = np.copy(ints.tmp115) * 2
     del ints.tmp115
     tmp9 += ints.tmp121
     del ints.tmp121
@@ -4980,7 +4980,7 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp88
     tmp9 += ints.tmp96 * -2
     del ints.tmp96
-    tmp8 = ints.tmp112.copy() * 2
+    tmp8 = np.copy(ints.tmp112) * 2
     del ints.tmp112
     tmp8 += ints.tmp118
     del ints.tmp118
@@ -5042,132 +5042,132 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp8 += ints.tmp98 * -2
     del ints.tmp98
     tmp27 = einsum(t1.bb, (0, 1), tmp25, (2, 3, 1), (2, 3, 0))
-    tmp26 = ints.tmp309.transpose((0, 1, 3, 2)).copy()
+    tmp26 = np.copy(np.transpose(ints.tmp309, (0, 1, 3, 2)))
     del ints.tmp309
     tmp26 += v.aabb.oovv
     tmp26 += ints.tmp294 * -1
     del ints.tmp294
-    tmp31 = ints.tmp175.transpose((1, 0)).copy()
+    tmp31 = np.copy(np.transpose(ints.tmp175, (1, 0)))
     del ints.tmp175
     tmp31 += ints.tmp230 * 2
     del ints.tmp230
     tmp31 += ints.tmp232
     del ints.tmp232
     tmp31 += f.bb.vv * -1
-    tmp31 += ints.tmp173.transpose((1, 0)) * -1
+    tmp31 += np.transpose(ints.tmp173, (1, 0)) * -1
     del ints.tmp173
-    tmp31 += ints.tmp177.transpose((1, 0)) * -1
+    tmp31 += np.transpose(ints.tmp177, (1, 0)) * -1
     del ints.tmp177
-    tmp20 = ints.tmp238.transpose((0, 3, 1, 2)).copy() * 0.5
+    tmp20 = np.copy(np.transpose(ints.tmp238, (0, 3, 1, 2))) * 0.5
     del ints.tmp238
-    tmp20 += ints.tmp247.transpose((0, 2, 1, 3))
+    tmp20 += np.transpose(ints.tmp247, (0, 2, 1, 3))
     del ints.tmp247
-    tmp20 += ints.tmp254.transpose((0, 2, 1, 3)) * 0.5
+    tmp20 += np.transpose(ints.tmp254, (0, 2, 1, 3)) * 0.5
     del ints.tmp254
-    tmp20 += v.bbbb.ovvv.transpose((0, 2, 1, 3)) * 0.5
+    tmp20 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3)) * 0.5
     tmp20 += ints.tmp226 * -0.5
     del ints.tmp226
-    tmp20 += ints.tmp250.transpose((0, 2, 1, 3)) * -1
+    tmp20 += np.transpose(ints.tmp250, (0, 2, 1, 3)) * -1
     del ints.tmp250
-    tmp20 += ints.tmp276.transpose((0, 3, 1, 2)) * -0.5
+    tmp20 += np.transpose(ints.tmp276, (0, 3, 1, 2)) * -0.5
     del ints.tmp276
-    tmp30 = ints.tmp114.copy()
+    tmp30 = np.copy(ints.tmp114)
     del ints.tmp114
     tmp30 += v.bbbb.ooov * -1
     tmp12 = einsum(t1.aa, (0, 1), tmp6, (2, 3, 1), (0, 2, 3))
-    tmp3 = ints.tmp139.copy() * 2
+    tmp3 = np.copy(ints.tmp139) * 2
     del ints.tmp139
     tmp3 += ints.tmp145
     del ints.tmp145
-    tmp3 += ints.tmp183.transpose((0, 1, 3, 2))
+    tmp3 += np.transpose(ints.tmp183, (0, 1, 3, 2))
     del ints.tmp183
-    tmp3 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp3 += ints.tmp142 * -2
     del ints.tmp142
-    tmp3 += ints.tmp181.transpose((0, 1, 3, 2)) * -1
+    tmp3 += np.transpose(ints.tmp181, (0, 1, 3, 2)) * -1
     del ints.tmp181
     tmp3 += v.aaaa.oovv * -1
-    tmp11 = ints.tmp111.copy()
+    tmp11 = np.copy(ints.tmp111)
     del ints.tmp111
     tmp11 += v.aaaa.ooov * -1
     tmp4 = einsum(t1.aa, (0, 1), r2.bab, (2, 1, 3), (0, 3, 2)) * -1
-    tmp5 = ints.tmp141.copy()
+    tmp5 = np.copy(ints.tmp141)
     del ints.tmp141
     tmp5 += ints.tmp147 * 2
     del ints.tmp147
     tmp5 += ints.tmp186
     del ints.tmp186
-    tmp5 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp5 += ints.tmp144 * -1
     del ints.tmp144
     tmp10 = einsum(tmp2, (0, 1, 2), t1.aa, (3, 2), (0, 1, 3)) * -1
-    tmp1 = ints.tmp59.copy() * 0.5
+    tmp1 = np.copy(ints.tmp59) * 0.5
     del ints.tmp59
-    tmp1 += ints.tmp71.transpose((0, 1, 3, 2))
+    tmp1 += np.transpose(ints.tmp71, (0, 1, 3, 2))
     del ints.tmp71
-    tmp1 += ints.tmp77.transpose((0, 1, 3, 2)) * 0.5
+    tmp1 += np.transpose(ints.tmp77, (0, 1, 3, 2)) * 0.5
     del ints.tmp77
     tmp1 += v.aaaa.ovvv * 0.5
     tmp1 += ints.tmp123 * -0.5
     del ints.tmp123
-    tmp1 += ints.tmp43.transpose((0, 2, 3, 1)) * -0.5
+    tmp1 += np.transpose(ints.tmp43, (0, 2, 3, 1)) * -0.5
     del ints.tmp43
-    tmp1 += ints.tmp74.transpose((0, 1, 3, 2)) * -1
+    tmp1 += np.transpose(ints.tmp74, (0, 1, 3, 2)) * -1
     del ints.tmp74
     tmp17 = einsum(t1.aa, (0, 1), r1.a, (1,), (0,))
     tmp17 += tmp15 * 2
     del tmp15
     tmp17 += tmp16
     del tmp16
-    tmp7 = ints.tmp185.transpose((0, 1, 3, 2)).copy()
+    tmp7 = np.copy(np.transpose(ints.tmp185, (0, 1, 3, 2)))
     del ints.tmp185
-    tmp7 += v.aabb.vvoo.transpose((2, 3, 0, 1))
+    tmp7 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1))
     tmp7 += ints.tmp149 * -1
     del ints.tmp149
-    tmp14 = ints.tmp27.transpose((1, 0)).copy()
+    tmp14 = np.copy(np.transpose(ints.tmp27, (1, 0)))
     del ints.tmp27
     tmp14 += ints.tmp47 * 2
     del ints.tmp47
     tmp14 += ints.tmp49
     del ints.tmp49
     tmp14 += f.aa.vv * -1
-    tmp14 += ints.tmp26.transpose((1, 0)) * -1
+    tmp14 += np.transpose(ints.tmp26, (1, 0)) * -1
     del ints.tmp26
-    tmp14 += ints.tmp28.transpose((1, 0)) * -1
+    tmp14 += np.transpose(ints.tmp28, (1, 0)) * -1
     del ints.tmp28
-    tmp13 = ints.tmp120.copy()
+    tmp13 = np.copy(ints.tmp120)
     del ints.tmp120
-    tmp13 += v.aabb.ovoo.transpose((0, 2, 3, 1))
-    tmp18 = f.aa.ov.copy()
+    tmp13 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
+    tmp18 = np.copy(f.aa.ov)
     tmp18 += ints.tmp29
     del ints.tmp29
     tmp18 += ints.tmp36
     del ints.tmp36
     tmp18 += ints.tmp82 * -1
     del ints.tmp82
-    tmp0 = ints.tmp125.copy()
+    tmp0 = np.copy(ints.tmp125)
     del ints.tmp125
-    tmp0 += ints.tmp45.transpose((0, 2, 1, 3))
+    tmp0 += np.transpose(ints.tmp45, (0, 2, 1, 3))
     del ints.tmp45
     tmp0 += ints.tmp61
     del ints.tmp61
-    tmp0 += ints.tmp73.transpose((0, 2, 1, 3))
+    tmp0 += np.transpose(ints.tmp73, (0, 2, 1, 3))
     del ints.tmp73
-    tmp0 += ints.tmp79.transpose((0, 2, 1, 3)) * 2
+    tmp0 += np.transpose(ints.tmp79, (0, 2, 1, 3)) * 2
     del ints.tmp79
-    tmp0 += v.aabb.vvov.transpose((2, 0, 1, 3))
-    tmp0 += ints.tmp76.transpose((0, 2, 1, 3)) * -1
+    tmp0 += np.transpose(v.aabb.vvov, (2, 0, 1, 3))
+    tmp0 += np.transpose(ints.tmp76, (0, 2, 1, 3)) * -1
     del ints.tmp76
     tmp0 += ints.tmp81 * -1
     del ints.tmp81
     r2new.bbb = einsum(v.bbbb.ovov, (0, 1, 2, 3), tmp71, (4, 2, 0), (1, 3, 4)) * -2
     del tmp71
     r2new.bbb += einsum(r2.bbb, (0, 1, 2), v.bbbb.vvvv, (3, 0, 4, 1), (3, 4, 2)) * 2
-    r2new.bbb += tmp82.transpose((1, 2, 0)) * -1
-    r2new.bbb += tmp82.transpose((2, 1, 0))
+    r2new.bbb += np.transpose(tmp82, (1, 2, 0)) * -1
+    r2new.bbb += np.transpose(tmp82, (2, 1, 0))
     del tmp82
-    r2new.bbb += tmp88.transpose((1, 2, 0))
-    r2new.bbb += tmp88.transpose((2, 1, 0)) * -1
+    r2new.bbb += np.transpose(tmp88, (1, 2, 0))
+    r2new.bbb += np.transpose(tmp88, (2, 1, 0)) * -1
     del tmp88
     r2new.bbb += einsum(r2.bbb, (0, 1, 2), tmp69, (2, 3), (0, 1, 3)) * -2
     r2new.bab = einsum(v.aabb.ovov, (0, 1, 2, 3), tmp64, (0, 4, 2), (3, 1, 4)) * -1
@@ -5209,11 +5209,11 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     r2new.aaa = einsum(r2.aaa, (0, 1, 2), v.aaaa.vvvv, (3, 1, 4, 0), (3, 4, 2)) * -2
     r2new.aaa += einsum(v.aaaa.ovov, (0, 1, 2, 3), tmp36, (4, 2, 0), (1, 3, 4)) * -2
     del tmp36
-    r2new.aaa += tmp46.transpose((1, 2, 0)) * -1
-    r2new.aaa += tmp46.transpose((2, 1, 0))
+    r2new.aaa += np.transpose(tmp46, (1, 2, 0)) * -1
+    r2new.aaa += np.transpose(tmp46, (2, 1, 0))
     del tmp46
-    r2new.aaa += tmp53.transpose((1, 2, 0))
-    r2new.aaa += tmp53.transpose((2, 1, 0)) * -1
+    r2new.aaa += np.transpose(tmp53, (1, 2, 0))
+    r2new.aaa += np.transpose(tmp53, (2, 1, 0)) * -1
     del tmp53
     r2new.aaa += einsum(r2.aaa, (0, 1, 2), tmp54, (2, 3), (0, 1, 3)) * -2
     del tmp54

--- a/ebcc/codegen/UCC2.py
+++ b/ebcc/codegen/UCC2.py
@@ -2090,9 +2090,9 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.abab = pack_2e(rdm2.abab.oooo, rdm2.abab.ooov, rdm2.abab.oovo, rdm2.abab.ovoo, rdm2.abab.vooo, rdm2.abab.oovv, rdm2.abab.ovov, rdm2.abab.ovvo, rdm2.abab.voov, rdm2.abab.vovo, rdm2.abab.vvoo, rdm2.abab.ovvv, rdm2.abab.vovv, rdm2.abab.vvov, rdm2.abab.vvvo, rdm2.abab.vvvv)
     rdm2.bbbb = pack_2e(rdm2.bbbb.oooo, rdm2.bbbb.ooov, rdm2.bbbb.oovo, rdm2.bbbb.ovoo, rdm2.bbbb.vooo, rdm2.bbbb.oovv, rdm2.bbbb.ovov, rdm2.bbbb.ovvo, rdm2.bbbb.voov, rdm2.bbbb.vovo, rdm2.bbbb.vvoo, rdm2.bbbb.ovvv, rdm2.bbbb.vovv, rdm2.bbbb.vvov, rdm2.bbbb.vvvo, rdm2.bbbb.vvvv)
     rdm2 = Namespace(
-        aaaa=rdm2.aaaa.swapaxes(1, 2),
-        aabb=rdm2.abab.swapaxes(1, 2),
-        bbbb=rdm2.bbbb.swapaxes(1, 2),
+        aaaa=rdm2.aaaa.transpose(0, 2, 1, 3),
+        aabb=rdm2.abab.transpose(0, 2, 1, 3),
+        bbbb=rdm2.bbbb.transpose(0, 2, 1, 3),
     )
 
     return rdm2

--- a/ebcc/codegen/UCC3.py
+++ b/ebcc/codegen/UCC3.py
@@ -37,17 +37,17 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp0 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp0 += v.bbbb.ovov.transpose((0, 2, 1, 3))
-    tmp2 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp2 += v.aaaa.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp1 = f.bb.ov.copy() * 2
+    tmp0 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1))) * -1
+    tmp0 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
+    tmp2 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1)))
+    tmp2 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3)) * -1
+    tmp1 = np.copy(f.bb.ov) * 2
     tmp1 += einsum(v.aabb.ovov, (0, 1, 2, 3), t1.aa, (0, 1), (2, 3)) * 2
     tmp1 += einsum(tmp0, (0, 1, 2, 3), t1.bb, (0, 3), (1, 2)) * -1
     del tmp0
     e_cc = einsum(t1.bb, (0, 1), tmp1, (0, 1), ()) * 0.5
     del tmp1
-    tmp3 = f.aa.ov.copy() * 2
+    tmp3 = np.copy(f.aa.ov) * 2
     tmp3 += einsum(tmp2, (0, 1, 2, 3), t1.aa, (0, 2), (1, 3)) * -1
     del tmp2
     e_cc += einsum(tmp3, (0, 1), t1.aa, (0, 1), ()) * 0.5
@@ -88,10 +88,10 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t1new = Namespace()
     t2new = Namespace()
     t3new = Namespace()
-    tmp14 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp14 += v.bbbb.ovov.transpose((0, 2, 1, 3))
-    tmp7 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp7 += v.aaaa.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp14 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1))) * -1
+    tmp14 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
+    tmp7 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1)))
+    tmp7 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3)) * -1
     tmp200 = einsum(v.bbbb.ooov, (0, 1, 2, 3), t1.bb, (4, 3), (4, 0, 1, 2))
     tmp22 = einsum(t1.bb, (0, 1), v.bbbb.ovov, (2, 3, 4, 1), (0, 2, 4, 3))
     t1new.bb = einsum(t2.bbbb, (0, 1, 2, 3), tmp22, (4, 1, 0, 3), (4, 2)) * -2
@@ -110,19 +110,19 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp8 = einsum(tmp7, (0, 1, 2, 3), t1.aa, (0, 2), (1, 3))
     tmp0 = einsum(v.aabb.ovov, (0, 1, 2, 3), t1.bb, (2, 3), (0, 1))
     t1new.aa += tmp0
-    tmp456 = tmp200.transpose((0, 2, 1, 3)).copy() * -1
-    tmp456 += tmp200.transpose((0, 2, 3, 1))
-    tmp558 = v.bbbb.ovvv.copy()
-    tmp558 += v.bbbb.ovvv.transpose((0, 2, 3, 1)) * -1
-    tmp493 = tmp200.transpose((0, 2, 1, 3)).copy() * -1
-    tmp493 += tmp200.transpose((0, 3, 2, 1))
-    tmp167 = v.bbbb.ovvv.copy()
-    tmp167 += v.bbbb.ovvv.transpose((0, 2, 3, 1)) * -1
+    tmp456 = np.copy(np.transpose(tmp200, (0, 2, 1, 3))) * -1
+    tmp456 += np.transpose(tmp200, (0, 2, 3, 1))
+    tmp558 = np.copy(v.bbbb.ovvv)
+    tmp558 += np.transpose(v.bbbb.ovvv, (0, 2, 3, 1)) * -1
+    tmp493 = np.copy(np.transpose(tmp200, (0, 2, 1, 3))) * -1
+    tmp493 += np.transpose(tmp200, (0, 3, 2, 1))
+    tmp167 = np.copy(v.bbbb.ovvv)
+    tmp167 += np.transpose(v.bbbb.ovvv, (0, 2, 3, 1)) * -1
     tmp211 = einsum(tmp22, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 4, 3))
-    t2new.bbbb = tmp211.copy() * -1
-    t2new.bbbb += tmp211.transpose((1, 0, 2, 3))
-    t2new.bbbb += tmp211.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp211.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb = np.copy(tmp211) * -1
+    t2new.bbbb += np.transpose(tmp211, (1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp211, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp211, (1, 0, 3, 2)) * -1
     tmp143 = einsum(t1.bb, (0, 1), v.aabb.vvov, (2, 3, 4, 1), (0, 4, 2, 3))
     tmp154 = einsum(tmp21, (0, 1, 2, 3), t1.aa, (4, 3), (4, 0, 1, 2))
     tmp140 = einsum(v.aabb.ovoo, (0, 1, 2, 3), t1.aa, (4, 1), (4, 0, 2, 3))
@@ -134,26 +134,26 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp77 = einsum(v.aabb.vvov, (0, 1, 2, 3), t1.aa, (4, 1), (4, 2, 0, 3))
     tmp78 = einsum(tmp1, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3))
     t2new.abab += tmp78 * -1
-    tmp288 = tmp66.transpose((0, 2, 1, 3)).copy()
-    tmp288 += tmp66.transpose((0, 3, 2, 1)) * -1
+    tmp288 = np.copy(np.transpose(tmp66, (0, 2, 1, 3)))
+    tmp288 += np.transpose(tmp66, (0, 3, 2, 1)) * -1
     tmp73 = einsum(tmp2, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
-    t2new.aaaa = tmp73.copy() * -1
-    t2new.aaaa += tmp73.transpose((1, 0, 2, 3))
-    t2new.aaaa += tmp73.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp73.transpose((1, 0, 3, 2)) * -1
-    tmp164 = v.aaaa.ovvv.copy()
-    tmp164 += v.aaaa.ovvv.transpose((0, 2, 3, 1)) * -1
-    tmp57 = v.aaaa.ovvv.copy()
-    tmp57 += v.aaaa.ovvv.transpose((0, 2, 3, 1)) * -1
-    tmp216 = v.bbbb.ovvv.copy() * -1
-    tmp216 += v.bbbb.ovvv.transpose((0, 2, 1, 3))
-    tmp169 = tmp22.copy()
-    tmp169 += tmp22.transpose((0, 2, 1, 3)) * -1
-    tmp223 = v.bbbb.ooov.copy() * -1
-    tmp223 += v.bbbb.ovoo.transpose((0, 2, 3, 1))
-    tmp159 = v.bbbb.ooov.copy()
-    tmp159 += v.bbbb.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp16 = f.bb.ov.copy()
+    t2new.aaaa = np.copy(tmp73) * -1
+    t2new.aaaa += np.transpose(tmp73, (1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp73, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp73, (1, 0, 3, 2)) * -1
+    tmp164 = np.copy(v.aaaa.ovvv)
+    tmp164 += np.transpose(v.aaaa.ovvv, (0, 2, 3, 1)) * -1
+    tmp57 = np.copy(v.aaaa.ovvv)
+    tmp57 += np.transpose(v.aaaa.ovvv, (0, 2, 3, 1)) * -1
+    tmp216 = np.copy(v.bbbb.ovvv) * -1
+    tmp216 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3))
+    tmp169 = np.copy(tmp22)
+    tmp169 += np.transpose(tmp22, (0, 2, 1, 3)) * -1
+    tmp223 = np.copy(v.bbbb.ooov) * -1
+    tmp223 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1))
+    tmp159 = np.copy(v.bbbb.ooov)
+    tmp159 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1)) * -1
+    tmp16 = np.copy(f.bb.ov)
     tmp16 += tmp13
     tmp16 += tmp15 * -1
     del tmp15
@@ -161,11 +161,11 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t2new.aaaa += einsum(t3.abaaba, (0, 1, 2, 3, 4, 5), tmp16, (1, 4), (0, 2, 3, 5))
     t1new.bb += einsum(tmp16, (0, 1), t2.bbbb, (2, 0, 3, 1), (2, 3)) * 2
     t1new.aa += einsum(t2.abab, (0, 1, 2, 3), tmp16, (1, 3), (0, 2))
-    tmp45 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp45 += v.bbbb.ovov.transpose((0, 2, 1, 3))
-    tmp92 = v.aaaa.ooov.copy() * -1
-    tmp92 += v.aaaa.ovoo.transpose((0, 2, 3, 1))
-    tmp9 = f.aa.ov.copy()
+    tmp45 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1))) * -1
+    tmp45 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
+    tmp92 = np.copy(v.aaaa.ooov) * -1
+    tmp92 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1))
+    tmp9 = np.copy(f.aa.ov)
     tmp9 += tmp0
     tmp9 += tmp8 * -1
     del tmp8
@@ -173,12 +173,12 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t2new.abab += einsum(tmp9, (0, 1), t3.abaaba, (2, 3, 0, 4, 5, 1), (2, 3, 4, 5)) * 2
     t1new.bb += einsum(tmp9, (0, 1), t2.abab, (0, 2, 1, 3), (2, 3))
     t1new.aa += einsum(tmp9, (0, 1), t2.aaaa, (2, 0, 3, 1), (2, 3)) * 2
-    tmp83 = tmp2.copy() * -1
-    tmp83 += tmp2.transpose((0, 2, 1, 3))
-    tmp81 = v.aaaa.ovvv.copy() * -1
-    tmp81 += v.aaaa.ovvv.transpose((0, 2, 1, 3))
-    tmp36 = v.aaaa.ooov.copy()
-    tmp36 += v.aaaa.ovoo.transpose((0, 2, 3, 1)) * -1
+    tmp83 = np.copy(tmp2) * -1
+    tmp83 += np.transpose(tmp2, (0, 2, 1, 3))
+    tmp81 = np.copy(v.aaaa.ovvv) * -1
+    tmp81 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3))
+    tmp36 = np.copy(v.aaaa.ooov)
+    tmp36 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1)) * -1
     tmp432 = einsum(v.bbbb.oooo, (0, 1, 2, 3), t1.bb, (3, 4), (0, 1, 2, 4))
     tmp433 = einsum(f.bb.ov, (0, 1), t2.bbbb, (2, 3, 4, 1), (0, 2, 3, 4))
     t3new.babbab = einsum(tmp433, (0, 1, 2, 3), t2.abab, (4, 0, 5, 6), (2, 4, 1, 6, 5, 3)) * -2
@@ -186,17 +186,17 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp456
     tmp204 = einsum(t1.bb, (0, 1), v.bbbb.oovv, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp210 = einsum(t1.bb, (0, 1), v.bbbb.ovvv, (2, 3, 4, 1), (0, 2, 3, 4))
-    t2new.bbbb += tmp210.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp210.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp210, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp210, (0, 1, 3, 2))
     t2new.bbbb += tmp210 * -1
-    t2new.bbbb += tmp210.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp210, (1, 0, 2, 3))
     tmp129 = einsum(t1.bb, (0, 1), v.bbbb.ovov, (2, 3, 0, 4), (2, 1, 3, 4))
     tmp512 = einsum(v.bbbb.ooov, (0, 1, 2, 3), t2.bbbb, (4, 5, 6, 3), (4, 5, 0, 1, 2, 6))
     tmp559 = einsum(tmp558, (0, 1, 2, 3), t1.bb, (4, 1), (0, 4, 2, 3))
     del tmp558
     tmp545 = einsum(tmp493, (0, 1, 2, 3), t1.bb, (3, 4), (0, 1, 2, 4))
-    tmp526 = tmp200.transpose((0, 2, 1, 3)).copy()
-    tmp526 += tmp200.transpose((0, 3, 2, 1)) * -1
+    tmp526 = np.copy(np.transpose(tmp200, (0, 2, 1, 3)))
+    tmp526 += np.transpose(tmp200, (0, 3, 2, 1)) * -1
     tmp234 = einsum(t1.bb, (0, 1), tmp22, (2, 3, 4, 1), (2, 0, 4, 3))
     tmp317 = einsum(t1.bb, (0, 1), f.bb.ov, (0, 2), (2, 1))
     tmp168 = einsum(t1.bb, (0, 1), tmp167, (2, 1, 3, 4), (0, 2, 3, 4))
@@ -219,7 +219,7 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp413 = einsum(v.aabb.ovoo, (0, 1, 2, 3), t2.abab, (4, 5, 1, 6), (4, 0, 5, 2, 3, 6))
     tmp330 = einsum(t2.abab, (0, 1, 2, 3), f.bb.ov, (4, 3), (0, 4, 1, 2))
     tmp329 = einsum(v.aabb.oooo, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 3, 4))
-    tmp172 = tmp141.copy()
+    tmp172 = np.copy(tmp141)
     tmp172 += tmp142 * -1
     t2new.abab += einsum(t2.aaaa, (0, 1, 2, 3), tmp172, (1, 4, 3, 5), (0, 4, 2, 5)) * 2
     tmp256 = einsum(f.aa.ov, (0, 1), t1.aa, (0, 2), (1, 2))
@@ -230,7 +230,7 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t2new.abab += einsum(tmp177, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3)) * -1
     tmp355 = einsum(tmp137, (0, 1, 2, 3), t1.bb, (3, 4), (1, 0, 2, 4))
     t3new.babbab += einsum(tmp355, (0, 1, 2, 3), t2.abab, (0, 4, 5, 6), (4, 1, 2, 6, 5, 3))
-    tmp87 = tmp77.copy()
+    tmp87 = np.copy(tmp77)
     tmp87 += tmp78 * -1
     t2new.abab += einsum(t2.bbbb, (0, 1, 2, 3), tmp87, (4, 1, 5, 3), (4, 0, 5, 2)) * 2
     tmp62 = einsum(v.aaaa.oovv, (0, 1, 2, 3), t1.aa, (4, 3), (4, 0, 1, 2))
@@ -242,10 +242,10 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp321 = einsum(tmp1, (0, 1, 2, 3), t2.abab, (4, 5, 6, 3), (0, 4, 1, 5, 2, 6))
     tmp127 = einsum(v.aabb.ovov, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 4, 3))
     tmp72 = einsum(t1.aa, (0, 1), v.aaaa.ovvv, (2, 3, 4, 1), (0, 2, 3, 4))
-    t2new.aaaa += tmp72.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp72.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp72, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp72, (0, 1, 3, 2))
     t2new.aaaa += tmp72 * -1
-    t2new.aaaa += tmp72.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp72, (1, 0, 2, 3))
     tmp360 = einsum(t2.abab, (0, 1, 2, 3), v.aaaa.ooov, (4, 5, 6, 2), (0, 4, 5, 6, 1, 3))
     tmp335 = einsum(t1.bb, (0, 1), v.aabb.oooo, (2, 3, 4, 0), (2, 3, 4, 1))
     tmp332 = einsum(f.aa.ov, (0, 1), t2.abab, (2, 3, 1, 4), (0, 2, 3, 4))
@@ -260,8 +260,8 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp53 = einsum(v.aaaa.ovov, (0, 1, 2, 3), t1.aa, (2, 4), (0, 4, 1, 3))
     tmp306 = einsum(tmp57, (0, 1, 2, 3), t1.aa, (4, 1), (4, 0, 2, 3))
     tmp264 = einsum(t2.aaaa, (0, 1, 2, 3), tmp2, (4, 5, 6, 3), (4, 0, 1, 6, 5, 2))
-    tmp267 = tmp66.transpose((0, 2, 1, 3)).copy() * -1
-    tmp267 += tmp66.transpose((0, 3, 2, 1))
+    tmp267 = np.copy(np.transpose(tmp66, (0, 2, 1, 3))) * -1
+    tmp267 += np.transpose(tmp66, (0, 3, 2, 1))
     tmp252 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.oooo, (4, 5, 6, 1), (0, 4, 5, 6, 2, 3))
     tmp253 = einsum(t3.aaaaaa, (0, 1, 2, 3, 4, 5), f.aa.ov, (6, 5), (6, 0, 1, 2, 3, 4))
     tmp249 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ooov, (4, 5, 6, 3), (0, 1, 4, 5, 6, 2))
@@ -274,10 +274,10 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp169
     tmp224 = einsum(t1.bb, (0, 1), tmp223, (0, 2, 3, 4), (2, 3, 4, 1))
     del tmp223
-    tmp29 = v.bbbb.ooov.copy()
-    tmp29 += v.bbbb.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp195 = v.bbbb.ovvv.copy() * -1
-    tmp195 += v.bbbb.ovvv.transpose((0, 2, 1, 3))
+    tmp29 = np.copy(v.bbbb.ooov)
+    tmp29 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1)) * -1
+    tmp195 = np.copy(v.bbbb.ovvv) * -1
+    tmp195 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3))
     tmp183 = einsum(t1.bb, (0, 1), tmp159, (0, 2, 3, 1), (2, 3))
     tmp28 = einsum(v.aabb.ovoo, (0, 1, 2, 3), t1.aa, (0, 1), (2, 3))
     tmp135 = einsum(tmp16, (0, 1), t1.bb, (2, 1), (2, 0))
@@ -293,77 +293,77 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp83
     tmp82 = einsum(t1.aa, (0, 1), tmp81, (2, 1, 3, 4), (0, 2, 3, 4))
     del tmp81
-    tmp18 = v.aaaa.ooov.copy()
-    tmp18 += v.aaaa.ovoo.transpose((0, 2, 3, 1)) * -1
+    tmp18 = np.copy(v.aaaa.ooov)
+    tmp18 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1)) * -1
     tmp37 = einsum(tmp36, (0, 1, 2, 3), t1.aa, (0, 3), (1, 2))
     tmp17 = einsum(v.aabb.ooov, (0, 1, 2, 3), t1.bb, (2, 3), (0, 1))
-    tmp434 = tmp432.transpose((1, 0, 2, 3)).copy() * -1
-    tmp434 += tmp433.transpose((0, 2, 1, 3)) * 2
+    tmp434 = np.copy(np.transpose(tmp432, (1, 0, 2, 3))) * -1
+    tmp434 += np.transpose(tmp433, (0, 2, 1, 3)) * 2
     t3new.babbab += einsum(t2.abab, (0, 1, 2, 3), tmp434, (1, 4, 5, 6), (4, 0, 5, 6, 2, 3))
-    tmp554 = tmp200.transpose((0, 2, 1, 3)).copy()
-    tmp554 += tmp200.transpose((0, 3, 2, 1)) * -1
-    tmp458 = tmp204.transpose((0, 2, 1, 3)).copy()
-    tmp458 += tmp457.transpose((0, 2, 1, 3))
+    tmp554 = np.copy(np.transpose(tmp200, (0, 2, 1, 3)))
+    tmp554 += np.transpose(tmp200, (0, 3, 2, 1)) * -1
+    tmp458 = np.copy(np.transpose(tmp204, (0, 2, 1, 3)))
+    tmp458 += np.transpose(tmp457, (0, 2, 1, 3))
     del tmp457
-    tmp530 = tmp432.transpose((1, 0, 2, 3)).copy() * -0.5
-    tmp530 += tmp433.transpose((0, 2, 1, 3))
+    tmp530 = np.copy(np.transpose(tmp432, (1, 0, 2, 3))) * -0.5
+    tmp530 += np.transpose(tmp433, (0, 2, 1, 3))
     tmp516 = einsum(t3.bbbbbb, (0, 1, 2, 3, 4, 5), f.bb.ov, (6, 5), (6, 0, 1, 2, 3, 4))
     tmp515 = einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.oooo, (4, 5, 6, 1), (0, 4, 5, 6, 2, 3))
     tmp238 = einsum(t1.bb, (0, 1), tmp210, (2, 3, 1, 4), (0, 2, 3, 4))
     del tmp210
-    tmp538 = v.bbbb.ovvv.copy()
-    tmp538 += tmp129.transpose((0, 2, 3, 1)) * -1
+    tmp538 = np.copy(v.bbbb.ovvv)
+    tmp538 += np.transpose(tmp129, (0, 2, 3, 1)) * -1
     tmp534 = einsum(v.bbbb.oovv, (0, 1, 2, 3), t2.bbbb, (4, 5, 6, 3), (4, 5, 0, 1, 6, 2))
     tmp324 = einsum(t1.bb, (0, 1), f.bb.ov, (2, 1), (2, 0))
     tmp513 = einsum(t1.bb, (0, 1), tmp512, (2, 3, 4, 5, 0, 6), (2, 3, 4, 5, 1, 6))
     del tmp512
     tmp560 = einsum(tmp559, (0, 1, 2, 3), t2.bbbb, (4, 5, 6, 3), (1, 0, 4, 5, 2, 6))
     del tmp559
-    tmp447 = v.bbbb.ovvv.transpose((0, 2, 1, 3)).copy() * -1
+    tmp447 = np.copy(np.transpose(v.bbbb.ovvv, (0, 2, 1, 3))) * -1
     tmp447 += tmp129
     t3new.babbab += einsum(tmp447, (0, 1, 2, 3), t2.abab, (4, 5, 6, 3), (5, 4, 0, 2, 6, 1))
-    tmp546 = tmp204.transpose((0, 2, 1, 3)).copy()
-    tmp546 += tmp545.transpose((0, 2, 1, 3))
+    tmp546 = np.copy(np.transpose(tmp204, (0, 2, 1, 3)))
+    tmp546 += np.transpose(tmp545, (0, 2, 1, 3))
     del tmp545
     tmp527 = einsum(tmp526, (0, 1, 2, 3), t1.bb, (3, 4), (0, 1, 2, 4))
     del tmp526
     tmp240 = einsum(tmp234, (0, 1, 2, 3), t1.bb, (2, 4), (1, 0, 3, 4))
-    tmp318 = f.bb.vv.copy()
+    tmp318 = np.copy(f.bb.vv)
     tmp318 += tmp317 * -1
     t3new.babbab += einsum(t3.babbab, (0, 1, 2, 3, 4, 5), tmp318, (5, 6), (0, 1, 2, 6, 4, 3)) * -1
-    tmp420 = f.bb.vv.copy()
+    tmp420 = np.copy(f.bb.vv)
     tmp420 += tmp317 * -1
     del tmp317
     t3new.babbab += einsum(tmp420, (0, 1), t3.babbab, (2, 3, 4, 5, 6, 0), (2, 3, 4, 1, 6, 5)) * -1
     tmp552 = einsum(tmp168, (0, 1, 2, 3), t2.bbbb, (4, 5, 6, 3), (0, 1, 4, 5, 2, 6))
-    tmp425 = tmp200.transpose((0, 2, 1, 3)).copy() * -1
-    tmp425 += tmp200.transpose((0, 3, 2, 1))
+    tmp425 = np.copy(np.transpose(tmp200, (0, 2, 1, 3))) * -1
+    tmp425 += np.transpose(tmp200, (0, 3, 2, 1))
     tmp494 = einsum(tmp493, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 3, 4))
     del tmp493
     t3new.babbab += einsum(t2.abab, (0, 1, 2, 3), tmp494, (4, 5, 1, 6), (4, 0, 5, 3, 2, 6)) * -1
     tmp548 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.bbbb, (4, 5, 6, 3), (4, 5, 0, 2, 6, 1))
     tmp524 = einsum(t1.bb, (0, 1), tmp523, (2, 3, 4, 5, 0, 6), (2, 3, 4, 5, 1, 6))
     del tmp523
-    tmp448 = v.bbbb.ovvv.copy()
-    tmp448 += tmp129.transpose((0, 2, 3, 1)) * -1
+    tmp448 = np.copy(v.bbbb.ovvv)
+    tmp448 += np.transpose(tmp129, (0, 2, 3, 1)) * -1
     t3new.babbab += einsum(t2.abab, (0, 1, 2, 3), tmp448, (4, 5, 3, 6), (4, 0, 1, 5, 2, 6))
-    tmp480 = tmp173.transpose((0, 1, 3, 2)).copy()
+    tmp480 = np.copy(np.transpose(tmp173, (0, 1, 3, 2)))
     tmp480 += tmp174 * -1
     tmp377 = einsum(v.aabb.vvvv, (0, 1, 2, 3), t1.aa, (4, 1), (4, 0, 2, 3))
-    tmp483 = tmp236.transpose((0, 2, 1, 3)).copy()
-    tmp483 += tmp482.transpose((0, 3, 1, 2))
+    tmp483 = np.copy(np.transpose(tmp236, (0, 2, 1, 3)))
+    tmp483 += np.transpose(tmp482, (0, 3, 1, 2))
     del tmp482
     tmp424 = einsum(tmp423, (0, 1, 2, 3, 4, 5), t1.aa, (1, 6), (0, 2, 3, 4, 6, 5))
     del tmp423
     tmp428 = einsum(tmp1, (0, 1, 2, 3), t2.bbbb, (4, 5, 6, 3), (0, 1, 4, 5, 2, 6))
-    tmp499 = tmp151.copy()
+    tmp499 = np.copy(tmp151)
     tmp499 += tmp396 * -1
-    tmp150 = v.aabb.oovv.copy()
-    tmp150 += tmp149.transpose((1, 0, 3, 2)) * -1
+    tmp150 = np.copy(v.aabb.oovv)
+    tmp150 += np.transpose(tmp149, (1, 0, 3, 2)) * -1
     del tmp149
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp150, (0, 4, 3, 5), (4, 1, 2, 5)) * -1
-    tmp365 = tmp139.transpose((0, 2, 1, 3)).copy()
-    tmp365 += tmp363.transpose((0, 2, 1, 3)) * -1
+    tmp365 = np.copy(np.transpose(tmp139, (0, 2, 1, 3)))
+    tmp365 += np.transpose(tmp363, (0, 2, 1, 3)) * -1
     t3new.abaaba += einsum(tmp365, (0, 1, 2, 3), t2.abab, (4, 1, 5, 6), (0, 2, 4, 3, 6, 5)) * -1
     tmp506 = einsum(tmp141, (0, 1, 2, 3), t2.abab, (4, 5, 2, 6), (4, 0, 1, 5, 6, 3))
     tmp502 = einsum(tmp143, (0, 1, 2, 3), t2.abab, (4, 5, 3, 6), (4, 0, 5, 1, 2, 6))
@@ -376,15 +376,15 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp439 = einsum(tmp413, (0, 1, 2, 3, 4, 5), t1.bb, (4, 6), (0, 1, 2, 3, 6, 5))
     del tmp413
     tmp394 = einsum(t1.bb, (0, 1), tmp140, (2, 3, 4, 0), (2, 3, 4, 1))
-    tmp437 = tmp329.transpose((0, 2, 1, 3)).copy()
+    tmp437 = np.copy(np.transpose(tmp329, (0, 2, 1, 3)))
     tmp437 += tmp330 * -1
     tmp478 = einsum(tmp172, (0, 1, 2, 3), t1.aa, (0, 4), (1, 4, 2, 3))
     tmp472 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.abab, (4, 5, 6, 3), (4, 5, 0, 2, 6, 1))
-    tmp259 = f.aa.vv.copy()
+    tmp259 = np.copy(f.aa.vv)
     tmp259 += tmp256 * -1
     t3new.abaaba += einsum(t3.abaaba, (0, 1, 2, 3, 4, 5), tmp259, (5, 6), (0, 1, 2, 6, 4, 3)) * -1
-    tmp51 = v.aabb.vvov.transpose((2, 0, 1, 3)).copy()
-    tmp51 += tmp50.transpose((0, 2, 1, 3)) * -1
+    tmp51 = np.copy(np.transpose(v.aabb.vvov, (2, 0, 1, 3)))
+    tmp51 += np.transpose(tmp50, (0, 2, 1, 3)) * -1
     t2new.abab += einsum(t3.babbab, (0, 1, 2, 3, 4, 5), tmp51, (2, 4, 6, 5), (1, 0, 6, 3)) * 2
     tmp464 = einsum(tmp463, (0, 1, 2, 3, 4, 5), t1.bb, (4, 6), (0, 1, 2, 3, 5, 6))
     del tmp463
@@ -395,21 +395,21 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp367 = einsum(v.aabb.oovv, (0, 1, 2, 3), t2.abab, (4, 5, 6, 3), (4, 0, 1, 5, 6, 2))
     tmp358 = einsum(v.aaaa.oovv, (0, 1, 2, 3), t2.abab, (4, 5, 3, 6), (4, 0, 1, 5, 2, 6))
     tmp311 = einsum(tmp310, (0, 1, 2, 3, 4, 5), t1.bb, (4, 6), (0, 2, 1, 3, 5, 6))
-    tmp356 = tmp177.transpose((1, 0, 2, 3)).copy()
+    tmp356 = np.copy(np.transpose(tmp177, (1, 0, 2, 3)))
     tmp356 += tmp355 * -1
     t3new.babbab += einsum(t2.abab, (0, 1, 2, 3), tmp356, (0, 4, 5, 6), (5, 4, 1, 6, 2, 3)) * -1
     tmp378 = einsum(tmp87, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 4, 3))
-    tmp290 = tmp62.transpose((0, 2, 1, 3)).copy()
-    tmp290 += tmp289.transpose((0, 2, 1, 3))
-    tmp383 = tmp111.transpose((0, 2, 1, 3)).copy()
-    tmp383 += tmp382.transpose((0, 3, 1, 2))
+    tmp290 = np.copy(np.transpose(tmp62, (0, 2, 1, 3)))
+    tmp290 += np.transpose(tmp289, (0, 2, 1, 3))
+    tmp383 = np.copy(np.transpose(tmp111, (0, 2, 1, 3)))
+    tmp383 += np.transpose(tmp382, (0, 3, 1, 2))
     del tmp382
     tmp322 = einsum(t1.bb, (0, 1), tmp321, (2, 3, 4, 5, 0, 6), (2, 3, 4, 5, 6, 1))
     del tmp321
-    tmp292 = tmp66.transpose((0, 2, 1, 3)).copy()
-    tmp292 += tmp66.transpose((0, 3, 2, 1)) * -1
-    tmp128 = v.aabb.ovvv.copy()
-    tmp128 += tmp127.transpose((0, 1, 3, 2)) * -1
+    tmp292 = np.copy(np.transpose(tmp66, (0, 2, 1, 3)))
+    tmp292 += np.transpose(tmp66, (0, 3, 2, 1)) * -1
+    tmp128 = np.copy(v.aabb.ovvv)
+    tmp128 += np.transpose(tmp127, (0, 1, 3, 2)) * -1
     t2new.abab += einsum(tmp128, (0, 1, 2, 3), t3.abaaba, (4, 5, 0, 6, 2, 1), (4, 5, 6, 3)) * 2
     tmp371 = einsum(v.aaaa.ovov, (0, 1, 2, 3), t2.abab, (4, 5, 3, 6), (4, 0, 2, 5, 1, 6))
     tmp113 = einsum(tmp72, (0, 1, 2, 3), t1.aa, (4, 2), (4, 0, 1, 3))
@@ -417,30 +417,30 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp326 = einsum(tmp21, (0, 1, 2, 3), t2.aaaa, (4, 5, 6, 3), (4, 5, 0, 1, 2, 6))
     tmp361 = einsum(tmp360, (0, 1, 2, 3, 4, 5), t1.aa, (3, 6), (0, 1, 2, 4, 6, 5))
     del tmp360
-    tmp336 = tmp335.transpose((1, 0, 2, 3)).copy()
+    tmp336 = np.copy(np.transpose(tmp335, (1, 0, 2, 3)))
     tmp336 += tmp332 * -1
     tmp408 = einsum(tmp77, (0, 1, 2, 3), t2.abab, (4, 5, 6, 3), (0, 4, 5, 1, 6, 2))
     tmp404 = einsum(t2.abab, (0, 1, 2, 3), tmp173, (4, 5, 6, 3), (4, 0, 5, 1, 2, 6))
     tmp314 = einsum(v.aabb.ovoo, (0, 1, 2, 3), t2.aaaa, (4, 5, 6, 1), (4, 5, 0, 2, 3, 6))
-    tmp401 = tmp178.copy()
+    tmp401 = np.copy(tmp178)
     tmp401 += tmp400 * -1
     tmp109 = einsum(t1.aa, (0, 1), tmp107, (2, 3, 0, 4), (3, 2, 4, 1))
     tmp385 = einsum(t2.abab, (0, 1, 2, 3), tmp165, (4, 5, 6, 2), (4, 5, 0, 1, 6, 3)) * -1
     tmp388 = einsum(tmp173, (0, 1, 2, 3), t1.aa, (1, 4), (0, 4, 3, 2))
     tmp338 = einsum(tmp310, (0, 1, 2, 3, 4, 5), t1.aa, (2, 6), (0, 1, 3, 4, 6, 5))
     del tmp310
-    tmp380 = tmp143.transpose((0, 1, 3, 2)).copy()
+    tmp380 = np.copy(np.transpose(tmp143, (0, 1, 3, 2)))
     tmp380 += tmp144 * -1
-    tmp340 = v.aabb.vvoo.transpose((2, 3, 0, 1)).copy()
-    tmp340 += tmp147.transpose((1, 0, 3, 2)) * -1
+    tmp340 = np.copy(np.transpose(v.aabb.vvoo, (2, 3, 0, 1)))
+    tmp340 += np.transpose(tmp147, (1, 0, 3, 2)) * -1
     tmp373 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (4, 5, 6, 3), (4, 0, 5, 2, 6, 1))
-    tmp302 = tmp66.transpose((0, 2, 1, 3)).copy() * -1
-    tmp302 += tmp66.transpose((0, 3, 2, 1))
-    tmp283 = v.aaaa.ovvv.transpose((0, 2, 1, 3)).copy() * -1
+    tmp302 = np.copy(np.transpose(tmp66, (0, 2, 1, 3))) * -1
+    tmp302 += np.transpose(tmp66, (0, 3, 2, 1))
+    tmp283 = np.copy(np.transpose(v.aaaa.ovvv, (0, 2, 1, 3))) * -1
     tmp283 += tmp53
     t3new.abaaba += einsum(tmp283, (0, 1, 2, 3), t2.abab, (4, 5, 3, 6), (4, 5, 0, 2, 6, 1))
-    tmp281 = v.aaaa.ovvv.copy()
-    tmp281 += tmp53.transpose((0, 2, 3, 1)) * -1
+    tmp281 = np.copy(v.aaaa.ovvv)
+    tmp281 += np.transpose(tmp53, (0, 2, 3, 1)) * -1
     tmp307 = einsum(t2.aaaa, (0, 1, 2, 3), tmp306, (4, 5, 6, 3), (4, 5, 0, 1, 6, 2))
     del tmp306
     tmp296 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 5, 6, 3), (0, 1, 4, 6, 2, 5))
@@ -451,38 +451,38 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp267
     t3new.abaaba += einsum(tmp268, (0, 1, 2, 3), t2.abab, (2, 4, 5, 6), (0, 4, 1, 5, 6, 3)) * -1
     tmp300 = einsum(tmp165, (0, 1, 2, 3), t2.aaaa, (4, 5, 6, 3), (0, 1, 4, 5, 2, 6))
-    tmp254 = tmp252.transpose((0, 2, 1, 3, 5, 4)).copy()
+    tmp254 = np.copy(np.transpose(tmp252, (0, 2, 1, 3, 5, 4)))
     del tmp252
-    tmp254 += tmp253.transpose((1, 0, 2, 3, 5, 4)) * 3
+    tmp254 += np.transpose(tmp253, (1, 0, 2, 3, 5, 4)) * 3
     del tmp253
-    tmp294 = tmp62.transpose((0, 2, 1, 3)).copy()
+    tmp294 = np.copy(np.transpose(tmp62, (0, 2, 1, 3)))
     tmp294 += tmp289
     del tmp289
-    tmp257 = f.aa.vv.copy()
+    tmp257 = np.copy(f.aa.vv)
     tmp257 += tmp256 * -1
     del tmp256
     t3new.abaaba += einsum(t3.abaaba, (0, 1, 2, 3, 4, 5), tmp257, (5, 6), (0, 1, 2, 6, 4, 3)) * -1
     tmp250 = einsum(t1.aa, (0, 1), tmp249, (2, 3, 4, 5, 0, 6), (2, 3, 4, 5, 1, 6))
     del tmp249
-    tmp274 = tmp247.transpose((1, 0, 2, 3)).copy() * -1
-    tmp274 += tmp271.transpose((0, 2, 1, 3)) * 2
+    tmp274 = np.copy(np.transpose(tmp247, (1, 0, 2, 3))) * -1
+    tmp274 += np.transpose(tmp271, (0, 2, 1, 3)) * 2
     t3new.abaaba += einsum(t2.abab, (0, 1, 2, 3), tmp274, (0, 4, 5, 6), (4, 1, 5, 6, 3, 2))
-    tmp272 = tmp247.transpose((1, 0, 2, 3)).copy() * -1
-    tmp272 += tmp271.transpose((0, 2, 1, 3)) * 2
-    tmp285 = v.aaaa.ovvv.copy()
-    tmp285 += tmp53.transpose((0, 2, 3, 1)) * -1
+    tmp272 = np.copy(np.transpose(tmp247, (1, 0, 2, 3))) * -1
+    tmp272 += np.transpose(tmp271, (0, 2, 1, 3)) * 2
+    tmp285 = np.copy(v.aaaa.ovvv)
+    tmp285 += np.transpose(tmp53, (0, 2, 3, 1)) * -1
     t3new.abaaba += einsum(t2.abab, (0, 1, 2, 3), tmp285, (4, 5, 2, 6), (4, 1, 0, 5, 3, 6))
     tmp242 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.bbbb, (4, 5, 3, 1), (4, 5, 0, 2)) * -1
     tmp123 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.bbbb, (0, 2, 4, 3), (4, 1))
     tmp122 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (0, 2, 1, 4), (3, 4))
-    tmp218 = tmp217.transpose((1, 0, 3, 2)).copy() * -1
+    tmp218 = np.copy(np.transpose(tmp217, (1, 0, 3, 2))) * -1
     del tmp217
     tmp218 += tmp170 * -1
-    tmp232 = v.bbbb.oovv.copy()
-    tmp232 += tmp224.transpose((1, 0, 3, 2)) * -1
-    tmp188 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp188 += v.aaaa.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp214 = tmp141.copy() * -1
+    tmp232 = np.copy(v.bbbb.oovv)
+    tmp232 += np.transpose(tmp224, (1, 0, 3, 2)) * -1
+    tmp188 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1)))
+    tmp188 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3)) * -1
+    tmp214 = np.copy(tmp141) * -1
     tmp214 += tmp142
     del tmp142
     tmp206 = einsum(tmp200, (0, 1, 2, 3), t1.bb, (3, 4), (0, 2, 1, 4))
@@ -491,25 +491,25 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp131 = einsum(v.aabb.ovvv, (0, 1, 2, 3), t1.aa, (0, 1), (2, 3))
     tmp196 = einsum(t1.bb, (0, 1), tmp195, (0, 2, 1, 3), (2, 3))
     tmp197 = einsum(t1.bb, (0, 1), tmp16, (0, 2), (1, 2))
-    tmp184 = f.bb.oo.copy()
-    tmp184 += tmp28.transpose((1, 0))
-    tmp184 += tmp183.transpose((1, 0)) * -1
+    tmp184 = np.copy(f.bb.oo)
+    tmp184 += np.transpose(tmp28, (1, 0))
+    tmp184 += np.transpose(tmp183, (1, 0)) * -1
     del tmp183
     tmp146 = einsum(t1.bb, (0, 1), v.aabb.ovoo, (2, 3, 4, 0), (2, 4, 3, 1))
     t2new.abab += tmp146 * -1
-    tmp208 = tmp24.copy()
+    tmp208 = np.copy(tmp24)
     tmp208 += tmp25 * 2
     tmp208 += tmp135
     tmp230 = einsum(v.aabb.ovoo, (0, 1, 2, 3), t2.abab, (0, 4, 1, 5), (4, 2, 3, 5))
-    tmp227 = v.bbbb.ooov.copy() * -1
-    tmp227 += v.bbbb.ovoo.transpose((0, 2, 3, 1))
-    tmp192 = v.bbbb.ovvv.copy()
-    tmp192 += tmp129.transpose((0, 3, 2, 1))
+    tmp227 = np.copy(v.bbbb.ooov) * -1
+    tmp227 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1))
+    tmp192 = np.copy(v.bbbb.ovvv)
+    tmp192 += np.transpose(tmp129, (0, 3, 2, 1))
     tmp125 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.bbbb, (4, 2, 5, 3), (0, 4, 1, 5))
     t2new.abab += tmp125 * 2
-    tmp212 = tmp22.copy()
-    tmp212 += tmp22.transpose((0, 2, 1, 3)) * -1
-    tmp162 = v.aabb.vvov.transpose((2, 0, 1, 3)).copy()
+    tmp212 = np.copy(tmp22)
+    tmp212 += np.transpose(tmp22, (0, 2, 1, 3)) * -1
+    tmp162 = np.copy(np.transpose(v.aabb.vvov, (2, 0, 1, 3)))
     tmp162 += tmp50 * -1
     tmp56 = einsum(v.aabb.vvov, (0, 1, 2, 3), t1.bb, (2, 3), (0, 1))
     tmp58 = einsum(t1.aa, (0, 1), tmp57, (0, 1, 2, 3), (2, 3))
@@ -521,566 +521,566 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t2new.abab += tmp156 * 2
     tmp95 = einsum(v.aabb.ooov, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3))
     t2new.abab += tmp95 * -1
-    tmp91 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp91 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp91 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1))) * -1
+    tmp91 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp49 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (4, 5, 1, 3), (0, 4, 2, 5))
     t2new.aaaa += tmp49
-    t2new.aaaa += tmp49.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp49.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp49.transpose((1, 0, 3, 2))
-    tmp132 = v.bbbb.ovvv.copy() * -1
-    tmp132 += v.bbbb.ovvv.transpose((0, 2, 3, 1))
-    tmp47 = f.bb.ov.copy()
+    t2new.aaaa += np.transpose(tmp49, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp49, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp49, (1, 0, 3, 2))
+    tmp132 = np.copy(v.bbbb.ovvv) * -1
+    tmp132 += np.transpose(v.bbbb.ovvv, (0, 2, 3, 1))
+    tmp47 = np.copy(f.bb.ov)
     tmp47 += tmp13
     del tmp13
     tmp47 += tmp46 * -1
     del tmp46
     t2new.abab += einsum(t3.babbab, (0, 1, 2, 3, 4, 5), tmp47, (2, 5), (1, 0, 4, 3))
     t2new.aaaa += einsum(t3.abaaba, (0, 1, 2, 3, 4, 5), tmp47, (1, 4), (0, 2, 3, 5))
-    tmp54 = v.aaaa.ovvv.copy()
-    tmp54 += tmp53.transpose((0, 3, 2, 1))
-    tmp101 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp101 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp54 = np.copy(v.aaaa.ovvv)
+    tmp54 += np.transpose(tmp53, (0, 3, 2, 1))
+    tmp101 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp101 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
     tmp115 = einsum(v.aaaa.ovov, (0, 1, 2, 3), t2.aaaa, (4, 5, 3, 1), (4, 5, 0, 2)) * -1
-    tmp105 = v.aaaa.oovv.copy()
-    tmp105 += tmp93.transpose((1, 0, 2, 3)) * -1
+    tmp105 = np.copy(v.aaaa.oovv)
+    tmp105 += np.transpose(tmp93, (1, 0, 2, 3)) * -1
     tmp68 = einsum(tmp66, (0, 1, 2, 3), t1.aa, (3, 4), (0, 2, 1, 4))
-    tmp70 = tmp5.copy()
+    tmp70 = np.copy(tmp5)
     tmp70 += tmp6 * 0.5
     tmp70 += tmp10
-    tmp85 = tmp82.transpose((0, 1, 3, 2)).copy() * -1
+    tmp85 = np.copy(np.transpose(tmp82, (0, 1, 3, 2))) * -1
     del tmp82
     tmp85 += tmp84 * -1
-    tmp96 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp96 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp96 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp96 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
     tmp19 = einsum(tmp18, (0, 1, 2, 3), t1.aa, (0, 3), (1, 2))
     del tmp18
-    tmp38 = f.aa.oo.copy()
-    tmp38 += tmp17.transpose((1, 0))
-    tmp38 += tmp37.transpose((1, 0)) * -1
+    tmp38 = np.copy(f.aa.oo)
+    tmp38 += np.transpose(tmp17, (1, 0))
+    tmp38 += np.transpose(tmp37, (1, 0)) * -1
     del tmp37
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp38, (0, 4), (4, 1, 2, 3)) * -1
-    tmp79 = tmp77.copy() * -1
+    tmp79 = np.copy(tmp77) * -1
     tmp79 += tmp78
     del tmp78
-    tmp99 = v.aaaa.ooov.copy() * -1
-    tmp99 += v.aaaa.ovoo.transpose((0, 2, 3, 1))
-    tmp98 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp98 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp99 = np.copy(v.aaaa.ooov) * -1
+    tmp99 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1))
+    tmp98 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1))) * -1
+    tmp98 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp103 = einsum(v.aabb.ooov, (0, 1, 2, 3), t2.abab, (4, 2, 5, 3), (4, 0, 1, 5))
-    tmp74 = v.aaaa.ovvv.copy() * -1
-    tmp74 += v.aaaa.ovvv.transpose((0, 2, 1, 3))
-    tmp75 = tmp2.copy() * -1
-    tmp75 += tmp2.transpose((0, 2, 1, 3))
+    tmp74 = np.copy(v.aaaa.ovvv) * -1
+    tmp74 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3))
+    tmp75 = np.copy(tmp2) * -1
+    tmp75 += np.transpose(tmp2, (0, 2, 1, 3))
     tmp532 = einsum(t2.bbbb, (0, 1, 2, 3), tmp434, (1, 4, 5, 6), (4, 5, 0, 6, 2, 3)) * -1
     del tmp434
-    t3new.bbbbbb = tmp532.transpose((0, 1, 2, 5, 3, 4)).copy()
-    t3new.bbbbbb += tmp532.transpose((0, 1, 2, 5, 3, 4))
-    t3new.bbbbbb += tmp532.transpose((0, 1, 2, 3, 5, 4)) * -1
-    t3new.bbbbbb += tmp532.transpose((0, 2, 1, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp532.transpose((0, 2, 1, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp532.transpose((2, 0, 1, 5, 3, 4))
-    t3new.bbbbbb += tmp532.transpose((2, 0, 1, 5, 3, 4))
-    t3new.bbbbbb += tmp532.transpose((0, 2, 1, 3, 5, 4))
-    t3new.bbbbbb += tmp532.transpose((0, 2, 1, 3, 5, 4))
-    t3new.bbbbbb += tmp532.transpose((2, 0, 1, 3, 5, 4)) * -1
+    t3new.bbbbbb = np.copy(np.transpose(tmp532, (0, 1, 2, 5, 3, 4)))
+    t3new.bbbbbb += np.transpose(tmp532, (0, 1, 2, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp532, (0, 1, 2, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp532, (0, 2, 1, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp532, (0, 2, 1, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp532, (2, 0, 1, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp532, (2, 0, 1, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp532, (0, 2, 1, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp532, (0, 2, 1, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp532, (2, 0, 1, 3, 5, 4)) * -1
     del tmp532
     tmp542 = einsum(tmp22, (0, 1, 2, 3), t2.bbbb, (4, 2, 5, 6), (0, 4, 1, 5, 6, 3))
-    t3new.bbbbbb += tmp542.transpose((2, 0, 1, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp542.transpose((2, 0, 1, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp542.transpose((2, 1, 0, 4, 3, 5))
-    t3new.bbbbbb += tmp542.transpose((2, 1, 0, 4, 3, 5))
-    t3new.bbbbbb += tmp542.transpose((0, 2, 1, 4, 3, 5))
-    t3new.bbbbbb += tmp542.transpose((0, 2, 1, 4, 3, 5))
-    t3new.bbbbbb += tmp542.transpose((1, 2, 0, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp542.transpose((1, 2, 0, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp542.transpose((0, 1, 2, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp542.transpose((0, 1, 2, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp542.transpose((1, 0, 2, 4, 3, 5))
-    t3new.bbbbbb += tmp542.transpose((1, 0, 2, 4, 3, 5))
-    t3new.bbbbbb += tmp542.transpose((2, 0, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp542.transpose((2, 0, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp542.transpose((2, 1, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp542.transpose((2, 1, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp542.transpose((2, 0, 1, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp542.transpose((2, 0, 1, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp542.transpose((2, 1, 0, 5, 4, 3))
-    t3new.bbbbbb += tmp542.transpose((2, 1, 0, 5, 4, 3))
-    t3new.bbbbbb += tmp542.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp542.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp542.transpose((1, 2, 0, 4, 5, 3))
-    t3new.bbbbbb += tmp542.transpose((1, 2, 0, 4, 5, 3))
-    t3new.bbbbbb += tmp542.transpose((0, 2, 1, 5, 4, 3))
-    t3new.bbbbbb += tmp542.transpose((0, 2, 1, 5, 4, 3))
-    t3new.bbbbbb += tmp542.transpose((1, 2, 0, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp542.transpose((1, 2, 0, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp542.transpose((0, 1, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp542.transpose((0, 1, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp542.transpose((1, 0, 2, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp542.transpose((1, 0, 2, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp542.transpose((0, 1, 2, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp542.transpose((0, 1, 2, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp542.transpose((1, 0, 2, 5, 4, 3))
-    t3new.bbbbbb += tmp542.transpose((1, 0, 2, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp542, (2, 0, 1, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (2, 0, 1, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (2, 1, 0, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp542, (2, 1, 0, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp542, (0, 2, 1, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp542, (0, 2, 1, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp542, (1, 2, 0, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (1, 2, 0, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (0, 1, 2, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (0, 1, 2, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (1, 0, 2, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp542, (1, 0, 2, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp542, (2, 0, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp542, (2, 0, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp542, (2, 1, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (2, 1, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (2, 0, 1, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (2, 0, 1, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (2, 1, 0, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp542, (2, 1, 0, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp542, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (1, 2, 0, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp542, (1, 2, 0, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp542, (0, 2, 1, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp542, (0, 2, 1, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp542, (1, 2, 0, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (1, 2, 0, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (0, 1, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp542, (0, 1, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp542, (1, 0, 2, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (1, 0, 2, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (0, 1, 2, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (0, 1, 2, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp542, (1, 0, 2, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp542, (1, 0, 2, 5, 4, 3))
     del tmp542
     tmp511 = einsum(f.bb.oo, (0, 1), t3.bbbbbb, (2, 3, 1, 4, 5, 6), (0, 2, 3, 4, 5, 6))
-    t3new.bbbbbb += tmp511.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp511.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp511.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp511.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp511.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp511.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp511.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp511.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp511.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp511.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp511.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp511.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp511.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp511.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp511.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp511.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp511.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp511.transpose((1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp511, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp511, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp511, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp511, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp511, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp511, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp511, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp511, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp511, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp511, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp511, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp511, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp511, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp511, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp511, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp511, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp511, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp511, (1, 2, 0, 4, 5, 3)) * -1
     del tmp511
     tmp555 = einsum(tmp554, (0, 1, 2, 3), t1.bb, (3, 4), (0, 2, 1, 4))
     del tmp554
     t3new.bbbbbb += einsum(tmp555, (0, 1, 2, 3), t2.bbbb, (4, 2, 5, 6), (4, 1, 0, 5, 6, 3))
     del tmp555
     tmp543 = einsum(t2.bbbb, (0, 1, 2, 3), tmp458, (4, 1, 5, 6), (4, 5, 0, 6, 2, 3)) * -1
-    t3new.bbbbbb += tmp543.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp543.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp543.transpose((0, 1, 2, 3, 5, 4))
-    t3new.bbbbbb += tmp543.transpose((0, 1, 2, 3, 5, 4))
-    t3new.bbbbbb += tmp543.transpose((0, 2, 1, 5, 3, 4))
-    t3new.bbbbbb += tmp543.transpose((0, 2, 1, 5, 3, 4))
-    t3new.bbbbbb += tmp543.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp543.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp543.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.bbbbbb += tmp543.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.bbbbbb += tmp543.transpose((2, 0, 1, 3, 5, 4))
-    t3new.bbbbbb += tmp543.transpose((2, 0, 1, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp543, (0, 1, 2, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp543, (0, 1, 2, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp543, (0, 1, 2, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp543, (0, 1, 2, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp543, (0, 2, 1, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp543, (0, 2, 1, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp543, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp543, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp543, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp543, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp543, (2, 0, 1, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp543, (2, 0, 1, 3, 5, 4))
     del tmp543
     tmp531 = einsum(tmp530, (0, 1, 2, 3), t2.bbbb, (4, 0, 5, 6), (1, 2, 4, 3, 5, 6)) * -2
     del tmp530
-    t3new.bbbbbb += tmp531.transpose((0, 1, 2, 3, 5, 4)) * -1
-    t3new.bbbbbb += tmp531.transpose((2, 0, 1, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp531, (0, 1, 2, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp531, (2, 0, 1, 3, 5, 4)) * -1
     del tmp531
     tmp536 = einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.ooov, (4, 1, 5, 6), (0, 4, 5, 2, 3, 6))
-    t3new.bbbbbb += tmp536.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp536.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp536.transpose((1, 2, 0, 4, 3, 5))
-    t3new.bbbbbb += tmp536.transpose((1, 2, 0, 4, 3, 5))
-    t3new.bbbbbb += tmp536.transpose((2, 0, 1, 4, 3, 5))
-    t3new.bbbbbb += tmp536.transpose((2, 0, 1, 4, 3, 5))
-    t3new.bbbbbb += tmp536.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp536.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp536.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp536.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp536.transpose((0, 1, 2, 4, 3, 5))
-    t3new.bbbbbb += tmp536.transpose((0, 1, 2, 4, 3, 5))
-    t3new.bbbbbb += tmp536.transpose((2, 1, 0, 4, 5, 3))
-    t3new.bbbbbb += tmp536.transpose((2, 1, 0, 4, 5, 3))
-    t3new.bbbbbb += tmp536.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp536.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp536.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp536.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp536.transpose((1, 2, 0, 5, 4, 3))
-    t3new.bbbbbb += tmp536.transpose((1, 2, 0, 5, 4, 3))
-    t3new.bbbbbb += tmp536.transpose((2, 0, 1, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp536.transpose((2, 0, 1, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp536.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp536.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp536.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp536.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp536.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp536.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp536.transpose((2, 0, 1, 5, 4, 3))
-    t3new.bbbbbb += tmp536.transpose((2, 0, 1, 5, 4, 3))
-    t3new.bbbbbb += tmp536.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp536.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp536.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp536.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp536.transpose((0, 1, 2, 5, 4, 3))
-    t3new.bbbbbb += tmp536.transpose((0, 1, 2, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp536, (2, 1, 0, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (2, 1, 0, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (1, 2, 0, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp536, (1, 2, 0, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp536, (2, 0, 1, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp536, (2, 0, 1, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp536, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (0, 2, 1, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (0, 2, 1, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (0, 1, 2, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp536, (0, 1, 2, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp536, (2, 1, 0, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp536, (2, 1, 0, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp536, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (2, 1, 0, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (2, 1, 0, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (1, 2, 0, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp536, (1, 2, 0, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp536, (2, 0, 1, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (2, 0, 1, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp536, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp536, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp536, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp536, (0, 1, 2, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (0, 1, 2, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (2, 0, 1, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp536, (2, 0, 1, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp536, (1, 0, 2, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (1, 0, 2, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp536, (0, 1, 2, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp536, (0, 1, 2, 5, 4, 3))
     del tmp536
-    tmp517 = tmp515.transpose((0, 2, 1, 3, 5, 4)).copy()
-    tmp517 += tmp516.transpose((1, 0, 2, 3, 5, 4)) * 3
+    tmp517 = np.copy(np.transpose(tmp515, (0, 2, 1, 3, 5, 4)))
+    tmp517 += np.transpose(tmp516, (1, 0, 2, 3, 5, 4)) * 3
     t3new.bbbbbb += einsum(t1.bb, (0, 1), tmp517, (2, 0, 3, 4, 5, 6), (4, 3, 2, 6, 5, 1))
     del tmp517
     tmp556 = einsum(t2.bbbb, (0, 1, 2, 3), tmp238, (4, 5, 1, 6), (4, 5, 0, 2, 3, 6))
-    t3new.bbbbbb += tmp556.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp556.transpose((0, 1, 2, 4, 3, 5))
-    t3new.bbbbbb += tmp556.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp556.transpose((0, 1, 2, 4, 3, 5))
-    t3new.bbbbbb += tmp556.transpose((1, 2, 0, 4, 3, 5))
-    t3new.bbbbbb += tmp556.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp556.transpose((1, 2, 0, 4, 3, 5))
-    t3new.bbbbbb += tmp556.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp556.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp556.transpose((2, 0, 1, 4, 3, 5))
-    t3new.bbbbbb += tmp556.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp556.transpose((2, 0, 1, 4, 3, 5))
-    t3new.bbbbbb += tmp556.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp556.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp556.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp556.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp556.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp556.transpose((0, 1, 2, 5, 4, 3))
-    t3new.bbbbbb += tmp556.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp556.transpose((0, 1, 2, 5, 4, 3))
-    t3new.bbbbbb += tmp556.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp556.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp556.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp556.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp556.transpose((2, 1, 0, 4, 5, 3))
-    t3new.bbbbbb += tmp556.transpose((2, 0, 1, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp556.transpose((2, 1, 0, 4, 5, 3))
-    t3new.bbbbbb += tmp556.transpose((2, 0, 1, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp556.transpose((1, 2, 0, 5, 4, 3))
-    t3new.bbbbbb += tmp556.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp556.transpose((1, 2, 0, 5, 4, 3))
-    t3new.bbbbbb += tmp556.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp556.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp556.transpose((2, 0, 1, 5, 4, 3))
-    t3new.bbbbbb += tmp556.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp556.transpose((2, 0, 1, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp556, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (0, 1, 2, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp556, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (0, 1, 2, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp556, (1, 2, 0, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp556, (0, 2, 1, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (1, 2, 0, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp556, (0, 2, 1, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (2, 1, 0, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (2, 0, 1, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp556, (2, 1, 0, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (2, 0, 1, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp556, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp556, (0, 1, 2, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp556, (0, 1, 2, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (1, 0, 2, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (0, 1, 2, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp556, (1, 0, 2, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (0, 1, 2, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp556, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp556, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp556, (2, 1, 0, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp556, (2, 0, 1, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (2, 1, 0, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp556, (2, 0, 1, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (1, 2, 0, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp556, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (1, 2, 0, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp556, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (2, 1, 0, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (2, 0, 1, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp556, (2, 1, 0, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp556, (2, 0, 1, 5, 4, 3))
     del tmp556
     tmp539 = einsum(t2.bbbb, (0, 1, 2, 3), tmp538, (4, 5, 3, 6), (4, 0, 1, 5, 6, 2)) * -2
     del tmp538
-    t3new.bbbbbb += tmp539.transpose((0, 2, 1, 3, 4, 5)) * -1
-    t3new.bbbbbb += tmp539.transpose((2, 1, 0, 3, 4, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp539, (0, 2, 1, 3, 4, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp539, (2, 1, 0, 3, 4, 5)) * -1
     del tmp539
     tmp535 = einsum(tmp534, (0, 1, 2, 3, 4, 5), t1.bb, (2, 6), (0, 1, 3, 6, 4, 5))
     del tmp534
-    t3new.bbbbbb += tmp535.transpose((2, 1, 0, 4, 3, 5)) * -2
-    t3new.bbbbbb += tmp535.transpose((2, 1, 0, 3, 4, 5)) * 2
-    t3new.bbbbbb += tmp535.transpose((0, 2, 1, 4, 3, 5)) * -2
-    t3new.bbbbbb += tmp535.transpose((0, 1, 2, 4, 3, 5)) * 2
-    t3new.bbbbbb += tmp535.transpose((0, 2, 1, 3, 4, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp535, (2, 1, 0, 4, 3, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp535, (2, 1, 0, 3, 4, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp535, (0, 2, 1, 4, 3, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp535, (0, 1, 2, 4, 3, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp535, (0, 2, 1, 3, 4, 5)) * 2
     t3new.bbbbbb += tmp535 * -2
-    t3new.bbbbbb += tmp535.transpose((2, 1, 0, 4, 5, 3)) * 2
-    t3new.bbbbbb += tmp535.transpose((0, 2, 1, 4, 5, 3)) * 2
-    t3new.bbbbbb += tmp535.transpose((0, 1, 2, 4, 5, 3)) * -2
-    t3new.bbbbbb += tmp535.transpose((2, 1, 0, 5, 4, 3)) * -2
-    t3new.bbbbbb += tmp535.transpose((0, 2, 1, 5, 4, 3)) * -2
-    t3new.bbbbbb += tmp535.transpose((0, 1, 2, 5, 4, 3)) * 2
-    t3new.bbbbbb += tmp535.transpose((0, 1, 2, 3, 5, 4)) * 2
-    t3new.bbbbbb += tmp535.transpose((0, 1, 2, 5, 3, 4)) * -2
-    t3new.bbbbbb += tmp535.transpose((0, 2, 1, 3, 5, 4)) * -2
-    t3new.bbbbbb += tmp535.transpose((0, 2, 1, 5, 3, 4)) * 2
-    t3new.bbbbbb += tmp535.transpose((2, 1, 0, 3, 5, 4)) * -2
-    t3new.bbbbbb += tmp535.transpose((2, 1, 0, 5, 3, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp535, (2, 1, 0, 4, 5, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp535, (0, 2, 1, 4, 5, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp535, (0, 1, 2, 4, 5, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp535, (2, 1, 0, 5, 4, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp535, (0, 2, 1, 5, 4, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp535, (0, 1, 2, 5, 4, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp535, (0, 1, 2, 3, 5, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp535, (0, 1, 2, 5, 3, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp535, (0, 2, 1, 3, 5, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp535, (0, 2, 1, 5, 3, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp535, (2, 1, 0, 3, 5, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp535, (2, 1, 0, 5, 3, 4)) * 2
     del tmp535
     tmp522 = einsum(t3.bbbbbb, (0, 1, 2, 3, 4, 5), tmp324, (2, 6), (6, 0, 1, 3, 4, 5))
-    t3new.bbbbbb += tmp522.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp522.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp522.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp522.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp522.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp522.transpose((0, 2, 1, 4, 5, 3))
-    t3new.bbbbbb += tmp522.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp522.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp522.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp522.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp522.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp522.transpose((1, 0, 2, 4, 5, 3))
-    t3new.bbbbbb += tmp522.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp522.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp522.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp522.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp522.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.bbbbbb += tmp522.transpose((1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp522, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp522, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp522, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp522, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp522, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp522, (0, 2, 1, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp522, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp522, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp522, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp522, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp522, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp522, (1, 0, 2, 4, 5, 3))
+    t3new.bbbbbb += np.transpose(tmp522, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp522, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp522, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp522, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp522, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp522, (1, 2, 0, 4, 5, 3)) * -1
     del tmp522
     tmp514 = einsum(tmp513, (0, 1, 2, 3, 4, 5), t1.bb, (2, 6), (0, 1, 3, 6, 4, 5))
     del tmp513
-    t3new.bbbbbb += tmp514.transpose((2, 1, 0, 4, 5, 3)) * 2
-    t3new.bbbbbb += tmp514.transpose((2, 1, 0, 3, 5, 4)) * -2
-    t3new.bbbbbb += tmp514.transpose((0, 2, 1, 4, 5, 3)) * 2
-    t3new.bbbbbb += tmp514.transpose((0, 2, 1, 3, 5, 4)) * -2
-    t3new.bbbbbb += tmp514.transpose((0, 1, 2, 4, 5, 3)) * -2
-    t3new.bbbbbb += tmp514.transpose((0, 1, 2, 3, 5, 4)) * 2
-    t3new.bbbbbb += tmp514.transpose((0, 1, 2, 4, 3, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp514, (2, 1, 0, 4, 5, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp514, (2, 1, 0, 3, 5, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp514, (0, 2, 1, 4, 5, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp514, (0, 2, 1, 3, 5, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp514, (0, 1, 2, 4, 5, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp514, (0, 1, 2, 3, 5, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp514, (0, 1, 2, 4, 3, 5)) * 2
     t3new.bbbbbb += tmp514 * -2
-    t3new.bbbbbb += tmp514.transpose((0, 2, 1, 4, 3, 5)) * -2
-    t3new.bbbbbb += tmp514.transpose((0, 2, 1, 3, 4, 5)) * 2
-    t3new.bbbbbb += tmp514.transpose((2, 1, 0, 4, 3, 5)) * -2
-    t3new.bbbbbb += tmp514.transpose((2, 1, 0, 3, 4, 5)) * 2
-    t3new.bbbbbb += tmp514.transpose((2, 1, 0, 5, 4, 3)) * -2
-    t3new.bbbbbb += tmp514.transpose((2, 1, 0, 5, 3, 4)) * 2
-    t3new.bbbbbb += tmp514.transpose((0, 2, 1, 5, 4, 3)) * -2
-    t3new.bbbbbb += tmp514.transpose((0, 2, 1, 5, 3, 4)) * 2
-    t3new.bbbbbb += tmp514.transpose((0, 1, 2, 5, 4, 3)) * 2
-    t3new.bbbbbb += tmp514.transpose((0, 1, 2, 5, 3, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp514, (0, 2, 1, 4, 3, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp514, (0, 2, 1, 3, 4, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp514, (2, 1, 0, 4, 3, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp514, (2, 1, 0, 3, 4, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp514, (2, 1, 0, 5, 4, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp514, (2, 1, 0, 5, 3, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp514, (0, 2, 1, 5, 4, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp514, (0, 2, 1, 5, 3, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp514, (0, 1, 2, 5, 4, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp514, (0, 1, 2, 5, 3, 4)) * -2
     del tmp514
     tmp561 = einsum(t1.bb, (0, 1), tmp560, (2, 0, 3, 4, 5, 6), (2, 4, 3, 6, 5, 1)) * -2
     del tmp560
-    t3new.bbbbbb += tmp561.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp561.transpose((1, 2, 0, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp561, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp561, (1, 2, 0, 5, 4, 3))
     del tmp561
     tmp533 = einsum(t2.bbbb, (0, 1, 2, 3), tmp433, (1, 4, 5, 6), (5, 4, 0, 6, 2, 3)) * -1
     del tmp433
-    t3new.bbbbbb += tmp533.transpose((0, 1, 2, 5, 4, 3)) * -2
-    t3new.bbbbbb += tmp533.transpose((0, 1, 2, 5, 4, 3)) * -2
-    t3new.bbbbbb += tmp533.transpose((0, 2, 1, 5, 4, 3)) * 2
-    t3new.bbbbbb += tmp533.transpose((0, 2, 1, 5, 4, 3)) * 2
-    t3new.bbbbbb += tmp533.transpose((2, 1, 0, 5, 4, 3)) * 2
-    t3new.bbbbbb += tmp533.transpose((2, 1, 0, 5, 4, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp533, (0, 1, 2, 5, 4, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp533, (0, 1, 2, 5, 4, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp533, (0, 2, 1, 5, 4, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp533, (0, 2, 1, 5, 4, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp533, (2, 1, 0, 5, 4, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp533, (2, 1, 0, 5, 4, 3)) * 2
     del tmp533
     tmp540 = einsum(tmp447, (0, 1, 2, 3), t2.bbbb, (4, 5, 6, 3), (0, 4, 5, 1, 2, 6)) * -1
     del tmp447
-    t3new.bbbbbb += tmp540.transpose((2, 0, 1, 5, 4, 3)) * -2
-    t3new.bbbbbb += tmp540.transpose((2, 0, 1, 4, 5, 3)) * 2
-    t3new.bbbbbb += tmp540.transpose((2, 0, 1, 4, 3, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp540, (2, 0, 1, 5, 4, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp540, (2, 0, 1, 4, 5, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp540, (2, 0, 1, 4, 3, 5)) * -2
     del tmp540
     tmp547 = einsum(tmp546, (0, 1, 2, 3), t2.bbbb, (4, 2, 5, 6), (0, 1, 4, 3, 5, 6)) * -1
     del tmp546
-    t3new.bbbbbb += tmp547.transpose((1, 0, 2, 5, 3, 4))
-    t3new.bbbbbb += tmp547.transpose((1, 0, 2, 5, 3, 4))
-    t3new.bbbbbb += tmp547.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp547.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp547.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new.bbbbbb += tmp547.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new.bbbbbb += tmp547.transpose((1, 2, 0, 3, 5, 4))
-    t3new.bbbbbb += tmp547.transpose((1, 2, 0, 3, 5, 4))
-    t3new.bbbbbb += tmp547.transpose((2, 1, 0, 5, 3, 4))
-    t3new.bbbbbb += tmp547.transpose((2, 1, 0, 5, 3, 4))
-    t3new.bbbbbb += tmp547.transpose((2, 1, 0, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp547, (1, 0, 2, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp547, (1, 0, 2, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp547, (1, 2, 0, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp547, (1, 2, 0, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp547, (1, 0, 2, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp547, (1, 0, 2, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp547, (1, 2, 0, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp547, (1, 2, 0, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp547, (2, 1, 0, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp547, (2, 1, 0, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp547, (2, 1, 0, 3, 5, 4)) * -1
     del tmp547
     tmp528 = einsum(t2.bbbb, (0, 1, 2, 3), tmp527, (4, 1, 5, 6), (4, 5, 0, 6, 2, 3)) * -1
     del tmp527
-    t3new.bbbbbb += tmp528.transpose((2, 1, 0, 5, 4, 3))
-    t3new.bbbbbb += tmp528.transpose((1, 0, 2, 5, 4, 3))
-    t3new.bbbbbb += tmp528.transpose((1, 0, 2, 5, 4, 3))
-    t3new.bbbbbb += tmp528.transpose((1, 2, 0, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp528.transpose((1, 2, 0, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp528, (2, 1, 0, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp528, (1, 0, 2, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp528, (1, 0, 2, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp528, (1, 2, 0, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp528, (1, 2, 0, 5, 4, 3)) * -1
     del tmp528
-    tmp518 = tmp515.transpose((0, 2, 1, 3, 5, 4)).copy() * 0.3333333333333333
+    tmp518 = np.copy(np.transpose(tmp515, (0, 2, 1, 3, 5, 4))) * 0.3333333333333333
     del tmp515
-    tmp518 += tmp516.transpose((1, 0, 2, 3, 5, 4))
+    tmp518 += np.transpose(tmp516, (1, 0, 2, 3, 5, 4))
     del tmp516
     t3new.bbbbbb += einsum(t1.bb, (0, 1), tmp518, (2, 0, 3, 4, 5, 6), (4, 3, 2, 6, 5, 1)) * 3
     del tmp518
     tmp557 = einsum(tmp240, (0, 1, 2, 3), t2.bbbb, (4, 2, 5, 6), (1, 0, 4, 3, 5, 6))
-    t3new.bbbbbb += tmp557.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp557.transpose((0, 1, 2, 5, 4, 3))
-    t3new.bbbbbb += tmp557.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp557.transpose((0, 1, 2, 5, 4, 3))
-    t3new.bbbbbb += tmp557.transpose((1, 2, 0, 5, 4, 3))
-    t3new.bbbbbb += tmp557.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp557.transpose((1, 2, 0, 5, 4, 3))
-    t3new.bbbbbb += tmp557.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp557.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp557.transpose((2, 0, 1, 5, 4, 3))
-    t3new.bbbbbb += tmp557.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp557.transpose((2, 0, 1, 5, 4, 3))
-    t3new.bbbbbb += tmp557.transpose((1, 0, 2, 5, 3, 4))
-    t3new.bbbbbb += tmp557.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp557.transpose((1, 0, 2, 5, 3, 4))
-    t3new.bbbbbb += tmp557.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp557.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new.bbbbbb += tmp557.transpose((0, 1, 2, 3, 5, 4))
-    t3new.bbbbbb += tmp557.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new.bbbbbb += tmp557.transpose((0, 1, 2, 3, 5, 4))
-    t3new.bbbbbb += tmp557.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp557.transpose((0, 2, 1, 5, 3, 4))
-    t3new.bbbbbb += tmp557.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp557.transpose((0, 2, 1, 5, 3, 4))
-    t3new.bbbbbb += tmp557.transpose((2, 1, 0, 5, 3, 4))
-    t3new.bbbbbb += tmp557.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp557.transpose((2, 1, 0, 5, 3, 4))
-    t3new.bbbbbb += tmp557.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp557.transpose((1, 2, 0, 3, 5, 4))
-    t3new.bbbbbb += tmp557.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.bbbbbb += tmp557.transpose((1, 2, 0, 3, 5, 4))
-    t3new.bbbbbb += tmp557.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.bbbbbb += tmp557.transpose((2, 1, 0, 3, 5, 4)) * -1
-    t3new.bbbbbb += tmp557.transpose((2, 0, 1, 3, 5, 4))
-    t3new.bbbbbb += tmp557.transpose((2, 1, 0, 3, 5, 4)) * -1
-    t3new.bbbbbb += tmp557.transpose((2, 0, 1, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp557, (1, 0, 2, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (0, 1, 2, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp557, (1, 0, 2, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (0, 1, 2, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp557, (1, 2, 0, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp557, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (1, 2, 0, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp557, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (2, 1, 0, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (2, 0, 1, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp557, (2, 1, 0, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (2, 0, 1, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp557, (1, 0, 2, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp557, (0, 1, 2, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (1, 0, 2, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp557, (0, 1, 2, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (1, 0, 2, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (0, 1, 2, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp557, (1, 0, 2, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (0, 1, 2, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp557, (1, 2, 0, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (0, 2, 1, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp557, (1, 2, 0, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (0, 2, 1, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp557, (2, 1, 0, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp557, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (2, 1, 0, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp557, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (1, 2, 0, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp557, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (1, 2, 0, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp557, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (2, 1, 0, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (2, 0, 1, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp557, (2, 1, 0, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp557, (2, 0, 1, 3, 5, 4))
     del tmp557
     tmp551 = einsum(t2.bbbb, (0, 1, 2, 3), tmp236, (4, 5, 3, 6), (4, 0, 1, 2, 6, 5))
-    t3new.bbbbbb += tmp551.transpose((0, 2, 1, 3, 5, 4)) * -2
-    t3new.bbbbbb += tmp551.transpose((0, 2, 1, 3, 4, 5)) * 2
-    t3new.bbbbbb += tmp551.transpose((1, 0, 2, 3, 5, 4)) * -2
-    t3new.bbbbbb += tmp551.transpose((1, 0, 2, 3, 4, 5)) * 2
-    t3new.bbbbbb += tmp551.transpose((1, 2, 0, 3, 5, 4)) * 2
-    t3new.bbbbbb += tmp551.transpose((1, 2, 0, 3, 4, 5)) * -2
-    t3new.bbbbbb += tmp551.transpose((0, 2, 1, 5, 3, 4)) * 2
-    t3new.bbbbbb += tmp551.transpose((0, 2, 1, 4, 3, 5)) * -2
-    t3new.bbbbbb += tmp551.transpose((0, 2, 1, 5, 4, 3)) * -2
-    t3new.bbbbbb += tmp551.transpose((0, 2, 1, 4, 5, 3)) * 2
-    t3new.bbbbbb += tmp551.transpose((1, 0, 2, 5, 3, 4)) * 2
-    t3new.bbbbbb += tmp551.transpose((1, 0, 2, 4, 3, 5)) * -2
-    t3new.bbbbbb += tmp551.transpose((1, 2, 0, 5, 3, 4)) * -2
-    t3new.bbbbbb += tmp551.transpose((1, 2, 0, 4, 3, 5)) * 2
-    t3new.bbbbbb += tmp551.transpose((1, 0, 2, 5, 4, 3)) * -2
-    t3new.bbbbbb += tmp551.transpose((1, 0, 2, 4, 5, 3)) * 2
-    t3new.bbbbbb += tmp551.transpose((1, 2, 0, 5, 4, 3)) * 2
-    t3new.bbbbbb += tmp551.transpose((1, 2, 0, 4, 5, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp551, (0, 2, 1, 3, 5, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp551, (0, 2, 1, 3, 4, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp551, (1, 0, 2, 3, 5, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp551, (1, 0, 2, 3, 4, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp551, (1, 2, 0, 3, 5, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp551, (1, 2, 0, 3, 4, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp551, (0, 2, 1, 5, 3, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp551, (0, 2, 1, 4, 3, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp551, (0, 2, 1, 5, 4, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp551, (0, 2, 1, 4, 5, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp551, (1, 0, 2, 5, 3, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp551, (1, 0, 2, 4, 3, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp551, (1, 2, 0, 5, 3, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp551, (1, 2, 0, 4, 3, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp551, (1, 0, 2, 5, 4, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp551, (1, 0, 2, 4, 5, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp551, (1, 2, 0, 5, 4, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp551, (1, 2, 0, 4, 5, 3)) * -2
     del tmp551
     tmp537 = einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.ovvv, (4, 5, 6, 3), (0, 1, 4, 2, 5, 6))
-    t3new.bbbbbb += tmp537.transpose((2, 1, 0, 3, 5, 4)) * -2
-    t3new.bbbbbb += tmp537.transpose((0, 2, 1, 3, 5, 4)) * -2
-    t3new.bbbbbb += tmp537.transpose((0, 1, 2, 3, 5, 4)) * 2
-    t3new.bbbbbb += tmp537.transpose((2, 1, 0, 5, 3, 4)) * 2
-    t3new.bbbbbb += tmp537.transpose((2, 1, 0, 5, 4, 3)) * -2
-    t3new.bbbbbb += tmp537.transpose((0, 2, 1, 5, 3, 4)) * 2
-    t3new.bbbbbb += tmp537.transpose((0, 1, 2, 5, 3, 4)) * -2
-    t3new.bbbbbb += tmp537.transpose((0, 2, 1, 5, 4, 3)) * -2
-    t3new.bbbbbb += tmp537.transpose((0, 1, 2, 5, 4, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp537, (2, 1, 0, 3, 5, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp537, (0, 2, 1, 3, 5, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp537, (0, 1, 2, 3, 5, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp537, (2, 1, 0, 5, 3, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp537, (2, 1, 0, 5, 4, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp537, (0, 2, 1, 5, 3, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp537, (0, 1, 2, 5, 3, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp537, (0, 2, 1, 5, 4, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp537, (0, 1, 2, 5, 4, 3)) * 2
     del tmp537
     tmp520 = einsum(tmp318, (0, 1), t3.bbbbbb, (2, 3, 4, 5, 6, 0), (2, 3, 4, 1, 5, 6))
-    t3new.bbbbbb += tmp520.transpose((1, 2, 0, 4, 3, 5)) * -3
-    t3new.bbbbbb += tmp520.transpose((1, 2, 0, 4, 3, 5)) * -3
+    t3new.bbbbbb += np.transpose(tmp520, (1, 2, 0, 4, 3, 5)) * -3
+    t3new.bbbbbb += np.transpose(tmp520, (1, 2, 0, 4, 3, 5)) * -3
     del tmp520
     tmp519 = einsum(t3.bbbbbb, (0, 1, 2, 3, 4, 5), tmp420, (5, 6), (0, 1, 2, 6, 3, 4)) * 3
     del tmp420
-    t3new.bbbbbb += tmp519.transpose((1, 2, 0, 3, 4, 5))
-    t3new.bbbbbb += tmp519.transpose((1, 2, 0, 3, 4, 5))
+    t3new.bbbbbb += np.transpose(tmp519, (1, 2, 0, 3, 4, 5))
+    t3new.bbbbbb += np.transpose(tmp519, (1, 2, 0, 3, 4, 5))
     del tmp519
     tmp553 = einsum(t1.bb, (0, 1), tmp552, (2, 0, 3, 4, 5, 6), (2, 4, 3, 6, 5, 1)) * -1
     del tmp552
-    t3new.bbbbbb += tmp553.transpose((0, 2, 1, 3, 5, 4)) * -2
-    t3new.bbbbbb += tmp553.transpose((0, 2, 1, 5, 3, 4)) * 2
-    t3new.bbbbbb += tmp553.transpose((1, 0, 2, 3, 5, 4)) * -2
-    t3new.bbbbbb += tmp553.transpose((1, 2, 0, 3, 5, 4)) * 2
-    t3new.bbbbbb += tmp553.transpose((1, 0, 2, 5, 3, 4)) * 2
-    t3new.bbbbbb += tmp553.transpose((1, 2, 0, 5, 3, 4)) * -2
-    t3new.bbbbbb += tmp553.transpose((1, 0, 2, 5, 4, 3)) * -2
-    t3new.bbbbbb += tmp553.transpose((0, 2, 1, 3, 4, 5)) * 2
-    t3new.bbbbbb += tmp553.transpose((1, 0, 2, 3, 4, 5)) * 2
-    t3new.bbbbbb += tmp553.transpose((1, 2, 0, 3, 4, 5)) * -2
-    t3new.bbbbbb += tmp553.transpose((0, 2, 1, 4, 3, 5)) * -2
-    t3new.bbbbbb += tmp553.transpose((0, 2, 1, 4, 5, 3)) * 2
-    t3new.bbbbbb += tmp553.transpose((1, 0, 2, 4, 3, 5)) * -2
-    t3new.bbbbbb += tmp553.transpose((1, 2, 0, 4, 3, 5)) * 2
-    t3new.bbbbbb += tmp553.transpose((1, 0, 2, 4, 5, 3)) * 2
-    t3new.bbbbbb += tmp553.transpose((1, 2, 0, 4, 5, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp553, (0, 2, 1, 3, 5, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp553, (0, 2, 1, 5, 3, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp553, (1, 0, 2, 3, 5, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp553, (1, 2, 0, 3, 5, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp553, (1, 0, 2, 5, 3, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp553, (1, 2, 0, 5, 3, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp553, (1, 0, 2, 5, 4, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp553, (0, 2, 1, 3, 4, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp553, (1, 0, 2, 3, 4, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp553, (1, 2, 0, 3, 4, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp553, (0, 2, 1, 4, 3, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp553, (0, 2, 1, 4, 5, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp553, (1, 0, 2, 4, 3, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp553, (1, 2, 0, 4, 3, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp553, (1, 0, 2, 4, 5, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp553, (1, 2, 0, 4, 5, 3)) * -2
     del tmp553
     tmp550 = einsum(tmp204, (0, 1, 2, 3), t2.bbbb, (4, 2, 5, 6), (0, 4, 1, 5, 6, 3))
-    t3new.bbbbbb += tmp550.transpose((2, 0, 1, 4, 3, 5))
-    t3new.bbbbbb += tmp550.transpose((2, 0, 1, 4, 3, 5))
-    t3new.bbbbbb += tmp550.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp550.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp550.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp550.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp550.transpose((1, 2, 0, 4, 3, 5))
-    t3new.bbbbbb += tmp550.transpose((1, 2, 0, 4, 3, 5))
-    t3new.bbbbbb += tmp550.transpose((0, 1, 2, 4, 3, 5))
-    t3new.bbbbbb += tmp550.transpose((0, 1, 2, 4, 3, 5))
-    t3new.bbbbbb += tmp550.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.bbbbbb += tmp550.transpose((1, 0, 2, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp550, (2, 0, 1, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp550, (2, 0, 1, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp550, (2, 1, 0, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp550, (2, 1, 0, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp550, (0, 2, 1, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp550, (0, 2, 1, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp550, (1, 2, 0, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp550, (1, 2, 0, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp550, (0, 1, 2, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp550, (0, 1, 2, 4, 3, 5))
+    t3new.bbbbbb += np.transpose(tmp550, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.bbbbbb += np.transpose(tmp550, (1, 0, 2, 4, 3, 5)) * -1
     del tmp550
-    tmp544 = tmp204.transpose((0, 2, 1, 3)).copy()
+    tmp544 = np.copy(np.transpose(tmp204, (0, 2, 1, 3)))
     tmp544 += einsum(tmp425, (0, 1, 2, 3), t1.bb, (3, 4), (0, 2, 1, 4))
     t3new.bbbbbb += einsum(tmp544, (0, 1, 2, 3), t2.bbbb, (4, 2, 5, 6), (4, 1, 0, 3, 5, 6)) * -1
     del tmp544
     tmp510 = einsum(tmp432, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 6), (4, 2, 0, 3, 5, 6))
-    t3new.bbbbbb += tmp510.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp510.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp510.transpose((1, 2, 0, 3, 5, 4))
-    t3new.bbbbbb += tmp510.transpose((1, 2, 0, 3, 5, 4))
-    t3new.bbbbbb += tmp510.transpose((2, 0, 1, 5, 4, 3))
-    t3new.bbbbbb += tmp510.transpose((2, 0, 1, 5, 4, 3))
-    t3new.bbbbbb += tmp510.transpose((0, 1, 2, 5, 4, 3))
-    t3new.bbbbbb += tmp510.transpose((0, 1, 2, 5, 4, 3))
-    t3new.bbbbbb += tmp510.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp510.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp510.transpose((1, 0, 2, 5, 3, 4))
-    t3new.bbbbbb += tmp510.transpose((1, 0, 2, 5, 3, 4))
-    t3new.bbbbbb += tmp510.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp510.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new.bbbbbb += tmp510.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new.bbbbbb += tmp510.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new.bbbbbb += tmp510.transpose((0, 1, 2, 3, 5, 4))
-    t3new.bbbbbb += tmp510.transpose((0, 1, 2, 3, 5, 4))
-    t3new.bbbbbb += tmp510.transpose((1, 2, 0, 5, 4, 3))
-    t3new.bbbbbb += tmp510.transpose((1, 2, 0, 5, 4, 3))
-    t3new.bbbbbb += tmp510.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp510.transpose((1, 0, 2, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp510, (1, 2, 0, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp510, (1, 2, 0, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp510, (1, 2, 0, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp510, (1, 2, 0, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp510, (2, 0, 1, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp510, (2, 0, 1, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp510, (0, 1, 2, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp510, (0, 1, 2, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp510, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp510, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp510, (1, 0, 2, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp510, (1, 0, 2, 5, 3, 4))
+    t3new.bbbbbb += np.transpose(tmp510, (0, 1, 2, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp510, (0, 1, 2, 5, 3, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp510, (1, 0, 2, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp510, (1, 0, 2, 3, 5, 4)) * -1
+    t3new.bbbbbb += np.transpose(tmp510, (0, 1, 2, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp510, (0, 1, 2, 3, 5, 4))
+    t3new.bbbbbb += np.transpose(tmp510, (1, 2, 0, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp510, (1, 2, 0, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp510, (1, 0, 2, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp510, (1, 0, 2, 5, 4, 3)) * -1
     del tmp510
     tmp529 = einsum(t2.bbbb, (0, 1, 2, 3), tmp494, (4, 5, 1, 6), (4, 5, 0, 6, 2, 3)) * -1
     del tmp494
-    t3new.bbbbbb += tmp529.transpose((0, 2, 1, 5, 4, 3))
-    t3new.bbbbbb += tmp529.transpose((0, 2, 1, 5, 4, 3))
-    t3new.bbbbbb += tmp529.transpose((2, 0, 1, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp529.transpose((2, 0, 1, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp529.transpose((0, 1, 2, 5, 4, 3)) * -1
-    t3new.bbbbbb += tmp529.transpose((0, 1, 2, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp529, (0, 2, 1, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp529, (0, 2, 1, 5, 4, 3))
+    t3new.bbbbbb += np.transpose(tmp529, (2, 0, 1, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp529, (2, 0, 1, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp529, (0, 1, 2, 5, 4, 3)) * -1
+    t3new.bbbbbb += np.transpose(tmp529, (0, 1, 2, 5, 4, 3)) * -1
     del tmp529
     tmp549 = einsum(t1.bb, (0, 1), tmp548, (2, 3, 4, 0, 5, 6), (2, 3, 4, 1, 5, 6))
     del tmp548
-    t3new.bbbbbb += tmp549.transpose((2, 1, 0, 4, 3, 5)) * 2
-    t3new.bbbbbb += tmp549.transpose((2, 1, 0, 3, 4, 5)) * -2
-    t3new.bbbbbb += tmp549.transpose((0, 2, 1, 4, 3, 5)) * 2
-    t3new.bbbbbb += tmp549.transpose((0, 1, 2, 4, 3, 5)) * -2
-    t3new.bbbbbb += tmp549.transpose((0, 2, 1, 3, 4, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp549, (2, 1, 0, 4, 3, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp549, (2, 1, 0, 3, 4, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp549, (0, 2, 1, 4, 3, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp549, (0, 1, 2, 4, 3, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp549, (0, 2, 1, 3, 4, 5)) * -2
     t3new.bbbbbb += tmp549 * 2
-    t3new.bbbbbb += tmp549.transpose((2, 1, 0, 3, 5, 4)) * 2
-    t3new.bbbbbb += tmp549.transpose((0, 2, 1, 3, 5, 4)) * 2
-    t3new.bbbbbb += tmp549.transpose((0, 1, 2, 3, 5, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp549, (2, 1, 0, 3, 5, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp549, (0, 2, 1, 3, 5, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp549, (0, 1, 2, 3, 5, 4)) * -2
     del tmp549
     tmp521 = einsum(f.bb.vv, (0, 1), t3.bbbbbb, (2, 3, 4, 5, 6, 1), (2, 3, 4, 0, 5, 6))
-    t3new.bbbbbb += tmp521.transpose((0, 1, 2, 5, 4, 3)) * -3
-    t3new.bbbbbb += tmp521.transpose((0, 1, 2, 5, 4, 3)) * -3
+    t3new.bbbbbb += np.transpose(tmp521, (0, 1, 2, 5, 4, 3)) * -3
+    t3new.bbbbbb += np.transpose(tmp521, (0, 1, 2, 5, 4, 3)) * -3
     del tmp521
     tmp525 = einsum(tmp524, (0, 1, 2, 3, 4, 5), t1.bb, (3, 6), (0, 1, 2, 6, 4, 5))
     del tmp524
-    t3new.bbbbbb += tmp525.transpose((0, 2, 1, 4, 5, 3)) * 2
-    t3new.bbbbbb += tmp525.transpose((0, 2, 1, 3, 5, 4)) * -2
-    t3new.bbbbbb += tmp525.transpose((0, 2, 1, 4, 3, 5)) * -2
-    t3new.bbbbbb += tmp525.transpose((0, 2, 1, 3, 4, 5)) * 2
-    t3new.bbbbbb += tmp525.transpose((1, 0, 2, 4, 5, 3)) * 2
-    t3new.bbbbbb += tmp525.transpose((1, 0, 2, 3, 5, 4)) * -2
-    t3new.bbbbbb += tmp525.transpose((1, 2, 0, 4, 5, 3)) * -2
-    t3new.bbbbbb += tmp525.transpose((1, 2, 0, 3, 5, 4)) * 2
-    t3new.bbbbbb += tmp525.transpose((1, 0, 2, 4, 3, 5)) * -2
-    t3new.bbbbbb += tmp525.transpose((1, 0, 2, 3, 4, 5)) * 2
-    t3new.bbbbbb += tmp525.transpose((1, 2, 0, 4, 3, 5)) * 2
-    t3new.bbbbbb += tmp525.transpose((1, 2, 0, 3, 4, 5)) * -2
-    t3new.bbbbbb += tmp525.transpose((0, 2, 1, 5, 4, 3)) * -2
-    t3new.bbbbbb += tmp525.transpose((0, 2, 1, 5, 3, 4)) * 2
-    t3new.bbbbbb += tmp525.transpose((1, 0, 2, 5, 4, 3)) * -2
-    t3new.bbbbbb += tmp525.transpose((1, 0, 2, 5, 3, 4)) * 2
-    t3new.bbbbbb += tmp525.transpose((1, 2, 0, 5, 4, 3)) * 2
-    t3new.bbbbbb += tmp525.transpose((1, 2, 0, 5, 3, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp525, (0, 2, 1, 4, 5, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp525, (0, 2, 1, 3, 5, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp525, (0, 2, 1, 4, 3, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp525, (0, 2, 1, 3, 4, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp525, (1, 0, 2, 4, 5, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp525, (1, 0, 2, 3, 5, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp525, (1, 2, 0, 4, 5, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp525, (1, 2, 0, 3, 5, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp525, (1, 0, 2, 4, 3, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp525, (1, 0, 2, 3, 4, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp525, (1, 2, 0, 4, 3, 5)) * 2
+    t3new.bbbbbb += np.transpose(tmp525, (1, 2, 0, 3, 4, 5)) * -2
+    t3new.bbbbbb += np.transpose(tmp525, (0, 2, 1, 5, 4, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp525, (0, 2, 1, 5, 3, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp525, (1, 0, 2, 5, 4, 3)) * -2
+    t3new.bbbbbb += np.transpose(tmp525, (1, 0, 2, 5, 3, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp525, (1, 2, 0, 5, 4, 3)) * 2
+    t3new.bbbbbb += np.transpose(tmp525, (1, 2, 0, 5, 3, 4)) * -2
     del tmp525
     tmp541 = einsum(tmp448, (0, 1, 2, 3), t2.bbbb, (4, 5, 6, 2), (0, 4, 5, 1, 3, 6)) * -1
     del tmp448
-    t3new.bbbbbb += tmp541.transpose((0, 2, 1, 5, 3, 4)) * -2
-    t3new.bbbbbb += tmp541.transpose((2, 1, 0, 5, 3, 4)) * -2
-    t3new.bbbbbb += tmp541.transpose((0, 2, 1, 3, 5, 4)) * 2
-    t3new.bbbbbb += tmp541.transpose((2, 1, 0, 3, 5, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp541, (0, 2, 1, 5, 3, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp541, (2, 1, 0, 5, 3, 4)) * -2
+    t3new.bbbbbb += np.transpose(tmp541, (0, 2, 1, 3, 5, 4)) * 2
+    t3new.bbbbbb += np.transpose(tmp541, (2, 1, 0, 3, 5, 4)) * 2
     del tmp541
     tmp449 = einsum(v.aabb.vvov, (0, 1, 2, 3), t2.abab, (4, 5, 1, 6), (4, 5, 2, 0, 6, 3))
-    t3new.babbab += tmp449.transpose((2, 0, 1, 4, 3, 5)) * -1
-    t3new.babbab += tmp449.transpose((1, 0, 2, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp449, (2, 0, 1, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp449, (1, 0, 2, 4, 3, 5))
     del tmp449
-    tmp481 = tmp377.transpose((0, 1, 3, 2)).copy()
+    tmp481 = np.copy(np.transpose(tmp377, (0, 1, 3, 2)))
     tmp481 += einsum(t1.aa, (0, 1), tmp480, (2, 0, 3, 4), (2, 1, 4, 3)) * -1
     del tmp480
     t3new.babbab += einsum(tmp481, (0, 1, 2, 3), t2.bbbb, (4, 5, 6, 2), (4, 0, 5, 3, 1, 6)) * -2
     del tmp481
     tmp484 = einsum(t2.abab, (0, 1, 2, 3), tmp483, (4, 3, 5, 6), (0, 4, 1, 2, 5, 6))
     del tmp483
-    t3new.babbab += tmp484.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.babbab += tmp484.transpose((1, 0, 2, 5, 3, 4))
-    t3new.babbab += tmp484.transpose((2, 0, 1, 4, 3, 5))
-    t3new.babbab += tmp484.transpose((2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp484, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp484, (1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp484, (2, 0, 1, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp484, (2, 0, 1, 5, 3, 4)) * -1
     del tmp484
     tmp443 = einsum(v.bbbb.ooov, (0, 1, 2, 3), t2.abab, (4, 1, 5, 6), (4, 0, 2, 5, 6, 3))
-    t3new.babbab += tmp443.transpose((2, 0, 1, 4, 3, 5))
-    t3new.babbab += tmp443.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.babbab += tmp443.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.babbab += tmp443.transpose((1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp443, (2, 0, 1, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp443, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp443, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp443, (1, 0, 2, 5, 3, 4))
     del tmp443
-    tmp426 = tmp424.copy()
+    tmp426 = np.copy(tmp424)
     tmp426 += einsum(tmp425, (0, 1, 2, 3), t2.abab, (4, 3, 5, 6), (4, 0, 2, 1, 5, 6))
     del tmp425
     t3new.babbab += einsum(t1.bb, (0, 1), tmp426, (2, 3, 4, 0, 5, 6), (4, 2, 3, 6, 5, 1))
     del tmp426
-    tmp490 = tmp377.transpose((0, 1, 3, 2)).copy()
+    tmp490 = np.copy(np.transpose(tmp377, (0, 1, 3, 2)))
     tmp490 += einsum(t1.bb, (0, 1), tmp77, (2, 0, 3, 4), (2, 3, 4, 1)) * -1
     t3new.babbab += einsum(tmp490, (0, 1, 2, 3), t2.bbbb, (4, 5, 6, 2), (4, 0, 5, 6, 1, 3)) * 2
     del tmp490
@@ -1090,169 +1090,169 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t3new.babbab += einsum(t1.bb, (0, 1), tmp429, (2, 3, 4, 0, 5, 6), (4, 2, 3, 6, 5, 1))
     del tmp429
     tmp444 = einsum(v.aabb.ovoo, (0, 1, 2, 3), t2.bbbb, (4, 3, 5, 6), (0, 4, 2, 1, 5, 6))
-    t3new.babbab += tmp444.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.babbab += tmp444.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.babbab += tmp444.transpose((1, 0, 2, 5, 3, 4))
-    t3new.babbab += tmp444.transpose((1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp444, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp444, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp444, (1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp444, (1, 0, 2, 5, 3, 4))
     del tmp444
     tmp500 = einsum(tmp499, (0, 1, 2, 3), t2.bbbb, (4, 2, 5, 6), (0, 1, 4, 3, 5, 6)) * -1
     del tmp499
-    t3new.babbab += tmp500.transpose((1, 0, 2, 5, 3, 4))
-    t3new.babbab += tmp500.transpose((1, 0, 2, 5, 3, 4))
-    t3new.babbab += tmp500.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.babbab += tmp500.transpose((2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp500, (1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp500, (1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp500, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp500, (2, 0, 1, 5, 3, 4)) * -1
     del tmp500
     tmp477 = einsum(t2.abab, (0, 1, 2, 3), tmp177, (4, 0, 5, 6), (4, 5, 1, 2, 3, 6))
-    t3new.babbab += tmp477.transpose((1, 0, 2, 4, 3, 5))
-    t3new.babbab += tmp477.transpose((2, 0, 1, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp477, (1, 0, 2, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp477, (2, 0, 1, 4, 3, 5)) * -1
     del tmp477
     tmp471 = einsum(tmp204, (0, 1, 2, 3), t2.abab, (4, 2, 5, 6), (4, 0, 1, 5, 6, 3))
-    t3new.babbab += tmp471.transpose((2, 0, 1, 4, 3, 5)) * -1
-    t3new.babbab += tmp471.transpose((1, 0, 2, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp471, (2, 0, 1, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp471, (1, 0, 2, 4, 3, 5))
     del tmp471
     tmp441 = einsum(tmp150, (0, 1, 2, 3), t2.bbbb, (4, 5, 6, 2), (1, 0, 4, 5, 6, 3))
     del tmp150
     t3new.babbab += einsum(tmp441, (0, 1, 2, 3, 4, 5), t1.aa, (0, 6), (2, 1, 3, 5, 6, 4)) * 2
     del tmp441
     tmp453 = einsum(t2.abab, (0, 1, 2, 3), tmp335, (4, 0, 5, 6), (4, 1, 5, 2, 6, 3))
-    t3new.babbab += tmp453.transpose((2, 0, 1, 4, 3, 5))
-    t3new.babbab += tmp453.transpose((1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp453, (2, 0, 1, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp453, (1, 0, 2, 5, 3, 4))
     del tmp453
     tmp460 = einsum(tmp365, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 6), (0, 2, 4, 3, 5, 6)) * -1
     del tmp365
-    t3new.babbab += tmp460.transpose((1, 0, 2, 5, 3, 4))
-    t3new.babbab += tmp460.transpose((1, 0, 2, 5, 3, 4))
-    t3new.babbab += tmp460.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.babbab += tmp460.transpose((2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp460, (1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp460, (1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp460, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp460, (2, 0, 1, 5, 3, 4)) * -1
     del tmp460
     tmp507 = einsum(t1.aa, (0, 1), tmp506, (2, 0, 3, 4, 5, 6), (2, 3, 4, 1, 5, 6))
     del tmp506
-    t3new.babbab += tmp507.transpose((1, 0, 2, 4, 3, 5))
-    t3new.babbab += tmp507.transpose((2, 0, 1, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp507, (1, 0, 2, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp507, (2, 0, 1, 4, 3, 5)) * -1
     del tmp507
     tmp476 = einsum(t2.bbbb, (0, 1, 2, 3), v.aabb.oovv, (4, 5, 6, 3), (4, 5, 0, 1, 2, 6))
     t3new.babbab += einsum(tmp476, (0, 1, 2, 3, 4, 5), t1.aa, (0, 6), (2, 1, 3, 4, 6, 5)) * -2
     del tmp476
-    tmp431 = tmp335.transpose((1, 0, 2, 3)).copy()
+    tmp431 = np.copy(np.transpose(tmp335, (1, 0, 2, 3)))
     tmp431 += tmp332 * -1
     t3new.babbab += einsum(t2.abab, (0, 1, 2, 3), tmp431, (0, 4, 5, 6), (1, 4, 5, 6, 2, 3)) * -1
     del tmp431
     tmp497 = einsum(tmp238, (0, 1, 2, 3), t2.abab, (4, 2, 5, 6), (4, 0, 1, 5, 6, 3))
-    t3new.babbab += tmp497.transpose((2, 0, 1, 4, 3, 5))
-    t3new.babbab += tmp497.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.babbab += tmp497.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.babbab += tmp497.transpose((1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp497, (2, 0, 1, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp497, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp497, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp497, (1, 0, 2, 5, 3, 4))
     del tmp497
-    tmp496 = tmp178.copy() * -1
+    tmp496 = np.copy(tmp178) * -1
     tmp496 += tmp400
     t3new.babbab += einsum(t2.abab, (0, 1, 2, 3), tmp496, (4, 0, 5, 6), (1, 4, 5, 6, 2, 3)) * -1
     del tmp496
     tmp503 = einsum(tmp502, (0, 1, 2, 3, 4, 5), t1.bb, (3, 6), (0, 1, 2, 4, 6, 5))
     del tmp502
-    t3new.babbab += tmp503.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.babbab += tmp503.transpose((2, 0, 1, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp503, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp503, (2, 0, 1, 4, 3, 5))
     del tmp503
     tmp454 = einsum(tmp1, (0, 1, 2, 3), t2.abab, (1, 4, 5, 6), (0, 4, 2, 5, 6, 3))
-    t3new.babbab += tmp454.transpose((2, 0, 1, 4, 3, 5))
-    t3new.babbab += tmp454.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.babbab += tmp454.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.babbab += tmp454.transpose((1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp454, (2, 0, 1, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp454, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp454, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp454, (1, 0, 2, 5, 3, 4))
     del tmp454
     tmp467 = einsum(t2.bbbb, (0, 1, 2, 3), tmp21, (4, 5, 1, 6), (4, 5, 0, 6, 2, 3))
-    t3new.babbab += tmp467.transpose((1, 0, 2, 5, 3, 4)) * -1
-    t3new.babbab += tmp467.transpose((1, 0, 2, 5, 3, 4)) * -1
-    t3new.babbab += tmp467.transpose((2, 0, 1, 5, 3, 4))
-    t3new.babbab += tmp467.transpose((2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp467, (1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp467, (1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp467, (2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp467, (2, 0, 1, 5, 3, 4))
     del tmp467
-    tmp489 = tmp152.transpose((0, 2, 1, 3)).copy() * -1
-    tmp489 += tmp488.transpose((0, 2, 1, 3))
+    tmp489 = np.copy(np.transpose(tmp152, (0, 2, 1, 3))) * -1
+    tmp489 += np.transpose(tmp488, (0, 2, 1, 3))
     t3new.babbab += einsum(tmp489, (0, 1, 2, 3), t2.abab, (4, 5, 1, 6), (5, 4, 0, 6, 2, 3)) * -1
     del tmp489
     tmp419 = einsum(f.bb.ov, (0, 1), t3.babbab, (2, 3, 4, 5, 6, 1), (3, 0, 2, 4, 6, 5))
-    tmp419 += tmp414.transpose((0, 3, 2, 1, 4, 5)) * 0.5
+    tmp419 += np.transpose(tmp414, (0, 3, 2, 1, 4, 5)) * 0.5
     t3new.babbab += einsum(t1.bb, (0, 1), tmp419, (2, 0, 3, 4, 5, 6), (3, 2, 4, 6, 5, 1)) * -2
     del tmp419
     tmp505 = einsum(t2.abab, (0, 1, 2, 3), tmp178, (4, 0, 5, 6), (4, 5, 1, 2, 3, 6))
-    t3new.babbab += tmp505.transpose((1, 0, 2, 4, 3, 5))
-    t3new.babbab += tmp505.transpose((2, 0, 1, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp505, (1, 0, 2, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp505, (2, 0, 1, 4, 3, 5)) * -1
     del tmp505
     tmp495 = einsum(tmp392, (0, 1, 2, 3), t2.bbbb, (4, 2, 5, 6), (0, 1, 4, 3, 5, 6))
-    t3new.babbab += tmp495.transpose((1, 0, 2, 5, 3, 4))
-    t3new.babbab += tmp495.transpose((1, 0, 2, 5, 3, 4))
-    t3new.babbab += tmp495.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.babbab += tmp495.transpose((2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp495, (1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp495, (1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp495, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp495, (2, 0, 1, 5, 3, 4)) * -1
     del tmp495
     tmp462 = einsum(t1.bb, (0, 1), tmp461, (2, 3, 0, 4, 5, 6), (2, 3, 4, 5, 1, 6))
     del tmp461
-    t3new.babbab += tmp462.transpose((2, 0, 1, 4, 3, 5)) * -1
-    t3new.babbab += tmp462.transpose((1, 0, 2, 4, 3, 5))
-    t3new.babbab += tmp462.transpose((2, 0, 1, 5, 3, 4))
-    t3new.babbab += tmp462.transpose((1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp462, (2, 0, 1, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp462, (1, 0, 2, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp462, (2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp462, (1, 0, 2, 5, 3, 4)) * -1
     del tmp462
     tmp455 = einsum(tmp22, (0, 1, 2, 3), t2.abab, (4, 2, 5, 6), (4, 0, 1, 5, 6, 3))
-    t3new.babbab += tmp455.transpose((2, 0, 1, 4, 3, 5))
-    t3new.babbab += tmp455.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.babbab += tmp455.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.babbab += tmp455.transpose((1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp455, (2, 0, 1, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp455, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp455, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp455, (1, 0, 2, 5, 3, 4))
     del tmp455
     tmp498 = einsum(t2.abab, (0, 1, 2, 3), tmp240, (4, 5, 1, 6), (0, 5, 4, 2, 6, 3))
-    t3new.babbab += tmp498.transpose((2, 0, 1, 5, 3, 4))
-    t3new.babbab += tmp498.transpose((1, 0, 2, 5, 3, 4)) * -1
-    t3new.babbab += tmp498.transpose((2, 0, 1, 4, 3, 5)) * -1
-    t3new.babbab += tmp498.transpose((1, 0, 2, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp498, (2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp498, (1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp498, (2, 0, 1, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp498, (1, 0, 2, 4, 3, 5))
     del tmp498
     tmp415 = einsum(t2.abab, (0, 1, 2, 3), v.bbbb.oooo, (4, 5, 6, 1), (0, 4, 5, 6, 2, 3))
-    tmp415 += tmp414.transpose((0, 1, 3, 2, 4, 5)) * -1
+    tmp415 += np.transpose(tmp414, (0, 1, 3, 2, 4, 5)) * -1
     del tmp414
     t3new.babbab += einsum(t1.bb, (0, 1), tmp415, (2, 3, 0, 4, 5, 6), (3, 2, 4, 6, 5, 1)) * -1
     del tmp415
-    tmp501 = tmp178.copy()
+    tmp501 = np.copy(tmp178)
     del tmp178
     tmp501 += tmp400 * -1
     t3new.babbab += einsum(t2.abab, (0, 1, 2, 3), tmp501, (4, 0, 5, 6), (5, 4, 1, 6, 2, 3)) * -1
     del tmp501
     tmp427 = einsum(t3.babbab, (0, 1, 2, 3, 4, 5), tmp262, (1, 6), (6, 0, 2, 4, 3, 5))
-    t3new.babbab += tmp427.transpose((1, 0, 2, 5, 3, 4))
-    t3new.babbab += tmp427.transpose((1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp427, (1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp427, (1, 0, 2, 5, 3, 4))
     del tmp427
     tmp440 = einsum(tmp439, (0, 1, 2, 3, 4, 5), t1.aa, (1, 6), (0, 2, 3, 6, 4, 5))
     del tmp439
-    t3new.babbab += tmp440.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.babbab += tmp440.transpose((2, 0, 1, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp440, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp440, (2, 0, 1, 4, 3, 5))
     del tmp440
     tmp492 = einsum(t2.abab, (0, 1, 2, 3), tmp394, (4, 0, 5, 6), (4, 1, 5, 2, 6, 3))
-    t3new.babbab += tmp492.transpose((2, 0, 1, 4, 3, 5))
-    t3new.babbab += tmp492.transpose((1, 0, 2, 5, 3, 4))
-    t3new.babbab += tmp492.transpose((1, 0, 2, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp492, (2, 0, 1, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp492, (1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp492, (1, 0, 2, 4, 3, 5)) * -1
     del tmp492
     tmp446 = einsum(v.bbbb.ovvv, (0, 1, 2, 3), t2.abab, (4, 5, 6, 3), (4, 5, 0, 6, 1, 2))
-    t3new.babbab += tmp446.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.babbab += tmp446.transpose((1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp446, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp446, (1, 0, 2, 5, 3, 4))
     del tmp446
-    tmp450 = v.aabb.ovvv.copy()
-    tmp450 += tmp127.transpose((0, 1, 3, 2)) * -1
+    tmp450 = np.copy(v.aabb.ovvv)
+    tmp450 += np.transpose(tmp127, (0, 1, 3, 2)) * -1
     del tmp127
     t3new.babbab += einsum(tmp450, (0, 1, 2, 3), t2.bbbb, (4, 5, 6, 2), (4, 0, 5, 6, 1, 3)) * 2
     del tmp450
     tmp438 = einsum(tmp437, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 6), (0, 2, 4, 3, 5, 6)) * -1
     del tmp437
-    t3new.babbab += tmp438.transpose((1, 0, 2, 5, 3, 4)) * -1
-    t3new.babbab += tmp438.transpose((1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp438, (1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp438, (1, 0, 2, 5, 3, 4)) * -1
     del tmp438
     tmp416 = einsum(t3.babbab, (0, 1, 2, 3, 4, 5), f.aa.oo, (6, 1), (6, 0, 2, 4, 3, 5))
-    t3new.babbab += tmp416.transpose((1, 0, 2, 5, 3, 4))
-    t3new.babbab += tmp416.transpose((1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp416, (1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp416, (1, 0, 2, 5, 3, 4))
     del tmp416
-    tmp479 = tmp152.transpose((0, 2, 1, 3)).copy()
+    tmp479 = np.copy(np.transpose(tmp152, (0, 2, 1, 3)))
     tmp479 += tmp478 * -1
     t3new.babbab += einsum(t2.abab, (0, 1, 2, 3), tmp479, (4, 5, 2, 6), (1, 0, 4, 6, 5, 3)) * -1
     del tmp479
     tmp459 = einsum(t2.abab, (0, 1, 2, 3), tmp458, (4, 1, 5, 6), (0, 4, 5, 2, 6, 3))
     del tmp458
-    t3new.babbab += tmp459.transpose((2, 0, 1, 4, 3, 5))
-    t3new.babbab += tmp459.transpose((1, 0, 2, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp459, (2, 0, 1, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp459, (1, 0, 2, 4, 3, 5)) * -1
     del tmp459
-    tmp466 = tmp177.transpose((1, 0, 2, 3)).copy() * -1
+    tmp466 = np.copy(np.transpose(tmp177, (1, 0, 2, 3))) * -1
     del tmp177
     tmp466 += tmp355
     del tmp355
@@ -1266,9 +1266,9 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t3new.babbab += einsum(tmp504, (0, 1, 2, 3, 4, 5), t1.bb, (3, 6), (1, 0, 2, 6, 4, 5)) * 2
     del tmp504
     tmp436 = einsum(t2.abab, (0, 1, 2, 3), tmp332, (0, 4, 5, 6), (4, 5, 1, 2, 6, 3))
-    t3new.babbab += tmp436.transpose((1, 0, 2, 5, 3, 4))
-    t3new.babbab += tmp436.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.babbab += tmp436.transpose((1, 0, 2, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp436, (1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp436, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp436, (1, 0, 2, 4, 3, 5)) * -1
     del tmp436
     tmp430 = einsum(t2.abab, (0, 1, 2, 3), tmp137, (4, 0, 5, 6), (4, 5, 1, 6, 2, 3))
     tmp430 += tmp424
@@ -1280,49 +1280,49 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp508
     tmp473 = einsum(t1.bb, (0, 1), tmp472, (2, 3, 4, 0, 5, 6), (2, 3, 4, 5, 1, 6))
     del tmp472
-    t3new.babbab += tmp473.transpose((2, 0, 1, 4, 3, 5))
-    t3new.babbab += tmp473.transpose((1, 0, 2, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp473, (2, 0, 1, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp473, (1, 0, 2, 4, 3, 5)) * -1
     del tmp473
     tmp412 = einsum(t3.babbab, (0, 1, 2, 3, 4, 5), f.bb.oo, (6, 2), (1, 6, 0, 4, 3, 5))
-    t3new.babbab += tmp412.transpose((1, 0, 2, 5, 3, 4)) * -1
-    t3new.babbab += tmp412.transpose((1, 0, 2, 5, 3, 4)) * -1
-    t3new.babbab += tmp412.transpose((2, 0, 1, 5, 3, 4))
-    t3new.babbab += tmp412.transpose((2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp412, (1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp412, (1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp412, (2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp412, (2, 0, 1, 5, 3, 4))
     del tmp412
     tmp451 = einsum(tmp432, (0, 1, 2, 3), t2.abab, (4, 1, 5, 6), (4, 2, 0, 5, 3, 6))
     del tmp432
-    t3new.babbab += tmp451.transpose((2, 0, 1, 5, 3, 4))
-    t3new.babbab += tmp451.transpose((1, 0, 2, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp451, (2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp451, (1, 0, 2, 4, 3, 5))
     del tmp451
     tmp509 = einsum(t2.abab, (0, 1, 2, 3), tmp400, (4, 0, 5, 6), (4, 5, 1, 2, 6, 3))
     del tmp400
-    t3new.babbab += tmp509.transpose((1, 0, 2, 5, 3, 4)) * -1
-    t3new.babbab += tmp509.transpose((2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp509, (1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp509, (2, 0, 1, 5, 3, 4))
     del tmp509
     tmp421 = einsum(t3.babbab, (0, 1, 2, 3, 4, 5), tmp259, (4, 6), (1, 0, 2, 6, 3, 5))
-    t3new.babbab += tmp421.transpose((2, 0, 1, 5, 3, 4))
-    t3new.babbab += tmp421.transpose((2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp421, (2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp421, (2, 0, 1, 5, 3, 4))
     del tmp421
     tmp442 = einsum(v.aabb.ooov, (0, 1, 2, 3), t2.abab, (1, 4, 5, 6), (0, 4, 2, 5, 6, 3))
-    t3new.babbab += tmp442.transpose((2, 0, 1, 4, 3, 5))
-    t3new.babbab += tmp442.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.babbab += tmp442.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.babbab += tmp442.transpose((1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp442, (2, 0, 1, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp442, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp442, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp442, (1, 0, 2, 5, 3, 4))
     del tmp442
     tmp435 = einsum(tmp330, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 6), (0, 4, 2, 3, 5, 6))
-    t3new.babbab += tmp435.transpose((1, 0, 2, 5, 3, 4))
-    t3new.babbab += tmp435.transpose((1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp435, (1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp435, (1, 0, 2, 5, 3, 4))
     del tmp435
     tmp445 = einsum(t2.abab, (0, 1, 2, 3), tmp51, (4, 2, 5, 6), (0, 1, 4, 5, 3, 6))
-    t3new.babbab += tmp445.transpose((2, 0, 1, 5, 3, 4))
-    t3new.babbab += tmp445.transpose((1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp445, (2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp445, (1, 0, 2, 5, 3, 4)) * -1
     del tmp445
     tmp465 = einsum(tmp464, (0, 1, 2, 3, 4, 5), t1.bb, (2, 6), (0, 1, 3, 4, 6, 5))
     del tmp464
-    t3new.babbab += tmp465.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.babbab += tmp465.transpose((2, 0, 1, 4, 3, 5))
-    t3new.babbab += tmp465.transpose((1, 0, 2, 5, 3, 4))
-    t3new.babbab += tmp465.transpose((1, 0, 2, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp465, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp465, (2, 0, 1, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp465, (1, 0, 2, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp465, (1, 0, 2, 4, 3, 5)) * -1
     del tmp465
     tmp418 = einsum(v.aabb.oooo, (0, 1, 2, 3), t2.abab, (1, 4, 5, 6), (0, 4, 2, 3, 5, 6)) * -1
     tmp418 += einsum(tmp417, (0, 1, 2, 3, 4, 5), t1.aa, (0, 6), (1, 3, 2, 4, 6, 5)) * 2
@@ -1330,182 +1330,182 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t3new.babbab += einsum(t1.bb, (0, 1), tmp418, (2, 3, 4, 0, 5, 6), (4, 2, 3, 6, 5, 1))
     del tmp418
     tmp452 = einsum(tmp329, (0, 1, 2, 3), t2.bbbb, (4, 2, 5, 6), (0, 4, 1, 3, 5, 6))
-    t3new.babbab += tmp452.transpose((1, 0, 2, 5, 3, 4)) * -1
-    t3new.babbab += tmp452.transpose((1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp452, (1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp452, (1, 0, 2, 5, 3, 4)) * -1
     del tmp452
     tmp486 = einsum(t1.bb, (0, 1), tmp485, (2, 3, 0, 4, 5, 6), (2, 3, 4, 5, 6, 1)) * -1
     del tmp485
-    t3new.babbab += tmp486.transpose((1, 0, 2, 5, 3, 4)) * -1
-    t3new.babbab += tmp486.transpose((2, 0, 1, 5, 3, 4))
-    t3new.babbab += tmp486.transpose((1, 0, 2, 4, 3, 5))
-    t3new.babbab += tmp486.transpose((2, 0, 1, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp486, (1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp486, (2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp486, (1, 0, 2, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp486, (2, 0, 1, 4, 3, 5)) * -1
     del tmp486
     tmp475 = einsum(tmp474, (0, 1, 2, 3, 4, 5), t1.aa, (1, 6), (0, 2, 3, 6, 4, 5))
     del tmp474
-    t3new.babbab += tmp475.transpose((2, 0, 1, 4, 3, 5))
-    t3new.babbab += tmp475.transpose((1, 0, 2, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp475, (2, 0, 1, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp475, (1, 0, 2, 4, 3, 5)) * -1
     del tmp475
-    tmp487 = tmp152.transpose((0, 2, 1, 3)).copy()
-    tmp487 += tmp478.transpose((0, 2, 1, 3)) * -1
+    tmp487 = np.copy(np.transpose(tmp152, (0, 2, 1, 3)))
+    tmp487 += np.transpose(tmp478, (0, 2, 1, 3)) * -1
     del tmp478
     t3new.babbab += einsum(t2.abab, (0, 1, 2, 3), tmp487, (4, 2, 5, 6), (4, 0, 1, 6, 5, 3))
     del tmp487
     tmp422 = einsum(t3.babbab, (0, 1, 2, 3, 4, 5), tmp324, (2, 6), (1, 6, 0, 4, 3, 5))
-    t3new.babbab += tmp422.transpose((1, 0, 2, 5, 3, 4)) * -1
-    t3new.babbab += tmp422.transpose((1, 0, 2, 5, 3, 4)) * -1
-    t3new.babbab += tmp422.transpose((2, 0, 1, 5, 3, 4))
-    t3new.babbab += tmp422.transpose((2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp422, (1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp422, (1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp422, (2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp422, (2, 0, 1, 5, 3, 4))
     del tmp422
-    tmp491 = tmp152.transpose((0, 2, 1, 3)).copy()
-    tmp491 += tmp488.transpose((0, 2, 1, 3)) * -1
+    tmp491 = np.copy(np.transpose(tmp152, (0, 2, 1, 3)))
+    tmp491 += np.transpose(tmp488, (0, 2, 1, 3)) * -1
     del tmp488
     t3new.babbab += einsum(tmp491, (0, 1, 2, 3), t2.abab, (4, 5, 1, 6), (0, 4, 5, 6, 2, 3)) * -1
     del tmp491
     tmp469 = einsum(t1.bb, (0, 1), tmp468, (2, 3, 0, 4, 5, 6), (2, 3, 4, 5, 1, 6))
     del tmp468
-    t3new.babbab += tmp469.transpose((2, 0, 1, 5, 3, 4))
-    t3new.babbab += tmp469.transpose((2, 0, 1, 4, 3, 5)) * -1
-    t3new.babbab += tmp469.transpose((1, 0, 2, 5, 3, 4)) * -1
-    t3new.babbab += tmp469.transpose((1, 0, 2, 4, 3, 5))
+    t3new.babbab += np.transpose(tmp469, (2, 0, 1, 5, 3, 4))
+    t3new.babbab += np.transpose(tmp469, (2, 0, 1, 4, 3, 5)) * -1
+    t3new.babbab += np.transpose(tmp469, (1, 0, 2, 5, 3, 4)) * -1
+    t3new.babbab += np.transpose(tmp469, (1, 0, 2, 4, 3, 5))
     del tmp469
-    tmp364 = tmp139.transpose((0, 2, 1, 3)).copy() * -1
-    tmp364 += tmp363.transpose((0, 2, 1, 3))
+    tmp364 = np.copy(np.transpose(tmp139, (0, 2, 1, 3))) * -1
+    tmp364 += np.transpose(tmp363, (0, 2, 1, 3))
     del tmp363
     t3new.abaaba += einsum(tmp364, (0, 1, 2, 3), t2.abab, (4, 2, 5, 6), (4, 1, 0, 3, 6, 5)) * -1
     del tmp364
     tmp349 = einsum(t2.abab, (0, 1, 2, 3), tmp247, (4, 0, 5, 6), (5, 4, 1, 6, 2, 3))
-    t3new.abaaba += tmp349.transpose((1, 2, 0, 4, 5, 3))
-    t3new.abaaba += tmp349.transpose((0, 2, 1, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp349, (1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp349, (0, 2, 1, 3, 5, 4))
     del tmp349
     tmp325 = einsum(t3.abaaba, (0, 1, 2, 3, 4, 5), tmp324, (1, 6), (0, 2, 6, 3, 5, 4))
     del tmp324
-    t3new.abaaba += tmp325.transpose((0, 2, 1, 4, 5, 3))
-    t3new.abaaba += tmp325.transpose((0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp325, (0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp325, (0, 2, 1, 4, 5, 3))
     del tmp325
     tmp368 = einsum(t1.aa, (0, 1), tmp367, (2, 0, 3, 4, 5, 6), (2, 3, 4, 1, 5, 6))
     del tmp367
-    t3new.abaaba += tmp368.transpose((1, 2, 0, 4, 5, 3))
-    t3new.abaaba += tmp368.transpose((1, 2, 0, 3, 5, 4)) * -1
-    t3new.abaaba += tmp368.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.abaaba += tmp368.transpose((0, 2, 1, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp368, (1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp368, (1, 2, 0, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp368, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp368, (0, 2, 1, 3, 5, 4))
     del tmp368
     tmp406 = einsum(tmp141, (0, 1, 2, 3), t2.aaaa, (4, 5, 6, 2), (4, 5, 0, 1, 6, 3))
     t3new.abaaba += einsum(tmp406, (0, 1, 2, 3, 4, 5), t1.aa, (2, 6), (0, 3, 1, 6, 5, 4)) * 2
     del tmp406
     tmp319 = einsum(tmp318, (0, 1), t3.abaaba, (2, 3, 4, 5, 0, 6), (2, 4, 3, 5, 6, 1))
     del tmp318
-    t3new.abaaba += tmp319.transpose((1, 2, 0, 4, 5, 3))
-    t3new.abaaba += tmp319.transpose((1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp319, (1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp319, (1, 2, 0, 4, 5, 3))
     del tmp319
     tmp410 = einsum(tmp143, (0, 1, 2, 3), t2.aaaa, (4, 5, 6, 3), (4, 5, 0, 1, 6, 2))
     t3new.abaaba += einsum(tmp410, (0, 1, 2, 3, 4, 5), t1.bb, (3, 6), (0, 2, 1, 4, 6, 5)) * -2
     del tmp410
     tmp342 = einsum(v.aabb.ovoo, (0, 1, 2, 3), t2.abab, (4, 3, 5, 6), (4, 0, 2, 5, 1, 6))
-    t3new.abaaba += tmp342.transpose((1, 2, 0, 3, 5, 4))
-    t3new.abaaba += tmp342.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.abaaba += tmp342.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.abaaba += tmp342.transpose((0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp342, (1, 2, 0, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp342, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp342, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp342, (0, 2, 1, 4, 5, 3))
     del tmp342
     tmp320 = einsum(t3.abaaba, (0, 1, 2, 3, 4, 5), tmp262, (2, 6), (6, 0, 1, 3, 5, 4))
-    t3new.abaaba += tmp320.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.abaaba += tmp320.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.abaaba += tmp320.transpose((1, 2, 0, 4, 5, 3))
-    t3new.abaaba += tmp320.transpose((1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp320, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp320, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp320, (1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp320, (1, 2, 0, 4, 5, 3))
     del tmp320
     tmp359 = einsum(tmp358, (0, 1, 2, 3, 4, 5), t1.aa, (1, 6), (0, 2, 3, 6, 4, 5))
     del tmp358
-    t3new.abaaba += tmp359.transpose((1, 2, 0, 3, 5, 4)) * -1
-    t3new.abaaba += tmp359.transpose((0, 2, 1, 3, 5, 4))
-    t3new.abaaba += tmp359.transpose((1, 2, 0, 4, 5, 3))
-    t3new.abaaba += tmp359.transpose((0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp359, (1, 2, 0, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp359, (0, 2, 1, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp359, (1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp359, (0, 2, 1, 4, 5, 3)) * -1
     del tmp359
     tmp333 = einsum(tmp332, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 6), (4, 1, 2, 5, 6, 3))
     del tmp332
-    t3new.abaaba += tmp333.transpose((0, 2, 1, 4, 5, 3))
-    t3new.abaaba += tmp333.transpose((0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp333, (0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp333, (0, 2, 1, 4, 5, 3))
     del tmp333
     tmp316 = einsum(t3.abaaba, (0, 1, 2, 3, 4, 5), f.aa.ov, (6, 5), (6, 0, 2, 1, 3, 4)) * 2
-    tmp316 += tmp311.transpose((1, 2, 0, 3, 4, 5))
+    tmp316 += np.transpose(tmp311, (1, 2, 0, 3, 4, 5))
     t3new.abaaba += einsum(tmp316, (0, 1, 2, 3, 4, 5), t1.aa, (0, 6), (1, 3, 2, 4, 5, 6)) * -1
     del tmp316
     tmp344 = einsum(v.aabb.ooov, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 6), (4, 0, 2, 5, 6, 3))
-    t3new.abaaba += tmp344.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.abaaba += tmp344.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.abaaba += tmp344.transpose((0, 2, 1, 4, 5, 3))
-    t3new.abaaba += tmp344.transpose((0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp344, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp344, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp344, (0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp344, (0, 2, 1, 4, 5, 3))
     del tmp344
     tmp370 = einsum(tmp62, (0, 1, 2, 3), t2.abab, (2, 4, 5, 6), (0, 1, 4, 5, 3, 6))
-    t3new.abaaba += tmp370.transpose((1, 2, 0, 3, 5, 4)) * -1
-    t3new.abaaba += tmp370.transpose((0, 2, 1, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp370, (1, 2, 0, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp370, (0, 2, 1, 3, 5, 4))
     del tmp370
     tmp393 = einsum(tmp392, (0, 1, 2, 3), t2.abab, (4, 2, 5, 6), (4, 0, 1, 3, 5, 6))
     del tmp392
-    t3new.abaaba += tmp393.transpose((1, 2, 0, 3, 5, 4))
-    t3new.abaaba += tmp393.transpose((0, 2, 1, 4, 5, 3))
-    t3new.abaaba += tmp393.transpose((0, 2, 1, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp393, (1, 2, 0, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp393, (0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp393, (0, 2, 1, 3, 5, 4)) * -1
     del tmp393
     tmp357 = einsum(t2.aaaa, (0, 1, 2, 3), tmp356, (1, 4, 5, 6), (4, 0, 5, 2, 3, 6)) * -1
     del tmp356
-    t3new.abaaba += tmp357.transpose((0, 2, 1, 4, 5, 3))
-    t3new.abaaba += tmp357.transpose((0, 2, 1, 4, 5, 3))
-    t3new.abaaba += tmp357.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.abaaba += tmp357.transpose((1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp357, (0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp357, (0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp357, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp357, (1, 2, 0, 4, 5, 3)) * -1
     del tmp357
-    tmp387 = tmp377.transpose((0, 1, 3, 2)).copy()
-    tmp387 += tmp378.transpose((0, 1, 3, 2)) * -1
+    tmp387 = np.copy(np.transpose(tmp377, (0, 1, 3, 2)))
+    tmp387 += np.transpose(tmp378, (0, 1, 3, 2)) * -1
     t3new.abaaba += einsum(tmp387, (0, 1, 2, 3), t2.abab, (4, 5, 6, 2), (0, 5, 4, 1, 3, 6))
     del tmp387
     tmp354 = einsum(t2.abab, (0, 1, 2, 3), tmp290, (4, 0, 5, 6), (4, 5, 1, 6, 2, 3))
-    t3new.abaaba += tmp354.transpose((1, 2, 0, 3, 5, 4))
-    t3new.abaaba += tmp354.transpose((0, 2, 1, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp354, (1, 2, 0, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp354, (0, 2, 1, 3, 5, 4)) * -1
     del tmp354
-    tmp379 = tmp377.transpose((0, 1, 3, 2)).copy()
+    tmp379 = np.copy(np.transpose(tmp377, (0, 1, 3, 2)))
     tmp379 += tmp378 * -1
     del tmp378
     t3new.abaaba += einsum(t2.abab, (0, 1, 2, 3), tmp379, (4, 5, 6, 3), (0, 1, 4, 5, 6, 2)) * -1
     del tmp379
     tmp384 = einsum(t2.abab, (0, 1, 2, 3), tmp383, (4, 2, 5, 6), (4, 0, 1, 5, 6, 3))
     del tmp383
-    t3new.abaaba += tmp384.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.abaaba += tmp384.transpose((0, 2, 1, 4, 5, 3))
-    t3new.abaaba += tmp384.transpose((1, 2, 0, 3, 5, 4))
-    t3new.abaaba += tmp384.transpose((1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp384, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp384, (0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp384, (1, 2, 0, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp384, (1, 2, 0, 4, 5, 3)) * -1
     del tmp384
     tmp375 = einsum(t2.aaaa, (0, 1, 2, 3), v.aabb.vvoo, (4, 3, 5, 6), (0, 1, 5, 6, 2, 4))
     t3new.abaaba += einsum(t1.bb, (0, 1), tmp375, (2, 3, 0, 4, 5, 6), (2, 4, 3, 5, 1, 6)) * -2
     del tmp375
-    tmp323 = tmp322.copy()
+    tmp323 = np.copy(tmp322)
     tmp323 += einsum(t2.abab, (0, 1, 2, 3), tmp292, (4, 0, 5, 6), (4, 5, 6, 1, 2, 3))
     t3new.abaaba += einsum(tmp323, (0, 1, 2, 3, 4, 5), t1.aa, (2, 6), (1, 3, 0, 4, 5, 6))
     del tmp323
     tmp351 = einsum(tmp329, (0, 1, 2, 3), t2.abab, (4, 2, 5, 6), (4, 0, 1, 3, 5, 6))
-    t3new.abaaba += tmp351.transpose((1, 2, 0, 3, 5, 4))
-    t3new.abaaba += tmp351.transpose((0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp351, (1, 2, 0, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp351, (0, 2, 1, 4, 5, 3))
     del tmp351
     tmp345 = einsum(tmp128, (0, 1, 2, 3), t2.abab, (4, 5, 6, 2), (4, 0, 5, 6, 1, 3))
-    t3new.abaaba += tmp345.transpose((1, 2, 0, 4, 5, 3))
-    t3new.abaaba += tmp345.transpose((0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp345, (1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp345, (0, 2, 1, 4, 5, 3)) * -1
     del tmp345
     tmp407 = einsum(t2.abab, (0, 1, 2, 3), tmp151, (4, 5, 1, 6), (4, 0, 5, 2, 6, 3))
-    t3new.abaaba += tmp407.transpose((0, 2, 1, 3, 5, 4))
-    t3new.abaaba += tmp407.transpose((1, 2, 0, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp407, (0, 2, 1, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp407, (1, 2, 0, 3, 5, 4)) * -1
     del tmp407
     tmp366 = einsum(tmp1, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 6), (0, 4, 2, 5, 6, 3))
-    t3new.abaaba += tmp366.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.abaaba += tmp366.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.abaaba += tmp366.transpose((1, 2, 0, 4, 5, 3))
-    t3new.abaaba += tmp366.transpose((1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp366, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp366, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp366, (1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp366, (1, 2, 0, 4, 5, 3))
     del tmp366
     tmp372 = einsum(t1.aa, (0, 1), tmp371, (2, 3, 0, 4, 5, 6), (2, 3, 4, 1, 5, 6))
     del tmp371
-    t3new.abaaba += tmp372.transpose((1, 2, 0, 3, 5, 4))
-    t3new.abaaba += tmp372.transpose((0, 2, 1, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp372, (1, 2, 0, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp372, (0, 2, 1, 3, 5, 4)) * -1
     del tmp372
     tmp399 = einsum(t2.abab, (0, 1, 2, 3), tmp113, (4, 5, 0, 6), (4, 5, 1, 2, 6, 3))
-    t3new.abaaba += tmp399.transpose((1, 2, 0, 3, 5, 4))
-    t3new.abaaba += tmp399.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.abaaba += tmp399.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.abaaba += tmp399.transpose((0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp399, (1, 2, 0, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp399, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp399, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp399, (0, 2, 1, 4, 5, 3))
     del tmp399
     tmp327 = einsum(t2.abab, (0, 1, 2, 3), tmp137, (4, 5, 6, 1), (0, 4, 5, 6, 2, 3)) * -1
     tmp327 += einsum(t1.bb, (0, 1), tmp326, (2, 3, 4, 5, 0, 6), (2, 3, 4, 5, 6, 1)) * -2
@@ -1514,42 +1514,42 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp327
     tmp362 = einsum(tmp361, (0, 1, 2, 3, 4, 5), t1.aa, (1, 6), (0, 2, 3, 6, 4, 5))
     del tmp361
-    t3new.abaaba += tmp362.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.abaaba += tmp362.transpose((1, 2, 0, 3, 5, 4))
-    t3new.abaaba += tmp362.transpose((0, 2, 1, 4, 5, 3))
-    t3new.abaaba += tmp362.transpose((0, 2, 1, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp362, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp362, (1, 2, 0, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp362, (0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp362, (0, 2, 1, 3, 5, 4)) * -1
     del tmp362
-    tmp397 = tmp151.copy() * -1
+    tmp397 = np.copy(tmp151) * -1
     tmp397 += tmp396
     t3new.abaaba += einsum(tmp397, (0, 1, 2, 3), t2.abab, (4, 2, 5, 6), (4, 1, 0, 3, 6, 5)) * -1
     del tmp397
     tmp337 = einsum(t2.aaaa, (0, 1, 2, 3), tmp336, (1, 4, 5, 6), (4, 0, 5, 2, 3, 6)) * -1
     del tmp336
-    t3new.abaaba += tmp337.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.abaaba += tmp337.transpose((0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp337, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp337, (0, 2, 1, 4, 5, 3)) * -1
     del tmp337
     tmp343 = einsum(t2.abab, (0, 1, 2, 3), v.aaaa.ooov, (4, 0, 5, 6), (4, 5, 1, 2, 6, 3))
-    t3new.abaaba += tmp343.transpose((1, 2, 0, 3, 5, 4))
-    t3new.abaaba += tmp343.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.abaaba += tmp343.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.abaaba += tmp343.transpose((0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp343, (1, 2, 0, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp343, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp343, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp343, (0, 2, 1, 4, 5, 3))
     del tmp343
     tmp409 = einsum(t1.bb, (0, 1), tmp408, (2, 3, 4, 0, 5, 6), (2, 3, 4, 5, 6, 1))
     del tmp408
-    t3new.abaaba += tmp409.transpose((0, 2, 1, 3, 5, 4))
-    t3new.abaaba += tmp409.transpose((1, 2, 0, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp409, (0, 2, 1, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp409, (1, 2, 0, 3, 5, 4)) * -1
     del tmp409
     tmp309 = einsum(f.aa.oo, (0, 1), t3.abaaba, (2, 3, 1, 4, 5, 6), (0, 2, 3, 4, 6, 5))
-    t3new.abaaba += tmp309.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.abaaba += tmp309.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.abaaba += tmp309.transpose((1, 2, 0, 4, 5, 3))
-    t3new.abaaba += tmp309.transpose((1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp309, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp309, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp309, (1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp309, (1, 2, 0, 4, 5, 3))
     del tmp309
     tmp353 = einsum(t2.abab, (0, 1, 2, 3), tmp2, (4, 5, 0, 6), (4, 5, 1, 2, 6, 3))
-    t3new.abaaba += tmp353.transpose((1, 2, 0, 3, 5, 4))
-    t3new.abaaba += tmp353.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.abaaba += tmp353.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.abaaba += tmp353.transpose((0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp353, (1, 2, 0, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp353, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp353, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp353, (0, 2, 1, 4, 5, 3))
     del tmp353
     tmp328 = einsum(t2.abab, (0, 1, 2, 3), tmp140, (4, 5, 6, 1), (4, 0, 5, 6, 2, 3))
     tmp328 += tmp322
@@ -1557,125 +1557,125 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t3new.abaaba += einsum(t1.aa, (0, 1), tmp328, (2, 3, 0, 4, 5, 6), (2, 4, 3, 5, 6, 1)) * -1
     del tmp328
     tmp411 = einsum(tmp396, (0, 1, 2, 3), t2.abab, (4, 2, 5, 6), (0, 4, 1, 3, 5, 6))
-    t3new.abaaba += tmp411.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.abaaba += tmp411.transpose((1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp411, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp411, (1, 2, 0, 4, 5, 3))
     del tmp411
     tmp376 = einsum(t2.abab, (0, 1, 2, 3), tmp139, (4, 5, 1, 6), (4, 0, 5, 2, 6, 3))
     del tmp139
-    t3new.abaaba += tmp376.transpose((0, 2, 1, 3, 5, 4))
-    t3new.abaaba += tmp376.transpose((1, 2, 0, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp376, (0, 2, 1, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp376, (1, 2, 0, 3, 5, 4)) * -1
     del tmp376
     tmp405 = einsum(t1.aa, (0, 1), tmp404, (2, 3, 0, 4, 5, 6), (2, 3, 4, 1, 5, 6))
     del tmp404
-    t3new.abaaba += tmp405.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.abaaba += tmp405.transpose((1, 2, 0, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp405, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp405, (1, 2, 0, 3, 5, 4))
     del tmp405
     tmp315 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.oooo, (4, 5, 6, 1), (0, 4, 5, 6, 2, 3)) * -1
     tmp315 += einsum(t1.bb, (0, 1), tmp314, (2, 3, 4, 0, 5, 6), (2, 3, 4, 5, 6, 1)) * -2
     del tmp314
     t3new.abaaba += einsum(tmp315, (0, 1, 2, 3, 4, 5), t1.aa, (2, 6), (1, 3, 0, 4, 5, 6))
     del tmp315
-    tmp348 = v.aabb.vvov.transpose((2, 0, 1, 3)).copy()
-    tmp348 += tmp50.transpose((0, 2, 1, 3)) * -1
+    tmp348 = np.copy(np.transpose(v.aabb.vvov, (2, 0, 1, 3)))
+    tmp348 += np.transpose(tmp50, (0, 2, 1, 3)) * -1
     del tmp50
     t3new.abaaba += einsum(t2.aaaa, (0, 1, 2, 3), tmp348, (4, 3, 5, 6), (0, 4, 1, 2, 6, 5)) * 2
     del tmp348
     tmp312 = einsum(t2.abab, (0, 1, 2, 3), v.aaaa.oooo, (4, 5, 6, 0), (4, 5, 6, 1, 2, 3))
-    tmp312 += tmp311.transpose((0, 2, 1, 3, 4, 5)) * -1
+    tmp312 += np.transpose(tmp311, (0, 2, 1, 3, 4, 5)) * -1
     del tmp311
     t3new.abaaba += einsum(t1.aa, (0, 1), tmp312, (2, 0, 3, 4, 5, 6), (2, 4, 3, 5, 6, 1)) * -1
     del tmp312
     tmp395 = einsum(tmp394, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 6), (0, 4, 2, 5, 6, 3))
     del tmp394
-    t3new.abaaba += tmp395.transpose((0, 2, 1, 4, 5, 3))
-    t3new.abaaba += tmp395.transpose((0, 2, 1, 4, 5, 3))
-    t3new.abaaba += tmp395.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.abaaba += tmp395.transpose((1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp395, (0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp395, (0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp395, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp395, (1, 2, 0, 4, 5, 3)) * -1
     del tmp395
-    tmp390 = tmp152.transpose((0, 2, 1, 3)).copy()
+    tmp390 = np.copy(np.transpose(tmp152, (0, 2, 1, 3)))
     tmp390 += einsum(tmp141, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3)) * -1
     del tmp141
     t3new.abaaba += einsum(t2.aaaa, (0, 1, 2, 3), tmp390, (4, 3, 5, 6), (0, 4, 1, 2, 6, 5)) * 2
     del tmp390
     tmp352 = einsum(tmp21, (0, 1, 2, 3), t2.abab, (4, 2, 5, 6), (4, 0, 1, 5, 3, 6))
-    t3new.abaaba += tmp352.transpose((1, 2, 0, 3, 5, 4))
-    t3new.abaaba += tmp352.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.abaaba += tmp352.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.abaaba += tmp352.transpose((0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp352, (1, 2, 0, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp352, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp352, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp352, (0, 2, 1, 4, 5, 3))
     del tmp352
     tmp334 = einsum(t2.abab, (0, 1, 2, 3), tmp330, (4, 1, 5, 6), (4, 0, 5, 6, 2, 3))
-    t3new.abaaba += tmp334.transpose((0, 2, 1, 4, 5, 3))
-    t3new.abaaba += tmp334.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.abaaba += tmp334.transpose((0, 2, 1, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp334, (0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp334, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp334, (0, 2, 1, 3, 5, 4)) * -1
     del tmp334
-    tmp403 = tmp151.copy()
+    tmp403 = np.copy(tmp151)
     del tmp151
     tmp403 += tmp396 * -1
     del tmp396
     t3new.abaaba += einsum(t2.abab, (0, 1, 2, 3), tmp403, (4, 5, 1, 6), (4, 5, 0, 6, 3, 2)) * -1
     del tmp403
     tmp346 = einsum(v.aaaa.ovvv, (0, 1, 2, 3), t2.abab, (4, 5, 3, 6), (4, 0, 5, 1, 2, 6))
-    t3new.abaaba += tmp346.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.abaaba += tmp346.transpose((0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp346, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp346, (0, 2, 1, 4, 5, 3))
     del tmp346
     tmp402 = einsum(t2.aaaa, (0, 1, 2, 3), tmp401, (4, 1, 5, 6), (4, 0, 5, 2, 3, 6)) * -1
     del tmp401
-    t3new.abaaba += tmp402.transpose((0, 2, 1, 4, 5, 3))
-    t3new.abaaba += tmp402.transpose((0, 2, 1, 4, 5, 3))
-    t3new.abaaba += tmp402.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.abaaba += tmp402.transpose((1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp402, (0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp402, (0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp402, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp402, (1, 2, 0, 4, 5, 3)) * -1
     del tmp402
     tmp398 = einsum(t2.abab, (0, 1, 2, 3), tmp109, (4, 5, 0, 6), (5, 4, 1, 6, 2, 3))
-    t3new.abaaba += tmp398.transpose((1, 2, 0, 4, 5, 3))
-    t3new.abaaba += tmp398.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.abaaba += tmp398.transpose((1, 2, 0, 3, 5, 4)) * -1
-    t3new.abaaba += tmp398.transpose((0, 2, 1, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp398, (1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp398, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp398, (1, 2, 0, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp398, (0, 2, 1, 3, 5, 4))
     del tmp398
     tmp386 = einsum(t1.aa, (0, 1), tmp385, (2, 0, 3, 4, 5, 6), (2, 3, 4, 5, 1, 6)) * -1
     del tmp385
-    t3new.abaaba += tmp386.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.abaaba += tmp386.transpose((1, 2, 0, 4, 5, 3))
-    t3new.abaaba += tmp386.transpose((0, 2, 1, 3, 5, 4))
-    t3new.abaaba += tmp386.transpose((1, 2, 0, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp386, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp386, (1, 2, 0, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp386, (0, 2, 1, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp386, (1, 2, 0, 3, 5, 4)) * -1
     del tmp386
     tmp369 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.aaaa, (4, 5, 6, 1), (4, 5, 0, 2, 6, 3))
     t3new.abaaba += einsum(t1.aa, (0, 1), tmp369, (2, 3, 0, 4, 5, 6), (2, 4, 3, 1, 6, 5)) * 2
     del tmp369
     tmp313 = einsum(t3.abaaba, (0, 1, 2, 3, 4, 5), f.bb.oo, (6, 1), (0, 2, 6, 3, 5, 4))
-    t3new.abaaba += tmp313.transpose((0, 2, 1, 4, 5, 3))
-    t3new.abaaba += tmp313.transpose((0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp313, (0, 2, 1, 4, 5, 3))
+    t3new.abaaba += np.transpose(tmp313, (0, 2, 1, 4, 5, 3))
     del tmp313
     tmp347 = einsum(v.aabb.ovvv, (0, 1, 2, 3), t2.abab, (4, 5, 6, 3), (4, 0, 5, 6, 1, 2))
-    t3new.abaaba += tmp347.transpose((1, 2, 0, 3, 5, 4)) * -1
-    t3new.abaaba += tmp347.transpose((0, 2, 1, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp347, (1, 2, 0, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp347, (0, 2, 1, 3, 5, 4))
     del tmp347
-    tmp331 = tmp329.transpose((0, 2, 1, 3)).copy()
+    tmp331 = np.copy(np.transpose(tmp329, (0, 2, 1, 3)))
     del tmp329
     tmp331 += tmp330 * -1
     del tmp330
     t3new.abaaba += einsum(tmp331, (0, 1, 2, 3), t2.abab, (4, 1, 5, 6), (4, 2, 0, 3, 6, 5)) * -1
     del tmp331
-    tmp391 = tmp377.transpose((0, 1, 3, 2)).copy()
-    tmp391 += tmp388.transpose((0, 1, 3, 2)) * -1
+    tmp391 = np.copy(np.transpose(tmp377, (0, 1, 3, 2)))
+    tmp391 += np.transpose(tmp388, (0, 1, 3, 2)) * -1
     t3new.abaaba += einsum(t2.abab, (0, 1, 2, 3), tmp391, (4, 5, 3, 6), (4, 1, 0, 2, 6, 5)) * -1
     del tmp391
     tmp350 = einsum(tmp335, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 6), (4, 0, 2, 5, 6, 3))
     del tmp335
-    t3new.abaaba += tmp350.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.abaaba += tmp350.transpose((0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp350, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.abaaba += np.transpose(tmp350, (0, 2, 1, 4, 5, 3)) * -1
     del tmp350
     tmp339 = einsum(t1.bb, (0, 1), tmp338, (2, 3, 4, 0, 5, 6), (2, 3, 4, 5, 6, 1))
     del tmp338
-    t3new.abaaba += tmp339.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.abaaba += tmp339.transpose((1, 2, 0, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp339, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp339, (1, 2, 0, 3, 5, 4))
     del tmp339
-    tmp389 = tmp377.transpose((0, 1, 3, 2)).copy() * -1
+    tmp389 = np.copy(np.transpose(tmp377, (0, 1, 3, 2))) * -1
     del tmp377
-    tmp389 += tmp388.transpose((0, 1, 3, 2))
+    tmp389 += np.transpose(tmp388, (0, 1, 3, 2))
     del tmp388
     t3new.abaaba += einsum(tmp389, (0, 1, 2, 3), t2.abab, (4, 5, 6, 2), (4, 5, 0, 6, 3, 1)) * -1
     del tmp389
-    tmp381 = tmp152.transpose((0, 2, 1, 3)).copy()
+    tmp381 = np.copy(np.transpose(tmp152, (0, 2, 1, 3)))
     tmp381 += einsum(t1.bb, (0, 1), tmp380, (2, 0, 3, 4), (2, 4, 3, 1)) * -1
     del tmp380
     t3new.abaaba += einsum(t2.aaaa, (0, 1, 2, 3), tmp381, (4, 3, 5, 6), (0, 4, 1, 5, 6, 2)) * -2
@@ -1686,517 +1686,517 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp341
     tmp374 = einsum(t1.bb, (0, 1), tmp373, (2, 3, 4, 0, 5, 6), (2, 3, 4, 5, 6, 1))
     del tmp373
-    t3new.abaaba += tmp374.transpose((1, 2, 0, 3, 5, 4))
-    t3new.abaaba += tmp374.transpose((0, 2, 1, 3, 5, 4)) * -1
+    t3new.abaaba += np.transpose(tmp374, (1, 2, 0, 3, 5, 4))
+    t3new.abaaba += np.transpose(tmp374, (0, 2, 1, 3, 5, 4)) * -1
     del tmp374
     tmp299 = einsum(tmp111, (0, 1, 2, 3), t2.aaaa, (4, 5, 6, 2), (0, 4, 5, 6, 3, 1))
-    t3new.aaaaaa = tmp299.transpose((0, 2, 1, 3, 5, 4)).copy() * -2
-    t3new.aaaaaa += tmp299.transpose((0, 2, 1, 3, 4, 5)) * 2
-    t3new.aaaaaa += tmp299.transpose((1, 0, 2, 3, 5, 4)) * -2
-    t3new.aaaaaa += tmp299.transpose((1, 0, 2, 3, 4, 5)) * 2
-    t3new.aaaaaa += tmp299.transpose((1, 2, 0, 3, 5, 4)) * 2
-    t3new.aaaaaa += tmp299.transpose((1, 2, 0, 3, 4, 5)) * -2
-    t3new.aaaaaa += tmp299.transpose((0, 2, 1, 5, 3, 4)) * 2
-    t3new.aaaaaa += tmp299.transpose((0, 2, 1, 4, 3, 5)) * -2
-    t3new.aaaaaa += tmp299.transpose((0, 2, 1, 5, 4, 3)) * -2
-    t3new.aaaaaa += tmp299.transpose((0, 2, 1, 4, 5, 3)) * 2
-    t3new.aaaaaa += tmp299.transpose((1, 0, 2, 5, 3, 4)) * 2
-    t3new.aaaaaa += tmp299.transpose((1, 0, 2, 4, 3, 5)) * -2
-    t3new.aaaaaa += tmp299.transpose((1, 2, 0, 5, 3, 4)) * -2
-    t3new.aaaaaa += tmp299.transpose((1, 2, 0, 4, 3, 5)) * 2
-    t3new.aaaaaa += tmp299.transpose((1, 0, 2, 5, 4, 3)) * -2
-    t3new.aaaaaa += tmp299.transpose((1, 0, 2, 4, 5, 3)) * 2
-    t3new.aaaaaa += tmp299.transpose((1, 2, 0, 5, 4, 3)) * 2
-    t3new.aaaaaa += tmp299.transpose((1, 2, 0, 4, 5, 3)) * -2
+    t3new.aaaaaa = np.copy(np.transpose(tmp299, (0, 2, 1, 3, 5, 4))) * -2
+    t3new.aaaaaa += np.transpose(tmp299, (0, 2, 1, 3, 4, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp299, (1, 0, 2, 3, 5, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp299, (1, 0, 2, 3, 4, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp299, (1, 2, 0, 3, 5, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp299, (1, 2, 0, 3, 4, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp299, (0, 2, 1, 5, 3, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp299, (0, 2, 1, 4, 3, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp299, (0, 2, 1, 5, 4, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp299, (0, 2, 1, 4, 5, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp299, (1, 0, 2, 5, 3, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp299, (1, 0, 2, 4, 3, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp299, (1, 2, 0, 5, 3, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp299, (1, 2, 0, 4, 3, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp299, (1, 0, 2, 5, 4, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp299, (1, 0, 2, 4, 5, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp299, (1, 2, 0, 5, 4, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp299, (1, 2, 0, 4, 5, 3)) * -2
     del tmp299
     tmp261 = einsum(f.aa.vv, (0, 1), t3.aaaaaa, (2, 3, 4, 5, 6, 1), (2, 3, 4, 0, 5, 6))
-    t3new.aaaaaa += tmp261.transpose((0, 1, 2, 5, 4, 3)) * -3
-    t3new.aaaaaa += tmp261.transpose((0, 1, 2, 5, 4, 3)) * -3
+    t3new.aaaaaa += np.transpose(tmp261, (0, 1, 2, 5, 4, 3)) * -3
+    t3new.aaaaaa += np.transpose(tmp261, (0, 1, 2, 5, 4, 3)) * -3
     del tmp261
     tmp303 = einsum(tmp302, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 3, 4))
     del tmp302
     t3new.aaaaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp303, (4, 5, 1, 6), (0, 5, 4, 2, 3, 6))
     del tmp303
     tmp287 = einsum(t2.aaaa, (0, 1, 2, 3), tmp2, (4, 5, 1, 6), (4, 0, 5, 2, 3, 6))
-    t3new.aaaaaa += tmp287.transpose((2, 0, 1, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp287.transpose((2, 0, 1, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp287.transpose((2, 1, 0, 4, 3, 5))
-    t3new.aaaaaa += tmp287.transpose((2, 1, 0, 4, 3, 5))
-    t3new.aaaaaa += tmp287.transpose((0, 2, 1, 4, 3, 5))
-    t3new.aaaaaa += tmp287.transpose((0, 2, 1, 4, 3, 5))
-    t3new.aaaaaa += tmp287.transpose((1, 2, 0, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp287.transpose((1, 2, 0, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp287.transpose((0, 1, 2, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp287.transpose((0, 1, 2, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp287.transpose((1, 0, 2, 4, 3, 5))
-    t3new.aaaaaa += tmp287.transpose((1, 0, 2, 4, 3, 5))
-    t3new.aaaaaa += tmp287.transpose((2, 0, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp287.transpose((2, 0, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp287.transpose((2, 1, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp287.transpose((2, 1, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp287.transpose((2, 0, 1, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp287.transpose((2, 0, 1, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp287.transpose((2, 1, 0, 5, 4, 3))
-    t3new.aaaaaa += tmp287.transpose((2, 1, 0, 5, 4, 3))
-    t3new.aaaaaa += tmp287.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp287.transpose((0, 2, 1, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp287.transpose((1, 2, 0, 4, 5, 3))
-    t3new.aaaaaa += tmp287.transpose((1, 2, 0, 4, 5, 3))
-    t3new.aaaaaa += tmp287.transpose((0, 2, 1, 5, 4, 3))
-    t3new.aaaaaa += tmp287.transpose((0, 2, 1, 5, 4, 3))
-    t3new.aaaaaa += tmp287.transpose((1, 2, 0, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp287.transpose((1, 2, 0, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp287.transpose((0, 1, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp287.transpose((0, 1, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp287.transpose((1, 0, 2, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp287.transpose((1, 0, 2, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp287.transpose((0, 1, 2, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp287.transpose((0, 1, 2, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp287.transpose((1, 0, 2, 5, 4, 3))
-    t3new.aaaaaa += tmp287.transpose((1, 0, 2, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp287, (2, 0, 1, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (2, 0, 1, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (2, 1, 0, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp287, (2, 1, 0, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp287, (0, 2, 1, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp287, (0, 2, 1, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp287, (1, 2, 0, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (1, 2, 0, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (0, 1, 2, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (0, 1, 2, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (1, 0, 2, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp287, (1, 0, 2, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp287, (2, 0, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp287, (2, 0, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp287, (2, 1, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (2, 1, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (2, 0, 1, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (2, 0, 1, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (2, 1, 0, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp287, (2, 1, 0, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp287, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (0, 2, 1, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (1, 2, 0, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp287, (1, 2, 0, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp287, (0, 2, 1, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp287, (0, 2, 1, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp287, (1, 2, 0, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (1, 2, 0, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (0, 1, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp287, (0, 1, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp287, (1, 0, 2, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (1, 0, 2, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (0, 1, 2, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (0, 1, 2, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp287, (1, 0, 2, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp287, (1, 0, 2, 5, 4, 3))
     del tmp287
     tmp284 = einsum(tmp283, (0, 1, 2, 3), t2.aaaa, (4, 5, 6, 3), (0, 4, 5, 1, 2, 6)) * -1
     del tmp283
-    t3new.aaaaaa += tmp284.transpose((2, 0, 1, 5, 4, 3)) * -2
-    t3new.aaaaaa += tmp284.transpose((2, 0, 1, 4, 5, 3)) * 2
-    t3new.aaaaaa += tmp284.transpose((2, 0, 1, 4, 3, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp284, (2, 0, 1, 5, 4, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp284, (2, 0, 1, 4, 5, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp284, (2, 0, 1, 4, 3, 5)) * -2
     del tmp284
     tmp291 = einsum(tmp290, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 6), (0, 2, 4, 3, 5, 6)) * -1
     del tmp290
-    t3new.aaaaaa += tmp291.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp291.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp291.transpose((0, 1, 2, 3, 5, 4))
-    t3new.aaaaaa += tmp291.transpose((0, 1, 2, 3, 5, 4))
-    t3new.aaaaaa += tmp291.transpose((0, 2, 1, 5, 3, 4))
-    t3new.aaaaaa += tmp291.transpose((0, 2, 1, 5, 3, 4))
-    t3new.aaaaaa += tmp291.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp291.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp291.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.aaaaaa += tmp291.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.aaaaaa += tmp291.transpose((2, 0, 1, 3, 5, 4))
-    t3new.aaaaaa += tmp291.transpose((2, 0, 1, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp291, (0, 1, 2, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp291, (0, 1, 2, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp291, (0, 1, 2, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp291, (0, 1, 2, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp291, (0, 2, 1, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp291, (0, 2, 1, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp291, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp291, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp291, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp291, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp291, (2, 0, 1, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp291, (2, 0, 1, 3, 5, 4))
     del tmp291
-    tmp293 = tmp62.transpose((0, 2, 1, 3)).copy()
+    tmp293 = np.copy(np.transpose(tmp62, (0, 2, 1, 3)))
     tmp293 += einsum(tmp292, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 3, 4))
     del tmp292
     t3new.aaaaaa += einsum(tmp293, (0, 1, 2, 3), t2.aaaa, (4, 2, 5, 6), (4, 1, 0, 3, 5, 6)) * -1
     del tmp293
     tmp282 = einsum(tmp281, (0, 1, 2, 3), t2.aaaa, (4, 5, 6, 2), (0, 4, 5, 1, 3, 6)) * -2
     del tmp281
-    t3new.aaaaaa += tmp282.transpose((0, 2, 1, 3, 4, 5)) * -1
-    t3new.aaaaaa += tmp282.transpose((2, 1, 0, 3, 4, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp282, (0, 2, 1, 3, 4, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp282, (2, 1, 0, 3, 4, 5)) * -1
     del tmp282
     tmp308 = einsum(tmp307, (0, 1, 2, 3, 4, 5), t1.aa, (1, 6), (0, 3, 2, 5, 4, 6)) * -2
     del tmp307
-    t3new.aaaaaa += tmp308.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp308.transpose((1, 2, 0, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp308, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp308, (1, 2, 0, 5, 4, 3))
     del tmp308
     tmp304 = einsum(t2.aaaa, (0, 1, 2, 3), tmp109, (4, 5, 1, 6), (5, 4, 0, 6, 2, 3))
-    t3new.aaaaaa += tmp304.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp304.transpose((0, 1, 2, 5, 4, 3))
-    t3new.aaaaaa += tmp304.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp304.transpose((0, 1, 2, 5, 4, 3))
-    t3new.aaaaaa += tmp304.transpose((1, 2, 0, 5, 4, 3))
-    t3new.aaaaaa += tmp304.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp304.transpose((1, 2, 0, 5, 4, 3))
-    t3new.aaaaaa += tmp304.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp304.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp304.transpose((2, 0, 1, 5, 4, 3))
-    t3new.aaaaaa += tmp304.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp304.transpose((2, 0, 1, 5, 4, 3))
-    t3new.aaaaaa += tmp304.transpose((1, 0, 2, 5, 3, 4))
-    t3new.aaaaaa += tmp304.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp304.transpose((1, 0, 2, 5, 3, 4))
-    t3new.aaaaaa += tmp304.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp304.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new.aaaaaa += tmp304.transpose((0, 1, 2, 3, 5, 4))
-    t3new.aaaaaa += tmp304.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new.aaaaaa += tmp304.transpose((0, 1, 2, 3, 5, 4))
-    t3new.aaaaaa += tmp304.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp304.transpose((0, 2, 1, 5, 3, 4))
-    t3new.aaaaaa += tmp304.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp304.transpose((0, 2, 1, 5, 3, 4))
-    t3new.aaaaaa += tmp304.transpose((2, 1, 0, 5, 3, 4))
-    t3new.aaaaaa += tmp304.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp304.transpose((2, 1, 0, 5, 3, 4))
-    t3new.aaaaaa += tmp304.transpose((2, 0, 1, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp304.transpose((1, 2, 0, 3, 5, 4))
-    t3new.aaaaaa += tmp304.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.aaaaaa += tmp304.transpose((1, 2, 0, 3, 5, 4))
-    t3new.aaaaaa += tmp304.transpose((0, 2, 1, 3, 5, 4)) * -1
-    t3new.aaaaaa += tmp304.transpose((2, 1, 0, 3, 5, 4)) * -1
-    t3new.aaaaaa += tmp304.transpose((2, 0, 1, 3, 5, 4))
-    t3new.aaaaaa += tmp304.transpose((2, 1, 0, 3, 5, 4)) * -1
-    t3new.aaaaaa += tmp304.transpose((2, 0, 1, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp304, (1, 0, 2, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (0, 1, 2, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp304, (1, 0, 2, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (0, 1, 2, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp304, (1, 2, 0, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp304, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (1, 2, 0, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp304, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (2, 1, 0, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (2, 0, 1, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp304, (2, 1, 0, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (2, 0, 1, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp304, (1, 0, 2, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp304, (0, 1, 2, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (1, 0, 2, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp304, (0, 1, 2, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (1, 0, 2, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (0, 1, 2, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp304, (1, 0, 2, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (0, 1, 2, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp304, (1, 2, 0, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (0, 2, 1, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp304, (1, 2, 0, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (0, 2, 1, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp304, (2, 1, 0, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp304, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (2, 1, 0, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp304, (2, 0, 1, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (1, 2, 0, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp304, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (1, 2, 0, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp304, (0, 2, 1, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (2, 1, 0, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (2, 0, 1, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp304, (2, 1, 0, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp304, (2, 0, 1, 3, 5, 4))
     del tmp304
     tmp297 = einsum(tmp296, (0, 1, 2, 3, 4, 5), t1.aa, (3, 6), (0, 1, 2, 6, 4, 5))
     del tmp296
-    t3new.aaaaaa += tmp297.transpose((2, 1, 0, 4, 3, 5)) * 2
-    t3new.aaaaaa += tmp297.transpose((2, 1, 0, 3, 4, 5)) * -2
-    t3new.aaaaaa += tmp297.transpose((0, 2, 1, 4, 3, 5)) * 2
-    t3new.aaaaaa += tmp297.transpose((0, 1, 2, 4, 3, 5)) * -2
-    t3new.aaaaaa += tmp297.transpose((0, 2, 1, 3, 4, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp297, (2, 1, 0, 4, 3, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp297, (2, 1, 0, 3, 4, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp297, (0, 2, 1, 4, 3, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp297, (0, 1, 2, 4, 3, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp297, (0, 2, 1, 3, 4, 5)) * -2
     t3new.aaaaaa += tmp297 * 2
-    t3new.aaaaaa += tmp297.transpose((2, 1, 0, 3, 5, 4)) * 2
-    t3new.aaaaaa += tmp297.transpose((0, 2, 1, 3, 5, 4)) * 2
-    t3new.aaaaaa += tmp297.transpose((0, 1, 2, 3, 5, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp297, (2, 1, 0, 3, 5, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp297, (0, 2, 1, 3, 5, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp297, (0, 1, 2, 3, 5, 4)) * -2
     del tmp297
     tmp266 = einsum(tmp265, (0, 1, 2, 3, 4, 5), t1.aa, (3, 6), (0, 1, 2, 6, 4, 5))
     del tmp265
-    t3new.aaaaaa += tmp266.transpose((0, 2, 1, 4, 5, 3)) * 2
-    t3new.aaaaaa += tmp266.transpose((0, 2, 1, 3, 5, 4)) * -2
-    t3new.aaaaaa += tmp266.transpose((0, 2, 1, 4, 3, 5)) * -2
-    t3new.aaaaaa += tmp266.transpose((0, 2, 1, 3, 4, 5)) * 2
-    t3new.aaaaaa += tmp266.transpose((1, 0, 2, 4, 5, 3)) * 2
-    t3new.aaaaaa += tmp266.transpose((1, 0, 2, 3, 5, 4)) * -2
-    t3new.aaaaaa += tmp266.transpose((1, 2, 0, 4, 5, 3)) * -2
-    t3new.aaaaaa += tmp266.transpose((1, 2, 0, 3, 5, 4)) * 2
-    t3new.aaaaaa += tmp266.transpose((1, 0, 2, 4, 3, 5)) * -2
-    t3new.aaaaaa += tmp266.transpose((1, 0, 2, 3, 4, 5)) * 2
-    t3new.aaaaaa += tmp266.transpose((1, 2, 0, 4, 3, 5)) * 2
-    t3new.aaaaaa += tmp266.transpose((1, 2, 0, 3, 4, 5)) * -2
-    t3new.aaaaaa += tmp266.transpose((0, 2, 1, 5, 4, 3)) * -2
-    t3new.aaaaaa += tmp266.transpose((0, 2, 1, 5, 3, 4)) * 2
-    t3new.aaaaaa += tmp266.transpose((1, 0, 2, 5, 4, 3)) * -2
-    t3new.aaaaaa += tmp266.transpose((1, 0, 2, 5, 3, 4)) * 2
-    t3new.aaaaaa += tmp266.transpose((1, 2, 0, 5, 4, 3)) * 2
-    t3new.aaaaaa += tmp266.transpose((1, 2, 0, 5, 3, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp266, (0, 2, 1, 4, 5, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp266, (0, 2, 1, 3, 5, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp266, (0, 2, 1, 4, 3, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp266, (0, 2, 1, 3, 4, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp266, (1, 0, 2, 4, 5, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp266, (1, 0, 2, 3, 5, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp266, (1, 2, 0, 4, 5, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp266, (1, 2, 0, 3, 5, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp266, (1, 0, 2, 4, 3, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp266, (1, 0, 2, 3, 4, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp266, (1, 2, 0, 4, 3, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp266, (1, 2, 0, 3, 4, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp266, (0, 2, 1, 5, 4, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp266, (0, 2, 1, 5, 3, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp266, (1, 0, 2, 5, 4, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp266, (1, 0, 2, 5, 3, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp266, (1, 2, 0, 5, 4, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp266, (1, 2, 0, 5, 3, 4)) * -2
     del tmp266
     tmp279 = einsum(v.aaaa.ooov, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 6), (4, 0, 2, 5, 6, 3))
-    t3new.aaaaaa += tmp279.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp279.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp279.transpose((1, 2, 0, 4, 3, 5))
-    t3new.aaaaaa += tmp279.transpose((1, 2, 0, 4, 3, 5))
-    t3new.aaaaaa += tmp279.transpose((2, 0, 1, 4, 3, 5))
-    t3new.aaaaaa += tmp279.transpose((2, 0, 1, 4, 3, 5))
-    t3new.aaaaaa += tmp279.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp279.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp279.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp279.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp279.transpose((0, 1, 2, 4, 3, 5))
-    t3new.aaaaaa += tmp279.transpose((0, 1, 2, 4, 3, 5))
-    t3new.aaaaaa += tmp279.transpose((2, 1, 0, 4, 5, 3))
-    t3new.aaaaaa += tmp279.transpose((2, 1, 0, 4, 5, 3))
-    t3new.aaaaaa += tmp279.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp279.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp279.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp279.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp279.transpose((1, 2, 0, 5, 4, 3))
-    t3new.aaaaaa += tmp279.transpose((1, 2, 0, 5, 4, 3))
-    t3new.aaaaaa += tmp279.transpose((2, 0, 1, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp279.transpose((2, 0, 1, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp279.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp279.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp279.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp279.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp279.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp279.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp279.transpose((2, 0, 1, 5, 4, 3))
-    t3new.aaaaaa += tmp279.transpose((2, 0, 1, 5, 4, 3))
-    t3new.aaaaaa += tmp279.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp279.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp279.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp279.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp279.transpose((0, 1, 2, 5, 4, 3))
-    t3new.aaaaaa += tmp279.transpose((0, 1, 2, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp279, (2, 1, 0, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (2, 1, 0, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (1, 2, 0, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp279, (1, 2, 0, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp279, (2, 0, 1, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp279, (2, 0, 1, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp279, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (0, 2, 1, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (0, 2, 1, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (0, 1, 2, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp279, (0, 1, 2, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp279, (2, 1, 0, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp279, (2, 1, 0, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp279, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (2, 1, 0, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (2, 1, 0, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (1, 2, 0, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp279, (1, 2, 0, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp279, (2, 0, 1, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (2, 0, 1, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp279, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp279, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp279, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp279, (0, 1, 2, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (0, 1, 2, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (2, 0, 1, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp279, (2, 0, 1, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp279, (1, 0, 2, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (1, 0, 2, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp279, (0, 1, 2, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp279, (0, 1, 2, 5, 4, 3))
     del tmp279
     tmp260 = einsum(tmp259, (0, 1), t3.aaaaaa, (2, 3, 4, 5, 6, 0), (2, 3, 4, 1, 5, 6))
     del tmp259
-    t3new.aaaaaa += tmp260.transpose((1, 2, 0, 4, 3, 5)) * -3
-    t3new.aaaaaa += tmp260.transpose((1, 2, 0, 4, 3, 5)) * -3
+    t3new.aaaaaa += np.transpose(tmp260, (1, 2, 0, 4, 3, 5)) * -3
+    t3new.aaaaaa += np.transpose(tmp260, (1, 2, 0, 4, 3, 5)) * -3
     del tmp260
     tmp278 = einsum(t1.aa, (0, 1), tmp277, (2, 3, 0, 4, 5, 6), (2, 3, 4, 1, 5, 6))
     del tmp277
-    t3new.aaaaaa += tmp278.transpose((2, 1, 0, 4, 3, 5)) * -2
-    t3new.aaaaaa += tmp278.transpose((2, 1, 0, 3, 4, 5)) * 2
-    t3new.aaaaaa += tmp278.transpose((0, 2, 1, 4, 3, 5)) * -2
-    t3new.aaaaaa += tmp278.transpose((0, 1, 2, 4, 3, 5)) * 2
-    t3new.aaaaaa += tmp278.transpose((0, 2, 1, 3, 4, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp278, (2, 1, 0, 4, 3, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp278, (2, 1, 0, 3, 4, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp278, (0, 2, 1, 4, 3, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp278, (0, 1, 2, 4, 3, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp278, (0, 2, 1, 3, 4, 5)) * 2
     t3new.aaaaaa += tmp278 * -2
-    t3new.aaaaaa += tmp278.transpose((2, 1, 0, 4, 5, 3)) * 2
-    t3new.aaaaaa += tmp278.transpose((0, 2, 1, 4, 5, 3)) * 2
-    t3new.aaaaaa += tmp278.transpose((0, 1, 2, 4, 5, 3)) * -2
-    t3new.aaaaaa += tmp278.transpose((2, 1, 0, 5, 4, 3)) * -2
-    t3new.aaaaaa += tmp278.transpose((0, 2, 1, 5, 4, 3)) * -2
-    t3new.aaaaaa += tmp278.transpose((0, 1, 2, 5, 4, 3)) * 2
-    t3new.aaaaaa += tmp278.transpose((0, 1, 2, 3, 5, 4)) * 2
-    t3new.aaaaaa += tmp278.transpose((0, 1, 2, 5, 3, 4)) * -2
-    t3new.aaaaaa += tmp278.transpose((0, 2, 1, 3, 5, 4)) * -2
-    t3new.aaaaaa += tmp278.transpose((0, 2, 1, 5, 3, 4)) * 2
-    t3new.aaaaaa += tmp278.transpose((2, 1, 0, 3, 5, 4)) * -2
-    t3new.aaaaaa += tmp278.transpose((2, 1, 0, 5, 3, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp278, (2, 1, 0, 4, 5, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp278, (0, 2, 1, 4, 5, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp278, (0, 1, 2, 4, 5, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp278, (2, 1, 0, 5, 4, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp278, (0, 2, 1, 5, 4, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp278, (0, 1, 2, 5, 4, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp278, (0, 1, 2, 3, 5, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp278, (0, 1, 2, 5, 3, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp278, (0, 2, 1, 3, 5, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp278, (0, 2, 1, 5, 3, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp278, (2, 1, 0, 3, 5, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp278, (2, 1, 0, 5, 3, 4)) * 2
     del tmp278
     tmp270 = einsum(t2.aaaa, (0, 1, 2, 3), tmp268, (4, 5, 1, 6), (4, 5, 0, 6, 2, 3)) * -1
-    t3new.aaaaaa += tmp270.transpose((0, 2, 1, 5, 4, 3))
-    t3new.aaaaaa += tmp270.transpose((0, 2, 1, 5, 4, 3))
-    t3new.aaaaaa += tmp270.transpose((2, 0, 1, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp270.transpose((2, 0, 1, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp270.transpose((0, 1, 2, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp270.transpose((0, 1, 2, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp270, (0, 2, 1, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp270, (0, 2, 1, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp270, (2, 0, 1, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp270, (2, 0, 1, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp270, (0, 1, 2, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp270, (0, 1, 2, 5, 4, 3)) * -1
     del tmp270
     tmp263 = einsum(tmp262, (0, 1), t3.aaaaaa, (2, 3, 0, 4, 5, 6), (1, 2, 3, 4, 5, 6))
     del tmp262
-    t3new.aaaaaa += tmp263.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp263.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp263.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp263.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp263.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp263.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp263.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp263.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp263.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp263.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp263.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp263.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp263.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp263.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp263.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp263.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp263.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp263.transpose((1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp263, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp263, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp263, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp263, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp263, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp263, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp263, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp263, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp263, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp263, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp263, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp263, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp263, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp263, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp263, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp263, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp263, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp263, (1, 2, 0, 4, 5, 3)) * -1
     del tmp263
     tmp298 = einsum(t2.aaaa, (0, 1, 2, 3), tmp62, (4, 5, 1, 6), (4, 0, 5, 2, 3, 6))
-    t3new.aaaaaa += tmp298.transpose((2, 0, 1, 4, 3, 5))
-    t3new.aaaaaa += tmp298.transpose((2, 0, 1, 4, 3, 5))
-    t3new.aaaaaa += tmp298.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp298.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp298.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp298.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp298.transpose((1, 2, 0, 4, 3, 5))
-    t3new.aaaaaa += tmp298.transpose((1, 2, 0, 4, 3, 5))
-    t3new.aaaaaa += tmp298.transpose((0, 1, 2, 4, 3, 5))
-    t3new.aaaaaa += tmp298.transpose((0, 1, 2, 4, 3, 5))
-    t3new.aaaaaa += tmp298.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp298.transpose((1, 0, 2, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp298, (2, 0, 1, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp298, (2, 0, 1, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp298, (2, 1, 0, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp298, (2, 1, 0, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp298, (0, 2, 1, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp298, (0, 2, 1, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp298, (1, 2, 0, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp298, (1, 2, 0, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp298, (0, 1, 2, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp298, (0, 1, 2, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp298, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp298, (1, 0, 2, 4, 3, 5)) * -1
     del tmp298
     tmp269 = einsum(t2.aaaa, (0, 1, 2, 3), tmp268, (4, 5, 1, 6), (4, 5, 0, 6, 2, 3)) * -1
     del tmp268
-    t3new.aaaaaa += tmp269.transpose((2, 1, 0, 5, 4, 3))
-    t3new.aaaaaa += tmp269.transpose((1, 0, 2, 5, 4, 3))
-    t3new.aaaaaa += tmp269.transpose((1, 0, 2, 5, 4, 3))
-    t3new.aaaaaa += tmp269.transpose((1, 2, 0, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp269.transpose((1, 2, 0, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp269, (2, 1, 0, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp269, (1, 0, 2, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp269, (1, 0, 2, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp269, (1, 2, 0, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp269, (1, 2, 0, 5, 4, 3)) * -1
     del tmp269
     tmp276 = einsum(t2.aaaa, (0, 1, 2, 3), tmp271, (1, 4, 5, 6), (5, 4, 0, 6, 2, 3)) * -1
     del tmp271
-    t3new.aaaaaa += tmp276.transpose((0, 1, 2, 5, 4, 3)) * -2
-    t3new.aaaaaa += tmp276.transpose((0, 1, 2, 5, 4, 3)) * -2
-    t3new.aaaaaa += tmp276.transpose((0, 2, 1, 5, 4, 3)) * 2
-    t3new.aaaaaa += tmp276.transpose((0, 2, 1, 5, 4, 3)) * 2
-    t3new.aaaaaa += tmp276.transpose((2, 1, 0, 5, 4, 3)) * 2
-    t3new.aaaaaa += tmp276.transpose((2, 1, 0, 5, 4, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp276, (0, 1, 2, 5, 4, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp276, (0, 1, 2, 5, 4, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp276, (0, 2, 1, 5, 4, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp276, (0, 2, 1, 5, 4, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp276, (2, 1, 0, 5, 4, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp276, (2, 1, 0, 5, 4, 3)) * 2
     del tmp276
     tmp301 = einsum(t1.aa, (0, 1), tmp300, (2, 0, 3, 4, 5, 6), (2, 4, 3, 6, 5, 1)) * -1
     del tmp300
-    t3new.aaaaaa += tmp301.transpose((0, 2, 1, 3, 5, 4)) * -2
-    t3new.aaaaaa += tmp301.transpose((0, 2, 1, 5, 3, 4)) * 2
-    t3new.aaaaaa += tmp301.transpose((1, 0, 2, 3, 5, 4)) * -2
-    t3new.aaaaaa += tmp301.transpose((1, 2, 0, 3, 5, 4)) * 2
-    t3new.aaaaaa += tmp301.transpose((1, 0, 2, 5, 3, 4)) * 2
-    t3new.aaaaaa += tmp301.transpose((1, 2, 0, 5, 3, 4)) * -2
-    t3new.aaaaaa += tmp301.transpose((1, 0, 2, 5, 4, 3)) * -2
-    t3new.aaaaaa += tmp301.transpose((0, 2, 1, 3, 4, 5)) * 2
-    t3new.aaaaaa += tmp301.transpose((1, 0, 2, 3, 4, 5)) * 2
-    t3new.aaaaaa += tmp301.transpose((1, 2, 0, 3, 4, 5)) * -2
-    t3new.aaaaaa += tmp301.transpose((0, 2, 1, 4, 3, 5)) * -2
-    t3new.aaaaaa += tmp301.transpose((0, 2, 1, 4, 5, 3)) * 2
-    t3new.aaaaaa += tmp301.transpose((1, 0, 2, 4, 3, 5)) * -2
-    t3new.aaaaaa += tmp301.transpose((1, 2, 0, 4, 3, 5)) * 2
-    t3new.aaaaaa += tmp301.transpose((1, 0, 2, 4, 5, 3)) * 2
-    t3new.aaaaaa += tmp301.transpose((1, 2, 0, 4, 5, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp301, (0, 2, 1, 3, 5, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp301, (0, 2, 1, 5, 3, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp301, (1, 0, 2, 3, 5, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp301, (1, 2, 0, 3, 5, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp301, (1, 0, 2, 5, 3, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp301, (1, 2, 0, 5, 3, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp301, (1, 0, 2, 5, 4, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp301, (0, 2, 1, 3, 4, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp301, (1, 0, 2, 3, 4, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp301, (1, 2, 0, 3, 4, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp301, (0, 2, 1, 4, 3, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp301, (0, 2, 1, 4, 5, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp301, (1, 0, 2, 4, 3, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp301, (1, 2, 0, 4, 3, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp301, (1, 0, 2, 4, 5, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp301, (1, 2, 0, 4, 5, 3)) * -2
     del tmp301
     tmp255 = einsum(t1.aa, (0, 1), tmp254, (2, 0, 3, 4, 5, 6), (2, 3, 4, 5, 6, 1))
     del tmp254
-    t3new.aaaaaa += tmp255.transpose((2, 1, 0, 4, 3, 5))
-    t3new.aaaaaa += tmp255.transpose((2, 1, 0, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp255, (2, 1, 0, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp255, (2, 1, 0, 4, 3, 5))
     del tmp255
     tmp295 = einsum(tmp294, (0, 1, 2, 3), t2.aaaa, (4, 2, 5, 6), (0, 1, 4, 3, 5, 6)) * -1
     del tmp294
-    t3new.aaaaaa += tmp295.transpose((1, 0, 2, 5, 3, 4))
-    t3new.aaaaaa += tmp295.transpose((1, 0, 2, 5, 3, 4))
-    t3new.aaaaaa += tmp295.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp295.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp295.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new.aaaaaa += tmp295.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new.aaaaaa += tmp295.transpose((1, 2, 0, 3, 5, 4))
-    t3new.aaaaaa += tmp295.transpose((1, 2, 0, 3, 5, 4))
-    t3new.aaaaaa += tmp295.transpose((2, 1, 0, 5, 3, 4))
-    t3new.aaaaaa += tmp295.transpose((2, 1, 0, 5, 3, 4))
-    t3new.aaaaaa += tmp295.transpose((2, 1, 0, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp295, (1, 0, 2, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp295, (1, 0, 2, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp295, (1, 2, 0, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp295, (1, 2, 0, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp295, (1, 0, 2, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp295, (1, 0, 2, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp295, (1, 2, 0, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp295, (1, 2, 0, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp295, (2, 1, 0, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp295, (2, 1, 0, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp295, (2, 1, 0, 3, 5, 4)) * -1
     del tmp295
     tmp248 = einsum(tmp247, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 6), (4, 2, 0, 3, 5, 6))
     del tmp247
-    t3new.aaaaaa += tmp248.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp248.transpose((1, 2, 0, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp248.transpose((1, 2, 0, 3, 5, 4))
-    t3new.aaaaaa += tmp248.transpose((1, 2, 0, 3, 5, 4))
-    t3new.aaaaaa += tmp248.transpose((2, 0, 1, 5, 4, 3))
-    t3new.aaaaaa += tmp248.transpose((2, 0, 1, 5, 4, 3))
-    t3new.aaaaaa += tmp248.transpose((0, 1, 2, 5, 4, 3))
-    t3new.aaaaaa += tmp248.transpose((0, 1, 2, 5, 4, 3))
-    t3new.aaaaaa += tmp248.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp248.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp248.transpose((1, 0, 2, 5, 3, 4))
-    t3new.aaaaaa += tmp248.transpose((1, 0, 2, 5, 3, 4))
-    t3new.aaaaaa += tmp248.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp248.transpose((0, 1, 2, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp248.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new.aaaaaa += tmp248.transpose((1, 0, 2, 3, 5, 4)) * -1
-    t3new.aaaaaa += tmp248.transpose((0, 1, 2, 3, 5, 4))
-    t3new.aaaaaa += tmp248.transpose((0, 1, 2, 3, 5, 4))
-    t3new.aaaaaa += tmp248.transpose((1, 2, 0, 5, 4, 3))
-    t3new.aaaaaa += tmp248.transpose((1, 2, 0, 5, 4, 3))
-    t3new.aaaaaa += tmp248.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp248.transpose((1, 0, 2, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp248, (1, 2, 0, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp248, (1, 2, 0, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp248, (1, 2, 0, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp248, (1, 2, 0, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp248, (2, 0, 1, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp248, (2, 0, 1, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp248, (0, 1, 2, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp248, (0, 1, 2, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp248, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp248, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp248, (1, 0, 2, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp248, (1, 0, 2, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp248, (0, 1, 2, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp248, (0, 1, 2, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp248, (1, 0, 2, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp248, (1, 0, 2, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp248, (0, 1, 2, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp248, (0, 1, 2, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp248, (1, 2, 0, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp248, (1, 2, 0, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp248, (1, 0, 2, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp248, (1, 0, 2, 5, 4, 3)) * -1
     del tmp248
     tmp258 = einsum(tmp257, (0, 1), t3.aaaaaa, (2, 3, 4, 5, 6, 0), (2, 3, 4, 1, 5, 6)) * 3
     del tmp257
-    t3new.aaaaaa += tmp258.transpose((1, 2, 0, 3, 4, 5))
-    t3new.aaaaaa += tmp258.transpose((1, 2, 0, 3, 4, 5))
+    t3new.aaaaaa += np.transpose(tmp258, (1, 2, 0, 3, 4, 5))
+    t3new.aaaaaa += np.transpose(tmp258, (1, 2, 0, 3, 4, 5))
     del tmp258
     tmp280 = einsum(v.aaaa.ovvv, (0, 1, 2, 3), t2.aaaa, (4, 5, 6, 3), (4, 5, 0, 6, 1, 2))
-    t3new.aaaaaa += tmp280.transpose((2, 1, 0, 3, 5, 4)) * -2
-    t3new.aaaaaa += tmp280.transpose((0, 2, 1, 3, 5, 4)) * -2
-    t3new.aaaaaa += tmp280.transpose((0, 1, 2, 3, 5, 4)) * 2
-    t3new.aaaaaa += tmp280.transpose((2, 1, 0, 5, 3, 4)) * 2
-    t3new.aaaaaa += tmp280.transpose((2, 1, 0, 5, 4, 3)) * -2
-    t3new.aaaaaa += tmp280.transpose((0, 2, 1, 5, 3, 4)) * 2
-    t3new.aaaaaa += tmp280.transpose((0, 1, 2, 5, 3, 4)) * -2
-    t3new.aaaaaa += tmp280.transpose((0, 2, 1, 5, 4, 3)) * -2
-    t3new.aaaaaa += tmp280.transpose((0, 1, 2, 5, 4, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp280, (2, 1, 0, 3, 5, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp280, (0, 2, 1, 3, 5, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp280, (0, 1, 2, 3, 5, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp280, (2, 1, 0, 5, 3, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp280, (2, 1, 0, 5, 4, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp280, (0, 2, 1, 5, 3, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp280, (0, 1, 2, 5, 3, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp280, (0, 2, 1, 5, 4, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp280, (0, 1, 2, 5, 4, 3)) * 2
     del tmp280
     tmp251 = einsum(tmp250, (0, 1, 2, 3, 4, 5), t1.aa, (2, 6), (0, 1, 3, 6, 4, 5))
     del tmp250
-    t3new.aaaaaa += tmp251.transpose((2, 1, 0, 4, 5, 3)) * 2
-    t3new.aaaaaa += tmp251.transpose((2, 1, 0, 3, 5, 4)) * -2
-    t3new.aaaaaa += tmp251.transpose((0, 2, 1, 4, 5, 3)) * 2
-    t3new.aaaaaa += tmp251.transpose((0, 2, 1, 3, 5, 4)) * -2
-    t3new.aaaaaa += tmp251.transpose((0, 1, 2, 4, 5, 3)) * -2
-    t3new.aaaaaa += tmp251.transpose((0, 1, 2, 3, 5, 4)) * 2
-    t3new.aaaaaa += tmp251.transpose((0, 1, 2, 4, 3, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp251, (2, 1, 0, 4, 5, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp251, (2, 1, 0, 3, 5, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp251, (0, 2, 1, 4, 5, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp251, (0, 2, 1, 3, 5, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp251, (0, 1, 2, 4, 5, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp251, (0, 1, 2, 3, 5, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp251, (0, 1, 2, 4, 3, 5)) * 2
     t3new.aaaaaa += tmp251 * -2
-    t3new.aaaaaa += tmp251.transpose((0, 2, 1, 4, 3, 5)) * -2
-    t3new.aaaaaa += tmp251.transpose((0, 2, 1, 3, 4, 5)) * 2
-    t3new.aaaaaa += tmp251.transpose((2, 1, 0, 4, 3, 5)) * -2
-    t3new.aaaaaa += tmp251.transpose((2, 1, 0, 3, 4, 5)) * 2
-    t3new.aaaaaa += tmp251.transpose((2, 1, 0, 5, 4, 3)) * -2
-    t3new.aaaaaa += tmp251.transpose((2, 1, 0, 5, 3, 4)) * 2
-    t3new.aaaaaa += tmp251.transpose((0, 2, 1, 5, 4, 3)) * -2
-    t3new.aaaaaa += tmp251.transpose((0, 2, 1, 5, 3, 4)) * 2
-    t3new.aaaaaa += tmp251.transpose((0, 1, 2, 5, 4, 3)) * 2
-    t3new.aaaaaa += tmp251.transpose((0, 1, 2, 5, 3, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp251, (0, 2, 1, 4, 3, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp251, (0, 2, 1, 3, 4, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp251, (2, 1, 0, 4, 3, 5)) * -2
+    t3new.aaaaaa += np.transpose(tmp251, (2, 1, 0, 3, 4, 5)) * 2
+    t3new.aaaaaa += np.transpose(tmp251, (2, 1, 0, 5, 4, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp251, (2, 1, 0, 5, 3, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp251, (0, 2, 1, 5, 4, 3)) * -2
+    t3new.aaaaaa += np.transpose(tmp251, (0, 2, 1, 5, 3, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp251, (0, 1, 2, 5, 4, 3)) * 2
+    t3new.aaaaaa += np.transpose(tmp251, (0, 1, 2, 5, 3, 4)) * -2
     del tmp251
     tmp275 = einsum(tmp274, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 6), (1, 2, 4, 3, 5, 6)) * -1
     del tmp274
-    t3new.aaaaaa += tmp275.transpose((0, 1, 2, 5, 3, 4))
-    t3new.aaaaaa += tmp275.transpose((0, 1, 2, 5, 3, 4))
-    t3new.aaaaaa += tmp275.transpose((0, 1, 2, 3, 5, 4)) * -1
-    t3new.aaaaaa += tmp275.transpose((0, 2, 1, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp275.transpose((0, 2, 1, 5, 3, 4)) * -1
-    t3new.aaaaaa += tmp275.transpose((2, 0, 1, 5, 3, 4))
-    t3new.aaaaaa += tmp275.transpose((2, 0, 1, 5, 3, 4))
-    t3new.aaaaaa += tmp275.transpose((0, 2, 1, 3, 5, 4))
-    t3new.aaaaaa += tmp275.transpose((0, 2, 1, 3, 5, 4))
-    t3new.aaaaaa += tmp275.transpose((2, 0, 1, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp275, (0, 1, 2, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp275, (0, 1, 2, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp275, (0, 1, 2, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp275, (0, 2, 1, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp275, (0, 2, 1, 5, 3, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp275, (2, 0, 1, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp275, (2, 0, 1, 5, 3, 4))
+    t3new.aaaaaa += np.transpose(tmp275, (0, 2, 1, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp275, (0, 2, 1, 3, 5, 4))
+    t3new.aaaaaa += np.transpose(tmp275, (2, 0, 1, 3, 5, 4)) * -1
     del tmp275
     tmp273 = einsum(tmp272, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 6), (1, 2, 4, 3, 5, 6)) * -1
     del tmp272
-    t3new.aaaaaa += tmp273.transpose((0, 1, 2, 3, 5, 4)) * -1
-    t3new.aaaaaa += tmp273.transpose((2, 0, 1, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp273, (0, 1, 2, 3, 5, 4)) * -1
+    t3new.aaaaaa += np.transpose(tmp273, (2, 0, 1, 3, 5, 4)) * -1
     del tmp273
     tmp246 = einsum(f.aa.oo, (0, 1), t3.aaaaaa, (2, 3, 1, 4, 5, 6), (0, 2, 3, 4, 5, 6))
-    t3new.aaaaaa += tmp246.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp246.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp246.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp246.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp246.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp246.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp246.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp246.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp246.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp246.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp246.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp246.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp246.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp246.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp246.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp246.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp246.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp246.transpose((1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp246, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp246, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp246, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp246, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp246, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp246, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp246, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp246, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp246, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp246, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp246, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp246, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp246, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp246, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp246, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp246, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp246, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp246, (1, 2, 0, 4, 5, 3)) * -1
     del tmp246
     tmp305 = einsum(t2.aaaa, (0, 1, 2, 3), tmp113, (4, 5, 1, 6), (4, 5, 0, 2, 3, 6))
-    t3new.aaaaaa += tmp305.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp305.transpose((0, 1, 2, 4, 3, 5))
-    t3new.aaaaaa += tmp305.transpose((1, 0, 2, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp305.transpose((0, 1, 2, 4, 3, 5))
-    t3new.aaaaaa += tmp305.transpose((1, 2, 0, 4, 3, 5))
-    t3new.aaaaaa += tmp305.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp305.transpose((1, 2, 0, 4, 3, 5))
-    t3new.aaaaaa += tmp305.transpose((0, 2, 1, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp305.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp305.transpose((2, 0, 1, 4, 3, 5))
-    t3new.aaaaaa += tmp305.transpose((2, 1, 0, 4, 3, 5)) * -1
-    t3new.aaaaaa += tmp305.transpose((2, 0, 1, 4, 3, 5))
-    t3new.aaaaaa += tmp305.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp305.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp305.transpose((1, 0, 2, 4, 5, 3))
-    t3new.aaaaaa += tmp305.transpose((0, 1, 2, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp305.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp305.transpose((0, 1, 2, 5, 4, 3))
-    t3new.aaaaaa += tmp305.transpose((1, 0, 2, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp305.transpose((0, 1, 2, 5, 4, 3))
-    t3new.aaaaaa += tmp305.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp305.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp305.transpose((1, 2, 0, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp305.transpose((0, 2, 1, 4, 5, 3))
-    t3new.aaaaaa += tmp305.transpose((2, 1, 0, 4, 5, 3))
-    t3new.aaaaaa += tmp305.transpose((2, 0, 1, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp305.transpose((2, 1, 0, 4, 5, 3))
-    t3new.aaaaaa += tmp305.transpose((2, 0, 1, 4, 5, 3)) * -1
-    t3new.aaaaaa += tmp305.transpose((1, 2, 0, 5, 4, 3))
-    t3new.aaaaaa += tmp305.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp305.transpose((1, 2, 0, 5, 4, 3))
-    t3new.aaaaaa += tmp305.transpose((0, 2, 1, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp305.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp305.transpose((2, 0, 1, 5, 4, 3))
-    t3new.aaaaaa += tmp305.transpose((2, 1, 0, 5, 4, 3)) * -1
-    t3new.aaaaaa += tmp305.transpose((2, 0, 1, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp305, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (0, 1, 2, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp305, (1, 0, 2, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (0, 1, 2, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp305, (1, 2, 0, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp305, (0, 2, 1, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (1, 2, 0, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp305, (0, 2, 1, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (2, 1, 0, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (2, 0, 1, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp305, (2, 1, 0, 4, 3, 5)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (2, 0, 1, 4, 3, 5))
+    t3new.aaaaaa += np.transpose(tmp305, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp305, (0, 1, 2, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (1, 0, 2, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp305, (0, 1, 2, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (1, 0, 2, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (0, 1, 2, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp305, (1, 0, 2, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (0, 1, 2, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp305, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp305, (1, 2, 0, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (0, 2, 1, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp305, (2, 1, 0, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp305, (2, 0, 1, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (2, 1, 0, 4, 5, 3))
+    t3new.aaaaaa += np.transpose(tmp305, (2, 0, 1, 4, 5, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (1, 2, 0, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp305, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (1, 2, 0, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp305, (0, 2, 1, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (2, 1, 0, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (2, 0, 1, 5, 4, 3))
+    t3new.aaaaaa += np.transpose(tmp305, (2, 1, 0, 5, 4, 3)) * -1
+    t3new.aaaaaa += np.transpose(tmp305, (2, 0, 1, 5, 4, 3))
     del tmp305
     tmp286 = einsum(t2.aaaa, (0, 1, 2, 3), tmp285, (4, 5, 3, 6), (4, 0, 1, 5, 6, 2)) * -1
     del tmp285
-    t3new.aaaaaa += tmp286.transpose((0, 2, 1, 5, 3, 4)) * -2
-    t3new.aaaaaa += tmp286.transpose((2, 1, 0, 5, 3, 4)) * -2
-    t3new.aaaaaa += tmp286.transpose((0, 2, 1, 3, 5, 4)) * 2
-    t3new.aaaaaa += tmp286.transpose((2, 1, 0, 3, 5, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp286, (0, 2, 1, 5, 3, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp286, (2, 1, 0, 5, 3, 4)) * -2
+    t3new.aaaaaa += np.transpose(tmp286, (0, 2, 1, 3, 5, 4)) * 2
+    t3new.aaaaaa += np.transpose(tmp286, (2, 1, 0, 3, 5, 4)) * 2
     del tmp286
     tmp221 = einsum(v.bbbb.ooov, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 4, 3))
-    t2new.bbbb += tmp221.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp221, (1, 0, 2, 3))
     t2new.bbbb += tmp221 * -1
-    t2new.bbbb += tmp221.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp221.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp221, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp221, (0, 1, 3, 2))
     del tmp221
     tmp243 = einsum(tmp242, (0, 1, 2, 3), t2.bbbb, (3, 2, 4, 5), (1, 0, 4, 5))
     del tmp242
-    t2new.bbbb += tmp243.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp243.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp243, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp243, (0, 1, 3, 2)) * -1
     del tmp243
     tmp235 = einsum(tmp234, (0, 1, 2, 3), t2.bbbb, (2, 3, 4, 5), (1, 0, 4, 5)) * -1
     del tmp234
-    t2new.bbbb += tmp235.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp235.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp235, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp235, (0, 1, 3, 2)) * -1
     del tmp235
     tmp239 = einsum(tmp238, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 4, 3))
     del tmp238
-    t2new.bbbb += tmp239.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp239, (1, 0, 2, 3))
     t2new.bbbb += tmp239 * -1
-    t2new.bbbb += tmp239.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp239.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp239, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp239, (0, 1, 3, 2))
     del tmp239
     tmp191 = einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.ovov, (4, 5, 1, 3), (0, 4, 2, 5))
     t2new.bbbb += tmp191 * 2
-    t2new.bbbb += tmp191.transpose((0, 1, 3, 2)) * -2
-    t2new.bbbb += tmp191.transpose((1, 0, 2, 3)) * -2
-    t2new.bbbb += tmp191.transpose((1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp191, (0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp191, (1, 0, 2, 3)) * -2
+    t2new.bbbb += np.transpose(tmp191, (1, 0, 3, 2)) * 2
     del tmp191
     tmp186 = einsum(tmp16, (0, 1), t3.bbbbbb, (2, 3, 0, 4, 5, 1), (2, 3, 4, 5)) * 3
     t2new.bbbb += tmp186
@@ -2204,44 +2204,44 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp186
     tmp237 = einsum(t1.bb, (0, 1), tmp236, (2, 3, 1, 4), (0, 2, 3, 4))
     del tmp236
-    t2new.bbbb += tmp237.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp237, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp237
     del tmp237
     tmp220 = einsum(tmp172, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (4, 1, 5, 3))
     del tmp172
-    t2new.bbbb += tmp220.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp220.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp220, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp220, (1, 0, 3, 2))
     del tmp220
-    tmp124 = tmp122.copy()
+    tmp124 = np.copy(tmp122)
     tmp124 += tmp123 * 2
     t2new.bbbb += einsum(tmp124, (0, 1), t2.bbbb, (2, 3, 4, 1), (2, 3, 4, 0)) * -2
     t2new.abab += einsum(tmp124, (0, 1), t2.abab, (2, 3, 4, 1), (2, 3, 4, 0)) * -1
     del tmp124
     tmp219 = einsum(t2.bbbb, (0, 1, 2, 3), tmp218, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp218
-    t2new.bbbb += tmp219.transpose((0, 1, 3, 2)) * 2
-    t2new.bbbb += tmp219.transpose((1, 0, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp219, (0, 1, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp219, (1, 0, 3, 2)) * -2
     t2new.bbbb += tmp219 * -2
     del tmp219
     tmp233 = einsum(t2.bbbb, (0, 1, 2, 3), tmp232, (1, 4, 5, 3), (4, 0, 5, 2))
     del tmp232
-    t2new.bbbb += tmp233.transpose((1, 0, 3, 2)) * -2
-    t2new.bbbb += tmp233.transpose((0, 1, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp233, (1, 0, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp233, (0, 1, 3, 2)) * 2
     del tmp233
     tmp201 = einsum(t2.bbbb, (0, 1, 2, 3), tmp200, (4, 5, 1, 0), (4, 5, 2, 3)) * -1
     del tmp200
-    t2new.bbbb += tmp201.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp201.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp201.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp201.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp201, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp201, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp201, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp201, (1, 0, 3, 2)) * -1
     del tmp201
     tmp179 = einsum(t3.bbbbbb, (0, 1, 2, 3, 4, 5), v.bbbb.ooov, (6, 2, 1, 5), (0, 6, 3, 4)) * -1
-    t2new.bbbb += tmp179.transpose((1, 0, 3, 2)) * -3
-    t2new.bbbb += tmp179.transpose((1, 0, 3, 2)) * -3
-    t2new.bbbb += tmp179.transpose((0, 1, 3, 2)) * 3
-    t2new.bbbb += tmp179.transpose((0, 1, 3, 2)) * 3
+    t2new.bbbb += np.transpose(tmp179, (1, 0, 3, 2)) * -3
+    t2new.bbbb += np.transpose(tmp179, (1, 0, 3, 2)) * -3
+    t2new.bbbb += np.transpose(tmp179, (0, 1, 3, 2)) * 3
+    t2new.bbbb += np.transpose(tmp179, (0, 1, 3, 2)) * 3
     del tmp179
-    tmp189 = f.aa.ov.copy()
+    tmp189 = np.copy(f.aa.ov)
     tmp189 += tmp0
     del tmp0
     tmp189 += einsum(tmp188, (0, 1, 2, 3), t1.aa, (0, 2), (1, 3)) * -1
@@ -2250,9 +2250,9 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp205 = einsum(t1.bb, (0, 1), tmp204, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp204
     t2new.bbbb += tmp205
-    t2new.bbbb += tmp205.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp205.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp205.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp205, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp205, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp205, (1, 0, 3, 2))
     del tmp205
     tmp181 = einsum(t1.bb, (0, 1), t1.bb, (2, 3), (0, 2, 3, 1)) * 2
     tmp181 += t2.bbbb * -1
@@ -2260,58 +2260,58 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp181
     tmp215 = einsum(tmp214, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5))
     del tmp214
-    t2new.bbbb += tmp215.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp215.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp215, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp215, (1, 0, 2, 3))
     del tmp215
     tmp207 = einsum(tmp206, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 4, 3))
     del tmp206
-    t2new.bbbb += tmp207.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp207, (0, 1, 3, 2))
     t2new.bbbb += tmp207 * -1
-    t2new.bbbb += tmp207.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp207.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp207, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp207, (1, 0, 2, 3))
     del tmp207
     tmp202 = einsum(tmp21, (0, 1, 2, 3), t3.babbab, (4, 0, 2, 5, 3, 6), (1, 4, 5, 6))
     del tmp21
-    t2new.bbbb += tmp202.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp202.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp202.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp202.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp202, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp202, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp202, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp202, (1, 0, 3, 2))
     del tmp202
-    tmp187 = t2.bbbb.copy()
+    tmp187 = np.copy(t2.bbbb)
     tmp187 += einsum(t1.bb, (0, 1), t1.bb, (2, 3), (2, 0, 3, 1)) * 2
     t2new.bbbb += einsum(tmp187, (0, 1, 2, 3), v.bbbb.oooo, (4, 0, 5, 1), (4, 5, 3, 2)) * -0.5
     del tmp187
-    tmp31 = f.bb.oo.copy()
-    tmp31 += tmp28.transpose((1, 0))
+    tmp31 = np.copy(f.bb.oo)
+    tmp31 += np.transpose(tmp28, (1, 0))
     del tmp28
-    tmp31 += tmp30.transpose((1, 0)) * -1
+    tmp31 += np.transpose(tmp30, (1, 0)) * -1
     del tmp30
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), tmp31, (1, 4), (0, 4, 2, 3)) * -1
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp31, (1, 4), (0, 4, 2, 3)) * -1
     t1new.bb += einsum(t1.bb, (0, 1), tmp31, (0, 2), (2, 1)) * -1
     del tmp31
-    tmp198 = f.bb.vv.copy() * -1
-    tmp198 += tmp131.transpose((1, 0)) * -1
-    tmp198 += tmp122.transpose((1, 0))
+    tmp198 = np.copy(f.bb.vv) * -1
+    tmp198 += np.transpose(tmp131, (1, 0)) * -1
+    tmp198 += np.transpose(tmp122, (1, 0))
     del tmp122
-    tmp198 += tmp123.transpose((1, 0)) * 2
+    tmp198 += np.transpose(tmp123, (1, 0)) * 2
     del tmp123
     tmp198 += tmp196 * -1
-    tmp198 += tmp197.transpose((1, 0))
+    tmp198 += np.transpose(tmp197, (1, 0))
     t2new.bbbb += einsum(tmp198, (0, 1), t2.bbbb, (2, 3, 4, 0), (2, 3, 1, 4)) * 2
     del tmp198
     tmp185 = einsum(tmp184, (0, 1), t2.bbbb, (2, 0, 3, 4), (2, 1, 3, 4)) * -1
     del tmp184
-    t2new.bbbb += tmp185.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp185.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp185.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp185, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp185, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp185, (0, 1, 3, 2)) * -1
     del tmp185
-    tmp229 = tmp146.copy()
+    tmp229 = np.copy(tmp146)
     tmp229 += einsum(t2.abab, (0, 1, 2, 3), tmp7, (0, 4, 2, 5), (4, 1, 5, 3))
     del tmp7
     t2new.bbbb += einsum(tmp229, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (4, 1, 3, 5))
     del tmp229
-    tmp226 = tmp146.copy()
+    tmp226 = np.copy(tmp146)
     del tmp146
     tmp226 += einsum(t2.abab, (0, 1, 2, 3), tmp188, (0, 4, 2, 5), (4, 1, 5, 3))
     del tmp188
@@ -2319,35 +2319,35 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp226
     tmp209 = einsum(tmp208, (0, 1), t2.bbbb, (2, 1, 3, 4), (0, 2, 3, 4)) * -1
     del tmp208
-    t2new.bbbb += tmp209.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp209.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp209.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp209.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp209, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp209, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp209, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp209, (1, 0, 3, 2)) * -1
     del tmp209
     tmp231 = einsum(t1.bb, (0, 1), tmp230, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp230
-    t2new.bbbb += tmp231.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp231.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp231, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp231, (1, 0, 3, 2))
     del tmp231
-    tmp199 = f.bb.vv.copy() * -1
-    tmp199 += tmp131.transpose((1, 0)) * -1
+    tmp199 = np.copy(f.bb.vv) * -1
+    tmp199 += np.transpose(tmp131, (1, 0)) * -1
     tmp199 += tmp196 * -1
     del tmp196
-    tmp199 += tmp197.transpose((1, 0))
+    tmp199 += np.transpose(tmp197, (1, 0))
     del tmp197
     t2new.bbbb += einsum(tmp199, (0, 1), t2.bbbb, (2, 3, 4, 0), (2, 3, 4, 1)) * -2
     del tmp199
     tmp194 = einsum(t3.babbab, (0, 1, 2, 3, 4, 5), tmp128, (1, 4, 5, 6), (0, 2, 3, 6)) * -2
     del tmp128
-    t2new.bbbb += tmp194.transpose((1, 0, 2, 3))
-    t2new.bbbb += tmp194.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp194, (1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp194, (1, 0, 3, 2)) * -1
     del tmp194
     tmp241 = einsum(tmp240, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 4, 3))
     del tmp240
-    t2new.bbbb += tmp241.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp241, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp241
     del tmp241
-    tmp228 = v.bbbb.oovv.copy() * 0.5
+    tmp228 = np.copy(v.bbbb.oovv) * 0.5
     tmp228 += einsum(t2.bbbb, (0, 1, 2, 3), tmp14, (1, 4, 3, 5), (0, 4, 2, 5)) * -1
     del tmp14
     tmp228 += einsum(tmp227, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 4, 3)) * -0.5
@@ -2355,29 +2355,29 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), tmp228, (4, 1, 5, 3), (0, 4, 5, 2)) * 4
     del tmp228
     tmp193 = einsum(t3.bbbbbb, (0, 1, 2, 3, 4, 5), tmp192, (2, 4, 5, 6), (0, 1, 6, 3)) * -6
-    t2new.bbbb += tmp193.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp193, (0, 1, 3, 2))
     t2new.bbbb += tmp193 * -1
     del tmp193
     tmp180 = einsum(v.aabb.ovoo, (0, 1, 2, 3), t3.babbab, (4, 0, 3, 5, 1, 6), (4, 2, 5, 6))
-    t2new.bbbb += tmp180.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp180.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp180.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp180.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp180, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp180, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp180, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp180, (0, 1, 3, 2))
     del tmp180
     tmp182 = einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.oooo, (4, 0, 5, 1), (4, 5, 2, 3))
-    t2new.bbbb += tmp182.transpose((1, 0, 3, 2)) * 0.5
-    t2new.bbbb += tmp182.transpose((1, 0, 3, 2)) * 0.5
+    t2new.bbbb += np.transpose(tmp182, (1, 0, 3, 2)) * 0.5
+    t2new.bbbb += np.transpose(tmp182, (1, 0, 3, 2)) * 0.5
     del tmp182
-    tmp244 = v.bbbb.vvvv.copy()
+    tmp244 = np.copy(v.bbbb.vvvv)
     tmp244 += einsum(tmp192, (0, 1, 2, 3), t1.bb, (0, 4), (1, 3, 2, 4))
     del tmp192
     t2new.bbbb += einsum(tmp244, (0, 1, 2, 3), t2.bbbb, (4, 5, 0, 2), (4, 5, 1, 3)) * 2
     del tmp244
     tmp222 = einsum(tmp125, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (4, 1, 5, 3))
     del tmp125
-    t2new.bbbb += tmp222.transpose((1, 0, 2, 3)) * -2
-    t2new.bbbb += tmp222.transpose((0, 1, 3, 2)) * -2
-    t2new.bbbb += tmp222.transpose((1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp222, (1, 0, 2, 3)) * -2
+    t2new.bbbb += np.transpose(tmp222, (0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp222, (1, 0, 3, 2)) * 2
     t2new.bbbb += tmp222 * 2
     del tmp222
     tmp245 = einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.ovvv, (4, 3, 5, 2), (0, 1, 4, 5)) * -1
@@ -2385,19 +2385,19 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp245
     tmp190 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (0, 2, 4, 5), (1, 4, 3, 5))
     t2new.bbbb += tmp190
-    t2new.bbbb += tmp190.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp190.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp190.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp190, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp190, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp190, (1, 0, 3, 2))
     del tmp190
     tmp203 = einsum(t3.bbbbbb, (0, 1, 2, 3, 4, 5), tmp22, (6, 1, 2, 5), (6, 0, 3, 4)) * -1
-    t2new.bbbb += tmp203.transpose((0, 1, 3, 2)) * -3
-    t2new.bbbb += tmp203.transpose((0, 1, 3, 2)) * -3
-    t2new.bbbb += tmp203.transpose((1, 0, 3, 2)) * 3
-    t2new.bbbb += tmp203.transpose((1, 0, 3, 2)) * 3
+    t2new.bbbb += np.transpose(tmp203, (0, 1, 3, 2)) * -3
+    t2new.bbbb += np.transpose(tmp203, (0, 1, 3, 2)) * -3
+    t2new.bbbb += np.transpose(tmp203, (1, 0, 3, 2)) * 3
+    t2new.bbbb += np.transpose(tmp203, (1, 0, 3, 2)) * 3
     del tmp203
-    tmp225 = v.bbbb.oovv.copy()
+    tmp225 = np.copy(v.bbbb.oovv)
     tmp225 += einsum(t2.bbbb, (0, 1, 2, 3), tmp45, (1, 4, 3, 5), (0, 4, 2, 5)) * -2
-    tmp225 += tmp224.transpose((0, 1, 3, 2)) * -1
+    tmp225 += np.transpose(tmp224, (0, 1, 3, 2)) * -1
     del tmp224
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), tmp225, (4, 1, 5, 3), (4, 0, 5, 2)) * -2
     del tmp225
@@ -2407,53 +2407,53 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp212
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), tmp213, (4, 1, 5, 3), (0, 4, 5, 2)) * 2
     del tmp213
-    tmp163 = v.aabb.vvvv.copy()
+    tmp163 = np.copy(v.aabb.vvvv)
     tmp163 += einsum(t1.bb, (0, 1), tmp162, (0, 2, 3, 4), (3, 2, 4, 1)) * -1
     del tmp162
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp163, (2, 4, 3, 5), (0, 1, 4, 5))
     del tmp163
-    tmp126 = v.aaaa.ovvv.transpose((0, 2, 3, 1)).copy()
+    tmp126 = np.copy(np.transpose(v.aaaa.ovvv, (0, 2, 3, 1)))
     tmp126 += tmp53
     del tmp53
     t2new.abab += einsum(t3.abaaba, (0, 1, 2, 3, 4, 5), tmp126, (2, 6, 3, 5), (0, 1, 6, 4)) * 2
     del tmp126
-    tmp160 = v.bbbb.oovv.copy()
+    tmp160 = np.copy(v.bbbb.oovv)
     tmp160 += einsum(t1.bb, (0, 1), tmp159, (0, 2, 3, 4), (3, 2, 4, 1))
     del tmp159
     t2new.abab += einsum(tmp160, (0, 1, 2, 3), t2.abab, (4, 0, 5, 2), (4, 1, 5, 3)) * -1
     del tmp160
-    tmp60 = f.aa.vv.copy() * -1
-    tmp60 += tmp56.transpose((1, 0)) * -1
-    tmp60 += tmp41.transpose((1, 0)) * 2
-    tmp60 += tmp42.transpose((1, 0))
-    tmp60 += tmp58.transpose((1, 0)) * -1
-    tmp60 += tmp59.transpose((1, 0))
+    tmp60 = np.copy(f.aa.vv) * -1
+    tmp60 += np.transpose(tmp56, (1, 0)) * -1
+    tmp60 += np.transpose(tmp41, (1, 0)) * 2
+    tmp60 += np.transpose(tmp42, (1, 0))
+    tmp60 += np.transpose(tmp58, (1, 0)) * -1
+    tmp60 += np.transpose(tmp59, (1, 0))
     t2new.abab += einsum(tmp60, (0, 1), t2.abab, (2, 3, 0, 4), (2, 3, 1, 4)) * -1
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp60, (3, 4), (0, 1, 4, 2)) * 2
     del tmp60
-    tmp120 = t2.abab.copy()
+    tmp120 = np.copy(t2.abab)
     tmp120 += einsum(t1.bb, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1)) * 2
     t2new.abab += einsum(v.aabb.oooo, (0, 1, 2, 3), tmp120, (1, 3, 4, 5), (0, 2, 4, 5)) * 0.5
     del tmp120
-    tmp145 = tmp143.transpose((0, 1, 3, 2)).copy()
+    tmp145 = np.copy(np.transpose(tmp143, (0, 1, 3, 2)))
     del tmp143
-    tmp145 += tmp144.transpose((0, 1, 3, 2)) * -1
+    tmp145 += np.transpose(tmp144, (0, 1, 3, 2)) * -1
     del tmp144
     t2new.abab += einsum(tmp145, (0, 1, 2, 3), t2.abab, (4, 1, 2, 5), (4, 0, 3, 5)) * -1
     del tmp145
-    tmp136 = tmp24.transpose((1, 0)).copy()
-    tmp136 += tmp25.transpose((1, 0)) * 2
-    tmp136 += tmp135.transpose((1, 0))
+    tmp136 = np.copy(np.transpose(tmp24, (1, 0)))
+    tmp136 += np.transpose(tmp25, (1, 0)) * 2
+    tmp136 += np.transpose(tmp135, (1, 0))
     del tmp135
     t2new.abab += einsum(tmp136, (0, 1), t2.abab, (2, 0, 3, 4), (2, 1, 3, 4)) * -1
     del tmp136
-    tmp130 = v.bbbb.ovvv.transpose((0, 2, 3, 1)).copy()
+    tmp130 = np.copy(np.transpose(v.bbbb.ovvv, (0, 2, 3, 1)))
     tmp130 += tmp129
     del tmp129
     t2new.abab += einsum(t3.babbab, (0, 1, 2, 3, 4, 5), tmp130, (2, 6, 5, 3), (1, 0, 4, 6)) * -2
     del tmp130
-    tmp148 = v.aabb.vvoo.transpose((2, 3, 0, 1)).copy() * -1
-    tmp148 += tmp147.transpose((1, 0, 3, 2))
+    tmp148 = np.copy(np.transpose(v.aabb.vvoo, (2, 3, 0, 1))) * -1
+    tmp148 += np.transpose(tmp147, (1, 0, 3, 2))
     del tmp147
     tmp148 += einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (0, 4, 5, 3), (2, 4, 1, 5))
     t2new.abab += einsum(tmp148, (0, 1, 2, 3), t2.abab, (4, 0, 2, 5), (4, 1, 3, 5))
@@ -2461,7 +2461,7 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     tmp161 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (4, 2, 5, 3), (0, 4, 1, 5))
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp161, (4, 0, 5, 1), (4, 5, 2, 3))
     del tmp161
-    tmp157 = tmp95.copy() * -1
+    tmp157 = np.copy(tmp95) * -1
     tmp157 += tmp156 * 2
     del tmp156
     tmp157 += einsum(tmp45, (0, 1, 2, 3), t2.abab, (4, 0, 5, 3), (4, 1, 5, 2)) * -1
@@ -2473,13 +2473,13 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t2new.abab += tmp134 * -1
     t2new.abab += tmp134 * -1
     del tmp134
-    tmp175 = tmp173.transpose((0, 1, 3, 2)).copy()
+    tmp175 = np.copy(np.transpose(tmp173, (0, 1, 3, 2)))
     del tmp173
-    tmp175 += tmp174.transpose((0, 1, 3, 2)) * -1
+    tmp175 += np.transpose(tmp174, (0, 1, 3, 2)) * -1
     del tmp174
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp175, (4, 0, 3, 5), (4, 1, 2, 5)) * -1
     del tmp175
-    tmp3 = t2.abab.copy()
+    tmp3 = np.copy(t2.abab)
     tmp3 += einsum(t1.bb, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
     t2new.abab += einsum(tmp3, (0, 1, 2, 3), tmp154, (4, 0, 5, 1), (4, 5, 2, 3))
     del tmp154
@@ -2490,18 +2490,18 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t1new.bb += einsum(tmp3, (0, 1, 2, 3), v.aabb.ovvv, (0, 2, 4, 3), (1, 4))
     t1new.aa += einsum(tmp3, (0, 1, 2, 3), v.aabb.vvov, (4, 2, 1, 3), (0, 4))
     del tmp3
-    tmp166 = tmp165.transpose((0, 1, 3, 2)).copy() * -1
+    tmp166 = np.copy(np.transpose(tmp165, (0, 1, 3, 2))) * -1
     del tmp165
-    tmp166 += tmp84.transpose((0, 1, 3, 2))
+    tmp166 += np.transpose(tmp84, (0, 1, 3, 2))
     del tmp84
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp166, (4, 0, 2, 5), (4, 1, 5, 3))
     del tmp166
     tmp176 = einsum(v.aabb.ovvv, (0, 1, 2, 3), t2.abab, (4, 5, 1, 3), (4, 0, 5, 2))
     t2new.abab += einsum(t1.aa, (0, 1), tmp176, (2, 0, 3, 4), (2, 3, 1, 4)) * -1
     del tmp176
-    tmp171 = tmp168.transpose((0, 1, 3, 2)).copy() * -1
+    tmp171 = np.copy(np.transpose(tmp168, (0, 1, 3, 2))) * -1
     del tmp168
-    tmp171 += tmp170.transpose((0, 1, 3, 2))
+    tmp171 += np.transpose(tmp170, (0, 1, 3, 2))
     del tmp170
     t2new.abab += einsum(tmp171, (0, 1, 2, 3), t2.abab, (4, 1, 5, 2), (4, 0, 5, 3))
     del tmp171
@@ -2512,29 +2512,29 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t2new.abab += tmp121 * -1
     t2new.abab += tmp121 * -1
     del tmp121
-    tmp11 = tmp5.transpose((1, 0)).copy()
+    tmp11 = np.copy(np.transpose(tmp5, (1, 0)))
     del tmp5
-    tmp11 += tmp6.transpose((1, 0)) * 0.5
+    tmp11 += np.transpose(tmp6, (1, 0)) * 0.5
     del tmp6
-    tmp11 += tmp10.transpose((1, 0))
+    tmp11 += np.transpose(tmp10, (1, 0))
     del tmp10
     t2new.abab += einsum(tmp11, (0, 1), t2.abab, (0, 2, 3, 4), (1, 2, 3, 4)) * -2
     t1new.aa += einsum(tmp11, (0, 1), t1.aa, (0, 2), (1, 2)) * -2
     del tmp11
-    tmp155 = v.aaaa.oovv.copy()
-    tmp155 += tmp49.transpose((1, 0, 3, 2)) * -1
+    tmp155 = np.copy(v.aaaa.oovv)
+    tmp155 += np.transpose(tmp49, (1, 0, 3, 2)) * -1
     tmp155 += einsum(t2.aaaa, (0, 1, 2, 3), tmp91, (1, 4, 5, 3), (4, 0, 5, 2)) * 2
     tmp155 += einsum(t1.aa, (0, 1), tmp36, (0, 2, 3, 4), (3, 2, 4, 1))
     del tmp36
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp155, (0, 4, 2, 5), (4, 1, 5, 3)) * -1
     del tmp155
-    tmp153 = v.aabb.vvov.transpose((2, 0, 1, 3)).copy()
-    tmp153 += tmp152.transpose((0, 2, 1, 3))
+    tmp153 = np.copy(np.transpose(v.aabb.vvov, (2, 0, 1, 3)))
+    tmp153 += np.transpose(tmp152, (0, 2, 1, 3))
     del tmp152
     t2new.abab += einsum(tmp153, (0, 1, 2, 3), t1.aa, (4, 1), (4, 0, 2, 3))
     del tmp153
-    tmp133 = f.bb.vv.copy()
-    tmp133 += tmp131.transpose((1, 0))
+    tmp133 = np.copy(f.bb.vv)
+    tmp133 += np.transpose(tmp131, (1, 0))
     del tmp131
     tmp133 += einsum(t1.bb, (0, 1), tmp132, (0, 1, 2, 3), (3, 2)) * -1
     del tmp132
@@ -2552,106 +2552,106 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp119
     tmp55 = einsum(tmp54, (0, 1, 2, 3), t3.aaaaaa, (4, 5, 0, 6, 1, 2), (4, 5, 6, 3)) * -6
     t2new.aaaa += tmp55
-    t2new.aaaa += tmp55.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp55, (0, 1, 3, 2)) * -1
     del tmp55
-    tmp102 = tmp95.copy()
+    tmp102 = np.copy(tmp95)
     tmp102 += einsum(tmp101, (0, 1, 2, 3), t2.abab, (4, 0, 5, 3), (4, 1, 5, 2)) * -1
     del tmp101
     t2new.aaaa += einsum(tmp102, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 2, 5))
     del tmp102
     tmp65 = einsum(t3.aaaaaa, (0, 1, 2, 3, 4, 5), tmp2, (6, 1, 2, 5), (6, 0, 3, 4)) * -1
     del tmp2
-    t2new.aaaa += tmp65.transpose((0, 1, 3, 2)) * -3
-    t2new.aaaa += tmp65.transpose((0, 1, 3, 2)) * -3
-    t2new.aaaa += tmp65.transpose((1, 0, 3, 2)) * 3
-    t2new.aaaa += tmp65.transpose((1, 0, 3, 2)) * 3
+    t2new.aaaa += np.transpose(tmp65, (0, 1, 3, 2)) * -3
+    t2new.aaaa += np.transpose(tmp65, (0, 1, 3, 2)) * -3
+    t2new.aaaa += np.transpose(tmp65, (1, 0, 3, 2)) * 3
+    t2new.aaaa += np.transpose(tmp65, (1, 0, 3, 2)) * 3
     del tmp65
     tmp64 = einsum(tmp1, (0, 1, 2, 3), t3.abaaba, (4, 2, 1, 5, 3, 6), (0, 4, 5, 6))
     del tmp1
-    t2new.aaaa += tmp64.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp64.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp64.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp64.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp64, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp64, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp64, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp64, (1, 0, 3, 2))
     del tmp64
     tmp63 = einsum(tmp62, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
     del tmp62
     t2new.aaaa += tmp63
-    t2new.aaaa += tmp63.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp63.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp63.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp63, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp63, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp63, (1, 0, 3, 2))
     del tmp63
     tmp112 = einsum(tmp111, (0, 1, 2, 3), t1.aa, (4, 2), (4, 0, 1, 3))
     del tmp111
-    t2new.aaaa += tmp112.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp112, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp112
     del tmp112
     tmp116 = einsum(tmp115, (0, 1, 2, 3), t2.aaaa, (3, 2, 4, 5), (1, 0, 4, 5))
     del tmp115
-    t2new.aaaa += tmp116.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp116.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp116, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp116, (0, 1, 3, 2)) * -1
     del tmp116
     tmp52 = einsum(tmp51, (0, 1, 2, 3), t3.abaaba, (4, 0, 5, 6, 3, 1), (4, 5, 6, 2)) * -2
     del tmp51
-    t2new.aaaa += tmp52.transpose((1, 0, 2, 3))
-    t2new.aaaa += tmp52.transpose((1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp52, (1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp52, (1, 0, 3, 2)) * -1
     del tmp52
     tmp67 = einsum(tmp66, (0, 1, 2, 3), t2.aaaa, (3, 2, 4, 5), (0, 1, 4, 5)) * -1
     del tmp66
-    t2new.aaaa += tmp67.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp67.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp67.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp67.transpose((1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp67, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp67, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp67, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp67, (1, 0, 3, 2)) * -1
     del tmp67
     tmp89 = einsum(v.aaaa.ooov, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3))
-    t2new.aaaa += tmp89.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp89, (1, 0, 2, 3))
     t2new.aaaa += tmp89 * -1
-    t2new.aaaa += tmp89.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp89.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp89, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp89, (0, 1, 3, 2))
     del tmp89
-    tmp44 = t2.aaaa.copy()
+    tmp44 = np.copy(t2.aaaa)
     tmp44 += einsum(t1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1)) * 2
     t2new.aaaa += einsum(v.aaaa.oooo, (0, 1, 2, 3), tmp44, (1, 3, 4, 5), (0, 2, 5, 4)) * -0.5
     del tmp44
     tmp108 = einsum(tmp107, (0, 1, 2, 3), t2.aaaa, (2, 3, 4, 5), (1, 0, 4, 5)) * -1
     del tmp107
-    t2new.aaaa += tmp108.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp108.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp108, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp108, (0, 1, 3, 2)) * -1
     del tmp108
     tmp110 = einsum(tmp109, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
     del tmp109
-    t2new.aaaa += tmp110.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp110, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp110
     del tmp110
     tmp33 = einsum(v.aabb.ooov, (0, 1, 2, 3), t3.abaaba, (4, 2, 1, 5, 3, 6), (4, 0, 5, 6))
-    t2new.aaaa += tmp33.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp33.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp33.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp33.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp33, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp33, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp33, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp33, (0, 1, 3, 2))
     del tmp33
     tmp106 = einsum(t2.aaaa, (0, 1, 2, 3), tmp105, (1, 4, 5, 3), (0, 4, 2, 5))
     del tmp105
     t2new.aaaa += tmp106 * -2
-    t2new.aaaa += tmp106.transpose((1, 0, 2, 3)) * 2
+    t2new.aaaa += np.transpose(tmp106, (1, 0, 2, 3)) * 2
     del tmp106
     tmp32 = einsum(t3.aaaaaa, (0, 1, 2, 3, 4, 5), v.aaaa.ooov, (6, 2, 1, 5), (0, 6, 3, 4)) * -1
-    t2new.aaaa += tmp32.transpose((1, 0, 3, 2)) * -3
-    t2new.aaaa += tmp32.transpose((1, 0, 3, 2)) * -3
-    t2new.aaaa += tmp32.transpose((0, 1, 3, 2)) * 3
-    t2new.aaaa += tmp32.transpose((0, 1, 3, 2)) * 3
+    t2new.aaaa += np.transpose(tmp32, (1, 0, 3, 2)) * -3
+    t2new.aaaa += np.transpose(tmp32, (1, 0, 3, 2)) * -3
+    t2new.aaaa += np.transpose(tmp32, (0, 1, 3, 2)) * 3
+    t2new.aaaa += np.transpose(tmp32, (0, 1, 3, 2)) * 3
     del tmp32
     tmp69 = einsum(tmp68, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3))
     del tmp68
-    t2new.aaaa += tmp69.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp69, (0, 1, 3, 2))
     t2new.aaaa += tmp69 * -1
-    t2new.aaaa += tmp69.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp69.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp69, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp69, (1, 0, 2, 3))
     del tmp69
-    tmp61 = f.aa.vv.copy() * -1
-    tmp61 += tmp56.transpose((1, 0)) * -1
+    tmp61 = np.copy(f.aa.vv) * -1
+    tmp61 += np.transpose(tmp56, (1, 0)) * -1
     del tmp56
-    tmp61 += tmp58.transpose((1, 0)) * -1
+    tmp61 += np.transpose(tmp58, (1, 0)) * -1
     del tmp58
-    tmp61 += tmp59.transpose((1, 0))
+    tmp61 += np.transpose(tmp59, (1, 0))
     del tmp59
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp61, (3, 4), (0, 1, 2, 4)) * -2
     del tmp61
@@ -2660,50 +2660,50 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp118
     tmp88 = einsum(tmp87, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp87
-    t2new.aaaa += tmp88.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp88.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp88, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp88, (1, 0, 3, 2))
     del tmp88
     tmp48 = einsum(v.aaaa.ovov, (0, 1, 2, 3), t2.aaaa, (4, 2, 5, 3), (4, 0, 5, 1))
     t2new.aaaa += tmp48 * 2
-    t2new.aaaa += tmp48.transpose((0, 1, 3, 2)) * -2
-    t2new.aaaa += tmp48.transpose((1, 0, 2, 3)) * -2
-    t2new.aaaa += tmp48.transpose((1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp48, (0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp48, (1, 0, 2, 3)) * -2
+    t2new.aaaa += np.transpose(tmp48, (1, 0, 3, 2)) * 2
     del tmp48
     tmp71 = einsum(t2.aaaa, (0, 1, 2, 3), tmp70, (4, 1), (0, 4, 2, 3)) * -2
     del tmp70
-    t2new.aaaa += tmp71.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp71.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp71.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp71.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp71, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp71, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp71, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp71, (0, 1, 3, 2)) * -1
     del tmp71
     tmp86 = einsum(t2.aaaa, (0, 1, 2, 3), tmp85, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp85
-    t2new.aaaa += tmp86.transpose((1, 0, 2, 3)) * 2
+    t2new.aaaa += np.transpose(tmp86, (1, 0, 2, 3)) * 2
     t2new.aaaa += tmp86 * -2
-    t2new.aaaa += tmp86.transpose((1, 0, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp86, (1, 0, 3, 2)) * -2
     del tmp86
-    tmp97 = tmp95.copy()
+    tmp97 = np.copy(tmp95)
     del tmp95
     tmp97 += einsum(tmp96, (0, 1, 2, 3), t2.abab, (4, 0, 5, 3), (4, 1, 5, 2)) * -1
     del tmp96
     t2new.aaaa += einsum(t2.abab, (0, 1, 2, 3), tmp97, (4, 1, 5, 3), (4, 0, 5, 2)) * -1
     del tmp97
-    tmp20 = f.aa.oo.copy()
-    tmp20 += tmp17.transpose((1, 0))
+    tmp20 = np.copy(f.aa.oo)
+    tmp20 += np.transpose(tmp17, (1, 0))
     del tmp17
-    tmp20 += tmp19.transpose((1, 0)) * -1
+    tmp20 += np.transpose(tmp19, (1, 0)) * -1
     del tmp19
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp20, (1, 4), (0, 4, 2, 3)) * -1
     t1new.aa += einsum(t1.aa, (0, 1), tmp20, (0, 2), (2, 1)) * -1
     del tmp20
     tmp114 = einsum(tmp113, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
     del tmp113
-    t2new.aaaa += tmp114.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp114, (1, 0, 2, 3))
     t2new.aaaa += tmp114 * -1
-    t2new.aaaa += tmp114.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp114.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp114, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp114, (0, 1, 3, 2))
     del tmp114
-    tmp94 = v.aaaa.oovv.copy()
+    tmp94 = np.copy(v.aaaa.oovv)
     tmp94 += einsum(t2.aaaa, (0, 1, 2, 3), tmp91, (1, 4, 3, 5), (0, 4, 2, 5)) * -2
     del tmp91
     tmp94 += tmp93 * -1
@@ -2712,9 +2712,9 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp94
     tmp90 = einsum(tmp49, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp49
-    t2new.aaaa += tmp90.transpose((1, 0, 2, 3)) * -2
-    t2new.aaaa += tmp90.transpose((0, 1, 3, 2)) * -2
-    t2new.aaaa += tmp90.transpose((1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp90, (1, 0, 2, 3)) * -2
+    t2new.aaaa += np.transpose(tmp90, (0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp90, (1, 0, 3, 2)) * 2
     t2new.aaaa += tmp90 * 2
     del tmp90
     tmp34 = einsum(t1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 1, 3)) * 2
@@ -2728,16 +2728,16 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp40
     tmp39 = einsum(t2.aaaa, (0, 1, 2, 3), tmp38, (1, 4), (0, 4, 2, 3)) * -1
     del tmp38
-    t2new.aaaa += tmp39.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp39.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp39.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp39, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp39, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp39, (0, 1, 3, 2)) * -1
     del tmp39
     tmp80 = einsum(t2.abab, (0, 1, 2, 3), tmp79, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp79
     t2new.aaaa += tmp80 * -1
-    t2new.aaaa += tmp80.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp80, (0, 1, 3, 2))
     del tmp80
-    tmp100 = v.aaaa.oovv.copy() * 0.5
+    tmp100 = np.copy(v.aaaa.oovv) * 0.5
     tmp100 += einsum(t2.aaaa, (0, 1, 2, 3), tmp98, (1, 4, 3, 5), (0, 4, 2, 5)) * -1
     del tmp98
     tmp100 += einsum(tmp99, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3)) * -0.5
@@ -2745,10 +2745,10 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp100, (4, 1, 5, 3), (0, 4, 5, 2)) * 4
     del tmp100
     tmp35 = einsum(v.aaaa.oooo, (0, 1, 2, 3), t2.aaaa, (1, 3, 4, 5), (0, 2, 4, 5))
-    t2new.aaaa += tmp35.transpose((1, 0, 3, 2)) * 0.5
-    t2new.aaaa += tmp35.transpose((1, 0, 3, 2)) * 0.5
+    t2new.aaaa += np.transpose(tmp35, (1, 0, 3, 2)) * 0.5
+    t2new.aaaa += np.transpose(tmp35, (1, 0, 3, 2)) * 0.5
     del tmp35
-    tmp43 = tmp41.copy()
+    tmp43 = np.copy(tmp41)
     del tmp41
     tmp43 += tmp42 * 0.5
     del tmp42
@@ -2756,8 +2756,8 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp43
     tmp104 = einsum(tmp103, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
     del tmp103
-    t2new.aaaa += tmp104.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp104.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp104, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp104, (1, 0, 3, 2))
     del tmp104
     tmp76 = einsum(tmp74, (0, 1, 2, 3), t1.aa, (4, 1), (4, 0, 3, 2)) * -1
     del tmp74
@@ -2765,32 +2765,32 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     del tmp75
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp76, (4, 1, 5, 3), (0, 4, 5, 2)) * 2
     del tmp76
-    tmp117 = v.aaaa.vvvv.copy()
+    tmp117 = np.copy(v.aaaa.vvvv)
     tmp117 += einsum(t1.aa, (0, 1), tmp54, (0, 2, 3, 4), (2, 4, 3, 1))
     del tmp54
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp117, (2, 4, 3, 5), (0, 1, 4, 5)) * 2
     del tmp117
-    tmp26 = tmp24.transpose((1, 0)).copy() * 0.5
+    tmp26 = np.copy(np.transpose(tmp24, (1, 0))) * 0.5
     del tmp24
-    tmp26 += tmp25.transpose((1, 0))
+    tmp26 += np.transpose(tmp25, (1, 0))
     del tmp25
     tmp26 += einsum(t1.bb, (0, 1), tmp16, (2, 1), (2, 0)) * 0.5
     del tmp16
     t1new.bb += einsum(tmp26, (0, 1), t1.bb, (0, 2), (1, 2)) * -2
     del tmp26
-    tmp23 = t2.bbbb.copy() * 2
+    tmp23 = np.copy(t2.bbbb) * 2
     tmp23 += einsum(t1.bb, (0, 1), t1.bb, (2, 3), (2, 0, 3, 1))
     t1new.bb += einsum(v.bbbb.ovvv, (0, 1, 2, 3), tmp23, (0, 4, 1, 3), (4, 2))
     del tmp23
-    tmp27 = f.bb.vv.copy()
+    tmp27 = np.copy(f.bb.vv)
     tmp27 += einsum(v.bbbb.ovvv, (0, 1, 2, 3), t1.bb, (0, 3), (1, 2)) * -1
     t1new.bb += einsum(t1.bb, (0, 1), tmp27, (1, 2), (0, 2))
     del tmp27
-    tmp4 = t2.aaaa.copy() * 2
+    tmp4 = np.copy(t2.aaaa) * 2
     tmp4 += einsum(t1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
     t1new.aa += einsum(v.aaaa.ovvv, (0, 1, 2, 3), tmp4, (0, 4, 3, 1), (4, 2)) * -1
     del tmp4
-    tmp12 = f.aa.vv.copy()
+    tmp12 = np.copy(f.aa.vv)
     tmp12 += einsum(v.aaaa.ovvv, (0, 1, 2, 3), t1.aa, (0, 1), (2, 3))
     t1new.aa += einsum(tmp12, (0, 1), t1.aa, (2, 0), (2, 1))
     del tmp12
@@ -2810,16 +2810,16 @@ def update_amps(f=None, t1=None, t2=None, t3=None, v=None, **kwargs):
     t1new.bb += einsum(v.aaaa.ovov, (0, 1, 2, 3), t3.abaaba, (0, 4, 2, 1, 5, 3), (4, 5))
     t1new.bb += einsum(t1.bb, (0, 1), v.bbbb.oovv, (2, 0, 3, 1), (2, 3)) * -1
     t1new.bb += einsum(v.bbbb.ovov, (0, 1, 2, 3), t3.bbbbbb, (4, 0, 2, 5, 3, 1), (4, 5)) * -3
-    t2new.aaaa += v.aaaa.ovov.transpose((0, 2, 1, 3))
-    t2new.aaaa += v.aaaa.ovov.transpose((0, 2, 3, 1)) * -1
+    t2new.aaaa += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
+    t2new.aaaa += np.transpose(v.aaaa.ovov, (0, 2, 3, 1)) * -1
     t2new.abab += einsum(t3.abaaba, (0, 1, 2, 3, 4, 5), v.aabb.ovoo, (2, 5, 6, 1), (0, 6, 3, 4)) * -2
     t2new.abab += einsum(t3.abaaba, (0, 1, 2, 3, 4, 5), v.aaaa.ooov, (6, 0, 2, 5), (6, 1, 3, 4)) * -2
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), v.aabb.oooo, (4, 0, 5, 1), (4, 5, 2, 3)) * 0.5
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), v.aaaa.ovov, (4, 5, 0, 2), (4, 1, 5, 3))
-    t2new.abab += v.aabb.ovov.transpose((0, 2, 1, 3))
+    t2new.abab += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     t2new.abab += einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.abab, (4, 2, 5, 3), (4, 0, 5, 1))
-    t2new.bbbb += v.bbbb.ovov.transpose((0, 2, 1, 3))
-    t2new.bbbb += v.bbbb.ovov.transpose((0, 2, 3, 1)) * -1
+    t2new.bbbb += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
+    t2new.bbbb += np.transpose(v.bbbb.ovov, (0, 2, 3, 1)) * -1
     t3new.abaaba += einsum(f.aa.vv, (0, 1), t3.abaaba, (2, 3, 4, 5, 6, 1), (2, 3, 4, 5, 6, 0)) * 2
     t3new.abaaba += einsum(v.aabb.vvov, (0, 1, 2, 3), t2.aaaa, (4, 5, 6, 1), (4, 2, 5, 0, 3, 6)) * -2
     t3new.babbab += einsum(f.bb.vv, (0, 1), t3.babbab, (2, 3, 4, 5, 6, 1), (2, 3, 4, 5, 6, 0)) * 2

--- a/ebcc/codegen/UCCD.py
+++ b/ebcc/codegen/UCCD.py
@@ -59,10 +59,10 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     """
 
     t2new = Namespace()
-    tmp13 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp13 += v.bbbb.ovov.transpose((0, 2, 1, 3))
-    tmp9 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp9 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp13 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1))) * -1
+    tmp13 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
+    tmp9 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1))) * -1
+    tmp9 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp35 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (0, 2, 4, 3), (1, 4))
     tmp36 = einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.ovov, (4, 3, 1, 2), (0, 4)) * -1
     tmp45 = einsum(t2.bbbb, (0, 1, 2, 3), tmp13, (1, 4, 3, 5), (0, 4, 2, 5))
@@ -75,28 +75,28 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp48 = einsum(tmp9, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5))
     del tmp9
     tmp51 = einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.ovov, (4, 2, 5, 3), (0, 1, 4, 5))
-    tmp37 = tmp35.copy()
+    tmp37 = np.copy(tmp35)
     del tmp35
     tmp37 += tmp36 * 2
     del tmp36
-    tmp46 = v.bbbb.oovv.copy()
+    tmp46 = np.copy(v.bbbb.oovv)
     tmp46 += tmp45 * -2
     del tmp45
     tmp32 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 1), (4, 2, 5, 3))
     tmp14 = einsum(tmp13, (0, 1, 2, 3), t2.abab, (4, 0, 5, 3), (4, 1, 5, 2))
     del tmp13
-    tmp30 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp30 += v.aaaa.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp30 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1)))
+    tmp30 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3)) * -1
     tmp6 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (4, 2, 5, 3), (4, 0, 5, 1))
     tmp3 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (0, 2, 4, 3), (4, 1))
     tmp2 = einsum(v.aaaa.ovov, (0, 1, 2, 3), t2.aaaa, (0, 2, 4, 3), (4, 1))
-    tmp21 = tmp19.copy()
+    tmp21 = np.copy(tmp19)
     tmp21 += tmp20 * 0.5
     tmp17 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 3, 5, 2), (0, 1, 4, 5)) * -1
-    tmp11 = v.aaaa.oovv.copy()
+    tmp11 = np.copy(v.aaaa.oovv)
     tmp11 += tmp10 * -2
     del tmp10
-    tmp43 = f.bb.vv.copy() * -1
+    tmp43 = np.copy(f.bb.vv) * -1
     tmp43 += tmp24
     tmp43 += tmp25 * 2
     tmp50 = einsum(v.bbbb.oovv, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (4, 0, 5, 2))
@@ -112,24 +112,24 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp47 = einsum(tmp46, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp46
     tmp40 = einsum(f.bb.oo, (0, 1), t2.bbbb, (2, 1, 3, 4), (0, 2, 3, 4))
-    tmp26 = tmp24.copy() * 0.5
+    tmp26 = np.copy(tmp24) * 0.5
     del tmp24
     tmp26 += tmp25
     del tmp25
-    tmp33 = tmp32.copy() * 2
+    tmp33 = np.copy(tmp32) * 2
     tmp33 += tmp14 * -1
-    tmp31 = v.aaaa.oovv.copy()
-    tmp31 += tmp6.transpose((1, 0, 3, 2)) * -1
+    tmp31 = np.copy(v.aaaa.oovv)
+    tmp31 += np.transpose(tmp6, (1, 0, 3, 2)) * -1
     tmp31 += einsum(tmp30, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 2), (1, 4, 3, 5)) * 2
     del tmp30
-    tmp29 = v.aabb.vvoo.transpose((2, 3, 0, 1)).copy()
+    tmp29 = np.copy(np.transpose(v.aabb.vvoo, (2, 3, 0, 1)))
     tmp29 += einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (0, 4, 5, 3), (2, 4, 1, 5)) * -1
     tmp34 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (4, 5, 1, 3), (4, 0, 5, 2))
     tmp23 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.oooo, (4, 0, 5, 1), (4, 5, 2, 3))
-    tmp28 = f.aa.vv.copy() * -1
-    tmp28 += tmp2.transpose((1, 0)) * 2
-    tmp28 += tmp3.transpose((1, 0))
-    tmp38 = tmp19.copy() * 2
+    tmp28 = np.copy(f.aa.vv) * -1
+    tmp28 += np.transpose(tmp2, (1, 0)) * 2
+    tmp28 += np.transpose(tmp3, (1, 0))
+    tmp38 = np.copy(tmp19) * 2
     del tmp19
     tmp38 += tmp20
     del tmp20
@@ -142,10 +142,10 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     del tmp17
     tmp1 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.oooo, (4, 1, 5, 0), (4, 5, 2, 3)) * -1
     tmp0 = einsum(t2.aaaa, (0, 1, 2, 3), f.aa.oo, (4, 1), (4, 0, 2, 3))
-    tmp7 = f.aa.vv.copy() * -1
+    tmp7 = np.copy(f.aa.vv) * -1
     tmp7 += tmp2 * 2
     tmp7 += tmp3
-    tmp4 = tmp2.copy()
+    tmp4 = np.copy(tmp2)
     del tmp2
     tmp4 += tmp3 * 0.5
     del tmp3
@@ -153,31 +153,31 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp16 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.oovv, (4, 1, 5, 3), (0, 4, 2, 5))
     tmp12 = einsum(tmp11, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp11
-    t2new.bbbb = tmp39.transpose((1, 0, 3, 2)).copy() * 2
+    t2new.bbbb = np.copy(np.transpose(tmp39, (1, 0, 3, 2))) * 2
     del tmp39
-    t2new.bbbb += tmp40.transpose((1, 0, 3, 2)) * 2
-    t2new.bbbb += tmp40.transpose((0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp40, (1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp40, (0, 1, 3, 2)) * -2
     del tmp40
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), tmp26, (4, 3), (0, 1, 2, 4)) * -4
-    t2new.bbbb += tmp41.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp42.transpose((1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp41, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp42, (1, 0, 3, 2)) * 2
     t2new.bbbb += einsum(tmp43, (0, 1), t2.bbbb, (2, 3, 4, 1), (2, 3, 0, 4)) * 2
     del tmp43
-    t2new.bbbb += tmp41.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp42.transpose((1, 0, 2, 3)) * -2
+    t2new.bbbb += np.transpose(tmp41, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp42, (1, 0, 2, 3)) * -2
     t2new.bbbb += einsum(f.bb.vv, (0, 1), t2.bbbb, (2, 3, 4, 1), (2, 3, 4, 0)) * 2
-    t2new.bbbb += v.bbbb.ovov.transpose((0, 2, 1, 3))
-    t2new.bbbb += v.bbbb.ovov.transpose((0, 2, 3, 1)) * -1
-    t2new.bbbb += tmp41.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp42.transpose((0, 1, 3, 2)) * -2
-    t2new.bbbb += tmp44.transpose((0, 1, 3, 2)) * -2
-    t2new.bbbb += tmp44.transpose((1, 0, 2, 3)) * -2
-    t2new.bbbb += tmp47.transpose((0, 1, 3, 2)) * 2
-    t2new.bbbb += tmp49.transpose((1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
+    t2new.bbbb += np.transpose(v.bbbb.ovov, (0, 2, 3, 1)) * -1
+    t2new.bbbb += np.transpose(tmp41, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp42, (0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp44, (0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp44, (1, 0, 2, 3)) * -2
+    t2new.bbbb += np.transpose(tmp47, (0, 1, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp49, (1, 0, 2, 3)) * -1
     t2new.bbbb += tmp44 * 2
-    t2new.bbbb += tmp44.transpose((1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp44, (1, 0, 3, 2)) * 2
     del tmp44
-    t2new.bbbb += tmp47.transpose((1, 0, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp47, (1, 0, 3, 2)) * -2
     del tmp47
     t2new.bbbb += tmp49
     del tmp49
@@ -186,15 +186,15 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     t2new.bbbb += tmp42 * 2
     del tmp42
     t2new.bbbb += tmp50 * -2
-    t2new.bbbb += tmp50.transpose((1, 0, 2, 3)) * 2
+    t2new.bbbb += np.transpose(tmp50, (1, 0, 2, 3)) * 2
     del tmp50
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.vvvv, (4, 3, 5, 2), (0, 1, 4, 5)) * -2
-    t2new.bbbb += tmp52.transpose((0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp52, (0, 1, 3, 2)) * -2
     del tmp52
-    t2new.bbbb += tmp53.transpose((0, 1, 3, 2)) * -2
-    t2new.bbbb += tmp53.transpose((1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp53, (0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp53, (1, 0, 3, 2)) * 2
     del tmp53
-    t2new.abab = tmp23.copy()
+    t2new.abab = np.copy(tmp23)
     del tmp23
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), f.bb.oo, (4, 1), (0, 4, 2, 3)) * -1
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), f.aa.oo, (4, 0), (4, 1, 2, 3)) * -1
@@ -206,7 +206,7 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     t2new.abab += einsum(tmp28, (0, 1), t2.abab, (2, 3, 0, 4), (2, 3, 1, 4)) * -1
     del tmp28
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), f.bb.vv, (4, 3), (0, 1, 2, 4))
-    t2new.abab += v.aabb.ovov.transpose((0, 2, 1, 3))
+    t2new.abab += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     t2new.abab += einsum(tmp29, (0, 1, 2, 3), t2.abab, (4, 0, 2, 5), (4, 1, 3, 5)) * -1
     del tmp29
     t2new.abab += einsum(tmp31, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5)) * -1
@@ -225,47 +225,47 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     del tmp37
     t2new.abab += einsum(tmp38, (0, 1), t2.abab, (1, 2, 3, 4), (0, 2, 3, 4)) * -1
     del tmp38
-    t2new.aaaa = tmp0.transpose((1, 0, 3, 2)).copy() * 2
-    t2new.aaaa += tmp1.transpose((1, 0, 3, 2)) * 2
+    t2new.aaaa = np.copy(np.transpose(tmp0, (1, 0, 3, 2))) * 2
+    t2new.aaaa += np.transpose(tmp1, (1, 0, 3, 2)) * 2
     del tmp1
-    t2new.aaaa += tmp0.transpose((0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp0, (0, 1, 3, 2)) * -2
     del tmp0
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp4, (4, 3), (0, 1, 2, 4)) * -4
     del tmp4
-    t2new.aaaa += tmp5.transpose((1, 0, 3, 2)) * 2
-    t2new.aaaa += tmp6.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp5, (1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp6, (1, 0, 3, 2))
     t2new.aaaa += einsum(tmp7, (0, 1), t2.aaaa, (2, 3, 4, 1), (2, 3, 0, 4)) * 2
     del tmp7
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), f.aa.vv, (4, 3), (0, 1, 2, 4)) * 2
-    t2new.aaaa += tmp5.transpose((1, 0, 2, 3)) * -2
-    t2new.aaaa += tmp6.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += v.aaaa.ovov.transpose((0, 2, 1, 3))
-    t2new.aaaa += v.aaaa.ovov.transpose((0, 2, 3, 1)) * -1
-    t2new.aaaa += tmp5.transpose((0, 1, 3, 2)) * -2
-    t2new.aaaa += tmp6.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp8.transpose((0, 1, 3, 2)) * -2
-    t2new.aaaa += tmp8.transpose((1, 0, 2, 3)) * -2
-    t2new.aaaa += tmp12.transpose((0, 1, 3, 2)) * 2
-    t2new.aaaa += tmp15.transpose((1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp5, (1, 0, 2, 3)) * -2
+    t2new.aaaa += np.transpose(tmp6, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
+    t2new.aaaa += np.transpose(v.aaaa.ovov, (0, 2, 3, 1)) * -1
+    t2new.aaaa += np.transpose(tmp5, (0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp6, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp8, (0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp8, (1, 0, 2, 3)) * -2
+    t2new.aaaa += np.transpose(tmp12, (0, 1, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp15, (1, 0, 2, 3)) * -1
     t2new.aaaa += tmp8 * 2
-    t2new.aaaa += tmp8.transpose((1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp8, (1, 0, 3, 2)) * 2
     del tmp8
-    t2new.aaaa += tmp12.transpose((1, 0, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp12, (1, 0, 3, 2)) * -2
     del tmp12
-    t2new.aaaa += tmp15.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp15, (1, 0, 3, 2))
     del tmp15
     t2new.aaaa += tmp5 * 2
     del tmp5
     t2new.aaaa += tmp6
     del tmp6
     t2new.aaaa += tmp16 * -2
-    t2new.aaaa += tmp16.transpose((1, 0, 2, 3)) * 2
+    t2new.aaaa += np.transpose(tmp16, (1, 0, 2, 3)) * 2
     del tmp16
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.vvvv, (4, 2, 5, 3), (0, 1, 4, 5)) * 2
-    t2new.aaaa += tmp18.transpose((0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp18, (0, 1, 3, 2)) * -2
     del tmp18
-    t2new.aaaa += tmp22.transpose((1, 0, 3, 2)) * -2
-    t2new.aaaa += tmp22.transpose((0, 1, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp22, (1, 0, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp22, (0, 1, 3, 2)) * 2
     del tmp22
 
     return {f"t2new": t2new}
@@ -318,74 +318,74 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp28 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (4, 3, 5, 1), (5, 0, 4, 2))
     tmp4 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 5, 1, 3), (0, 4, 2, 5))
     tmp5 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (4, 2, 5, 3), (4, 0, 5, 1))
-    tmp39 = tmp37.copy()
+    tmp39 = np.copy(tmp37)
     del tmp37
     tmp39 += tmp38 * 2
     del tmp38
-    tmp53 = v.bbbb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp53 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 1, 3)))
     tmp53 += v.bbbb.oovv * -1
     tmp53 += tmp51
     tmp53 += tmp52 * 2
-    tmp66 = v.bbbb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp66 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 1, 3)))
     tmp66 += v.bbbb.oovv * -1
     tmp66 += tmp51
     del tmp51
     tmp66 += tmp52 * 2
     del tmp52
-    tmp69 = f.bb.oo.copy()
+    tmp69 = np.copy(f.bb.oo)
     tmp69 += tmp40
     tmp69 += tmp41 * 2
-    tmp56 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp56 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp56 += tmp54 * 2
     del tmp54
     tmp56 += tmp55
     del tmp55
     tmp72 = einsum(l2.bbbb, (0, 1, 2, 3), t2.bbbb, (4, 5, 0, 1), (2, 3, 4, 5))
-    tmp49 = f.bb.vv.copy() * -1
+    tmp49 = np.copy(f.bb.vv) * -1
     tmp49 += tmp47
     del tmp47
     tmp49 += tmp48 * 2
     del tmp48
-    tmp61 = tmp59.copy() * 0.5
+    tmp61 = np.copy(tmp59) * 0.5
     tmp61 += tmp60
-    tmp80 = tmp78.copy()
+    tmp80 = np.copy(tmp78)
     del tmp78
     tmp80 += tmp79 * 4
     del tmp79
-    tmp82 = tmp59.copy()
+    tmp82 = np.copy(tmp59)
     del tmp59
     tmp82 += tmp60 * 2
     del tmp60
     tmp43 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 3, 4, 5), (4, 0, 5, 1))
     tmp11 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 3, 1, 2), (0, 4)) * -1
     tmp12 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (4, 2, 1, 3), (4, 0))
-    tmp2 = tmp0.copy()
+    tmp2 = np.copy(tmp0)
     tmp2 += tmp1 * 0.5
-    tmp9 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp9 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp9 += tmp7
     del tmp7
     tmp9 += tmp8 * 2
     del tmp8
-    tmp35 = tmp31.copy() * 2
+    tmp35 = np.copy(tmp31) * 2
     tmp35 += tmp32
     tmp17 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (2, 3, 4, 5), (4, 5, 0, 1))
-    tmp21 = f.aa.vv.copy() * -1
+    tmp21 = np.copy(f.aa.vv) * -1
     tmp21 += tmp19 * 2
     tmp21 += tmp20
-    tmp29 = tmp27.copy() * 4
+    tmp29 = np.copy(tmp27) * 4
     del tmp27
     tmp29 += tmp28
     del tmp28
-    tmp33 = tmp31.copy()
+    tmp33 = np.copy(tmp31)
     del tmp31
     tmp33 += tmp32 * 0.5
     del tmp32
-    tmp25 = v.aaaa.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp25 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 1, 3)))
     tmp25 += v.aaaa.oovv * -1
     tmp25 += tmp4 * 2
     tmp25 += tmp5
     tmp76 = einsum(v.bbbb.ovov, (0, 1, 2, 3), tmp39, (4, 3), (0, 2, 4, 1))
-    tmp75 = v.bbbb.oooo.copy()
+    tmp75 = np.copy(v.bbbb.oooo)
     tmp75 += einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.ovov, (4, 3, 5, 2), (0, 4, 5, 1)) * -1
     tmp77 = einsum(tmp53, (0, 1, 2, 3), l2.bbbb, (4, 2, 5, 0), (5, 1, 4, 3))
     tmp67 = einsum(tmp66, (0, 1, 2, 3), l2.bbbb, (4, 2, 5, 0), (5, 1, 4, 3)) * 2
@@ -406,30 +406,30 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp57 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (0, 4, 5, 3), (1, 5, 2, 4))
     tmp44 = einsum(tmp43, (0, 1, 2, 3), v.aabb.ovov, (1, 4, 3, 5), (0, 2, 4, 5))
     del tmp43
-    tmp46 = f.aa.vv.copy() * -0.5
+    tmp46 = np.copy(f.aa.vv) * -0.5
     tmp46 += tmp19
     del tmp19
     tmp46 += tmp20 * 0.5
     del tmp20
-    tmp13 = f.aa.oo.copy() * 0.5
+    tmp13 = np.copy(f.aa.oo) * 0.5
     tmp13 += tmp11
     tmp13 += tmp12 * 0.5
-    tmp14 = v.aaaa.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp14 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 1, 3)))
     tmp14 += v.aaaa.oovv * -1
     tmp14 += tmp4 * 2
     tmp14 += tmp5
-    tmp50 = v.aabb.oooo.copy()
+    tmp50 = np.copy(v.aabb.oooo)
     tmp50 += einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (4, 5, 1, 3), (4, 0, 5, 2))
     tmp63 = einsum(l2.abab, (0, 1, 2, 3), t2.aaaa, (4, 2, 5, 0), (4, 3, 5, 1))
     tmp63 += einsum(l2.bbbb, (0, 1, 2, 3), t2.abab, (4, 3, 5, 1), (4, 2, 5, 0))
-    tmp42 = f.bb.oo.copy() * 0.5
+    tmp42 = np.copy(f.bb.oo) * 0.5
     tmp42 += tmp40 * 0.5
     del tmp40
     tmp42 += tmp41
     del tmp41
     tmp64 = einsum(l2.aaaa, (0, 1, 2, 3), t2.abab, (3, 4, 1, 5), (2, 4, 0, 5))
     tmp64 += einsum(t2.bbbb, (0, 1, 2, 3), l2.abab, (4, 3, 5, 1), (5, 0, 4, 2))
-    tmp62 = tmp0.copy() * 2
+    tmp62 = np.copy(tmp0) * 2
     del tmp0
     tmp62 += tmp1
     del tmp1
@@ -437,7 +437,7 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp58 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (4, 2, 1, 5), (4, 0, 5, 3))
     tmp24 = einsum(tmp2, (0, 1), v.aaaa.ovov, (2, 3, 4, 1), (2, 4, 3, 0)) * 2
     tmp10 = einsum(l2.abab, (0, 1, 2, 3), tmp9, (4, 3, 5, 1), (4, 2, 5, 0))
-    tmp15 = f.aa.oo.copy()
+    tmp15 = np.copy(f.aa.oo)
     tmp15 += tmp11 * 2
     del tmp11
     tmp15 += tmp12
@@ -449,7 +449,7 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     del tmp21
     tmp30 = einsum(tmp29, (0, 1, 2, 3), v.aaaa.ovov, (4, 3, 1, 5), (4, 0, 5, 2))
     del tmp29
-    tmp6 = v.aaaa.ovov.transpose((0, 2, 1, 3)).copy() * 0.5
+    tmp6 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 1, 3))) * 0.5
     tmp6 += v.aaaa.oovv * -0.5
     tmp6 += tmp4
     del tmp4
@@ -462,51 +462,51 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp16 = einsum(v.aaaa.vvvv, (0, 1, 2, 3), l2.aaaa, (3, 1, 4, 5), (4, 5, 0, 2)) * -1
     tmp26 = einsum(l2.aaaa, (0, 1, 2, 3), tmp25, (3, 4, 1, 5), (4, 2, 5, 0))
     del tmp25
-    tmp23 = v.aaaa.oooo.copy()
+    tmp23 = np.copy(v.aaaa.oooo)
     tmp23 += einsum(v.aaaa.ovov, (0, 1, 2, 3), t2.aaaa, (4, 5, 1, 3), (4, 0, 2, 5))
-    l2new.bbbb = v.bbbb.ovov.transpose((1, 3, 0, 2)).copy()
-    l2new.bbbb += tmp65.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += v.bbbb.ovov.transpose((3, 1, 0, 2)) * -1
-    l2new.bbbb += tmp65.transpose((2, 3, 1, 0))
+    l2new.bbbb = np.copy(np.transpose(v.bbbb.ovov, (1, 3, 0, 2)))
+    l2new.bbbb += np.transpose(tmp65, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(v.bbbb.ovov, (3, 1, 0, 2)) * -1
+    l2new.bbbb += np.transpose(tmp65, (2, 3, 1, 0))
     del tmp65
-    l2new.bbbb += tmp67.transpose((3, 2, 0, 1)) * -1
-    l2new.bbbb += tmp68.transpose((2, 3, 1, 0)) * -1
-    l2new.bbbb += tmp70.transpose((3, 2, 0, 1)) * -1
-    l2new.bbbb += tmp67.transpose((3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp67, (3, 2, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp68, (2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp70, (3, 2, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp67, (3, 2, 1, 0))
     del tmp67
-    l2new.bbbb += tmp68.transpose((2, 3, 0, 1))
-    l2new.bbbb += tmp70.transpose((3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp68, (2, 3, 0, 1))
+    l2new.bbbb += np.transpose(tmp70, (3, 2, 1, 0))
     del tmp70
-    l2new.bbbb += tmp71.transpose((3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp71, (3, 2, 1, 0)) * 2
     del tmp71
-    l2new.bbbb += tmp73.transpose((3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp73, (3, 2, 1, 0)) * 2
     del tmp73
-    l2new.bbbb += tmp74.transpose((3, 2, 1, 0)) * 2
-    l2new.bbbb += tmp74.transpose((2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp74, (3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp74, (2, 3, 1, 0)) * -2
     del tmp74
     l2new.bbbb += einsum(l2.bbbb, (0, 1, 2, 3), tmp75, (2, 4, 5, 3), (0, 1, 5, 4)) * -2
     del tmp75
-    l2new.bbbb += tmp76.transpose((3, 2, 1, 0))
-    l2new.bbbb += tmp77.transpose((2, 3, 0, 1)) * 2
-    l2new.bbbb += tmp68.transpose((3, 2, 1, 0))
-    l2new.bbbb += tmp77.transpose((2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp76, (3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp77, (2, 3, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp68, (3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp77, (2, 3, 1, 0)) * -2
     del tmp77
-    l2new.bbbb += tmp68.transpose((3, 2, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp68, (3, 2, 0, 1)) * -1
     del tmp68
-    l2new.bbbb += tmp81.transpose((3, 2, 0, 1))
-    l2new.bbbb += tmp83.transpose((2, 3, 0, 1)) * -1
-    l2new.bbbb += tmp81.transpose((2, 3, 0, 1)) * -1
-    l2new.bbbb += tmp83.transpose((3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp81, (3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp83, (2, 3, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp81, (2, 3, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp83, (3, 2, 0, 1))
     del tmp83
-    l2new.bbbb += tmp81.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += tmp84.transpose((2, 3, 1, 0))
-    l2new.bbbb += tmp81.transpose((2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp81, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp84, (2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp81, (2, 3, 1, 0))
     del tmp81
-    l2new.bbbb += tmp84.transpose((3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp84, (3, 2, 1, 0)) * -1
     del tmp84
-    l2new.bbbb += tmp76.transpose((2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp76, (2, 3, 1, 0)) * -1
     del tmp76
-    l2new.abab = v.aabb.ovov.transpose((1, 3, 0, 2)).copy()
+    l2new.abab = np.copy(np.transpose(v.aabb.ovov, (1, 3, 0, 2)))
     l2new.abab += einsum(tmp39, (0, 1), v.aabb.ovov, (2, 3, 4, 1), (3, 0, 2, 4)) * -1
     del tmp39
     l2new.abab += einsum(v.aabb.vvoo, (0, 1, 2, 3), l2.abab, (1, 4, 5, 3), (0, 4, 5, 2)) * -1
@@ -516,9 +516,9 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     l2new.abab += einsum(l2.bbbb, (0, 1, 2, 3), tmp9, (4, 3, 5, 1), (5, 0, 4, 2)) * 2
     del tmp9
     l2new.abab += einsum(tmp13, (0, 1), l2.abab, (2, 3, 0, 4), (2, 3, 1, 4)) * -2
-    l2new.abab += tmp44.transpose((2, 3, 0, 1))
+    l2new.abab += np.transpose(tmp44, (2, 3, 0, 1))
     del tmp44
-    l2new.abab += tmp45.transpose((2, 3, 0, 1))
+    l2new.abab += np.transpose(tmp45, (2, 3, 0, 1))
     del tmp45
     l2new.abab += einsum(l2.abab, (0, 1, 2, 3), tmp46, (0, 4), (4, 1, 2, 3)) * -2
     del tmp46
@@ -545,49 +545,49 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     del tmp63
     l2new.abab += einsum(v.bbbb.ovov, (0, 1, 2, 3), tmp64, (4, 2, 5, 1), (5, 3, 4, 0)) * -2
     del tmp64
-    l2new.aaaa = v.aaaa.ovov.transpose((1, 3, 0, 2)).copy()
-    l2new.aaaa += tmp3.transpose((2, 3, 1, 0)) * -1
-    l2new.aaaa += v.aaaa.ovov.transpose((3, 1, 0, 2)) * -1
-    l2new.aaaa += tmp3.transpose((3, 2, 1, 0))
+    l2new.aaaa = np.copy(np.transpose(v.aaaa.ovov, (1, 3, 0, 2)))
+    l2new.aaaa += np.transpose(tmp3, (2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(v.aaaa.ovov, (3, 1, 0, 2)) * -1
+    l2new.aaaa += np.transpose(tmp3, (3, 2, 1, 0))
     del tmp3
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp6, (3, 4, 1, 5), (5, 0, 2, 4)) * -4
     del tmp6
-    l2new.aaaa += tmp10.transpose((2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp10, (2, 3, 1, 0)) * -1
     l2new.aaaa += einsum(tmp13, (0, 1), l2.aaaa, (2, 3, 4, 0), (2, 3, 4, 1)) * -4
     del tmp13
     l2new.aaaa += einsum(tmp14, (0, 1, 2, 3), l2.aaaa, (4, 2, 5, 0), (3, 4, 1, 5)) * 2
     del tmp14
-    l2new.aaaa += tmp10.transpose((2, 3, 0, 1))
+    l2new.aaaa += np.transpose(tmp10, (2, 3, 0, 1))
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp15, (3, 4), (0, 1, 4, 2)) * 2
     del tmp15
-    l2new.aaaa += tmp16.transpose((3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp16, (3, 2, 1, 0)) * 2
     del tmp16
-    l2new.aaaa += tmp18.transpose((3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp18, (3, 2, 1, 0)) * 2
     del tmp18
-    l2new.aaaa += tmp22.transpose((2, 3, 1, 0)) * 2
-    l2new.aaaa += tmp22.transpose((3, 2, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp22, (2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp22, (3, 2, 1, 0)) * -2
     del tmp22
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp23, (2, 4, 5, 3), (0, 1, 5, 4)) * -2
     del tmp23
-    l2new.aaaa += tmp24.transpose((2, 3, 1, 0))
-    l2new.aaaa += tmp26.transpose((3, 2, 1, 0)) * 2
-    l2new.aaaa += tmp10.transpose((3, 2, 1, 0))
-    l2new.aaaa += tmp26.transpose((3, 2, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp24, (2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp26, (3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp10, (3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp26, (3, 2, 0, 1)) * -2
     del tmp26
-    l2new.aaaa += tmp10.transpose((3, 2, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp10, (3, 2, 0, 1)) * -1
     del tmp10
-    l2new.aaaa += tmp30.transpose((2, 3, 1, 0))
-    l2new.aaaa += tmp34.transpose((2, 3, 1, 0)) * -1
-    l2new.aaaa += tmp30.transpose((3, 2, 1, 0)) * -1
-    l2new.aaaa += tmp34.transpose((3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp30, (2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp34, (2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp30, (3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp34, (3, 2, 1, 0))
     del tmp34
-    l2new.aaaa += tmp30.transpose((2, 3, 0, 1)) * -1
-    l2new.aaaa += tmp36.transpose((2, 3, 0, 1))
-    l2new.aaaa += tmp30.transpose((3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp30, (2, 3, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp36, (2, 3, 0, 1))
+    l2new.aaaa += np.transpose(tmp30, (3, 2, 0, 1))
     del tmp30
-    l2new.aaaa += tmp36.transpose((3, 2, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp36, (3, 2, 0, 1)) * -1
     del tmp36
-    l2new.aaaa += tmp24.transpose((3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp24, (3, 2, 1, 0)) * -1
     del tmp24
 
     return {f"l2new": l2new}
@@ -623,7 +623,7 @@ def make_rdm1_f(l2=None, t2=None, **kwargs):
     rdm1.bb.oo = einsum(l2.bbbb, (0, 1, 2, 3), t2.bbbb, (4, 3, 0, 1), (4, 2)) * -2
     rdm1.bb.oo += delta.bb.oo
     rdm1.bb.oo += einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 4, 0, 1), (4, 3)) * -1
-    rdm1.aa.oo = delta.aa.oo.copy()
+    rdm1.aa.oo = np.copy(delta.aa.oo)
     del delta
     rdm1.aa.oo += einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 3, 4, 1), (0, 4)) * -1
     rdm1.aa.oo += einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (4, 3, 0, 1), (4, 2)) * -2
@@ -672,27 +672,27 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     tmp36 = einsum(t2.bbbb, (0, 1, 2, 3), l2.bbbb, (4, 3, 5, 1), (5, 0, 4, 2))
     tmp38 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 4, 0, 5), (3, 4, 1, 5))
     tmp34 = einsum(l2.aaaa, (0, 1, 2, 3), t2.abab, (3, 4, 1, 5), (2, 4, 0, 5))
-    tmp10 = tmp5.copy()
+    tmp10 = np.copy(tmp5)
     tmp10 += tmp6 * 2
     tmp11 = einsum(l2.bbbb, (0, 1, 2, 3), t2.bbbb, (4, 5, 0, 1), (2, 3, 4, 5))
     tmp21 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (4, 3, 5, 1), (5, 0, 4, 2))
     tmp19 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (4, 3, 5, 1), (5, 0, 4, 2))
     tmp29 = einsum(l2.abab, (0, 1, 2, 3), t2.aaaa, (4, 2, 5, 0), (4, 3, 5, 1))
     tmp17 = einsum(l2.bbbb, (0, 1, 2, 3), t2.abab, (4, 3, 5, 1), (4, 2, 5, 0))
-    tmp3 = tmp0.copy()
+    tmp3 = np.copy(tmp0)
     tmp3 += tmp1 * 0.5
     tmp4 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (2, 3, 4, 5), (4, 5, 0, 1))
     tmp42 = einsum(l2.bbbb, (0, 1, 2, 3), t2.bbbb, (2, 3, 4, 5), (0, 1, 4, 5))
     tmp41 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (4, 5, 0, 1), (4, 5, 2, 3))
-    tmp40 = tmp24.copy()
+    tmp40 = np.copy(tmp24)
     tmp40 += tmp25 * 2
-    tmp23 = tmp12.copy()
+    tmp23 = np.copy(tmp12)
     tmp23 += tmp13 * 0.5
-    tmp26 = tmp24.copy() * 0.5
+    tmp26 = np.copy(tmp24) * 0.5
     del tmp24
     tmp26 += tmp25
     del tmp25
-    tmp14 = tmp12.copy() * 2
+    tmp14 = np.copy(tmp12) * 2
     del tmp12
     tmp14 += tmp13
     del tmp13
@@ -703,98 +703,98 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     tmp32 = einsum(t2.bbbb, (0, 1, 2, 3), tmp10, (1, 4), (0, 4, 2, 3)) * -1
     tmp33 = einsum(tmp11, (0, 1, 2, 3), t2.bbbb, (1, 0, 4, 5), (3, 2, 4, 5))
     tmp8 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 3, 4, 5), (4, 0, 5, 1))
-    tmp31 = tmp19.copy() * 4
+    tmp31 = np.copy(tmp19) * 4
     tmp31 += tmp21
-    tmp30 = tmp29.copy()
+    tmp30 = np.copy(tmp29)
     tmp30 += tmp17
-    tmp27 = tmp0.copy() * 2
+    tmp27 = np.copy(tmp0) * 2
     tmp27 += tmp1
     tmp20 = einsum(t2.aaaa, (0, 1, 2, 3), tmp19, (1, 4, 3, 5), (4, 0, 5, 2))
     tmp15 = einsum(tmp3, (0, 1), t2.aaaa, (2, 0, 3, 4), (2, 1, 3, 4)) * -2
     tmp18 = einsum(t2.abab, (0, 1, 2, 3), tmp17, (4, 1, 5, 3), (4, 0, 5, 2))
     tmp22 = einsum(tmp21, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 2), (4, 1, 5, 3))
     tmp16 = einsum(t2.aaaa, (0, 1, 2, 3), tmp4, (1, 0, 4, 5), (5, 4, 2, 3))
-    tmp9 = delta.bb.oo.copy() * -0.5
+    tmp9 = np.copy(delta.bb.oo) * -0.5
     tmp9 += tmp5 * 0.5
     tmp9 += tmp6
-    tmp7 = delta.bb.oo.copy() * -1
+    tmp7 = np.copy(delta.bb.oo) * -1
     tmp7 += tmp5
     del tmp5
     tmp7 += tmp6 * 2
     del tmp6
-    tmp2 = delta.aa.oo.copy() * -1
+    tmp2 = np.copy(delta.aa.oo) * -1
     tmp2 += tmp0 * 2
     del tmp0
     tmp2 += tmp1
     del tmp1
-    rdm2.bbbb.vvvv = tmp42.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.bbbb.vvvv = np.copy(np.transpose(tmp42, (1, 0, 3, 2))) * 2
     del tmp42
     rdm2.abab.vvvv = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 3, 4, 5), (0, 1, 4, 5))
-    rdm2.aaaa.vvvv = tmp41.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.aaaa.vvvv = np.copy(np.transpose(tmp41, (1, 0, 3, 2))) * 2
     del tmp41
-    rdm2.bbbb.vvoo = l2.bbbb.copy() * 2
-    rdm2.abab.vvoo = l2.abab.copy()
-    rdm2.aaaa.vvoo = l2.aaaa.copy() * 2
+    rdm2.bbbb.vvoo = np.copy(l2.bbbb) * 2
+    rdm2.abab.vvoo = np.copy(l2.abab)
+    rdm2.aaaa.vvoo = np.copy(l2.aaaa) * 2
     rdm2.bbbb.vovo = einsum(delta.bb.oo, (0, 1), tmp40, (2, 3), (2, 0, 3, 1))
-    rdm2.bbbb.vovo += tmp38.transpose((2, 1, 3, 0)) * -1
-    rdm2.bbbb.vovo += tmp36.transpose((2, 1, 3, 0)) * -4
+    rdm2.bbbb.vovo += np.transpose(tmp38, (2, 1, 3, 0)) * -1
+    rdm2.bbbb.vovo += np.transpose(tmp36, (2, 1, 3, 0)) * -4
     rdm2.abab.vovo = einsum(tmp23, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3)) * 2
     rdm2.abab.vovo += einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 4, 5, 1), (0, 4, 5, 3)) * -1
     rdm2.aaaa.vovo = einsum(tmp23, (0, 1), delta.aa.oo, (2, 3), (0, 2, 1, 3)) * 2
-    rdm2.aaaa.vovo += tmp19.transpose((2, 1, 3, 0)) * -4
-    rdm2.aaaa.vovo += tmp21.transpose((2, 1, 3, 0)) * -1
+    rdm2.aaaa.vovo += np.transpose(tmp19, (2, 1, 3, 0)) * -4
+    rdm2.aaaa.vovo += np.transpose(tmp21, (2, 1, 3, 0)) * -1
     rdm2.bbbb.voov = einsum(tmp26, (0, 1), delta.bb.oo, (2, 3), (0, 2, 3, 1)) * -2
-    rdm2.bbbb.voov += tmp38.transpose((2, 1, 0, 3))
-    rdm2.bbbb.voov += tmp36.transpose((2, 1, 0, 3)) * 4
+    rdm2.bbbb.voov += np.transpose(tmp38, (2, 1, 0, 3))
+    rdm2.bbbb.voov += np.transpose(tmp36, (2, 1, 0, 3)) * 4
     rdm2.abab.voov = einsum(t2.bbbb, (0, 1, 2, 3), l2.abab, (4, 3, 5, 1), (4, 0, 5, 2)) * 2
-    rdm2.abab.voov += tmp34.transpose((2, 1, 0, 3)) * 2
+    rdm2.abab.voov += np.transpose(tmp34, (2, 1, 0, 3)) * 2
     del tmp34
     rdm2.aaaa.voov = einsum(tmp14, (0, 1), delta.aa.oo, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.aaaa.voov += tmp19.transpose((2, 1, 0, 3)) * 4
-    rdm2.aaaa.voov += tmp21.transpose((2, 1, 0, 3))
+    rdm2.aaaa.voov += np.transpose(tmp19, (2, 1, 0, 3)) * 4
+    rdm2.aaaa.voov += np.transpose(tmp21, (2, 1, 0, 3))
     rdm2.bbbb.ovvo = einsum(delta.bb.oo, (0, 1), tmp40, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.bbbb.ovvo += tmp38.transpose((1, 2, 3, 0))
-    rdm2.bbbb.ovvo += tmp36.transpose((1, 2, 3, 0)) * 4
-    rdm2.abab.ovvo = tmp17.transpose((0, 3, 2, 1)).copy() * 2
+    rdm2.bbbb.ovvo += np.transpose(tmp38, (1, 2, 3, 0))
+    rdm2.bbbb.ovvo += np.transpose(tmp36, (1, 2, 3, 0)) * 4
+    rdm2.abab.ovvo = np.copy(np.transpose(tmp17, (0, 3, 2, 1))) * 2
     del tmp17
-    rdm2.abab.ovvo += tmp29.transpose((0, 3, 2, 1)) * 2
+    rdm2.abab.ovvo += np.transpose(tmp29, (0, 3, 2, 1)) * 2
     del tmp29
     rdm2.aaaa.ovvo = einsum(tmp23, (0, 1), delta.aa.oo, (2, 3), (2, 0, 1, 3)) * -2
-    rdm2.aaaa.ovvo += tmp19.transpose((1, 2, 3, 0)) * 4
-    rdm2.aaaa.ovvo += tmp21.transpose((1, 2, 3, 0))
+    rdm2.aaaa.ovvo += np.transpose(tmp19, (1, 2, 3, 0)) * 4
+    rdm2.aaaa.ovvo += np.transpose(tmp21, (1, 2, 3, 0))
     rdm2.bbbb.ovov = einsum(tmp26, (0, 1), delta.bb.oo, (2, 3), (2, 0, 3, 1)) * 2
-    rdm2.bbbb.ovov += tmp38.transpose((1, 2, 0, 3)) * -1
+    rdm2.bbbb.ovov += np.transpose(tmp38, (1, 2, 0, 3)) * -1
     del tmp38
-    rdm2.bbbb.ovov += tmp36.transpose((1, 2, 0, 3)) * -4
+    rdm2.bbbb.ovov += np.transpose(tmp36, (1, 2, 0, 3)) * -4
     del tmp36
     rdm2.abab.ovov = einsum(tmp40, (0, 1), delta.aa.oo, (2, 3), (2, 0, 3, 1))
-    rdm2.abab.ovov += tmp28.transpose((1, 2, 0, 3)) * -1
+    rdm2.abab.ovov += np.transpose(tmp28, (1, 2, 0, 3)) * -1
     rdm2.aaaa.ovov = einsum(tmp14, (0, 1), delta.aa.oo, (2, 3), (2, 0, 3, 1))
-    rdm2.aaaa.ovov += tmp19.transpose((1, 2, 0, 3)) * -4
+    rdm2.aaaa.ovov += np.transpose(tmp19, (1, 2, 0, 3)) * -4
     del tmp19
-    rdm2.aaaa.ovov += tmp21.transpose((1, 2, 0, 3)) * -1
+    rdm2.aaaa.ovov += np.transpose(tmp21, (1, 2, 0, 3)) * -1
     del tmp21
-    rdm2.bbbb.oovv = t2.bbbb.copy() * 2
+    rdm2.bbbb.oovv = np.copy(t2.bbbb) * 2
     rdm2.bbbb.oovv += einsum(t2.bbbb, (0, 1, 2, 3), tmp26, (3, 4), (0, 1, 2, 4)) * -4
-    rdm2.bbbb.oovv += tmp32.transpose((1, 0, 3, 2)) * 2
-    rdm2.bbbb.oovv += tmp32.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp32, (1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp32, (0, 1, 3, 2)) * -2
     del tmp32
-    rdm2.bbbb.oovv += tmp33.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp33, (0, 1, 3, 2)) * -2
     del tmp33
-    rdm2.bbbb.oovv += tmp35.transpose((0, 1, 3, 2)) * -2
-    rdm2.bbbb.oovv += tmp37.transpose((0, 1, 3, 2)) * -8
-    rdm2.bbbb.oovv += tmp39.transpose((0, 1, 3, 2)) * -2
-    rdm2.bbbb.oovv += tmp39.transpose((1, 0, 2, 3)) * -2
-    rdm2.bbbb.oovv += tmp35.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp35, (0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp37, (0, 1, 3, 2)) * -8
+    rdm2.bbbb.oovv += np.transpose(tmp39, (0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp39, (1, 0, 2, 3)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp35, (1, 0, 3, 2)) * 2
     del tmp35
     rdm2.bbbb.oovv += tmp37 * 8
     del tmp37
     rdm2.bbbb.oovv += tmp39 * 2
-    rdm2.bbbb.oovv += tmp39.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp39, (1, 0, 3, 2)) * 2
     del tmp39
     rdm2.bbbb.oovv += einsum(tmp40, (0, 1), t2.bbbb, (2, 3, 4, 0), (2, 3, 1, 4)) * 2
     del tmp40
-    rdm2.abab.oovv = t2.abab.copy()
+    rdm2.abab.oovv = np.copy(t2.abab)
     rdm2.abab.oovv += einsum(tmp26, (0, 1), t2.abab, (2, 3, 4, 0), (2, 3, 4, 1)) * -2
     del tmp26
     rdm2.abab.oovv += einsum(t2.abab, (0, 1, 2, 3), tmp27, (0, 4), (4, 1, 2, 3)) * -1
@@ -808,24 +808,24 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.abab.oovv += einsum(tmp31, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5))
     del tmp31
     rdm2.abab.oovv += einsum(tmp14, (0, 1), t2.abab, (2, 3, 0, 4), (2, 3, 1, 4)) * -1
-    rdm2.aaaa.oovv = t2.aaaa.copy() * 2
+    rdm2.aaaa.oovv = np.copy(t2.aaaa) * 2
     rdm2.aaaa.oovv += einsum(t2.aaaa, (0, 1, 2, 3), tmp14, (3, 4), (0, 1, 2, 4)) * -2
     del tmp14
-    rdm2.aaaa.oovv += tmp15.transpose((1, 0, 3, 2)) * 2
-    rdm2.aaaa.oovv += tmp15.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp15, (1, 0, 3, 2)) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp15, (0, 1, 3, 2)) * -2
     del tmp15
-    rdm2.aaaa.oovv += tmp16.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp16, (0, 1, 3, 2)) * -2
     del tmp16
-    rdm2.aaaa.oovv += tmp18.transpose((0, 1, 3, 2)) * -2
-    rdm2.aaaa.oovv += tmp20.transpose((0, 1, 3, 2)) * -8
-    rdm2.aaaa.oovv += tmp22.transpose((0, 1, 3, 2)) * -2
-    rdm2.aaaa.oovv += tmp22.transpose((1, 0, 2, 3)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp18, (0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp20, (0, 1, 3, 2)) * -8
+    rdm2.aaaa.oovv += np.transpose(tmp22, (0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp22, (1, 0, 2, 3)) * -2
     rdm2.aaaa.oovv += tmp18 * 2
     del tmp18
     rdm2.aaaa.oovv += tmp20 * 8
     del tmp20
     rdm2.aaaa.oovv += tmp22 * 2
-    rdm2.aaaa.oovv += tmp22.transpose((1, 0, 3, 2)) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp22, (1, 0, 3, 2)) * 2
     del tmp22
     rdm2.aaaa.oovv += einsum(t2.aaaa, (0, 1, 2, 3), tmp23, (3, 4), (0, 1, 4, 2)) * 4
     del tmp23
@@ -835,12 +835,12 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.bbbb.oooo += einsum(tmp10, (0, 1), delta.bb.oo, (2, 3), (1, 2, 0, 3)) * -1
     rdm2.bbbb.oooo += einsum(tmp10, (0, 1), delta.bb.oo, (2, 3), (2, 1, 0, 3))
     del tmp10
-    rdm2.bbbb.oooo += tmp11.transpose((3, 2, 1, 0)) * 2
+    rdm2.bbbb.oooo += np.transpose(tmp11, (3, 2, 1, 0)) * 2
     del tmp11
     rdm2.abab.oooo = einsum(tmp7, (0, 1), delta.aa.oo, (2, 3), (2, 1, 3, 0)) * -1
     del tmp7
     rdm2.abab.oooo += einsum(tmp3, (0, 1), delta.bb.oo, (2, 3), (1, 2, 0, 3)) * -2
-    rdm2.abab.oooo += tmp8.transpose((1, 3, 0, 2))
+    rdm2.abab.oooo += np.transpose(tmp8, (1, 3, 0, 2))
     del tmp8
     rdm2.aaaa.oooo = einsum(delta.aa.oo, (0, 1), tmp2, (2, 3), (0, 3, 1, 2)) * -1
     rdm2.aaaa.oooo += einsum(delta.aa.oo, (0, 1), tmp2, (2, 3), (3, 0, 1, 2))
@@ -848,7 +848,7 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.aaaa.oooo += einsum(tmp3, (0, 1), delta.aa.oo, (2, 3), (1, 2, 0, 3)) * -2
     rdm2.aaaa.oooo += einsum(tmp3, (0, 1), delta.aa.oo, (2, 3), (2, 1, 0, 3)) * 2
     del tmp3, delta
-    rdm2.aaaa.oooo += tmp4.transpose((3, 2, 1, 0)) * 2
+    rdm2.aaaa.oooo += np.transpose(tmp4, (3, 2, 1, 0)) * 2
     del tmp4
     rdm2.aaaa.ooov = np.zeros((t2.aaaa.shape[0], t2.aaaa.shape[0], t2.aaaa.shape[0], t2.aaaa.shape[-1]))
     rdm2.aaaa.oovo = np.zeros((t2.aaaa.shape[0], t2.aaaa.shape[0], t2.aaaa.shape[-1], t2.aaaa.shape[0]))
@@ -878,9 +878,9 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.abab = pack_2e(rdm2.abab.oooo, rdm2.abab.ooov, rdm2.abab.oovo, rdm2.abab.ovoo, rdm2.abab.vooo, rdm2.abab.oovv, rdm2.abab.ovov, rdm2.abab.ovvo, rdm2.abab.voov, rdm2.abab.vovo, rdm2.abab.vvoo, rdm2.abab.ovvv, rdm2.abab.vovv, rdm2.abab.vvov, rdm2.abab.vvvo, rdm2.abab.vvvv)
     rdm2.bbbb = pack_2e(rdm2.bbbb.oooo, rdm2.bbbb.ooov, rdm2.bbbb.oovo, rdm2.bbbb.ovoo, rdm2.bbbb.vooo, rdm2.bbbb.oovv, rdm2.bbbb.ovov, rdm2.bbbb.ovvo, rdm2.bbbb.voov, rdm2.bbbb.vovo, rdm2.bbbb.vvoo, rdm2.bbbb.ovvv, rdm2.bbbb.vovv, rdm2.bbbb.vvov, rdm2.bbbb.vvvo, rdm2.bbbb.vvvv)
     rdm2 = Namespace(
-        aaaa=rdm2.aaaa.transpose(0, 2, 1, 3),
-        aabb=rdm2.abab.transpose(0, 2, 1, 3),
-        bbbb=rdm2.bbbb.transpose(0, 2, 1, 3),
+        aaaa=np.transpose(rdm2.aaaa, (0, 2, 1, 3)),
+        aabb=np.transpose(rdm2.abab, (0, 2, 1, 3)),
+        bbbb=np.transpose(rdm2.bbbb, (0, 2, 1, 3)),
     )
 
     return rdm2
@@ -1051,29 +1051,29 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     ints = kwargs["ints"]
     r1new = Namespace()
     r2new = Namespace()
-    tmp49 = ints.tmp137.copy()
+    tmp49 = np.copy(ints.tmp137)
     del ints.tmp137
-    tmp49 += v.bbbb.ooov.transpose((0, 2, 1, 3)) * 0.5
-    tmp45 = ints.tmp106.copy()
+    tmp49 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3)) * 0.5
+    tmp45 = np.copy(ints.tmp106)
     tmp45 += ints.tmp110 * 0.5
-    tmp47 = ints.tmp10.copy() * 2
+    tmp47 = np.copy(ints.tmp10) * 2
     tmp47 += ints.tmp12
-    tmp55 = ints.tmp102.copy()
+    tmp55 = np.copy(ints.tmp102)
     tmp55 += ints.tmp108 * 2
-    tmp57 = ints.tmp141.copy()
+    tmp57 = np.copy(ints.tmp141)
     del ints.tmp141
     tmp57 += ints.tmp139 * 2
     del ints.tmp139
-    tmp9 = ints.tmp29.copy()
+    tmp9 = np.copy(ints.tmp29)
     del ints.tmp29
-    tmp9 += v.aaaa.ooov.transpose((0, 2, 1, 3)) * 0.5
-    tmp7 = ints.tmp3.copy() * 2
+    tmp9 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3)) * 0.5
+    tmp7 = np.copy(ints.tmp3) * 2
     tmp7 += ints.tmp5
-    tmp5 = ints.tmp45.copy()
+    tmp5 = np.copy(ints.tmp45)
     tmp5 += ints.tmp49 * 2
-    tmp3 = ints.tmp41.copy()
+    tmp3 = np.copy(ints.tmp41)
     tmp3 += ints.tmp47 * 0.5
-    tmp17 = ints.tmp33.copy()
+    tmp17 = np.copy(ints.tmp33)
     del ints.tmp33
     tmp17 += ints.tmp31 * 2
     del ints.tmp31
@@ -1113,24 +1113,24 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp14 = einsum(v.aaaa.ovov, (0, 1, 2, 3), r2.aaa, (4, 2, 3), (4, 0, 1))
     tmp16 = einsum(r2.bab, (0, 1, 2), v.aabb.ovov, (3, 4, 0, 2), (1, 3, 4)) * -1
     tmp12 = einsum(r2.aaa, (0, 1, 2), f.aa.oo, (3, 1), (3, 0, 2))
-    tmp51 = tmp42.copy()
+    tmp51 = np.copy(tmp42)
     del tmp42
     tmp51 += tmp43
     del tmp43
     tmp51 += tmp44 * 2
     del tmp44
-    tmp51 += tmp46.transpose((1, 0, 2)) * -1
+    tmp51 += np.transpose(tmp46, (1, 0, 2)) * -1
     del tmp46
-    tmp51 += tmp48.transpose((1, 0, 2))
+    tmp51 += np.transpose(tmp48, (1, 0, 2))
     del tmp48
     tmp51 += tmp50
     del tmp50
-    tmp39 = ints.tmp115.transpose((1, 0)).copy() * 2
+    tmp39 = np.copy(np.transpose(ints.tmp115, (1, 0))) * 2
     del ints.tmp115
-    tmp39 += ints.tmp117.transpose((1, 0))
+    tmp39 += np.transpose(ints.tmp117, (1, 0))
     del ints.tmp117
     tmp39 += f.bb.vv * -1
-    tmp41 = f.bb.ov.copy()
+    tmp41 = np.copy(f.bb.ov)
     tmp41 += ints.tmp127
     del ints.tmp127
     tmp41 += ints.tmp93
@@ -1143,107 +1143,107 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp113
     tmp41 += ints.tmp126 * -2
     del ints.tmp126
-    tmp60 = ints.tmp133.copy()
+    tmp60 = np.copy(ints.tmp133)
     del ints.tmp133
-    tmp60 += v.bbbb.oooo.transpose((0, 2, 3, 1)) * -1
-    tmp59 = tmp52.copy() * 2
+    tmp60 += np.transpose(v.bbbb.oooo, (0, 2, 3, 1)) * -1
+    tmp59 = np.copy(tmp52) * 2
     del tmp52
     tmp59 += tmp53 * 4
     del tmp53
     tmp59 += tmp54 * 2
     del tmp54
-    tmp59 += tmp56.transpose((1, 0, 2))
+    tmp59 += np.transpose(tmp56, (1, 0, 2))
     del tmp56
     tmp59 += tmp58
     del tmp58
-    tmp61 = ints.tmp131.copy()
+    tmp61 = np.copy(ints.tmp131)
     del ints.tmp131
-    tmp61 += ints.tmp151.transpose((1, 2, 0, 3)) * -1
+    tmp61 += np.transpose(ints.tmp151, (1, 2, 0, 3)) * -1
     del ints.tmp151
-    tmp33 = tmp31.copy() * -1
+    tmp33 = np.copy(tmp31) * -1
     del tmp31
     tmp33 += tmp32 * 2
     del tmp32
-    tmp24 = tmp22.copy() * 2
+    tmp24 = np.copy(tmp22) * 2
     del tmp22
     tmp24 += tmp23
     del tmp23
-    tmp37 = ints.tmp119.copy()
+    tmp37 = np.copy(ints.tmp119)
     del ints.tmp119
     tmp37 += v.aabb.oovv * -1
-    tmp38 = ints.tmp64.copy()
+    tmp38 = np.copy(ints.tmp64)
     tmp38 += v.aabb.oooo
-    tmp36 = ints.tmp102.copy()
+    tmp36 = np.copy(ints.tmp102)
     del ints.tmp102
     tmp36 += ints.tmp108 * 2
     del ints.tmp108
-    tmp36 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp36 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp36 += ints.tmp100 * -1
     del ints.tmp100
-    tmp0 = f.aa.oo.copy()
-    tmp0 += ints.tmp3.transpose((1, 0)) * 2
+    tmp0 = np.copy(f.aa.oo)
+    tmp0 += np.transpose(ints.tmp3, (1, 0)) * 2
     del ints.tmp3
-    tmp0 += ints.tmp5.transpose((1, 0))
+    tmp0 += np.transpose(ints.tmp5, (1, 0))
     del ints.tmp5
-    tmp1 = f.bb.oo.copy()
-    tmp1 += ints.tmp10.transpose((1, 0)) * 2
+    tmp1 = np.copy(f.bb.oo)
+    tmp1 += np.transpose(ints.tmp10, (1, 0)) * 2
     del ints.tmp10
-    tmp1 += ints.tmp12.transpose((1, 0))
+    tmp1 += np.transpose(ints.tmp12, (1, 0))
     del ints.tmp12
-    tmp40 = ints.tmp111.copy()
+    tmp40 = np.copy(ints.tmp111)
     del ints.tmp111
-    tmp40 += ints.tmp90.transpose((1, 0, 2, 3))
+    tmp40 += np.transpose(ints.tmp90, (1, 0, 2, 3))
     del ints.tmp90
-    tmp40 += ints.tmp97.transpose((1, 0, 2, 3))
+    tmp40 += np.transpose(ints.tmp97, (1, 0, 2, 3))
     del ints.tmp97
-    tmp40 += ints.tmp98.transpose((1, 0, 2, 3)) * 2
+    tmp40 += np.transpose(ints.tmp98, (1, 0, 2, 3)) * 2
     del ints.tmp98
     tmp40 += v.aabb.ooov
-    tmp40 += ints.tmp114.transpose((1, 0, 2, 3)) * -1
+    tmp40 += np.transpose(ints.tmp114, (1, 0, 2, 3)) * -1
     del ints.tmp114
-    tmp40 += ints.tmp96.transpose((1, 0, 2, 3)) * -1
+    tmp40 += np.transpose(ints.tmp96, (1, 0, 2, 3)) * -1
     del ints.tmp96
-    tmp35 = ints.tmp106.copy() * 2
+    tmp35 = np.copy(ints.tmp106) * 2
     del ints.tmp106
     tmp35 += ints.tmp110
     del ints.tmp110
-    tmp35 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp35 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp35 += ints.tmp104 * -2
     del ints.tmp104
     tmp35 += v.bbbb.oovv * -1
-    tmp30 = ints.tmp64.copy()
+    tmp30 = np.copy(ints.tmp64)
     del ints.tmp64
     tmp30 += v.aabb.oooo
-    tmp27 = ints.tmp41.copy() * 2
+    tmp27 = np.copy(ints.tmp41) * 2
     del ints.tmp41
     tmp27 += ints.tmp47
     del ints.tmp47
-    tmp27 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp27 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp27 += ints.tmp39 * -2
     del ints.tmp39
     tmp27 += v.aaaa.oovv * -1
-    tmp29 = ints.tmp80.copy()
+    tmp29 = np.copy(ints.tmp80)
     del ints.tmp80
-    tmp29 += v.aabb.vvoo.transpose((2, 3, 0, 1)) * -1
-    tmp21 = ints.tmp35.transpose((1, 0)).copy() * 2
+    tmp29 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1)) * -1
+    tmp21 = np.copy(np.transpose(ints.tmp35, (1, 0))) * 2
     del ints.tmp35
-    tmp21 += ints.tmp37.transpose((1, 0))
+    tmp21 += np.transpose(ints.tmp37, (1, 0))
     del ints.tmp37
     tmp21 += f.aa.vv * -1
-    tmp34 = ints.tmp62.copy()
+    tmp34 = np.copy(ints.tmp62)
     del ints.tmp62
     tmp34 += ints.tmp68
     del ints.tmp68
     tmp34 += ints.tmp69 * 2
     del ints.tmp69
-    tmp34 += ints.tmp76.transpose((0, 2, 1, 3))
+    tmp34 += np.transpose(ints.tmp76, (0, 2, 1, 3))
     del ints.tmp76
-    tmp34 += v.aabb.ovoo.transpose((0, 2, 3, 1))
+    tmp34 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
     tmp34 += ints.tmp67 * -1
     del ints.tmp67
     tmp34 += ints.tmp77 * -1
     del ints.tmp77
-    tmp26 = f.aa.ov.copy()
+    tmp26 = np.copy(f.aa.ov)
     tmp26 += ints.tmp18
     del ints.tmp18
     tmp26 += ints.tmp24 * 2
@@ -1256,31 +1256,31 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp27
     tmp26 += ints.tmp28 * -1
     del ints.tmp28
-    tmp28 = ints.tmp45.copy()
+    tmp28 = np.copy(ints.tmp45)
     del ints.tmp45
     tmp28 += ints.tmp49 * 2
     del ints.tmp49
-    tmp28 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp28 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp28 += ints.tmp43 * -1
     del ints.tmp43
-    tmp20 = ints.tmp21.copy()
+    tmp20 = np.copy(ints.tmp21)
     del ints.tmp21
-    tmp20 += v.aaaa.oooo.transpose((0, 2, 3, 1)) * -1
-    tmp11 = tmp2.copy() * 2
+    tmp20 += np.transpose(v.aaaa.oooo, (0, 2, 3, 1)) * -1
+    tmp11 = np.copy(tmp2) * 2
     del tmp2
-    tmp11 += tmp4.transpose((1, 0, 2)) * -1
+    tmp11 += np.transpose(tmp4, (1, 0, 2)) * -1
     del tmp4
-    tmp11 += tmp6.transpose((1, 0, 2))
+    tmp11 += np.transpose(tmp6, (1, 0, 2))
     del tmp6
-    tmp11 += tmp8.transpose((1, 0, 2))
+    tmp11 += np.transpose(tmp8, (1, 0, 2))
     del tmp8
     tmp11 += tmp10
     del tmp10
-    tmp25 = ints.tmp19.copy()
+    tmp25 = np.copy(ints.tmp19)
     del ints.tmp19
-    tmp25 += ints.tmp51.transpose((1, 2, 0, 3)) * -1
+    tmp25 += np.transpose(ints.tmp51, (1, 2, 0, 3)) * -1
     del ints.tmp51
-    tmp19 = tmp12.copy() * 2
+    tmp19 = np.copy(tmp12) * 2
     del tmp12
     tmp19 += tmp13 * 4
     del tmp13
@@ -1292,11 +1292,11 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp16
     tmp19 += tmp18
     del tmp18
-    r2new.bbb = tmp51.copy() * -1
-    r2new.bbb += tmp51.transpose((1, 0, 2))
+    r2new.bbb = np.copy(tmp51) * -1
+    r2new.bbb += np.transpose(tmp51, (1, 0, 2))
     del tmp51
     r2new.bbb += tmp59
-    r2new.bbb += tmp59.transpose((1, 0, 2)) * -1
+    r2new.bbb += np.transpose(tmp59, (1, 0, 2)) * -1
     del tmp59
     r2new.bbb += einsum(tmp60, (0, 1, 2, 3), r2.bbb, (2, 3, 4), (0, 1, 4)) * 2
     del tmp60
@@ -1339,11 +1339,11 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     r2new.aba += einsum(r2.aba, (0, 1, 2), tmp1, (1, 3), (0, 3, 2)) * -1
     r2new.aba += einsum(tmp0, (0, 1), r2.aba, (0, 2, 3), (1, 2, 3)) * -1
     r2new.aba += einsum(r1.b, (0,), tmp26, (1, 2), (1, 0, 2)) * -1
-    r2new.aaa = tmp11.copy() * -1
-    r2new.aaa += tmp11.transpose((1, 0, 2))
+    r2new.aaa = np.copy(tmp11) * -1
+    r2new.aaa += np.transpose(tmp11, (1, 0, 2))
     del tmp11
     r2new.aaa += tmp19
-    r2new.aaa += tmp19.transpose((1, 0, 2)) * -1
+    r2new.aaa += np.transpose(tmp19, (1, 0, 2)) * -1
     del tmp19
     r2new.aaa += einsum(r2.aaa, (0, 1, 2), tmp20, (3, 4, 0, 1), (3, 4, 2)) * 2
     del tmp20
@@ -1523,29 +1523,29 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     ints = kwargs["ints"]
     r1new = Namespace()
     r2new = Namespace()
-    tmp50 = ints.tmp131.copy()
+    tmp50 = np.copy(ints.tmp131)
     del ints.tmp131
     tmp50 += ints.tmp135 * 0.5
     del ints.tmp135
     tmp50 += v.bbbb.ovvv * 0.5
-    tmp39 = ints.tmp10.transpose((1, 0)).copy()
-    tmp39 += ints.tmp12.transpose((1, 0)) * 0.5
+    tmp39 = np.copy(np.transpose(ints.tmp10, (1, 0)))
+    tmp39 += np.transpose(ints.tmp12, (1, 0)) * 0.5
     tmp39 += f.bb.vv * -0.5
-    tmp47 = ints.tmp121.copy() * 2
+    tmp47 = np.copy(ints.tmp121) * 2
     tmp47 += ints.tmp125
-    tmp56 = ints.tmp117.copy()
+    tmp56 = np.copy(ints.tmp117)
     tmp56 += ints.tmp123 * 2
-    tmp10 = ints.tmp19.copy()
+    tmp10 = np.copy(ints.tmp19)
     del ints.tmp19
     tmp10 += ints.tmp23 * 0.5
     del ints.tmp23
     tmp10 += v.aaaa.ovvv * 0.5
-    tmp8 = ints.tmp3.transpose((1, 0)).copy()
-    tmp8 += ints.tmp5.transpose((1, 0)) * 0.5
+    tmp8 = np.copy(np.transpose(ints.tmp3, (1, 0)))
+    tmp8 += np.transpose(ints.tmp5, (1, 0)) * 0.5
     tmp8 += f.aa.vv * -0.5
-    tmp4 = ints.tmp29.copy() * 2
+    tmp4 = np.copy(ints.tmp29) * 2
     tmp4 += ints.tmp35
-    tmp6 = ints.tmp33.copy() * 0.5
+    tmp6 = np.copy(ints.tmp33) * 0.5
     tmp6 += ints.tmp37
     tmp51 = einsum(tmp50, (0, 1, 2, 3), r1.b, (3,), (0, 1, 2)) * 2
     del tmp50
@@ -1582,12 +1582,12 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp7 = einsum(tmp6, (0, 1, 2, 3), r2.bab, (3, 4, 1), (0, 4, 2)) * -2
     del tmp6
     tmp3 = einsum(v.aaaa.oovv, (0, 1, 2, 3), r2.aaa, (4, 3, 1), (0, 4, 2))
-    tmp41 = f.bb.oo.copy()
-    tmp41 += ints.tmp103.transpose((1, 0)) * 2
+    tmp41 = np.copy(f.bb.oo)
+    tmp41 += np.transpose(ints.tmp103, (1, 0)) * 2
     del ints.tmp103
-    tmp41 += ints.tmp105.transpose((1, 0))
+    tmp41 += np.transpose(ints.tmp105, (1, 0))
     del ints.tmp105
-    tmp42 = f.bb.ov.copy()
+    tmp42 = np.copy(f.bb.ov)
     tmp42 += ints.tmp102
     del ints.tmp102
     tmp42 += ints.tmp107
@@ -1600,69 +1600,69 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp126
     tmp42 += ints.tmp127 * -1
     del ints.tmp127
-    tmp52 = tmp44.copy()
+    tmp52 = np.copy(tmp44)
     del tmp44
     tmp52 += tmp45
     del tmp45
     tmp52 += tmp46 * 2
     del tmp46
-    tmp52 += tmp48.transpose((0, 2, 1)) * -1
+    tmp52 += np.transpose(tmp48, (0, 2, 1)) * -1
     del tmp48
-    tmp52 += tmp49.transpose((0, 2, 1))
+    tmp52 += np.transpose(tmp49, (0, 2, 1))
     del tmp49
     tmp52 += tmp51
     del tmp51
     tmp43 = einsum(v.bbbb.ovov, (0, 1, 2, 3), r2.bbb, (3, 1, 4), (4, 0, 2)) * -1
-    tmp59 = tmp30.copy() * 0.5
+    tmp59 = np.copy(tmp30) * 0.5
     tmp59 += tmp31 * -0.5
     tmp59 += tmp32
-    tmp58 = tmp53.copy() * 2
+    tmp58 = np.copy(tmp53) * 2
     del tmp53
     tmp58 += tmp54 * 4
     del tmp54
     tmp58 += tmp55 * 2
     del tmp55
-    tmp58 += tmp57.transpose((0, 2, 1))
+    tmp58 += np.transpose(tmp57, (0, 2, 1))
     del tmp57
-    tmp37 = ints.tmp93.copy()
+    tmp37 = np.copy(ints.tmp93)
     del ints.tmp93
-    tmp37 += v.aabb.vvoo.transpose((2, 3, 0, 1)) * -1
-    tmp38 = ints.tmp109.copy()
+    tmp37 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1)) * -1
+    tmp38 = np.copy(ints.tmp109)
     del ints.tmp109
     tmp38 += ints.tmp111 * 2
     del ints.tmp111
     tmp38 += ints.tmp94
     del ints.tmp94
-    tmp38 += v.aabb.vvov.transpose((2, 0, 1, 3))
-    tmp38 += ints.tmp110.transpose((0, 2, 1, 3)) * -1
+    tmp38 += np.transpose(v.aabb.vvov, (2, 0, 1, 3))
+    tmp38 += np.transpose(ints.tmp110, (0, 2, 1, 3)) * -1
     del ints.tmp110
     tmp38 += ints.tmp90 * -1
     del ints.tmp90
-    tmp36 = ints.tmp117.copy()
+    tmp36 = np.copy(ints.tmp117)
     del ints.tmp117
     tmp36 += ints.tmp123 * 2
     del ints.tmp123
-    tmp36 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp36 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp36 += ints.tmp115 * -1
     del ints.tmp115
-    tmp0 = ints.tmp3.transpose((1, 0)).copy() * 2
+    tmp0 = np.copy(np.transpose(ints.tmp3, (1, 0))) * 2
     del ints.tmp3
-    tmp0 += ints.tmp5.transpose((1, 0))
+    tmp0 += np.transpose(ints.tmp5, (1, 0))
     del ints.tmp5
     tmp0 += f.aa.vv * -1
-    tmp40 = tmp19.copy()
+    tmp40 = np.copy(tmp19)
     tmp40 += tmp20 * 2
     tmp40 += tmp21
-    tmp35 = ints.tmp121.copy() * 2
+    tmp35 = np.copy(ints.tmp121) * 2
     del ints.tmp121
     tmp35 += ints.tmp125
     del ints.tmp125
-    tmp35 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp35 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp35 += ints.tmp119 * -2
     del ints.tmp119
     tmp35 += v.bbbb.oovv * -1
     tmp34 = einsum(v.aabb.ovov, (0, 1, 2, 3), r2.bab, (3, 1, 4), (0, 4, 2)) * -1
-    tmp24 = f.aa.ov.copy()
+    tmp24 = np.copy(f.aa.ov)
     tmp24 += ints.tmp14 * 2
     del ints.tmp14
     tmp24 += ints.tmp15
@@ -1675,20 +1675,20 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp44
     tmp24 += ints.tmp55 * -2
     del ints.tmp55
-    tmp1 = ints.tmp10.transpose((1, 0)).copy() * 2
+    tmp1 = np.copy(np.transpose(ints.tmp10, (1, 0))) * 2
     del ints.tmp10
-    tmp1 += ints.tmp12.transpose((1, 0))
+    tmp1 += np.transpose(ints.tmp12, (1, 0))
     del ints.tmp12
     tmp1 += f.bb.vv * -1
-    tmp27 = ints.tmp33.copy()
+    tmp27 = np.copy(ints.tmp33)
     del ints.tmp33
     tmp27 += ints.tmp37 * 2
     del ints.tmp37
-    tmp27 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp27 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp27 += ints.tmp31 * -1
     del ints.tmp31
     tmp25 = einsum(v.aabb.ovov, (0, 1, 2, 3), r2.aba, (1, 3, 4), (4, 0, 2))
-    tmp29 = ints.tmp67.copy()
+    tmp29 = np.copy(ints.tmp67)
     del ints.tmp67
     tmp29 += ints.tmp78
     del ints.tmp78
@@ -1697,38 +1697,38 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp29 += v.aabb.ovvv
     tmp29 += ints.tmp62 * -1
     del ints.tmp62
-    tmp29 += ints.tmp79.transpose((0, 1, 3, 2)) * -1
+    tmp29 += np.transpose(ints.tmp79, (0, 1, 3, 2)) * -1
     del ints.tmp79
-    tmp23 = f.aa.oo.copy()
-    tmp23 += ints.tmp57.transpose((1, 0)) * 2
+    tmp23 = np.copy(f.aa.oo)
+    tmp23 += np.transpose(ints.tmp57, (1, 0)) * 2
     del ints.tmp57
-    tmp23 += ints.tmp59.transpose((1, 0))
+    tmp23 += np.transpose(ints.tmp59, (1, 0))
     del ints.tmp59
-    tmp33 = tmp30.copy()
+    tmp33 = np.copy(tmp30)
     del tmp30
     tmp33 += tmp31 * -1
     del tmp31
     tmp33 += tmp32 * 2
     del tmp32
-    tmp28 = ints.tmp65.copy()
+    tmp28 = np.copy(ints.tmp65)
     del ints.tmp65
     tmp28 += v.aabb.oovv * -1
-    tmp26 = ints.tmp29.copy() * 2
+    tmp26 = np.copy(ints.tmp29) * 2
     del ints.tmp29
     tmp26 += ints.tmp35
     del ints.tmp35
-    tmp26 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp26 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp26 += ints.tmp27 * -2
     del ints.tmp27
     tmp26 += v.aaaa.oovv * -1
     tmp2 = einsum(v.aaaa.ovov, (0, 1, 2, 3), r2.aaa, (1, 3, 4), (4, 0, 2))
-    tmp22 = tmp19.copy() * 0.5
+    tmp22 = np.copy(tmp19) * 0.5
     del tmp19
     tmp22 += tmp20
     del tmp20
     tmp22 += tmp21 * 0.5
     del tmp21
-    tmp18 = tmp13.copy() * 2
+    tmp18 = np.copy(tmp13) * 2
     del tmp13
     tmp18 += tmp14 * 4
     del tmp14
@@ -1738,13 +1738,13 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp16
     tmp18 += tmp17
     del tmp17
-    tmp12 = tmp3.copy() * 2
+    tmp12 = np.copy(tmp3) * 2
     del tmp3
-    tmp12 += tmp5.transpose((0, 2, 1)) * -1
+    tmp12 += np.transpose(tmp5, (0, 2, 1)) * -1
     del tmp5
-    tmp12 += tmp7.transpose((0, 2, 1))
+    tmp12 += np.transpose(tmp7, (0, 2, 1))
     del tmp7
-    tmp12 += tmp9.transpose((0, 2, 1))
+    tmp12 += np.transpose(tmp9, (0, 2, 1))
     del tmp9
     tmp12 += tmp11
     del tmp11
@@ -1753,11 +1753,11 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     r2new.bbb += einsum(tmp43, (0, 1, 2), t2.bbbb, (2, 1, 3, 4), (3, 4, 0)) * -2
     del tmp43
     r2new.bbb += einsum(v.bbbb.vvvv, (0, 1, 2, 3), r2.bbb, (3, 1, 4), (0, 2, 4)) * -2
-    r2new.bbb += tmp52.transpose((1, 2, 0)) * -1
-    r2new.bbb += tmp52.transpose((2, 1, 0))
+    r2new.bbb += np.transpose(tmp52, (1, 2, 0)) * -1
+    r2new.bbb += np.transpose(tmp52, (2, 1, 0))
     del tmp52
-    r2new.bbb += tmp58.transpose((1, 2, 0))
-    r2new.bbb += tmp58.transpose((2, 1, 0)) * -1
+    r2new.bbb += np.transpose(tmp58, (1, 2, 0))
+    r2new.bbb += np.transpose(tmp58, (2, 1, 0)) * -1
     del tmp58
     r2new.bbb += einsum(tmp59, (0,), t2.bbbb, (1, 0, 2, 3), (2, 3, 1)) * 4
     del tmp59
@@ -1806,11 +1806,11 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp45
     r2new.aaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp2, (4, 1, 0), (2, 3, 4)) * -2
     del tmp2
-    r2new.aaa += tmp12.transpose((1, 2, 0)) * -1
-    r2new.aaa += tmp12.transpose((2, 1, 0))
+    r2new.aaa += np.transpose(tmp12, (1, 2, 0)) * -1
+    r2new.aaa += np.transpose(tmp12, (2, 1, 0))
     del tmp12
-    r2new.aaa += tmp18.transpose((1, 2, 0))
-    r2new.aaa += tmp18.transpose((2, 1, 0)) * -1
+    r2new.aaa += np.transpose(tmp18, (1, 2, 0))
+    r2new.aaa += np.transpose(tmp18, (2, 1, 0)) * -1
     del tmp18
     r2new.aaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp22, (1,), (2, 3, 0)) * 4
     del tmp22
@@ -2002,20 +2002,20 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     r2new = Namespace()
     tmp35 = einsum(r2.aba, (0, 1, 2), t2.abab, (0, 1, 2, 3), (3,))
     tmp36 = einsum(t2.bbbb, (0, 1, 2, 3), r2.bbb, (0, 1, 3), (2,))
-    tmp58 = ints.tmp142.copy()
+    tmp58 = np.copy(ints.tmp142)
     tmp58 += ints.tmp146 * 2
-    tmp50 = tmp35.copy() * -0.5
+    tmp50 = np.copy(tmp35) * -0.5
     tmp50 += tmp36
-    tmp48 = ints.tmp144.copy()
+    tmp48 = np.copy(ints.tmp144)
     tmp48 += ints.tmp148 * 0.5
-    tmp52 = ints.tmp59.copy() * 2
+    tmp52 = np.copy(ints.tmp59) * 2
     tmp52 += ints.tmp61
-    tmp14 = ints.tmp93.copy()
+    tmp14 = np.copy(ints.tmp93)
     tmp14 += ints.tmp97 * 0.5
-    tmp18 = ints.tmp14.copy() * 2
+    tmp18 = np.copy(ints.tmp14) * 2
     tmp18 += ints.tmp16
     tmp12 = einsum(r2.aaa, (0, 1, 2), t2.aaaa, (0, 1, 3, 2), (3,))
-    tmp16 = ints.tmp95.copy()
+    tmp16 = np.copy(ints.tmp95)
     tmp16 += ints.tmp99 * 2
     tmp26 = einsum(r2.bab, (0, 1, 2), t2.abab, (1, 0, 3, 2), (3,)) * -1
     tmp59 = einsum(r2.aba, (0, 1, 2), tmp58, (0, 3, 2, 4), (1, 3, 4))
@@ -2048,18 +2048,18 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp25 = einsum(r2.bab, (0, 1, 2), v.aabb.ovov, (3, 4, 0, 2), (1, 3, 4)) * -1
     tmp21 = einsum(r2.aaa, (0, 1, 2), f.aa.oo, (3, 1), (3, 0, 2))
     tmp23 = einsum(v.aaaa.ovov, (0, 1, 2, 3), r2.aaa, (4, 2, 3), (4, 0, 1))
-    tmp42 = ints.tmp157.copy() * 2
+    tmp42 = np.copy(ints.tmp157) * 2
     del ints.tmp157
     tmp42 += ints.tmp159
     del ints.tmp159
     tmp42 += f.bb.vv * -1
-    tmp60 = tmp55.copy() * 2
+    tmp60 = np.copy(tmp55) * 2
     del tmp55
     tmp60 += tmp56 * 4
     del tmp56
     tmp60 += tmp57 * 2
     del tmp57
-    tmp60 += tmp59.transpose((1, 0, 2))
+    tmp60 += np.transpose(tmp59, (1, 0, 2))
     del tmp59
     tmp54 = einsum(f.bb.ov, (0, 1), r1.b, (2,), (0, 2, 1))
     tmp54 += tmp44
@@ -2070,79 +2070,79 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp46
     tmp54 += tmp47 * 2
     del tmp47
-    tmp54 += tmp49.transpose((1, 0, 2)) * -1
+    tmp54 += np.transpose(tmp49, (1, 0, 2)) * -1
     del tmp49
-    tmp54 += tmp51.transpose((1, 0, 2)) * -1
+    tmp54 += np.transpose(tmp51, (1, 0, 2)) * -1
     del tmp51
-    tmp54 += tmp53.transpose((1, 0, 2))
+    tmp54 += np.transpose(tmp53, (1, 0, 2))
     del tmp53
-    tmp61 = ints.tmp178.copy()
+    tmp61 = np.copy(ints.tmp178)
     del ints.tmp178
-    tmp61 += v.bbbb.oooo.transpose((0, 2, 3, 1)) * -1
-    tmp43 = tmp12.copy() * 2
+    tmp61 += np.transpose(v.bbbb.oooo, (0, 2, 3, 1)) * -1
+    tmp43 = np.copy(tmp12) * 2
     del tmp12
     tmp43 += tmp26
     del tmp26
-    tmp38 = ints.tmp144.copy() * 2
+    tmp38 = np.copy(ints.tmp144) * 2
     del ints.tmp144
     tmp38 += ints.tmp148
     del ints.tmp148
-    tmp38 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp38 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp38 += ints.tmp140 * -2
     del ints.tmp140
     tmp38 += v.bbbb.oovv * -1
-    tmp39 = ints.tmp142.copy()
+    tmp39 = np.copy(ints.tmp142)
     del ints.tmp142
     tmp39 += ints.tmp146 * 2
     del ints.tmp146
-    tmp39 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp39 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp39 += ints.tmp138 * -1
     del ints.tmp138
-    tmp41 = ints.tmp132.copy()
+    tmp41 = np.copy(ints.tmp132)
     tmp41 += v.aabb.oooo
-    tmp40 = ints.tmp161.copy()
+    tmp40 = np.copy(ints.tmp161)
     del ints.tmp161
     tmp40 += v.aabb.oovv * -1
-    tmp9 = f.bb.oo.copy()
+    tmp9 = np.copy(f.bb.oo)
     tmp9 += ints.tmp59 * 2
     del ints.tmp59
     tmp9 += ints.tmp61
     del ints.tmp61
-    tmp4 = f.aa.oo.copy()
+    tmp4 = np.copy(f.aa.oo)
     tmp4 += ints.tmp14 * 2
     del ints.tmp14
     tmp4 += ints.tmp16
     del ints.tmp16
-    tmp37 = tmp35.copy() * -1
+    tmp37 = np.copy(tmp35) * -1
     del tmp35
     tmp37 += tmp36 * 2
     del tmp36
-    tmp31 = ints.tmp93.copy() * 2
+    tmp31 = np.copy(ints.tmp93) * 2
     del ints.tmp93
     tmp31 += ints.tmp97
     del ints.tmp97
-    tmp31 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp31 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp31 += ints.tmp89 * -2
     del ints.tmp89
     tmp31 += v.aaaa.oovv * -1
-    tmp30 = ints.tmp113.copy() * 2
+    tmp30 = np.copy(ints.tmp113) * 2
     del ints.tmp113
     tmp30 += ints.tmp115
     del ints.tmp115
     tmp30 += f.aa.vv * -1
-    tmp34 = ints.tmp132.copy()
+    tmp34 = np.copy(ints.tmp132)
     del ints.tmp132
     tmp34 += v.aabb.oooo
-    tmp32 = ints.tmp95.copy()
+    tmp32 = np.copy(ints.tmp95)
     del ints.tmp95
     tmp32 += ints.tmp99 * 2
     del ints.tmp99
-    tmp32 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp32 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp32 += ints.tmp91 * -1
     del ints.tmp91
-    tmp33 = ints.tmp136.copy()
+    tmp33 = np.copy(ints.tmp136)
     del ints.tmp136
-    tmp33 += v.aabb.vvoo.transpose((2, 3, 0, 1)) * -1
+    tmp33 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1)) * -1
     tmp20 = einsum(f.aa.ov, (0, 1), r1.a, (2,), (0, 2, 1))
     tmp20 += tmp10
     del tmp10
@@ -2150,16 +2150,16 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp11
     tmp20 += tmp13 * 2
     del tmp13
-    tmp20 += tmp15.transpose((1, 0, 2)) * -1
+    tmp20 += np.transpose(tmp15, (1, 0, 2)) * -1
     del tmp15
-    tmp20 += tmp17.transpose((1, 0, 2))
+    tmp20 += np.transpose(tmp17, (1, 0, 2))
     del tmp17
-    tmp20 += tmp19.transpose((1, 0, 2))
+    tmp20 += np.transpose(tmp19, (1, 0, 2))
     del tmp19
-    tmp29 = ints.tmp110.copy()
+    tmp29 = np.copy(ints.tmp110)
     del ints.tmp110
-    tmp29 += v.aaaa.oooo.transpose((0, 2, 3, 1)) * -1
-    tmp28 = tmp21.copy() * 2
+    tmp29 += np.transpose(v.aaaa.oooo, (0, 2, 3, 1)) * -1
+    tmp28 = np.copy(tmp21) * 2
     del tmp21
     tmp28 += tmp22 * 4
     del tmp22
@@ -2171,45 +2171,45 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp25
     tmp28 += tmp27
     del tmp27
-    tmp8 = f.bb.ov.copy()
+    tmp8 = np.copy(f.bb.ov)
     tmp8 += ints.tmp3
     tmp8 += ints.tmp41
     tmp8 += ints.tmp6 * 2
     tmp8 += ints.tmp20 * -2
     tmp8 += ints.tmp22 * -1
     tmp8 += ints.tmp39 * -2
-    tmp6 = ints.tmp55.copy()
+    tmp6 = np.copy(ints.tmp55)
     del ints.tmp55
-    tmp6 += ints.tmp71.transpose((1, 0, 2, 3)) * 2
+    tmp6 += np.transpose(ints.tmp71, (1, 0, 2, 3)) * 2
     del ints.tmp71
-    tmp6 += ints.tmp76.transpose((1, 0, 2, 3))
+    tmp6 += np.transpose(ints.tmp76, (1, 0, 2, 3))
     del ints.tmp76
-    tmp6 += ints.tmp68.transpose((2, 0, 1, 3)) * -2
+    tmp6 += np.transpose(ints.tmp68, (2, 0, 1, 3)) * -2
     del ints.tmp68
-    tmp6 += ints.tmp82.transpose((2, 0, 1, 3)) * -1
+    tmp6 += np.transpose(ints.tmp82, (2, 0, 1, 3)) * -1
     del ints.tmp82
     tmp6 += v.bbbb.ooov * -1
-    tmp5 = ints.tmp53.copy()
+    tmp5 = np.copy(ints.tmp53)
     del ints.tmp53
     tmp5 += ints.tmp70
     del ints.tmp70
     tmp5 += ints.tmp74 * 2
     del ints.tmp74
-    tmp5 += ints.tmp84.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp84, (0, 2, 1, 3))
     del ints.tmp84
-    tmp5 += v.aabb.ovoo.transpose((0, 2, 3, 1))
-    tmp5 += ints.tmp67.transpose((0, 2, 1, 3)) * -1
+    tmp5 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
+    tmp5 += np.transpose(ints.tmp67, (0, 2, 1, 3)) * -1
     del ints.tmp67
-    tmp5 += ints.tmp73.transpose((0, 2, 1, 3)) * -1
+    tmp5 += np.transpose(ints.tmp73, (0, 2, 1, 3)) * -1
     del ints.tmp73
-    tmp7 = f.aa.ov.copy() * 0.5
+    tmp7 = np.copy(f.aa.ov) * 0.5
     tmp7 += ints.tmp1
     tmp7 += ints.tmp43 * 0.5
     tmp7 += ints.tmp4 * 0.5
     tmp7 += ints.tmp18 * -1
     tmp7 += ints.tmp24 * -0.5
     tmp7 += ints.tmp37 * -1
-    tmp2 = f.aa.ov.copy()
+    tmp2 = np.copy(f.aa.ov)
     tmp2 += ints.tmp1 * 2
     del ints.tmp1
     tmp2 += ints.tmp43
@@ -2222,31 +2222,31 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp24
     tmp2 += ints.tmp37 * -2
     del ints.tmp37
-    tmp1 = ints.tmp26.copy() * 2
+    tmp1 = np.copy(ints.tmp26) * 2
     del ints.tmp26
     tmp1 += ints.tmp45
     del ints.tmp45
-    tmp1 += v.aaaa.ooov.transpose((0, 2, 1, 3))
-    tmp1 += ints.tmp29.transpose((0, 2, 1, 3)) * -2
+    tmp1 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3))
+    tmp1 += np.transpose(ints.tmp29, (0, 2, 1, 3)) * -2
     del ints.tmp29
-    tmp1 += ints.tmp33.transpose((0, 2, 1, 3)) * -1
+    tmp1 += np.transpose(ints.tmp33, (0, 2, 1, 3)) * -1
     del ints.tmp33
-    tmp1 += ints.tmp8.transpose((1, 2, 0, 3)) * -1
+    tmp1 += np.transpose(ints.tmp8, (1, 2, 0, 3)) * -1
     del ints.tmp8
-    tmp0 = ints.tmp10.copy()
+    tmp0 = np.copy(ints.tmp10)
     del ints.tmp10
     tmp0 += ints.tmp31
     del ints.tmp31
     tmp0 += ints.tmp35 * 2
     del ints.tmp35
-    tmp0 += ints.tmp47.transpose((1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp47, (1, 0, 2, 3))
     del ints.tmp47
     tmp0 += v.aabb.ooov
-    tmp0 += ints.tmp28.transpose((1, 0, 2, 3)) * -1
+    tmp0 += np.transpose(ints.tmp28, (1, 0, 2, 3)) * -1
     del ints.tmp28
-    tmp0 += ints.tmp32.transpose((1, 0, 2, 3)) * -1
+    tmp0 += np.transpose(ints.tmp32, (1, 0, 2, 3)) * -1
     del ints.tmp32
-    tmp3 = f.bb.ov.copy() * 0.5
+    tmp3 = np.copy(f.bb.ov) * 0.5
     tmp3 += ints.tmp3 * 0.5
     del ints.tmp3
     tmp3 += ints.tmp41 * 0.5
@@ -2259,11 +2259,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp22
     tmp3 += ints.tmp39 * -1
     del ints.tmp39
-    r2new.bbb = tmp54.copy() * -1
-    r2new.bbb += tmp54.transpose((1, 0, 2))
+    r2new.bbb = np.copy(tmp54) * -1
+    r2new.bbb += np.transpose(tmp54, (1, 0, 2))
     del tmp54
     r2new.bbb += tmp60
-    r2new.bbb += tmp60.transpose((1, 0, 2)) * -1
+    r2new.bbb += np.transpose(tmp60, (1, 0, 2)) * -1
     del tmp60
     r2new.bbb += einsum(tmp61, (0, 1, 2, 3), r2.bbb, (0, 1, 4), (2, 3, 4)) * 2
     del tmp61
@@ -2299,11 +2299,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp37
     r2new.aba += einsum(r2.aba, (0, 1, 2), tmp9, (1, 3), (0, 3, 2)) * -1
     r2new.aba += einsum(tmp4, (0, 1), r2.aba, (0, 2, 3), (1, 2, 3)) * -1
-    r2new.aaa = tmp20.copy() * -1
-    r2new.aaa += tmp20.transpose((1, 0, 2))
+    r2new.aaa = np.copy(tmp20) * -1
+    r2new.aaa += np.transpose(tmp20, (1, 0, 2))
     del tmp20
     r2new.aaa += tmp28
-    r2new.aaa += tmp28.transpose((1, 0, 2)) * -1
+    r2new.aaa += np.transpose(tmp28, (1, 0, 2)) * -1
     del tmp28
     r2new.aaa += einsum(r2.aaa, (0, 1, 2), tmp29, (0, 1, 3, 4), (3, 4, 2)) * 2
     del tmp29
@@ -2486,21 +2486,21 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     r2new = Namespace()
     tmp11 = einsum(t2.abab, (0, 1, 2, 3), r2.aba, (2, 3, 0), (1,))
     tmp12 = einsum(r2.bbb, (0, 1, 2), t2.bbbb, (3, 2, 0, 1), (3,))
-    tmp55 = ints.tmp142.copy()
+    tmp55 = np.copy(ints.tmp142)
     tmp55 += ints.tmp146 * 2
-    tmp41 = ints.tmp59.copy()
+    tmp41 = np.copy(ints.tmp59)
     tmp41 += ints.tmp61 * 0.5
     tmp41 += f.bb.vv * -0.5
-    tmp36 = tmp11.copy() * -0.5
+    tmp36 = np.copy(tmp11) * -0.5
     tmp36 += tmp12
-    tmp48 = ints.tmp144.copy() * 2
+    tmp48 = np.copy(ints.tmp144) * 2
     tmp48 += ints.tmp148
     tmp6 = einsum(t2.abab, (0, 1, 2, 3), r2.bab, (3, 2, 1), (0,)) * -1
-    tmp26 = ints.tmp101.copy() * 0.5
+    tmp26 = np.copy(ints.tmp101) * 0.5
     tmp26 += ints.tmp105
-    tmp24 = ints.tmp103.copy() * 0.5
+    tmp24 = np.copy(ints.tmp103) * 0.5
     tmp24 += ints.tmp99
-    tmp28 = ints.tmp14.copy()
+    tmp28 = np.copy(ints.tmp14)
     tmp28 += ints.tmp16 * 0.5
     tmp28 += f.aa.vv * -0.5
     tmp5 = einsum(r2.aaa, (0, 1, 2), t2.aaaa, (3, 2, 0, 1), (3,))
@@ -2530,16 +2530,16 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp28
     tmp21 = einsum(v.aaaa.ovvv, (0, 1, 2, 3), r1.a, (3,), (0, 1, 2))
     tmp23 = einsum(tmp5, (0,), v.aaaa.ovov, (1, 2, 0, 3), (1, 2, 3)) * -1
-    tmp42 = f.bb.oo.copy()
+    tmp42 = np.copy(f.bb.oo)
     tmp42 += ints.tmp134 * 2
     del ints.tmp134
     tmp42 += ints.tmp136
     del ints.tmp136
-    tmp57 = tmp53.copy() * 4
+    tmp57 = np.copy(tmp53) * 4
     del tmp53
     tmp57 += tmp54 * 2
     del tmp54
-    tmp57 += tmp56.transpose((0, 2, 1))
+    tmp57 += np.transpose(tmp56, (0, 2, 1))
     del tmp56
     tmp43 = einsum(t2.bbbb, (0, 1, 2, 3), r2.bbb, (2, 3, 4), (4, 0, 1))
     tmp52 = einsum(f.bb.ov, (0, 1), r1.b, (2,), (0, 1, 2))
@@ -2551,70 +2551,70 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp46
     tmp52 += tmp47 * 2
     del tmp47
-    tmp52 += tmp49.transpose((0, 2, 1)) * -1
+    tmp52 += np.transpose(tmp49, (0, 2, 1)) * -1
     del tmp49
-    tmp52 += tmp50.transpose((0, 2, 1))
+    tmp52 += np.transpose(tmp50, (0, 2, 1))
     del tmp50
-    tmp52 += tmp51.transpose((0, 2, 1)) * -1
+    tmp52 += np.transpose(tmp51, (0, 2, 1)) * -1
     del tmp51
     tmp37 = einsum(t2.abab, (0, 1, 2, 3), r2.bab, (3, 2, 4), (0, 4, 1)) * -1
-    tmp38 = ints.tmp144.copy() * 2
+    tmp38 = np.copy(ints.tmp144) * 2
     del ints.tmp144
     tmp38 += ints.tmp148
     del ints.tmp148
-    tmp38 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp38 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp38 += ints.tmp140 * -2
     del ints.tmp140
     tmp38 += v.bbbb.oovv * -1
-    tmp39 = ints.tmp142.copy()
+    tmp39 = np.copy(ints.tmp142)
     del ints.tmp142
     tmp39 += ints.tmp146 * 2
     del ints.tmp146
-    tmp39 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp39 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp39 += ints.tmp138 * -1
     del ints.tmp138
-    tmp40 = ints.tmp158.copy()
+    tmp40 = np.copy(ints.tmp158)
     del ints.tmp158
-    tmp40 += v.aabb.vvoo.transpose((2, 3, 0, 1)) * -1
-    tmp7 = tmp5.copy() * 2
+    tmp40 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1)) * -1
+    tmp7 = np.copy(tmp5) * 2
     del tmp5
     tmp7 += tmp6
     del tmp6
-    tmp4 = ints.tmp14.copy() * 2
+    tmp4 = np.copy(ints.tmp14) * 2
     del ints.tmp14
     tmp4 += ints.tmp16
     del ints.tmp16
     tmp4 += f.aa.vv * -1
-    tmp10 = ints.tmp59.copy() * 2
+    tmp10 = np.copy(ints.tmp59) * 2
     del ints.tmp59
     tmp10 += ints.tmp61
     del ints.tmp61
     tmp10 += f.bb.vv * -1
-    tmp31 = f.aa.oo.copy()
+    tmp31 = np.copy(f.aa.oo)
     tmp31 += ints.tmp91 * 2
     del ints.tmp91
     tmp31 += ints.tmp93
     del ints.tmp93
-    tmp35 = ints.tmp132.copy()
+    tmp35 = np.copy(ints.tmp132)
     del ints.tmp132
     tmp35 += v.aabb.oovv * -1
-    tmp34 = ints.tmp101.copy()
+    tmp34 = np.copy(ints.tmp101)
     del ints.tmp101
     tmp34 += ints.tmp105 * 2
     del ints.tmp105
-    tmp34 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp34 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp34 += ints.tmp97 * -1
     del ints.tmp97
     tmp32 = einsum(t2.abab, (0, 1, 2, 3), r2.aba, (2, 3, 4), (4, 0, 1))
-    tmp33 = ints.tmp103.copy()
+    tmp33 = np.copy(ints.tmp103)
     del ints.tmp103
     tmp33 += ints.tmp99 * 2
     del ints.tmp99
-    tmp33 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp33 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp33 += ints.tmp95 * -2
     del ints.tmp95
     tmp33 += v.aaaa.oovv * -1
-    tmp20 = tmp15.copy() * 4
+    tmp20 = np.copy(tmp15) * 4
     del tmp15
     tmp20 += tmp16 * 2
     del tmp16
@@ -2631,25 +2631,25 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp22
     tmp30 += tmp23 * 2
     del tmp23
-    tmp30 += tmp25.transpose((0, 2, 1)) * -1
+    tmp30 += np.transpose(tmp25, (0, 2, 1)) * -1
     del tmp25
-    tmp30 += tmp27.transpose((0, 2, 1))
+    tmp30 += np.transpose(tmp27, (0, 2, 1))
     del tmp27
-    tmp30 += tmp29.transpose((0, 2, 1))
+    tmp30 += np.transpose(tmp29, (0, 2, 1))
     del tmp29
     tmp14 = einsum(t2.aaaa, (0, 1, 2, 3), r2.aaa, (2, 3, 4), (4, 0, 1))
-    tmp8 = ints.tmp69.copy()
+    tmp8 = np.copy(ints.tmp69)
     del ints.tmp69
-    tmp8 += ints.tmp75.transpose((0, 1, 3, 2))
+    tmp8 += np.transpose(ints.tmp75, (0, 1, 3, 2))
     del ints.tmp75
-    tmp8 += ints.tmp81.transpose((0, 1, 3, 2)) * 2
+    tmp8 += np.transpose(ints.tmp81, (0, 1, 3, 2)) * 2
     del ints.tmp81
     tmp8 += v.aabb.ovvv
-    tmp8 += ints.tmp78.transpose((0, 1, 3, 2)) * -1
+    tmp8 += np.transpose(ints.tmp78, (0, 1, 3, 2)) * -1
     del ints.tmp78
     tmp8 += ints.tmp85 * -1
     del ints.tmp85
-    tmp2 = f.aa.ov.copy() * 0.5
+    tmp2 = np.copy(f.aa.ov) * 0.5
     tmp2 += ints.tmp1
     del ints.tmp1
     tmp2 += ints.tmp36 * 0.5
@@ -2662,20 +2662,20 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp24
     tmp2 += ints.tmp30 * -1
     del ints.tmp30
-    tmp13 = tmp11.copy() * -1
+    tmp13 = np.copy(tmp11) * -1
     del tmp11
     tmp13 += tmp12 * 2
     del tmp12
-    tmp9 = ints.tmp67.copy() * 0.5
+    tmp9 = np.copy(ints.tmp67) * 0.5
     del ints.tmp67
-    tmp9 += ints.tmp76.transpose((0, 1, 3, 2))
+    tmp9 += np.transpose(ints.tmp76, (0, 1, 3, 2))
     del ints.tmp76
-    tmp9 += ints.tmp83.transpose((0, 1, 3, 2)) * 0.5
+    tmp9 += np.transpose(ints.tmp83, (0, 1, 3, 2)) * 0.5
     del ints.tmp83
     tmp9 += v.bbbb.ovvv * 0.5
-    tmp9 += ints.tmp79.transpose((0, 1, 3, 2)) * -1
+    tmp9 += np.transpose(ints.tmp79, (0, 1, 3, 2)) * -1
     del ints.tmp79
-    tmp3 = f.bb.ov.copy() * 0.5
+    tmp3 = np.copy(f.bb.ov) * 0.5
     tmp3 += ints.tmp34 * 0.5
     del ints.tmp34
     tmp3 += ints.tmp3 * 0.5
@@ -2688,34 +2688,34 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp22
     tmp3 += ints.tmp32 * -1
     del ints.tmp32
-    tmp1 = ints.tmp26.copy() * 0.5
+    tmp1 = np.copy(ints.tmp26) * 0.5
     del ints.tmp26
-    tmp1 += ints.tmp38.transpose((0, 1, 3, 2))
+    tmp1 += np.transpose(ints.tmp38, (0, 1, 3, 2))
     del ints.tmp38
-    tmp1 += ints.tmp44.transpose((0, 1, 3, 2)) * 0.5
+    tmp1 += np.transpose(ints.tmp44, (0, 1, 3, 2)) * 0.5
     del ints.tmp44
     tmp1 += v.aaaa.ovvv * 0.5
-    tmp1 += ints.tmp41.transpose((0, 1, 3, 2)) * -1
+    tmp1 += np.transpose(ints.tmp41, (0, 1, 3, 2)) * -1
     del ints.tmp41
-    tmp0 = ints.tmp28.copy()
+    tmp0 = np.copy(ints.tmp28)
     del ints.tmp28
-    tmp0 += ints.tmp40.transpose((0, 2, 1, 3))
+    tmp0 += np.transpose(ints.tmp40, (0, 2, 1, 3))
     del ints.tmp40
-    tmp0 += ints.tmp46.transpose((0, 2, 1, 3)) * 2
+    tmp0 += np.transpose(ints.tmp46, (0, 2, 1, 3)) * 2
     del ints.tmp46
-    tmp0 += v.aabb.vvov.transpose((2, 0, 1, 3))
-    tmp0 += ints.tmp43.transpose((0, 2, 1, 3)) * -1
+    tmp0 += np.transpose(v.aabb.vvov, (2, 0, 1, 3))
+    tmp0 += np.transpose(ints.tmp43, (0, 2, 1, 3)) * -1
     del ints.tmp43
     tmp0 += ints.tmp48 * -1
     del ints.tmp48
     r2new.bbb = einsum(tmp43, (0, 1, 2), v.bbbb.ovov, (2, 3, 1, 4), (3, 4, 0)) * -2
     del tmp43
     r2new.bbb += einsum(v.bbbb.vvvv, (0, 1, 2, 3), r2.bbb, (3, 1, 4), (0, 2, 4)) * -2
-    r2new.bbb += tmp52.transpose((1, 2, 0)) * -1
-    r2new.bbb += tmp52.transpose((2, 1, 0))
+    r2new.bbb += np.transpose(tmp52, (1, 2, 0)) * -1
+    r2new.bbb += np.transpose(tmp52, (2, 1, 0))
     del tmp52
-    r2new.bbb += tmp57.transpose((1, 2, 0))
-    r2new.bbb += tmp57.transpose((2, 1, 0)) * -1
+    r2new.bbb += np.transpose(tmp57, (1, 2, 0))
+    r2new.bbb += np.transpose(tmp57, (2, 1, 0)) * -1
     del tmp57
     r2new.bbb += einsum(r2.bbb, (0, 1, 2), tmp42, (2, 3), (0, 1, 3)) * -2
     r2new.bab = einsum(r1.a, (0,), v.aabb.vvov, (1, 0, 2, 3), (3, 1, 2)) * -1
@@ -2754,11 +2754,11 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     r2new.aaa = einsum(v.aaaa.vvvv, (0, 1, 2, 3), r2.aaa, (3, 1, 4), (0, 2, 4)) * -2
     r2new.aaa += einsum(v.aaaa.ovov, (0, 1, 2, 3), tmp14, (4, 2, 0), (1, 3, 4)) * -2
     del tmp14
-    r2new.aaa += tmp20.transpose((1, 2, 0))
-    r2new.aaa += tmp20.transpose((2, 1, 0)) * -1
+    r2new.aaa += np.transpose(tmp20, (1, 2, 0))
+    r2new.aaa += np.transpose(tmp20, (2, 1, 0)) * -1
     del tmp20
-    r2new.aaa += tmp30.transpose((1, 2, 0)) * -1
-    r2new.aaa += tmp30.transpose((2, 1, 0))
+    r2new.aaa += np.transpose(tmp30, (1, 2, 0)) * -1
+    r2new.aaa += np.transpose(tmp30, (2, 1, 0))
     del tmp30
     r2new.aaa += einsum(tmp31, (0, 1), r2.aaa, (2, 3, 0), (2, 3, 1)) * -2
     del tmp31

--- a/ebcc/codegen/UCCD.py
+++ b/ebcc/codegen/UCCD.py
@@ -878,9 +878,9 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.abab = pack_2e(rdm2.abab.oooo, rdm2.abab.ooov, rdm2.abab.oovo, rdm2.abab.ovoo, rdm2.abab.vooo, rdm2.abab.oovv, rdm2.abab.ovov, rdm2.abab.ovvo, rdm2.abab.voov, rdm2.abab.vovo, rdm2.abab.vvoo, rdm2.abab.ovvv, rdm2.abab.vovv, rdm2.abab.vvov, rdm2.abab.vvvo, rdm2.abab.vvvv)
     rdm2.bbbb = pack_2e(rdm2.bbbb.oooo, rdm2.bbbb.ooov, rdm2.bbbb.oovo, rdm2.bbbb.ovoo, rdm2.bbbb.vooo, rdm2.bbbb.oovv, rdm2.bbbb.ovov, rdm2.bbbb.ovvo, rdm2.bbbb.voov, rdm2.bbbb.vovo, rdm2.bbbb.vvoo, rdm2.bbbb.ovvv, rdm2.bbbb.vovv, rdm2.bbbb.vvov, rdm2.bbbb.vvvo, rdm2.bbbb.vvvv)
     rdm2 = Namespace(
-        aaaa=rdm2.aaaa.swapaxes(1, 2),
-        aabb=rdm2.abab.swapaxes(1, 2),
-        bbbb=rdm2.bbbb.swapaxes(1, 2),
+        aaaa=rdm2.aaaa.transpose(0, 2, 1, 3),
+        aabb=rdm2.abab.transpose(0, 2, 1, 3),
+        bbbb=rdm2.bbbb.transpose(0, 2, 1, 3),
     )
 
     return rdm2

--- a/ebcc/codegen/UCCSD.py
+++ b/ebcc/codegen/UCCSD.py
@@ -2709,9 +2709,9 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.abab = pack_2e(rdm2.abab.oooo, rdm2.abab.ooov, rdm2.abab.oovo, rdm2.abab.ovoo, rdm2.abab.vooo, rdm2.abab.oovv, rdm2.abab.ovov, rdm2.abab.ovvo, rdm2.abab.voov, rdm2.abab.vovo, rdm2.abab.vvoo, rdm2.abab.ovvv, rdm2.abab.vovv, rdm2.abab.vvov, rdm2.abab.vvvo, rdm2.abab.vvvv)
     rdm2.bbbb = pack_2e(rdm2.bbbb.oooo, rdm2.bbbb.ooov, rdm2.bbbb.oovo, rdm2.bbbb.ovoo, rdm2.bbbb.vooo, rdm2.bbbb.oovv, rdm2.bbbb.ovov, rdm2.bbbb.ovvo, rdm2.bbbb.voov, rdm2.bbbb.vovo, rdm2.bbbb.vvoo, rdm2.bbbb.ovvv, rdm2.bbbb.vovv, rdm2.bbbb.vvov, rdm2.bbbb.vvvo, rdm2.bbbb.vvvv)
     rdm2 = Namespace(
-        aaaa=rdm2.aaaa.swapaxes(1, 2),
-        aabb=rdm2.abab.swapaxes(1, 2),
-        bbbb=rdm2.bbbb.swapaxes(1, 2),
+        aaaa=rdm2.aaaa.transpose(0, 2, 1, 3),
+        aabb=rdm2.abab.transpose(0, 2, 1, 3),
+        bbbb=rdm2.bbbb.transpose(0, 2, 1, 3),
     )
 
     return rdm2

--- a/ebcc/codegen/UCCSD.py
+++ b/ebcc/codegen/UCCSD.py
@@ -37,17 +37,17 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp0 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp0 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp2 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp2 += v.aaaa.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp1 = f.bb.ov.copy() * 2
+    tmp0 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp0 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
+    tmp2 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1)))
+    tmp2 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3)) * -1
+    tmp1 = np.copy(f.bb.ov) * 2
     tmp1 += einsum(t1.aa, (0, 1), v.aabb.ovov, (0, 1, 2, 3), (2, 3)) * 2
     tmp1 += einsum(t1.bb, (0, 1), tmp0, (0, 2, 1, 3), (2, 3)) * -1
     del tmp0
     e_cc = einsum(t1.bb, (0, 1), tmp1, (0, 1), ()) * 0.5
     del tmp1
-    tmp3 = f.aa.ov.copy()
+    tmp3 = np.copy(f.aa.ov)
     tmp3 += einsum(t1.aa, (0, 1), tmp2, (0, 2, 1, 3), (2, 3)) * -0.5
     del tmp2
     e_cc += einsum(tmp3, (0, 1), t1.aa, (0, 1), ())
@@ -83,74 +83,74 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
 
     t1new = Namespace()
     t2new = Namespace()
-    tmp13 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp13 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp7 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp7 += v.aaaa.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp114 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp114 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp13 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp13 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
+    tmp7 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1)))
+    tmp7 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3)) * -1
+    tmp114 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp114 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
     tmp12 = einsum(t1.aa, (0, 1), v.aabb.ovov, (0, 1, 2, 3), (2, 3))
-    t1new.bb = tmp12.copy()
+    t1new.bb = np.copy(tmp12)
     tmp14 = einsum(t1.bb, (0, 1), tmp13, (0, 2, 1, 3), (2, 3))
     del tmp13
     tmp20 = einsum(t1.bb, (0, 1), v.bbbb.ovov, (2, 3, 4, 1), (0, 2, 4, 3))
     t1new.bb += einsum(t2.bbbb, (0, 1, 2, 3), tmp20, (4, 0, 1, 3), (4, 2)) * 2
     tmp8 = einsum(t1.aa, (0, 1), tmp7, (0, 2, 1, 3), (2, 3))
     tmp0 = einsum(t1.bb, (0, 1), v.aabb.ovov, (2, 3, 0, 1), (2, 3))
-    t1new.aa = tmp0.copy()
+    t1new.aa = np.copy(tmp0)
     tmp2 = einsum(v.aaaa.ovov, (0, 1, 2, 3), t1.aa, (4, 3), (4, 0, 2, 1))
     t1new.aa += einsum(tmp2, (0, 1, 2, 3), t2.aaaa, (1, 2, 4, 3), (0, 4)) * 2
     tmp115 = einsum(t1.bb, (0, 1), tmp114, (0, 2, 1, 3), (2, 3))
-    tmp137 = v.bbbb.ooov.copy()
-    tmp137 += v.bbbb.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp194 = v.bbbb.ooov.copy()
-    tmp194 += v.bbbb.ooov.transpose((0, 2, 1, 3)) * -1
+    tmp137 = np.copy(v.bbbb.ooov)
+    tmp137 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1)) * -1
+    tmp194 = np.copy(v.bbbb.ooov)
+    tmp194 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3)) * -1
     tmp21 = einsum(v.aabb.ovov, (0, 1, 2, 3), t1.bb, (4, 3), (0, 4, 2, 1))
     t1new.bb += einsum(t2.abab, (0, 1, 2, 3), tmp21, (0, 4, 1, 2), (4, 3)) * -1
-    tmp15 = f.bb.ov.copy()
+    tmp15 = np.copy(f.bb.ov)
     tmp15 += tmp12
     tmp15 += tmp14 * -1
     del tmp14
     t1new.bb += einsum(t2.bbbb, (0, 1, 2, 3), tmp15, (1, 3), (0, 2)) * 2
     t1new.aa += einsum(tmp15, (0, 1), t2.abab, (2, 0, 3, 1), (2, 3))
-    tmp145 = tmp20.copy() * -1
-    tmp145 += tmp20.transpose((0, 2, 1, 3))
-    tmp113 = v.bbbb.ovvv.copy()
-    tmp113 += v.bbbb.ovvv.transpose((0, 2, 1, 3)) * -1
-    tmp9 = f.aa.ov.copy()
+    tmp145 = np.copy(tmp20) * -1
+    tmp145 += np.transpose(tmp20, (0, 2, 1, 3))
+    tmp113 = np.copy(v.bbbb.ovvv)
+    tmp113 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3)) * -1
+    tmp9 = np.copy(f.aa.ov)
     tmp9 += tmp0
     tmp9 += tmp8 * -1
     del tmp8
     t1new.bb += einsum(tmp9, (0, 1), t2.abab, (0, 2, 1, 3), (2, 3))
     t1new.aa += einsum(tmp9, (0, 1), t2.aaaa, (2, 0, 3, 1), (2, 3)) * 2
-    tmp79 = v.aaaa.ooov.copy() * -1
-    tmp79 += v.aaaa.ovoo.transpose((0, 2, 3, 1))
-    tmp35 = v.aaaa.ooov.copy()
-    tmp35 += v.aaaa.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp71 = tmp2.copy() * -1
-    tmp71 += tmp2.transpose((0, 2, 1, 3))
-    tmp69 = v.aaaa.ovvv.copy()
-    tmp69 += v.aaaa.ovvv.transpose((0, 2, 1, 3)) * -1
+    tmp79 = np.copy(v.aaaa.ooov) * -1
+    tmp79 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1))
+    tmp35 = np.copy(v.aaaa.ooov)
+    tmp35 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1)) * -1
+    tmp71 = np.copy(tmp2) * -1
+    tmp71 += np.transpose(tmp2, (0, 2, 1, 3))
+    tmp69 = np.copy(v.aaaa.ovvv)
+    tmp69 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3)) * -1
     tmp1 = einsum(t1.aa, (0, 1), v.aabb.ovov, (2, 1, 3, 4), (0, 2, 3, 4))
     t1new.aa += einsum(t2.abab, (0, 1, 2, 3), tmp1, (4, 0, 1, 3), (4, 2)) * -1
-    tmp116 = f.bb.ov.copy()
+    tmp116 = np.copy(f.bb.ov)
     tmp116 += tmp12
     del tmp12
     tmp116 += tmp115 * -1
     del tmp115
-    tmp29 = v.bbbb.ooov.copy()
-    tmp29 += v.bbbb.ovoo.transpose((0, 2, 3, 1)) * -1
+    tmp29 = np.copy(v.bbbb.ooov)
+    tmp29 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1)) * -1
     tmp28 = einsum(v.aabb.ovoo, (0, 1, 2, 3), t1.aa, (0, 1), (2, 3))
     tmp156 = einsum(tmp137, (0, 1, 2, 3), t1.bb, (0, 3), (1, 2))
     tmp195 = einsum(tmp194, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 4, 3))
     del tmp194
     tmp173 = einsum(t1.bb, (0, 1), v.bbbb.ovvv, (2, 3, 4, 1), (0, 2, 3, 4))
-    t2new.bbbb = tmp173.transpose((1, 0, 3, 2)).copy() * -1
-    t2new.bbbb += tmp173.transpose((0, 1, 3, 2))
+    t2new.bbbb = np.copy(np.transpose(tmp173, (1, 0, 3, 2))) * -1
+    t2new.bbbb += np.transpose(tmp173, (0, 1, 3, 2))
     t2new.bbbb += tmp173 * -1
-    t2new.bbbb += tmp173.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp173, (1, 0, 2, 3))
     tmp124 = einsum(v.aabb.ovvv, (0, 1, 2, 3), t1.bb, (4, 3), (0, 4, 1, 2))
-    t2new.abab = tmp124.copy()
+    t2new.abab = np.copy(tmp124)
     tmp123 = einsum(t1.bb, (0, 1), tmp21, (2, 3, 0, 4), (2, 3, 4, 1))
     t2new.abab += tmp123 * -1
     tmp198 = einsum(t1.bb, (0, 1), tmp20, (2, 3, 4, 1), (2, 0, 4, 3))
@@ -166,17 +166,17 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp57 = einsum(t1.aa, (0, 1), tmp9, (2, 1), (0, 2))
     tmp5 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 3, 1, 2), (0, 4)) * -1
     tmp51 = einsum(t1.aa, (0, 1), v.aaaa.ooov, (2, 3, 4, 1), (0, 2, 3, 4))
-    tmp17 = v.aaaa.ooov.copy()
-    tmp17 += v.aaaa.ovoo.transpose((0, 2, 3, 1)) * -1
+    tmp17 = np.copy(v.aaaa.ooov)
+    tmp17 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1)) * -1
     tmp61 = einsum(t1.aa, (0, 1), v.aaaa.ovvv, (2, 3, 4, 1), (0, 2, 3, 4))
-    t2new.aaaa = tmp61.transpose((1, 0, 3, 2)).copy() * -1
-    t2new.aaaa += tmp61.transpose((0, 1, 3, 2))
+    t2new.aaaa = np.copy(np.transpose(tmp61, (1, 0, 3, 2))) * -1
+    t2new.aaaa += np.transpose(tmp61, (0, 1, 3, 2))
     t2new.aaaa += tmp61 * -1
-    t2new.aaaa += tmp61.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp61, (1, 0, 2, 3))
     tmp80 = einsum(t1.aa, (0, 1), tmp79, (0, 2, 3, 4), (2, 3, 1, 4))
     del tmp79
-    tmp48 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp48 += v.aaaa.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp48 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1)))
+    tmp48 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3)) * -1
     tmp16 = einsum(v.aabb.ooov, (0, 1, 2, 3), t1.bb, (2, 3), (0, 1))
     tmp36 = einsum(tmp35, (0, 1, 2, 3), t1.aa, (0, 3), (1, 2))
     tmp72 = einsum(tmp71, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
@@ -188,89 +188,89 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new.abab += tmp66 * -1
     tmp117 = einsum(t1.bb, (0, 1), tmp116, (0, 2), (1, 2))
     del tmp116
-    tmp144 = v.bbbb.ovvv.copy() * -1
-    tmp144 += v.bbbb.ovvv.transpose((0, 2, 1, 3))
+    tmp144 = np.copy(v.bbbb.ovvv) * -1
+    tmp144 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3))
     tmp112 = einsum(v.aabb.ovvv, (0, 1, 2, 3), t1.aa, (0, 1), (2, 3))
     tmp202 = einsum(t1.bb, (0, 1), v.bbbb.vvvv, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp192 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovoo, (0, 2, 4, 5), (1, 4, 5, 3))
-    tmp162 = v.bbbb.ovvv.copy() * -1
-    tmp162 += v.bbbb.ovvv.transpose((0, 2, 1, 3))
+    tmp162 = np.copy(v.bbbb.ovvv) * -1
+    tmp162 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3))
     tmp107 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (0, 2, 1, 4), (4, 3))
     tmp108 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.bbbb, (0, 2, 4, 1), (4, 3)) * -1
     tmp154 = einsum(v.bbbb.oooo, (0, 1, 2, 3), t1.bb, (3, 4), (0, 1, 2, 4))
     tmp30 = einsum(tmp29, (0, 1, 2, 3), t1.bb, (0, 3), (1, 2))
     del tmp29
-    tmp186 = v.bbbb.ooov.copy() * -1
-    tmp186 += v.bbbb.ovoo.transpose((0, 2, 3, 1))
-    tmp83 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp83 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp186 = np.copy(v.bbbb.ooov) * -1
+    tmp186 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1))
+    tmp83 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1))) * -1
+    tmp83 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp167 = einsum(t1.bb, (0, 1), v.bbbb.oovv, (2, 3, 4, 1), (0, 2, 3, 4))
-    tmp157 = f.bb.oo.copy()
-    tmp157 += tmp28.transpose((1, 0))
-    tmp157 += tmp156.transpose((1, 0)) * -1
+    tmp157 = np.copy(f.bb.oo)
+    tmp157 += np.transpose(tmp28, (1, 0))
+    tmp157 += np.transpose(tmp156, (1, 0)) * -1
     del tmp156
     tmp110 = einsum(t2.bbbb, (0, 1, 2, 3), v.aabb.ovov, (4, 5, 1, 3), (4, 0, 5, 2))
     t2new.abab += tmp110 * 2
     tmp127 = einsum(v.aabb.ovoo, (0, 1, 2, 3), t1.bb, (3, 4), (0, 2, 1, 4))
     t2new.abab += tmp127 * -1
-    tmp196 = v.bbbb.oovv.copy()
-    tmp196 += tmp195.transpose((1, 0, 2, 3)) * -1
+    tmp196 = np.copy(v.bbbb.oovv)
+    tmp196 += np.transpose(tmp195, (1, 0, 2, 3)) * -1
     del tmp195
-    tmp208 = v.bbbb.ovvv.copy()
+    tmp208 = np.copy(v.bbbb.ovvv)
     tmp208 += einsum(v.bbbb.ovov, (0, 1, 2, 3), t1.bb, (2, 4), (0, 3, 4, 1))
     tmp204 = einsum(t1.bb, (0, 1), tmp173, (2, 3, 1, 4), (0, 2, 3, 4))
     del tmp173
-    tmp178 = tmp124.copy() * -1
+    tmp178 = np.copy(tmp124) * -1
     tmp178 += tmp123
     tmp200 = einsum(tmp198, (0, 1, 2, 3), t1.bb, (2, 4), (1, 0, 3, 4))
-    tmp176 = tmp20.copy() * -1
-    tmp176 += tmp20.transpose((0, 2, 1, 3))
-    tmp175 = v.bbbb.ovvv.copy()
-    tmp175 += v.bbbb.ovvv.transpose((0, 2, 1, 3)) * -1
-    tmp148 = tmp124.copy()
+    tmp176 = np.copy(tmp20) * -1
+    tmp176 += np.transpose(tmp20, (0, 2, 1, 3))
+    tmp175 = np.copy(v.bbbb.ovvv)
+    tmp175 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3)) * -1
+    tmp148 = np.copy(tmp124)
     tmp148 += tmp123 * -1
     del tmp123
     t2new.abab += einsum(tmp148, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 2), (4, 1, 5, 3)) * 2
     tmp206 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.bbbb, (4, 5, 3, 1), (4, 5, 0, 2)) * -1
-    tmp171 = tmp23.copy()
+    tmp171 = np.copy(tmp23)
     tmp171 += tmp24 * 2
     tmp171 += tmp25
-    tmp181 = tmp180.transpose((0, 1, 3, 2)).copy() * -1
+    tmp181 = np.copy(np.transpose(tmp180, (0, 1, 3, 2))) * -1
     del tmp180
     tmp181 += tmp146 * -1
     tmp169 = einsum(tmp165, (0, 1, 2, 3), t1.bb, (3, 4), (0, 2, 1, 4))
-    tmp189 = v.bbbb.ooov.copy() * -1
-    tmp189 += v.bbbb.ovoo.transpose((0, 2, 3, 1))
-    tmp87 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp87 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp189 = np.copy(v.bbbb.ooov) * -1
+    tmp189 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1))
+    tmp87 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1))) * -1
+    tmp87 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp125 = einsum(t1.bb, (0, 1), v.aabb.vvov, (2, 3, 4, 1), (0, 4, 2, 3))
     tmp42 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (4, 2, 5, 3), (4, 0, 5, 1))
     t2new.aaaa += tmp42
-    t2new.aaaa += tmp42.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp42.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp42.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp42, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp42, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp42, (1, 0, 3, 2))
     tmp44 = einsum(v.aabb.vvov, (0, 1, 2, 3), t1.bb, (2, 3), (0, 1))
-    tmp45 = v.aaaa.ovvv.copy() * -1
-    tmp45 += v.aaaa.ovvv.transpose((0, 2, 1, 3))
+    tmp45 = np.copy(v.aaaa.ovvv) * -1
+    tmp45 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3))
     tmp39 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (0, 3, 1, 4), (2, 4)) * -1
     tmp40 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (0, 4, 1, 3), (2, 4))
-    tmp47 = v.aaaa.ovvv.copy() * -1
-    tmp47 += v.aaaa.ovvv.transpose((0, 2, 1, 3))
-    tmp142 = tmp2.copy()
-    tmp142 += tmp2.transpose((0, 2, 1, 3)) * -1
+    tmp47 = np.copy(v.aaaa.ovvv) * -1
+    tmp47 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3))
+    tmp142 = np.copy(tmp2)
+    tmp142 += np.transpose(tmp2, (0, 2, 1, 3)) * -1
     tmp82 = einsum(v.aabb.ooov, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3))
     t2new.abab += tmp82 * -1
     tmp134 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 1), (4, 2, 5, 3))
     t2new.abab += tmp134 * 2
-    tmp140 = v.aabb.vvov.transpose((2, 0, 1, 3)).copy()
+    tmp140 = np.copy(np.transpose(v.aabb.vvov, (2, 0, 1, 3)))
     tmp140 += einsum(t1.aa, (0, 1), v.aabb.ovov, (0, 2, 3, 4), (3, 1, 2, 4)) * -1
     tmp99 = einsum(tmp93, (0, 1, 2, 3), t1.aa, (2, 4), (1, 0, 3, 4))
-    tmp62 = v.aaaa.ovvv.copy()
-    tmp62 += v.aaaa.ovvv.transpose((0, 2, 1, 3)) * -1
-    tmp63 = tmp2.copy() * -1
-    tmp63 += tmp2.transpose((0, 2, 1, 3))
+    tmp62 = np.copy(v.aaaa.ovvv)
+    tmp62 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3)) * -1
+    tmp63 = np.copy(tmp2) * -1
+    tmp63 += np.transpose(tmp2, (0, 2, 1, 3))
     tmp53 = einsum(v.aaaa.oovv, (0, 1, 2, 3), t1.aa, (4, 3), (4, 0, 1, 2))
-    tmp58 = tmp5.copy() * 2
+    tmp58 = np.copy(tmp5) * 2
     tmp58 += tmp6
     tmp58 += tmp57
     tmp55 = einsum(tmp51, (0, 1, 2, 3), t1.aa, (3, 4), (0, 2, 1, 4))
@@ -279,55 +279,55 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp95 = einsum(tmp61, (0, 1, 2, 3), t1.aa, (4, 2), (4, 0, 1, 3))
     del tmp61
     tmp101 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 3, 5, 2), (0, 1, 4, 5)) * -1
-    tmp91 = v.aaaa.oovv.copy()
-    tmp91 += tmp80.transpose((1, 0, 2, 3)) * -1
+    tmp91 = np.copy(v.aaaa.oovv)
+    tmp91 += np.transpose(tmp80, (1, 0, 2, 3)) * -1
     tmp33 = einsum(t1.aa, (0, 1), v.aaaa.oooo, (2, 3, 4, 0), (2, 3, 4, 1))
-    tmp103 = v.aaaa.ovvv.copy()
+    tmp103 = np.copy(v.aaaa.ovvv)
     tmp103 += einsum(t1.aa, (0, 1), v.aaaa.ovov, (2, 3, 0, 4), (2, 4, 1, 3))
-    tmp85 = v.aaaa.ooov.copy() * -1
-    tmp85 += v.aaaa.ovoo.transpose((0, 2, 3, 1))
+    tmp85 = np.copy(v.aaaa.ooov) * -1
+    tmp85 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1))
     tmp97 = einsum(v.aaaa.vvvv, (0, 1, 2, 3), t1.aa, (4, 3), (4, 0, 1, 2))
-    tmp49 = f.aa.ov.copy()
+    tmp49 = np.copy(f.aa.ov)
     tmp49 += tmp0
     del tmp0
     tmp49 += einsum(t1.aa, (0, 1), tmp48, (0, 2, 1, 3), (2, 3)) * -1
-    tmp37 = f.aa.oo.copy()
-    tmp37 += tmp16.transpose((1, 0))
-    tmp37 += tmp36.transpose((1, 0)) * -1
+    tmp37 = np.copy(f.aa.oo)
+    tmp37 += np.transpose(tmp16, (1, 0))
+    tmp37 += np.transpose(tmp36, (1, 0)) * -1
     del tmp36
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp37, (0, 4), (4, 1, 2, 3)) * -1
-    tmp73 = tmp70.transpose((0, 1, 3, 2)).copy() * -1
+    tmp73 = np.copy(np.transpose(tmp70, (0, 1, 3, 2))) * -1
     del tmp70
     tmp73 += tmp72 * -1
     del tmp72
-    tmp75 = tmp65.copy()
+    tmp75 = np.copy(tmp65)
     tmp75 += tmp66 * -1
     t2new.abab += einsum(tmp75, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (0, 4, 2, 5)) * 2
     tmp89 = einsum(v.aabb.ooov, (0, 1, 2, 3), t2.abab, (4, 2, 5, 3), (4, 0, 1, 5))
-    tmp67 = tmp65.copy() * -1
+    tmp67 = np.copy(tmp65) * -1
     del tmp65
     tmp67 += tmp66
     del tmp66
-    tmp164 = f.bb.vv.copy() * -1
-    tmp164 += tmp112.transpose((1, 0)) * -1
+    tmp164 = np.copy(f.bb.vv) * -1
+    tmp164 += np.transpose(tmp112, (1, 0)) * -1
     tmp164 += einsum(t1.bb, (0, 1), tmp144, (0, 2, 1, 3), (2, 3)) * -1
-    tmp164 += tmp117.transpose((1, 0))
+    tmp164 += np.transpose(tmp117, (1, 0))
     t2new.bbbb += einsum(tmp164, (0, 1), t2.bbbb, (2, 3, 4, 0), (2, 3, 4, 1)) * -2
     del tmp164
     tmp203 = einsum(t1.bb, (0, 1), tmp202, (2, 3, 1, 4), (0, 2, 3, 4))
     del tmp202
-    t2new.bbbb += tmp203.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp203, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp203
     del tmp203
     tmp193 = einsum(tmp192, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 4, 3))
     del tmp192
-    t2new.bbbb += tmp193.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp193.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp193, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp193, (1, 0, 3, 2))
     del tmp193
-    tmp163 = f.bb.vv.copy() * -1
-    tmp163 += tmp112.transpose((1, 0)) * -1
-    tmp163 += tmp107.transpose((1, 0))
-    tmp163 += tmp108.transpose((1, 0)) * 2
+    tmp163 = np.copy(f.bb.vv) * -1
+    tmp163 += np.transpose(tmp112, (1, 0)) * -1
+    tmp163 += np.transpose(tmp107, (1, 0))
+    tmp163 += np.transpose(tmp108, (1, 0)) * 2
     tmp163 += einsum(t1.bb, (0, 1), tmp162, (0, 2, 1, 3), (2, 3)) * -1
     del tmp162
     tmp163 += einsum(t1.bb, (0, 1), tmp15, (0, 2), (2, 1))
@@ -335,38 +335,38 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new.bbbb += einsum(tmp163, (0, 1), t2.bbbb, (2, 3, 4, 0), (2, 3, 1, 4)) * 2
     del tmp163
     tmp153 = einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.oooo, (4, 1, 5, 0), (4, 5, 2, 3)) * -1
-    t2new.bbbb += tmp153.transpose((1, 0, 3, 2)) * 0.5
-    t2new.bbbb += tmp153.transpose((1, 0, 3, 2)) * 0.5
-    t2new.bbbb += tmp153.transpose((1, 0, 3, 2)) * 0.5
-    t2new.bbbb += tmp153.transpose((1, 0, 3, 2)) * 0.5
+    t2new.bbbb += np.transpose(tmp153, (1, 0, 3, 2)) * 0.5
+    t2new.bbbb += np.transpose(tmp153, (1, 0, 3, 2)) * 0.5
+    t2new.bbbb += np.transpose(tmp153, (1, 0, 3, 2)) * 0.5
+    t2new.bbbb += np.transpose(tmp153, (1, 0, 3, 2)) * 0.5
     del tmp153
     tmp161 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (0, 2, 4, 5), (1, 4, 3, 5))
     t2new.bbbb += tmp161
-    t2new.bbbb += tmp161.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp161.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp161.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp161, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp161, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp161, (1, 0, 3, 2))
     del tmp161
     tmp155 = einsum(tmp154, (0, 1, 2, 3), t1.bb, (1, 4), (2, 0, 3, 4))
     del tmp154
-    t2new.bbbb += tmp155.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp155, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp155
     del tmp155
-    tmp31 = f.bb.oo.copy()
-    tmp31 += tmp28.transpose((1, 0))
+    tmp31 = np.copy(f.bb.oo)
+    tmp31 += np.transpose(tmp28, (1, 0))
     del tmp28
-    tmp31 += tmp30.transpose((1, 0)) * -1
+    tmp31 += np.transpose(tmp30, (1, 0)) * -1
     del tmp30
     t2new.bbbb += einsum(tmp31, (0, 1), t2.bbbb, (2, 0, 3, 4), (2, 1, 3, 4)) * -1
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp31, (1, 4), (0, 4, 2, 3)) * -1
     t1new.bb += einsum(t1.bb, (0, 1), tmp31, (0, 2), (2, 1)) * -1
     del tmp31
     tmp184 = einsum(t1.bb, (0, 1), v.bbbb.ooov, (2, 0, 3, 4), (2, 3, 1, 4))
-    t2new.bbbb += tmp184.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp184, (1, 0, 2, 3))
     t2new.bbbb += tmp184 * -1
-    t2new.bbbb += tmp184.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp184.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp184, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp184, (0, 1, 3, 2))
     del tmp184
-    tmp187 = v.bbbb.oovv.copy()
+    tmp187 = np.copy(v.bbbb.oovv)
     tmp187 += einsum(t2.bbbb, (0, 1, 2, 3), tmp83, (1, 4, 3, 5), (0, 4, 2, 5)) * -2
     tmp187 += einsum(tmp186, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 4, 3)) * -1
     del tmp186
@@ -375,66 +375,66 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp168 = einsum(t1.bb, (0, 1), tmp167, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp167
     t2new.bbbb += tmp168
-    t2new.bbbb += tmp168.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp168.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp168.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp168, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp168, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp168, (1, 0, 3, 2))
     del tmp168
     tmp158 = einsum(t2.bbbb, (0, 1, 2, 3), tmp157, (1, 4), (0, 4, 2, 3)) * -1
     del tmp157
-    t2new.bbbb += tmp158.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp158.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp158.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp158, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp158, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp158, (0, 1, 3, 2)) * -1
     del tmp158
     tmp185 = einsum(tmp110, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (4, 1, 5, 3))
     del tmp110
-    t2new.bbbb += tmp185.transpose((1, 0, 2, 3)) * -2
-    t2new.bbbb += tmp185.transpose((0, 1, 3, 2)) * -2
-    t2new.bbbb += tmp185.transpose((1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp185, (1, 0, 2, 3)) * -2
+    t2new.bbbb += np.transpose(tmp185, (0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp185, (1, 0, 3, 2)) * 2
     t2new.bbbb += tmp185 * 2
     del tmp185
     tmp174 = einsum(t1.bb, (0, 1), tmp20, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp20
     t2new.bbbb += tmp174 * -1
-    t2new.bbbb += tmp174.transpose((1, 0, 2, 3))
-    t2new.bbbb += tmp174.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp174.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp174, (1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp174, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp174, (1, 0, 3, 2)) * -1
     del tmp174
-    tmp191 = tmp127.copy()
+    tmp191 = np.copy(tmp127)
     tmp191 += einsum(tmp7, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5))
     t2new.bbbb += einsum(t2.abab, (0, 1, 2, 3), tmp191, (0, 4, 2, 5), (1, 4, 5, 3))
     del tmp191
     tmp197 = einsum(tmp196, (0, 1, 2, 3), t2.bbbb, (4, 0, 5, 3), (4, 1, 5, 2))
     del tmp196
     t2new.bbbb += tmp197 * -2
-    t2new.bbbb += tmp197.transpose((1, 0, 2, 3)) * 2
+    t2new.bbbb += np.transpose(tmp197, (1, 0, 2, 3)) * 2
     del tmp197
-    tmp209 = v.bbbb.vvvv.copy() * -1
+    tmp209 = np.copy(v.bbbb.vvvv) * -1
     tmp209 += einsum(tmp208, (0, 1, 2, 3), t1.bb, (0, 4), (3, 2, 1, 4))
     del tmp208
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), tmp209, (2, 4, 3, 5), (0, 1, 4, 5)) * -2
     del tmp209
     tmp205 = einsum(tmp204, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 4, 3))
     del tmp204
-    t2new.bbbb += tmp205.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp205, (1, 0, 2, 3))
     t2new.bbbb += tmp205 * -1
-    t2new.bbbb += tmp205.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp205.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp205, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp205, (0, 1, 3, 2))
     del tmp205
     tmp179 = einsum(tmp178, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (4, 1, 5, 3))
     del tmp178
     t2new.bbbb += tmp179 * -1
-    t2new.bbbb += tmp179.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp179, (0, 1, 3, 2))
     del tmp179
     tmp166 = einsum(t2.bbbb, (0, 1, 2, 3), tmp165, (4, 5, 0, 1), (4, 5, 2, 3))
     del tmp165
-    t2new.bbbb += tmp166.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp166.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp166.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp166.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp166, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp166, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp166, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp166, (1, 0, 3, 2)) * -1
     del tmp166
     tmp201 = einsum(t1.bb, (0, 1), tmp200, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp200
-    t2new.bbbb += tmp201.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp201, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp201
     del tmp201
     tmp177 = einsum(t1.bb, (0, 1), tmp175, (2, 3, 1, 4), (0, 2, 4, 3)) * -1
@@ -445,83 +445,83 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp177
     tmp183 = einsum(t2.abab, (0, 1, 2, 3), tmp148, (0, 4, 2, 5), (1, 4, 3, 5))
     del tmp148
-    t2new.bbbb += tmp183.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp183.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp183, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp183, (1, 0, 3, 2))
     del tmp183
-    tmp188 = tmp127.copy()
+    tmp188 = np.copy(tmp127)
     del tmp127
     tmp188 += einsum(tmp48, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5))
     t2new.bbbb += einsum(tmp188, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5)) * -1
     del tmp188
     tmp160 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.bbbb, (4, 2, 5, 3), (4, 0, 5, 1))
     t2new.bbbb += tmp160 * 2
-    t2new.bbbb += tmp160.transpose((0, 1, 3, 2)) * -2
-    t2new.bbbb += tmp160.transpose((1, 0, 2, 3)) * -2
-    t2new.bbbb += tmp160.transpose((1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp160, (0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp160, (1, 0, 2, 3)) * -2
+    t2new.bbbb += np.transpose(tmp160, (1, 0, 3, 2)) * 2
     del tmp160
     tmp207 = einsum(t2.bbbb, (0, 1, 2, 3), tmp206, (4, 5, 1, 0), (5, 4, 2, 3))
     del tmp206
-    t2new.bbbb += tmp207.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp207.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp207, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp207, (0, 1, 3, 2)) * -1
     del tmp207
     tmp172 = einsum(t2.bbbb, (0, 1, 2, 3), tmp171, (4, 1), (0, 4, 2, 3)) * -1
     del tmp171
-    t2new.bbbb += tmp172.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp172.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp172.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp172.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp172, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp172, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp172, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp172, (0, 1, 3, 2)) * -1
     del tmp172
     tmp199 = einsum(t2.bbbb, (0, 1, 2, 3), tmp198, (4, 5, 1, 0), (5, 4, 2, 3))
     del tmp198
-    t2new.bbbb += tmp199.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp199.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp199, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp199, (0, 1, 3, 2)) * -1
     del tmp199
     tmp182 = einsum(tmp181, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp181
-    t2new.bbbb += tmp182.transpose((1, 0, 2, 3)) * 2
+    t2new.bbbb += np.transpose(tmp182, (1, 0, 2, 3)) * 2
     t2new.bbbb += tmp182 * -2
-    t2new.bbbb += tmp182.transpose((1, 0, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp182, (1, 0, 3, 2)) * -2
     del tmp182
     tmp210 = einsum(v.bbbb.ovvv, (0, 1, 2, 3), t2.bbbb, (4, 5, 1, 3), (4, 5, 0, 2))
     t2new.bbbb += einsum(t1.bb, (0, 1), tmp210, (2, 3, 0, 4), (2, 3, 1, 4)) * -2
     del tmp210
-    tmp159 = tmp107.copy() * 0.5
+    tmp159 = np.copy(tmp107) * 0.5
     tmp159 += tmp108
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), tmp159, (4, 3), (0, 1, 2, 4)) * -4
     del tmp159
     tmp170 = einsum(tmp169, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 4, 3))
     del tmp169
-    t2new.bbbb += tmp170.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp170, (0, 1, 3, 2))
     t2new.bbbb += tmp170 * -1
-    t2new.bbbb += tmp170.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp170.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp170, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp170, (1, 0, 2, 3))
     del tmp170
-    tmp190 = v.bbbb.oovv.copy() * 0.5
+    tmp190 = np.copy(v.bbbb.oovv) * 0.5
     tmp190 += einsum(tmp87, (0, 1, 2, 3), t2.bbbb, (4, 0, 5, 2), (4, 1, 5, 3)) * -1
     tmp190 += einsum(tmp189, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 4, 3)) * -0.5
     del tmp189
     t2new.bbbb += einsum(tmp190, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (4, 0, 2, 5)) * 4
     del tmp190
-    tmp131 = v.aabb.vvov.transpose((2, 0, 1, 3)).copy()
+    tmp131 = np.copy(np.transpose(v.aabb.vvov, (2, 0, 1, 3)))
     tmp131 += einsum(t1.bb, (0, 1), v.aabb.vvvv, (2, 3, 4, 1), (0, 2, 3, 4))
     t2new.abab += einsum(tmp131, (0, 1, 2, 3), t1.aa, (4, 1), (4, 0, 2, 3))
     del tmp131
-    tmp126 = tmp125.transpose((0, 1, 3, 2)).copy()
+    tmp126 = np.copy(np.transpose(tmp125, (0, 1, 3, 2)))
     tmp126 += einsum(tmp21, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 3, 4)) * -1
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp126, (4, 1, 2, 5), (0, 4, 5, 3)) * -1
     del tmp126
-    tmp109 = tmp107.copy()
+    tmp109 = np.copy(tmp107)
     del tmp107
     tmp109 += tmp108 * 2
     del tmp108
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp109, (4, 3), (0, 1, 2, 4)) * -1
     del tmp109
-    tmp118 = f.bb.vv.copy()
-    tmp118 += tmp112.transpose((1, 0))
+    tmp118 = np.copy(f.bb.vv)
+    tmp118 += np.transpose(tmp112, (1, 0))
     del tmp112
     tmp118 += einsum(tmp113, (0, 1, 2, 3), t1.bb, (0, 2), (1, 3)) * -1
     del tmp113
-    tmp118 += tmp117.transpose((1, 0)) * -1
+    tmp118 += np.transpose(tmp117, (1, 0)) * -1
     del tmp117
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp118, (3, 4), (0, 1, 2, 4))
     del tmp118
@@ -535,19 +535,19 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new.abab += einsum(tmp130, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 3, 4)) * -1
     del tmp130
     tmp122 = einsum(t1.aa, (0, 1), v.aabb.ovoo, (2, 1, 3, 4), (0, 2, 3, 4))
-    tmp133 = v.aaaa.oovv.copy()
-    tmp133 += tmp42.transpose((1, 0, 3, 2)) * -1
+    tmp133 = np.copy(v.aaaa.oovv)
+    tmp133 += np.transpose(tmp42, (1, 0, 3, 2)) * -1
     tmp133 += einsum(t2.aaaa, (0, 1, 2, 3), tmp48, (1, 4, 3, 5), (4, 0, 5, 2)) * 2
     tmp133 += einsum(tmp35, (0, 1, 2, 3), t1.aa, (0, 4), (2, 1, 3, 4))
     del tmp35
     t2new.abab += einsum(tmp133, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5)) * -1
     del tmp133
-    tmp138 = v.bbbb.oovv.copy()
+    tmp138 = np.copy(v.bbbb.oovv)
     tmp138 += einsum(t1.bb, (0, 1), tmp137, (0, 2, 3, 4), (3, 2, 4, 1))
     del tmp137
     t2new.abab += einsum(tmp138, (0, 1, 2, 3), t2.abab, (4, 0, 5, 2), (4, 1, 5, 3)) * -1
     del tmp138
-    tmp128 = v.aabb.vvoo.transpose((2, 3, 0, 1)).copy() * -1
+    tmp128 = np.copy(np.transpose(v.aabb.vvoo, (2, 3, 0, 1))) * -1
     tmp128 += einsum(v.aabb.ovoo, (0, 1, 2, 3), t1.aa, (0, 4), (2, 3, 1, 4))
     tmp128 += einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (0, 4, 5, 3), (2, 4, 1, 5))
     t2new.abab += einsum(tmp128, (0, 1, 2, 3), t2.abab, (4, 0, 2, 5), (4, 1, 3, 5))
@@ -556,14 +556,14 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp124
     t2new.abab += einsum(t1.aa, (0, 1), tmp152, (2, 0, 3, 4), (2, 3, 1, 4)) * -1
     del tmp152
-    tmp106 = t2.abab.copy()
+    tmp106 = np.copy(t2.abab)
     tmp106 += einsum(t1.aa, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3)) * 2
     t2new.abab += einsum(v.aabb.oooo, (0, 1, 2, 3), tmp106, (1, 3, 4, 5), (0, 2, 4, 5)) * 0.5
     del tmp106
-    tmp111 = f.aa.vv.copy() * -1
-    tmp111 += tmp44.transpose((1, 0)) * -1
-    tmp111 += tmp39.transpose((1, 0)) * 2
-    tmp111 += tmp40.transpose((1, 0))
+    tmp111 = np.copy(f.aa.vv) * -1
+    tmp111 += np.transpose(tmp44, (1, 0)) * -1
+    tmp111 += np.transpose(tmp39, (1, 0)) * 2
+    tmp111 += np.transpose(tmp40, (1, 0))
     tmp111 += einsum(t1.aa, (0, 1), tmp45, (0, 2, 1, 3), (2, 3)) * -1
     tmp111 += einsum(tmp9, (0, 1), t1.aa, (0, 2), (1, 2))
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp111, (2, 4), (0, 1, 4, 3)) * -1
@@ -576,26 +576,26 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp150 = einsum(v.aabb.ovvv, (0, 1, 2, 3), t2.abab, (4, 5, 1, 3), (4, 0, 5, 2))
     t2new.abab += einsum(t1.aa, (0, 1), tmp150, (2, 0, 3, 4), (2, 3, 1, 4)) * -1
     del tmp150
-    tmp135 = tmp82.copy() * -1
+    tmp135 = np.copy(tmp82) * -1
     tmp135 += tmp134 * 2
     del tmp134
     tmp135 += einsum(tmp114, (0, 1, 2, 3), t2.abab, (4, 0, 5, 2), (4, 1, 5, 3)) * -1
     del tmp114
     t2new.abab += einsum(tmp135, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (0, 4, 2, 5)) * 2
     del tmp135
-    tmp121 = tmp5.transpose((1, 0)).copy() * 2
-    tmp121 += tmp6.transpose((1, 0))
-    tmp121 += tmp57.transpose((1, 0))
+    tmp121 = np.copy(np.transpose(tmp5, (1, 0))) * 2
+    tmp121 += np.transpose(tmp6, (1, 0))
+    tmp121 += np.transpose(tmp57, (1, 0))
     del tmp57
     t2new.abab += einsum(tmp121, (0, 1), t2.abab, (0, 2, 3, 4), (1, 2, 3, 4)) * -1
     del tmp121
     tmp147 = einsum(t1.bb, (0, 1), tmp144, (2, 3, 1, 4), (0, 2, 3, 4)) * -1
     del tmp144
-    tmp147 += tmp146.transpose((0, 1, 3, 2))
+    tmp147 += np.transpose(tmp146, (0, 1, 3, 2))
     del tmp146
     t2new.abab += einsum(tmp147, (0, 1, 2, 3), t2.abab, (4, 1, 5, 2), (4, 0, 5, 3))
     del tmp147
-    tmp129 = v.aabb.oovv.copy()
+    tmp129 = np.copy(v.aabb.oovv)
     tmp129 += einsum(t1.bb, (0, 1), v.aabb.ooov, (2, 3, 0, 4), (2, 3, 4, 1)) * -1
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp129, (0, 4, 3, 5), (4, 1, 2, 5)) * -1
     del tmp129
@@ -605,7 +605,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp120
     tmp132 = einsum(t1.aa, (0, 1), tmp21, (2, 3, 4, 1), (0, 2, 3, 4))
     del tmp21
-    tmp141 = v.aabb.vvvv.copy()
+    tmp141 = np.copy(v.aabb.vvvv)
     tmp141 += einsum(t1.bb, (0, 1), tmp140, (0, 2, 3, 4), (3, 2, 4, 1)) * -1
     del tmp140
     t2new.abab += einsum(tmp141, (0, 1, 2, 3), t2.abab, (4, 5, 0, 2), (4, 5, 1, 3))
@@ -613,11 +613,11 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp136 = einsum(v.aabb.ovoo, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 1), (4, 2, 3, 5))
     t2new.abab += einsum(tmp136, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 3, 4)) * -2
     del tmp136
-    tmp26 = tmp23.transpose((1, 0)).copy()
+    tmp26 = np.copy(np.transpose(tmp23, (1, 0)))
     del tmp23
-    tmp26 += tmp24.transpose((1, 0)) * 2
+    tmp26 += np.transpose(tmp24, (1, 0)) * 2
     del tmp24
-    tmp26 += tmp25.transpose((1, 0))
+    tmp26 += np.transpose(tmp25, (1, 0))
     del tmp25
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp26, (1, 4), (0, 4, 2, 3)) * -1
     t1new.bb += einsum(t1.bb, (0, 1), tmp26, (0, 2), (2, 1)) * -1
@@ -628,7 +628,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp151 = einsum(t1.bb, (0, 1), v.aabb.oovv, (2, 3, 4, 1), (2, 3, 0, 4))
     t2new.abab += einsum(t1.aa, (0, 1), tmp151, (2, 0, 3, 4), (2, 3, 1, 4)) * -1
     del tmp151
-    tmp3 = t2.abab.copy()
+    tmp3 = np.copy(t2.abab)
     tmp3 += einsum(t1.aa, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3))
     t2new.abab += einsum(tmp3, (0, 1, 2, 3), tmp132, (4, 0, 5, 1), (4, 5, 2, 3))
     del tmp132
@@ -641,7 +641,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp3
     tmp100 = einsum(t1.aa, (0, 1), tmp99, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp99
-    t2new.aaaa += tmp100.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp100, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp100
     del tmp100
     tmp64 = einsum(t1.aa, (0, 1), tmp62, (2, 3, 1, 4), (0, 2, 4, 3)) * -1
@@ -650,10 +650,10 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp63
     t2new.aaaa += einsum(tmp64, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (4, 0, 2, 5)) * 2
     del tmp64
-    tmp46 = f.aa.vv.copy() * -0.5
-    tmp46 += tmp44.transpose((1, 0)) * -0.5
-    tmp46 += tmp39.transpose((1, 0))
-    tmp46 += tmp40.transpose((1, 0)) * 0.5
+    tmp46 = np.copy(f.aa.vv) * -0.5
+    tmp46 += np.transpose(tmp44, (1, 0)) * -0.5
+    tmp46 += np.transpose(tmp39, (1, 0))
+    tmp46 += np.transpose(tmp40, (1, 0)) * 0.5
     tmp46 += einsum(t1.aa, (0, 1), tmp45, (0, 2, 1, 3), (2, 3)) * -0.5
     del tmp45
     tmp46 += einsum(tmp9, (0, 1), t1.aa, (0, 2), (1, 2)) * 0.5
@@ -662,51 +662,51 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp54 = einsum(tmp53, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
     del tmp53
     t2new.aaaa += tmp54
-    t2new.aaaa += tmp54.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp54.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp54.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp54, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp54, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp54, (1, 0, 3, 2))
     del tmp54
-    tmp41 = tmp39.copy() * 2
+    tmp41 = np.copy(tmp39) * 2
     del tmp39
     tmp41 += tmp40
     del tmp40
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp41, (4, 3), (0, 1, 2, 4)) * -2
     del tmp41
-    tmp84 = tmp82.copy()
+    tmp84 = np.copy(tmp82)
     tmp84 += einsum(tmp83, (0, 1, 2, 3), t2.abab, (4, 0, 5, 2), (4, 1, 5, 3)) * -1
     del tmp83
     t2new.aaaa += einsum(t2.abab, (0, 1, 2, 3), tmp84, (4, 1, 5, 3), (4, 0, 5, 2)) * -1
     del tmp84
     tmp32 = einsum(v.aaaa.oooo, (0, 1, 2, 3), t2.aaaa, (3, 1, 4, 5), (0, 2, 4, 5)) * -1
-    t2new.aaaa += tmp32.transpose((1, 0, 3, 2)) * 0.5
-    t2new.aaaa += tmp32.transpose((1, 0, 3, 2)) * 0.5
-    t2new.aaaa += tmp32.transpose((1, 0, 3, 2)) * 0.5
-    t2new.aaaa += tmp32.transpose((1, 0, 3, 2)) * 0.5
+    t2new.aaaa += np.transpose(tmp32, (1, 0, 3, 2)) * 0.5
+    t2new.aaaa += np.transpose(tmp32, (1, 0, 3, 2)) * 0.5
+    t2new.aaaa += np.transpose(tmp32, (1, 0, 3, 2)) * 0.5
+    t2new.aaaa += np.transpose(tmp32, (1, 0, 3, 2)) * 0.5
     del tmp32
     tmp77 = einsum(v.aaaa.ooov, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3))
-    t2new.aaaa += tmp77.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp77, (1, 0, 2, 3))
     t2new.aaaa += tmp77 * -1
-    t2new.aaaa += tmp77.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp77.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp77, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp77, (0, 1, 3, 2))
     del tmp77
     tmp59 = einsum(t2.aaaa, (0, 1, 2, 3), tmp58, (4, 1), (0, 4, 2, 3)) * -1
     del tmp58
-    t2new.aaaa += tmp59.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp59.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp59.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp59.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp59, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp59, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp59, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp59, (0, 1, 3, 2)) * -1
     del tmp59
     tmp56 = einsum(tmp55, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3))
     del tmp55
-    t2new.aaaa += tmp56.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp56, (0, 1, 3, 2))
     t2new.aaaa += tmp56 * -1
-    t2new.aaaa += tmp56.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp56.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp56, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp56, (1, 0, 2, 3))
     del tmp56
-    tmp19 = f.aa.oo.copy()
-    tmp19 += tmp16.transpose((1, 0))
+    tmp19 = np.copy(f.aa.oo)
+    tmp19 += np.transpose(tmp16, (1, 0))
     del tmp16
-    tmp19 += tmp18.transpose((1, 0)) * -1
+    tmp19 += np.transpose(tmp18, (1, 0)) * -1
     del tmp18
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp19, (1, 4), (0, 4, 2, 3)) * -1
     t1new.aa += einsum(tmp19, (0, 1), t1.aa, (0, 2), (1, 2)) * -1
@@ -716,12 +716,12 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp105
     tmp96 = einsum(tmp95, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
     del tmp95
-    t2new.aaaa += tmp96.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp96, (1, 0, 2, 3))
     t2new.aaaa += tmp96 * -1
-    t2new.aaaa += tmp96.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp96.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp96, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp96, (0, 1, 3, 2))
     del tmp96
-    tmp88 = tmp82.copy()
+    tmp88 = np.copy(tmp82)
     del tmp82
     tmp88 += einsum(tmp87, (0, 1, 2, 3), t2.abab, (4, 0, 5, 2), (4, 1, 5, 3)) * -1
     del tmp87
@@ -729,38 +729,38 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp88
     tmp102 = einsum(tmp101, (0, 1, 2, 3), t2.aaaa, (3, 2, 4, 5), (1, 0, 4, 5))
     del tmp101
-    t2new.aaaa += tmp102.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp102.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp102, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp102, (0, 1, 3, 2)) * -1
     del tmp102
     tmp92 = einsum(tmp91, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 3), (4, 1, 5, 2))
     del tmp91
     t2new.aaaa += tmp92 * -2
-    t2new.aaaa += tmp92.transpose((1, 0, 2, 3)) * 2
+    t2new.aaaa += np.transpose(tmp92, (1, 0, 2, 3)) * 2
     del tmp92
     tmp34 = einsum(t1.aa, (0, 1), tmp33, (2, 0, 3, 4), (3, 2, 4, 1))
     del tmp33
-    t2new.aaaa += tmp34.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp34, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp34
     del tmp34
     tmp52 = einsum(tmp51, (0, 1, 2, 3), t2.aaaa, (2, 3, 4, 5), (0, 1, 4, 5))
     del tmp51
-    t2new.aaaa += tmp52.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp52.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp52.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp52.transpose((1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp52, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp52, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp52, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp52, (1, 0, 3, 2)) * -1
     del tmp52
     tmp43 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 5, 1, 3), (0, 4, 2, 5))
     t2new.aaaa += tmp43 * 2
-    t2new.aaaa += tmp43.transpose((0, 1, 3, 2)) * -2
-    t2new.aaaa += tmp43.transpose((1, 0, 2, 3)) * -2
-    t2new.aaaa += tmp43.transpose((1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp43, (0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp43, (1, 0, 2, 3)) * -2
+    t2new.aaaa += np.transpose(tmp43, (1, 0, 3, 2)) * 2
     del tmp43
-    tmp104 = v.aaaa.vvvv.copy()
+    tmp104 = np.copy(v.aaaa.vvvv)
     tmp104 += einsum(tmp103, (0, 1, 2, 3), t1.aa, (0, 4), (3, 4, 2, 1))
     del tmp103
     t2new.aaaa += einsum(tmp104, (0, 1, 2, 3), t2.aaaa, (4, 5, 0, 3), (4, 5, 2, 1)) * -2
     del tmp104
-    tmp86 = v.aaaa.oovv.copy() * 0.5
+    tmp86 = np.copy(v.aaaa.oovv) * 0.5
     tmp86 += einsum(tmp7, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 3), (4, 1, 5, 2)) * -1
     del tmp7
     tmp86 += einsum(t1.aa, (0, 1), tmp85, (0, 2, 3, 4), (2, 3, 1, 4)) * -0.5
@@ -769,11 +769,11 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp86
     tmp98 = einsum(t1.aa, (0, 1), tmp97, (2, 3, 1, 4), (0, 2, 3, 4))
     del tmp97
-    t2new.aaaa += tmp98.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp98, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp98
     del tmp98
-    tmp50 = f.aa.vv.copy() * -1
-    tmp50 += tmp44.transpose((1, 0)) * -1
+    tmp50 = np.copy(f.aa.vv) * -1
+    tmp50 += np.transpose(tmp44, (1, 0)) * -1
     del tmp44
     tmp50 += einsum(t1.aa, (0, 1), tmp47, (0, 2, 1, 3), (2, 3)) * -1
     del tmp47
@@ -783,11 +783,11 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp50
     tmp38 = einsum(t2.aaaa, (0, 1, 2, 3), tmp37, (1, 4), (0, 4, 2, 3)) * -1
     del tmp37
-    t2new.aaaa += tmp38.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp38.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp38.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp38, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp38, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp38, (0, 1, 3, 2)) * -1
     del tmp38
-    tmp81 = v.aaaa.oovv.copy()
+    tmp81 = np.copy(v.aaaa.oovv)
     tmp81 += einsum(tmp48, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 3), (4, 1, 5, 2)) * -2
     del tmp48
     tmp81 += tmp80 * -1
@@ -796,63 +796,63 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp81
     tmp74 = einsum(tmp73, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp73
-    t2new.aaaa += tmp74.transpose((1, 0, 2, 3)) * 2
+    t2new.aaaa += np.transpose(tmp74, (1, 0, 2, 3)) * 2
     t2new.aaaa += tmp74 * -2
-    t2new.aaaa += tmp74.transpose((1, 0, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp74, (1, 0, 3, 2)) * -2
     del tmp74
     tmp76 = einsum(tmp75, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp75
-    t2new.aaaa += tmp76.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp76.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp76, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp76, (1, 0, 3, 2))
     del tmp76
     tmp78 = einsum(tmp42, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp42
-    t2new.aaaa += tmp78.transpose((1, 0, 2, 3)) * -2
-    t2new.aaaa += tmp78.transpose((0, 1, 3, 2)) * -2
-    t2new.aaaa += tmp78.transpose((1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp78, (1, 0, 2, 3)) * -2
+    t2new.aaaa += np.transpose(tmp78, (0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp78, (1, 0, 3, 2)) * 2
     t2new.aaaa += tmp78 * 2
     del tmp78
     tmp94 = einsum(tmp93, (0, 1, 2, 3), t2.aaaa, (3, 2, 4, 5), (1, 0, 4, 5))
     del tmp93
-    t2new.aaaa += tmp94.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp94.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp94, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp94, (0, 1, 3, 2)) * -1
     del tmp94
     tmp90 = einsum(t1.aa, (0, 1), tmp89, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp89
-    t2new.aaaa += tmp90.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp90.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp90, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp90, (1, 0, 3, 2))
     del tmp90
     tmp60 = einsum(tmp2, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
     del tmp2
     t2new.aaaa += tmp60 * -1
-    t2new.aaaa += tmp60.transpose((1, 0, 2, 3))
-    t2new.aaaa += tmp60.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp60.transpose((1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp60, (1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp60, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp60, (1, 0, 3, 2)) * -1
     del tmp60
     tmp68 = einsum(t2.abab, (0, 1, 2, 3), tmp67, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp67
     t2new.aaaa += tmp68 * -1
-    t2new.aaaa += tmp68.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp68, (0, 1, 3, 2))
     del tmp68
-    tmp27 = f.bb.vv.copy()
+    tmp27 = np.copy(f.bb.vv)
     tmp27 += einsum(t1.bb, (0, 1), v.bbbb.ovvv, (0, 1, 2, 3), (2, 3))
     t1new.bb += einsum(t1.bb, (0, 1), tmp27, (1, 2), (0, 2))
     del tmp27
-    tmp22 = t2.bbbb.copy() * 2
+    tmp22 = np.copy(t2.bbbb) * 2
     tmp22 += einsum(t1.bb, (0, 1), t1.bb, (2, 3), (2, 0, 3, 1))
     t1new.bb += einsum(v.bbbb.ovvv, (0, 1, 2, 3), tmp22, (0, 4, 3, 1), (4, 2)) * -1
     del tmp22
-    tmp11 = f.aa.vv.copy()
+    tmp11 = np.copy(f.aa.vv)
     tmp11 += einsum(t1.aa, (0, 1), v.aaaa.ovvv, (0, 2, 3, 1), (2, 3)) * -1
     t1new.aa += einsum(tmp11, (0, 1), t1.aa, (2, 0), (2, 1))
     del tmp11
-    tmp4 = t2.aaaa.copy() * 2
+    tmp4 = np.copy(t2.aaaa) * 2
     tmp4 += einsum(t1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
     t1new.aa += einsum(v.aaaa.ovvv, (0, 1, 2, 3), tmp4, (0, 4, 1, 3), (4, 2))
     del tmp4
-    tmp10 = tmp5.transpose((1, 0)).copy()
+    tmp10 = np.copy(np.transpose(tmp5, (1, 0)))
     del tmp5
-    tmp10 += tmp6.transpose((1, 0)) * 0.5
+    tmp10 += np.transpose(tmp6, (1, 0)) * 0.5
     del tmp6
     tmp10 += einsum(tmp9, (0, 1), t1.aa, (2, 1), (0, 2)) * 0.5
     del tmp9
@@ -868,14 +868,14 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t1new.bb += einsum(v.aabb.ovoo, (0, 1, 2, 3), t2.abab, (0, 3, 1, 4), (2, 4)) * -1
     t1new.bb += einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.ooov, (4, 1, 0, 3), (4, 2)) * 2
     t1new.bb += einsum(t1.bb, (0, 1), v.bbbb.oovv, (2, 0, 3, 1), (2, 3)) * -1
-    t2new.aaaa += v.aaaa.ovov.transpose((0, 2, 1, 3))
-    t2new.aaaa += v.aaaa.ovov.transpose((0, 2, 3, 1)) * -1
+    t2new.aaaa += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
+    t2new.aaaa += np.transpose(v.aaaa.ovov, (0, 2, 3, 1)) * -1
     t2new.abab += einsum(v.aabb.oooo, (0, 1, 2, 3), t2.abab, (1, 3, 4, 5), (0, 2, 4, 5)) * 0.5
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), v.aaaa.ovov, (4, 5, 0, 2), (4, 1, 5, 3))
-    t2new.abab += v.aabb.ovov.transpose((0, 2, 1, 3))
+    t2new.abab += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     t2new.abab += einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.abab, (4, 2, 5, 3), (4, 0, 5, 1))
-    t2new.bbbb += v.bbbb.ovov.transpose((0, 2, 1, 3))
-    t2new.bbbb += v.bbbb.ovov.transpose((0, 2, 3, 1)) * -1
+    t2new.bbbb += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
+    t2new.bbbb += np.transpose(v.bbbb.ovov, (0, 2, 3, 1)) * -1
 
     return {f"t1new": t1new, f"t2new": t2new}
 
@@ -908,10 +908,10 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
 
     l1new = Namespace()
     l2new = Namespace()
-    tmp98 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp98 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp7 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp7 += v.aaaa.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp98 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp98 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
+    tmp7 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1)))
+    tmp7 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3)) * -1
     tmp97 = einsum(t1.aa, (0, 1), v.aabb.ovov, (0, 1, 2, 3), (2, 3))
     tmp99 = einsum(t1.bb, (0, 1), tmp98, (0, 2, 1, 3), (2, 3))
     del tmp98
@@ -919,19 +919,19 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp8 = einsum(t1.aa, (0, 1), tmp7, (0, 2, 1, 3), (2, 3))
     del tmp7
     tmp2 = einsum(v.aabb.ovov, (0, 1, 2, 3), t1.bb, (4, 3), (0, 4, 2, 1))
-    tmp112 = v.bbbb.ovvv.copy() * -1
-    tmp112 += v.bbbb.ovvv.transpose((0, 2, 1, 3))
-    tmp213 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp213 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp196 = v.bbbb.ovvv.copy() * -1
-    tmp196 += v.bbbb.ovvv.transpose((0, 2, 1, 3))
+    tmp112 = np.copy(v.bbbb.ovvv) * -1
+    tmp112 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3))
+    tmp213 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp213 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
+    tmp196 = np.copy(v.bbbb.ovvv) * -1
+    tmp196 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3))
     tmp39 = einsum(t1.bb, (0, 1), l2.bbbb, (2, 1, 3, 4), (3, 4, 0, 2))
     l2new.abab = einsum(tmp2, (0, 1, 2, 3), tmp39, (4, 1, 2, 5), (3, 5, 0, 4)) * -2
     l2new.abab += einsum(v.aabb.ovoo, (0, 1, 2, 3), tmp39, (4, 3, 2, 5), (1, 5, 0, 4)) * -2
     l1new.bb = einsum(v.bbbb.oovv, (0, 1, 2, 3), tmp39, (4, 1, 0, 3), (2, 4)) * -2
-    tmp118 = v.bbbb.ooov.copy()
-    tmp118 += v.bbbb.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp100 = f.bb.ov.copy()
+    tmp118 = np.copy(v.bbbb.ooov)
+    tmp118 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1)) * -1
+    tmp100 = np.copy(f.bb.ov)
     tmp100 += tmp97
     tmp100 += tmp99 * -1
     del tmp99
@@ -940,18 +940,18 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.abab += einsum(tmp37, (0, 1, 2, 3), v.aabb.vvov, (4, 3, 2, 5), (4, 5, 0, 1)) * -1
     l2new.abab += einsum(tmp37, (0, 1, 2, 3), v.bbbb.ovoo, (4, 5, 2, 1), (3, 5, 0, 4)) * -1
     l1new.aa = einsum(tmp37, (0, 1, 2, 3), v.aabb.vvoo, (4, 3, 2, 1), (4, 0)) * -1
-    tmp64 = v.aaaa.ooov.copy()
-    tmp64 += v.aaaa.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp9 = f.aa.ov.copy()
+    tmp64 = np.copy(v.aaaa.ooov)
+    tmp64 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1)) * -1
+    tmp9 = np.copy(f.aa.ov)
     tmp9 += tmp6
     tmp9 += tmp8 * -1
     del tmp8
-    tmp178 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp178 += v.aaaa.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp30 = v.aaaa.ovvv.copy() * -1
-    tmp30 += v.aaaa.ovvv.transpose((0, 2, 1, 3))
-    tmp93 = v.aaaa.ovvv.copy() * -1
-    tmp93 += v.aaaa.ovvv.transpose((0, 2, 1, 3))
+    tmp178 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1)))
+    tmp178 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3)) * -1
+    tmp30 = np.copy(v.aaaa.ovvv) * -1
+    tmp30 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3))
+    tmp93 = np.copy(v.aaaa.ovvv) * -1
+    tmp93 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3))
     tmp49 = einsum(t1.aa, (0, 1), l2.aaaa, (2, 1, 3, 4), (3, 4, 0, 2))
     l2new.abab += einsum(v.aabb.ooov, (0, 1, 2, 3), tmp49, (4, 1, 0, 5), (5, 3, 4, 2)) * -2
     l1new.aa += einsum(tmp49, (0, 1, 2, 3), v.aaaa.oovv, (2, 1, 4, 3), (4, 0)) * -2
@@ -961,7 +961,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp95 = einsum(t1.bb, (0, 1), v.bbbb.ovov, (2, 3, 4, 1), (0, 2, 4, 3))
     l2new.abab += einsum(tmp37, (0, 1, 2, 3), tmp95, (1, 2, 4, 5), (3, 5, 0, 4))
     l2new.abab += einsum(tmp37, (0, 1, 2, 3), tmp95, (1, 4, 2, 5), (3, 5, 0, 4)) * -1
-    tmp14 = v.aabb.ovoo.transpose((0, 2, 3, 1)).copy()
+    tmp14 = np.copy(np.transpose(v.aabb.ovoo, (0, 2, 3, 1)))
     tmp14 += tmp2
     l2new.abab += einsum(tmp14, (0, 1, 2, 3), l1.bb, (4, 1), (3, 4, 0, 2)) * -1
     tmp53 = einsum(l1.aa, (0, 1), t1.aa, (2, 0), (1, 2))
@@ -1023,7 +1023,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l1new.aa += einsum(v.aaaa.ooov, (0, 1, 2, 3), tmp70, (4, 0, 2, 1), (3, 4)) * 2
     tmp76 = einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (4, 3, 5, 1), (2, 4, 0, 5))
     tmp77 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 3, 5, 1), (2, 4, 0, 5))
-    tmp44 = tmp41.copy()
+    tmp44 = np.copy(tmp41)
     tmp44 += tmp42
     tmp44 += tmp43 * 2
     l1new.bb += einsum(tmp100, (0, 1), tmp44, (2, 0), (1, 2)) * -1
@@ -1046,46 +1046,46 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.abab += einsum(tmp51, (0, 1, 2, 3), tmp0, (0, 4, 1, 5), (5, 3, 4, 2)) * -1
     l2new.abab += einsum(v.aaaa.ovoo, (0, 1, 2, 3), tmp51, (3, 2, 4, 5), (1, 5, 0, 4)) * -1
     l1new.bb += einsum(tmp51, (0, 1, 2, 3), v.aabb.oovv, (1, 0, 4, 3), (4, 2)) * -1
-    tmp56 = tmp53.copy() * 0.5
+    tmp56 = np.copy(tmp53) * 0.5
     tmp56 += tmp54
     tmp56 += tmp55 * 0.5
     tmp22 = einsum(t1.aa, (0, 1), tmp0, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp21 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 2, 5, 3), (0, 1, 4, 5))
     tmp23 = einsum(t1.aa, (0, 1), v.aaaa.ooov, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp203 = einsum(t1.bb, (0, 1), v.bbbb.ovov, (2, 3, 0, 1), (2, 3))
-    tmp202 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp202 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp202 += tmp199
     tmp202 += tmp200 * 2
     tmp202 += tmp201
     l2new.abab += einsum(tmp202, (0, 1, 2, 3), l2.aaaa, (4, 2, 5, 0), (4, 3, 5, 1)) * 2
-    tmp244 = f.bb.vv.copy() * -1
-    tmp244 += tmp143.transpose((1, 0)) * -1
-    tmp244 += tmp210.transpose((1, 0))
-    tmp244 += tmp211.transpose((1, 0)) * 2
+    tmp244 = np.copy(f.bb.vv) * -1
+    tmp244 += np.transpose(tmp143, (1, 0)) * -1
+    tmp244 += np.transpose(tmp210, (1, 0))
+    tmp244 += np.transpose(tmp211, (1, 0)) * 2
     tmp244 += tmp243 * -1
     del tmp243
-    tmp215 = f.bb.ov.copy()
+    tmp215 = np.copy(f.bb.ov)
     tmp215 += tmp97
     tmp215 += tmp214 * -1
     del tmp214
     l2new.abab += einsum(tmp37, (0, 1, 2, 3), tmp215, (2, 4), (3, 4, 0, 1)) * -1
-    tmp132 = tmp130.copy()
+    tmp132 = np.copy(tmp130)
     del tmp130
     tmp132 += tmp131 * 4
     del tmp131
-    tmp198 = v.bbbb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp198 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 1, 3)))
     tmp198 += v.bbbb.oovv * -1
     tmp198 += tmp194
     tmp198 += tmp195 * 2
-    tmp198 += tmp197.transpose((1, 0, 3, 2)) * -1
+    tmp198 += np.transpose(tmp197, (1, 0, 3, 2)) * -1
     del tmp197
     l2new.abab += einsum(l2.abab, (0, 1, 2, 3), tmp198, (3, 4, 1, 5), (0, 5, 2, 4))
-    tmp138 = tmp124.transpose((1, 0, 3, 2)).copy()
+    tmp138 = np.copy(np.transpose(tmp124, (1, 0, 3, 2)))
     del tmp124
-    tmp138 += tmp125.transpose((0, 1, 3, 2)) * -1
+    tmp138 += np.transpose(tmp125, (0, 1, 3, 2)) * -1
     del tmp125
-    tmp121 = f.bb.oo.copy()
-    tmp121 += tmp115.transpose((1, 0))
+    tmp121 = np.copy(f.bb.oo)
+    tmp121 += np.transpose(tmp115, (1, 0))
     del tmp115
     tmp121 += tmp116
     del tmp116
@@ -1097,9 +1097,9 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp120
     l2new.abab += einsum(tmp121, (0, 1), l2.abab, (2, 3, 4, 0), (2, 3, 4, 1)) * -1
     l1new.bb += einsum(tmp121, (0, 1), l1.bb, (2, 0), (2, 1)) * -1
-    tmp227 = v.bbbb.ooov.transpose((0, 2, 1, 3)).copy()
+    tmp227 = np.copy(np.transpose(v.bbbb.ooov, (0, 2, 1, 3)))
     tmp227 += tmp95
-    tmp59 = tmp41.copy() * 0.5
+    tmp59 = np.copy(tmp41) * 0.5
     del tmp41
     tmp59 += tmp42 * 0.5
     del tmp42
@@ -1109,25 +1109,25 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l1new.bb += einsum(v.bbbb.ooov, (0, 1, 2, 3), tmp59, (1, 2), (3, 0)) * 2
     l1new.bb += einsum(tmp59, (0, 1), v.bbbb.ovoo, (2, 3, 0, 1), (3, 2)) * -2
     l1new.aa += einsum(v.aabb.ovoo, (0, 1, 2, 3), tmp59, (3, 2), (1, 0)) * -2
-    tmp224 = tmp32.copy()
+    tmp224 = np.copy(tmp32)
     tmp224 += tmp33 * 2
     l2new.bbbb = einsum(v.bbbb.ovov, (0, 1, 2, 3), tmp224, (4, 1), (3, 4, 0, 2))
     tmp162 = einsum(t1.aa, (0, 1), v.aaaa.ovov, (2, 3, 0, 1), (2, 3))
     tmp126 = einsum(l2.abab, (0, 1, 2, 3), t2.aaaa, (4, 2, 5, 0), (4, 3, 5, 1))
     tmp127 = einsum(l2.bbbb, (0, 1, 2, 3), t2.abab, (4, 3, 5, 1), (4, 2, 5, 0))
-    tmp208 = v.aaaa.ovvv.copy()
-    tmp208 += v.aaaa.ovvv.transpose((0, 2, 1, 3)) * -1
+    tmp208 = np.copy(v.aaaa.ovvv)
+    tmp208 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3)) * -1
     tmp74 = einsum(t2.bbbb, (0, 1, 2, 3), l2.abab, (4, 3, 5, 1), (5, 0, 4, 2))
     tmp73 = einsum(t2.abab, (0, 1, 2, 3), l2.aaaa, (4, 2, 5, 0), (5, 1, 4, 3))
-    tmp82 = tmp80.copy()
+    tmp82 = np.copy(tmp80)
     tmp82 += tmp81
-    tmp3 = v.aabb.ovoo.transpose((0, 2, 3, 1)).copy()
-    tmp3 += tmp2.transpose((0, 2, 1, 3))
-    tmp129 = v.bbbb.ovvv.copy()
-    tmp129 += v.bbbb.ovvv.transpose((0, 2, 1, 3)) * -1
+    tmp3 = np.copy(np.transpose(v.aabb.ovoo, (0, 2, 3, 1)))
+    tmp3 += np.transpose(tmp2, (0, 2, 1, 3))
+    tmp129 = np.copy(v.bbbb.ovvv)
+    tmp129 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3)) * -1
     l1new.bb += einsum(tmp129, (0, 1, 2, 3), tmp132, (4, 0, 3, 2), (1, 4)) * -1
-    tmp67 = f.aa.oo.copy()
-    tmp67 += tmp61.transpose((1, 0))
+    tmp67 = np.copy(f.aa.oo)
+    tmp67 += np.transpose(tmp61, (1, 0))
     del tmp61
     tmp67 += tmp62 * 2
     del tmp62
@@ -1139,19 +1139,19 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp66
     l2new.abab += einsum(l2.abab, (0, 1, 2, 3), tmp67, (2, 4), (0, 1, 4, 3)) * -1
     l1new.aa += einsum(tmp67, (0, 1), l1.aa, (2, 0), (2, 1)) * -1
-    tmp148 = v.aaaa.ooov.transpose((0, 2, 1, 3)).copy()
+    tmp148 = np.copy(np.transpose(v.aaaa.ooov, (0, 2, 1, 3)))
     tmp148 += tmp0
-    tmp167 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp167 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp167 += tmp10
     tmp167 += tmp158
     tmp167 += tmp159 * 2
     l2new.abab += einsum(tmp167, (0, 1, 2, 3), l2.bbbb, (4, 3, 5, 1), (2, 4, 0, 5)) * 2
-    tmp180 = f.aa.ov.copy()
+    tmp180 = np.copy(f.aa.ov)
     tmp180 += tmp6
     tmp180 += tmp179 * -1
     del tmp179
     l2new.abab += einsum(tmp51, (0, 1, 2, 3), tmp180, (1, 4), (4, 3, 0, 2)) * -1
-    tmp60 = tmp53.copy()
+    tmp60 = np.copy(tmp53)
     del tmp53
     tmp60 += tmp54 * 2
     del tmp54
@@ -1162,27 +1162,27 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l1new.aa += einsum(tmp60, (0, 1), tmp9, (1, 2), (2, 0)) * -1
     l1new.aa += einsum(tmp60, (0, 1), v.aaaa.ooov, (2, 0, 1, 3), (3, 2))
     l1new.aa += einsum(v.aaaa.ovoo, (0, 1, 2, 3), tmp60, (3, 2), (1, 0)) * -1
-    tmp145 = tmp27.copy()
+    tmp145 = np.copy(tmp27)
     tmp145 += tmp28 * 0.5
     l2new.aaaa = einsum(tmp145, (0, 1), v.aaaa.ovov, (2, 1, 3, 4), (4, 0, 2, 3)) * 2
-    tmp165 = v.aaaa.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp165 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 1, 3)))
     tmp165 += v.aaaa.oovv * -1
     tmp165 += tmp155 * 2
     tmp165 += tmp156
-    tmp165 += tmp164.transpose((0, 1, 3, 2)) * -1
+    tmp165 += np.transpose(tmp164, (0, 1, 3, 2)) * -1
     del tmp164
     l2new.abab += einsum(l2.abab, (0, 1, 2, 3), tmp165, (2, 4, 0, 5), (5, 1, 4, 3))
-    tmp176 = f.aa.vv.copy() * -1
-    tmp176 += tmp92.transpose((1, 0)) * -1
-    tmp176 += tmp173.transpose((1, 0)) * 2
-    tmp176 += tmp174.transpose((1, 0))
+    tmp176 = np.copy(f.aa.vv) * -1
+    tmp176 += np.transpose(tmp92, (1, 0)) * -1
+    tmp176 += np.transpose(tmp173, (1, 0)) * 2
+    tmp176 += np.transpose(tmp174, (1, 0))
     tmp176 += tmp175 * -1
     del tmp175
-    tmp87 = tmp70.transpose((1, 0, 3, 2)).copy()
+    tmp87 = np.copy(np.transpose(tmp70, (1, 0, 3, 2)))
     del tmp70
-    tmp87 += tmp71.transpose((0, 1, 3, 2)) * -1
+    tmp87 += np.transpose(tmp71, (0, 1, 3, 2)) * -1
     del tmp71
-    tmp189 = tmp76.copy() * 4
+    tmp189 = np.copy(tmp76) * 4
     tmp189 += tmp77
     tmp40 = einsum(tmp39, (0, 1, 2, 3), t2.bbbb, (1, 0, 4, 3), (2, 4))
     tmp38 = einsum(t2.abab, (0, 1, 2, 3), tmp37, (0, 1, 4, 2), (4, 3))
@@ -1190,33 +1190,33 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp35 = einsum(l1.aa, (0, 1), t2.abab, (1, 2, 0, 3), (2, 3))
     tmp26 = einsum(l1.aa, (0, 1), t1.aa, (1, 2), (0, 2))
     tmp45 = einsum(tmp44, (0, 1), t1.bb, (0, 2), (1, 2))
-    tmp104 = v.bbbb.ooov.copy() * -1
-    tmp104 += v.bbbb.ooov.transpose((0, 2, 1, 3))
+    tmp104 = np.copy(v.bbbb.ooov) * -1
+    tmp104 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3))
     tmp104 += tmp95
-    tmp104 += tmp95.transpose((0, 2, 1, 3)) * -1
-    tmp110 = v.bbbb.oooo.copy()
-    tmp110 += tmp107.transpose((3, 1, 2, 0))
-    tmp110 += tmp108.transpose((2, 1, 3, 0)) * -1
-    tmp110 += tmp109.transpose((2, 0, 3, 1)) * -1
-    tmp110 += tmp109.transpose((3, 0, 2, 1))
-    tmp106 = v.bbbb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp104 += np.transpose(tmp95, (0, 2, 1, 3)) * -1
+    tmp110 = np.copy(v.bbbb.oooo)
+    tmp110 += np.transpose(tmp107, (3, 1, 2, 0))
+    tmp110 += np.transpose(tmp108, (2, 1, 3, 0)) * -1
+    tmp110 += np.transpose(tmp109, (2, 0, 3, 1)) * -1
+    tmp110 += np.transpose(tmp109, (3, 0, 2, 1))
+    tmp106 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 1, 3)))
     tmp106 += v.bbbb.oovv * -1
-    tmp106 += tmp105.transpose((0, 1, 3, 2))
+    tmp106 += np.transpose(tmp105, (0, 1, 3, 2))
     del tmp105
     tmp31 = einsum(t1.bb, (0, 1), l1.bb, (2, 0), (2, 1))
-    tmp5 = v.aabb.ooov.copy()
-    tmp5 += tmp4.transpose((1, 0, 2, 3))
-    tmp16 = v.aabb.oooo.copy()
-    tmp16 += tmp12.transpose((1, 0, 3, 2))
-    tmp16 += tmp13.transpose((1, 0, 3, 2))
-    tmp16 += tmp15.transpose((1, 0, 3, 2))
+    tmp5 = np.copy(v.aabb.ooov)
+    tmp5 += np.transpose(tmp4, (1, 0, 2, 3))
+    tmp16 = np.copy(v.aabb.oooo)
+    tmp16 += np.transpose(tmp12, (1, 0, 3, 2))
+    tmp16 += np.transpose(tmp13, (1, 0, 3, 2))
+    tmp16 += np.transpose(tmp15, (1, 0, 3, 2))
     del tmp15
-    tmp96 = v.bbbb.ooov.copy() * -1
-    tmp96 += v.bbbb.ovoo.transpose((0, 2, 3, 1))
-    tmp96 += tmp95.transpose((1, 0, 2, 3))
-    tmp96 += tmp95.transpose((2, 0, 1, 3)) * -1
-    tmp102 = v.aabb.vvoo.transpose((2, 3, 0, 1)).copy()
-    tmp102 += tmp101.transpose((1, 0, 3, 2))
+    tmp96 = np.copy(v.bbbb.ooov) * -1
+    tmp96 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1))
+    tmp96 += np.transpose(tmp95, (1, 0, 2, 3))
+    tmp96 += np.transpose(tmp95, (2, 0, 1, 3)) * -1
+    tmp102 = np.copy(np.transpose(v.aabb.vvoo, (2, 3, 0, 1)))
+    tmp102 += np.transpose(tmp101, (1, 0, 3, 2))
     tmp137 = einsum(t2.bbbb, (0, 1, 2, 3), tmp39, (4, 1, 5, 3), (4, 5, 0, 2)) * -1
     tmp136 = einsum(t2.abab, (0, 1, 2, 3), tmp37, (0, 4, 5, 2), (4, 5, 1, 3))
     tmp52 = einsum(t2.abab, (0, 1, 2, 3), tmp51, (0, 4, 1, 3), (4, 2))
@@ -1224,110 +1224,110 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp48 = einsum(l1.bb, (0, 1), t2.abab, (2, 1, 3, 0), (2, 3))
     tmp50 = einsum(tmp49, (0, 1, 2, 3), t2.aaaa, (1, 0, 4, 3), (2, 4))
     tmp47 = einsum(l1.aa, (0, 1), t2.aaaa, (2, 1, 3, 0), (2, 3))
-    tmp18 = v.aaaa.ooov.copy()
-    tmp18 += v.aaaa.ooov.transpose((0, 2, 1, 3)) * -1
+    tmp18 = np.copy(v.aaaa.ooov)
+    tmp18 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3)) * -1
     tmp18 += tmp0 * -1
-    tmp18 += tmp0.transpose((0, 2, 1, 3))
-    tmp19 = v.aabb.ooov.copy()
+    tmp18 += np.transpose(tmp0, (0, 2, 1, 3))
+    tmp19 = np.copy(v.aabb.ooov)
     tmp19 += tmp4
-    tmp20 = v.aaaa.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp20 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 1, 3)))
     tmp20 += v.aaaa.oovv * -1
     tmp20 += einsum(t1.aa, (0, 1), v.aaaa.ovvv, (2, 3, 4, 1), (0, 2, 4, 3))
-    tmp24 = v.aaaa.oooo.copy()
-    tmp24 += tmp21.transpose((3, 1, 2, 0))
-    tmp24 += tmp22.transpose((2, 1, 3, 0)) * -1
-    tmp24 += tmp23.transpose((2, 0, 3, 1)) * -1
-    tmp24 += tmp23.transpose((3, 0, 2, 1))
-    tmp11 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp24 = np.copy(v.aaaa.oooo)
+    tmp24 += np.transpose(tmp21, (3, 1, 2, 0))
+    tmp24 += np.transpose(tmp22, (2, 1, 3, 0)) * -1
+    tmp24 += np.transpose(tmp23, (2, 0, 3, 1)) * -1
+    tmp24 += np.transpose(tmp23, (3, 0, 2, 1))
+    tmp11 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp11 += tmp10
-    tmp1 = v.aaaa.ooov.copy() * -1
-    tmp1 += v.aaaa.ovoo.transpose((0, 2, 3, 1))
-    tmp1 += tmp0.transpose((1, 0, 2, 3))
-    tmp1 += tmp0.transpose((2, 0, 1, 3)) * -1
+    tmp1 = np.copy(v.aaaa.ooov) * -1
+    tmp1 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1))
+    tmp1 += np.transpose(tmp0, (1, 0, 2, 3))
+    tmp1 += np.transpose(tmp0, (2, 0, 1, 3)) * -1
     tmp85 = einsum(t2.aaaa, (0, 1, 2, 3), tmp49, (4, 1, 5, 3), (4, 5, 0, 2)) * -1
     tmp86 = einsum(t2.abab, (0, 1, 2, 3), tmp51, (4, 5, 1, 3), (4, 5, 0, 2))
-    tmp237 = f.bb.ov.copy()
+    tmp237 = np.copy(f.bb.ov)
     tmp237 += tmp97
     tmp237 += tmp203
     l2new.bbbb += einsum(l1.bb, (0, 1), tmp237, (2, 3), (3, 0, 1, 2)) * -1
     del tmp237
     tmp239 = einsum(tmp202, (0, 1, 2, 3), l2.abab, (2, 4, 0, 5), (1, 5, 3, 4))
     del tmp202
-    l2new.bbbb += tmp239.transpose((3, 2, 0, 1)) * -1
-    l2new.bbbb += tmp239.transpose((3, 2, 1, 0))
-    l2new.bbbb += tmp239.transpose((2, 3, 0, 1))
+    l2new.bbbb += np.transpose(tmp239, (3, 2, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp239, (3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp239, (2, 3, 0, 1))
     del tmp239
-    tmp193 = tmp32.copy() * 0.5
+    tmp193 = np.copy(tmp32) * 0.5
     tmp193 += tmp33
     l2new.bbbb += einsum(tmp193, (0, 1), v.bbbb.ovov, (2, 1, 3, 4), (0, 4, 2, 3)) * -2
     l2new.abab += einsum(v.aabb.ovov, (0, 1, 2, 3), tmp193, (4, 3), (1, 4, 0, 2)) * -2
     del tmp193
     tmp245 = einsum(tmp244, (0, 1), l2.bbbb, (2, 1, 3, 4), (3, 4, 0, 2)) * -1
     del tmp244
-    l2new.bbbb += tmp245.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += tmp245.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += tmp245.transpose((2, 3, 1, 0))
-    l2new.bbbb += tmp245.transpose((2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp245, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp245, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp245, (2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp245, (2, 3, 1, 0))
     del tmp245
     tmp231 = einsum(v.bbbb.ovoo, (0, 1, 2, 3), tmp39, (3, 4, 2, 5), (4, 0, 5, 1)) * -1
-    l2new.bbbb += tmp231.transpose((2, 3, 1, 0)) * 2
-    l2new.bbbb += tmp231.transpose((2, 3, 0, 1)) * -2
-    l2new.bbbb += tmp231.transpose((3, 2, 1, 0)) * -2
-    l2new.bbbb += tmp231.transpose((3, 2, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp231, (2, 3, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp231, (2, 3, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp231, (3, 2, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp231, (3, 2, 0, 1)) * 2
     del tmp231
     tmp230 = einsum(tmp51, (0, 1, 2, 3), v.aabb.ooov, (1, 0, 4, 5), (2, 4, 3, 5))
-    l2new.bbbb += tmp230.transpose((2, 3, 1, 0))
-    l2new.bbbb += tmp230.transpose((2, 3, 0, 1)) * -1
-    l2new.bbbb += tmp230.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += tmp230.transpose((3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp230, (2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp230, (2, 3, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp230, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp230, (3, 2, 0, 1))
     del tmp230
     tmp246 = einsum(tmp215, (0, 1), tmp39, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp215
-    l2new.bbbb += tmp246.transpose((3, 2, 1, 0))
-    l2new.bbbb += tmp246.transpose((3, 2, 1, 0))
-    l2new.bbbb += tmp246.transpose((2, 3, 1, 0)) * -1
-    l2new.bbbb += tmp246.transpose((2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp246, (3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp246, (3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp246, (2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp246, (2, 3, 1, 0)) * -1
     del tmp246
     tmp229 = einsum(l1.bb, (0, 1), v.bbbb.ovvv, (2, 3, 4, 0), (1, 2, 3, 4))
-    l2new.bbbb += tmp229.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += tmp229.transpose((3, 2, 0, 1))
-    l2new.bbbb += tmp229.transpose((2, 3, 1, 0))
-    l2new.bbbb += tmp229.transpose((2, 3, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp229, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp229, (3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp229, (2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp229, (2, 3, 0, 1)) * -1
     del tmp229
     tmp240 = einsum(l2.bbbb, (0, 1, 2, 3), v.bbbb.vvvv, (4, 0, 5, 1), (2, 3, 4, 5))
-    l2new.bbbb += tmp240.transpose((3, 2, 1, 0)) * 0.5
-    l2new.bbbb += tmp240.transpose((3, 2, 1, 0)) * 0.5
-    l2new.bbbb += tmp240.transpose((3, 2, 1, 0)) * 0.5
-    l2new.bbbb += tmp240.transpose((3, 2, 1, 0)) * 0.5
+    l2new.bbbb += np.transpose(tmp240, (3, 2, 1, 0)) * 0.5
+    l2new.bbbb += np.transpose(tmp240, (3, 2, 1, 0)) * 0.5
+    l2new.bbbb += np.transpose(tmp240, (3, 2, 1, 0)) * 0.5
+    l2new.bbbb += np.transpose(tmp240, (3, 2, 1, 0)) * 0.5
     del tmp240
-    tmp249 = v.bbbb.ooov.copy()
-    tmp249 += tmp95.transpose((0, 2, 1, 3))
+    tmp249 = np.copy(v.bbbb.ooov)
+    tmp249 += np.transpose(tmp95, (0, 2, 1, 3))
     l2new.bbbb += einsum(l1.bb, (0, 1), tmp249, (1, 2, 3, 4), (4, 0, 2, 3))
     del tmp249
     tmp241 = einsum(v.bbbb.ovvv, (0, 1, 2, 3), tmp39, (4, 5, 0, 3), (5, 4, 1, 2))
-    l2new.bbbb += tmp241.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += tmp241.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += tmp241.transpose((2, 3, 1, 0))
-    l2new.bbbb += tmp241.transpose((2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp241, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp241, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp241, (2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp241, (2, 3, 1, 0))
     del tmp241
     tmp253 = einsum(tmp44, (0, 1), v.bbbb.ovov, (2, 3, 1, 4), (2, 0, 4, 3))
-    l2new.bbbb += tmp253.transpose((3, 2, 1, 0))
-    l2new.bbbb += tmp253.transpose((2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp253, (3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp253, (2, 3, 1, 0)) * -1
     del tmp253
     tmp251 = einsum(v.bbbb.ooov, (0, 1, 2, 3), tmp39, (1, 4, 2, 5), (4, 0, 5, 3)) * -1
-    l2new.bbbb += tmp251.transpose((2, 3, 1, 0)) * -2
-    l2new.bbbb += tmp251.transpose((3, 2, 1, 0)) * 2
-    l2new.bbbb += tmp251.transpose((2, 3, 0, 1)) * 2
-    l2new.bbbb += tmp251.transpose((3, 2, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp251, (2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp251, (3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp251, (2, 3, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp251, (3, 2, 0, 1)) * -2
     del tmp251
     tmp252 = einsum(v.bbbb.ovov, (0, 1, 2, 3), tmp132, (4, 2, 5, 1), (4, 0, 5, 3))
     del tmp132
-    l2new.bbbb += tmp252.transpose((2, 3, 1, 0))
-    l2new.bbbb += tmp252.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += tmp252.transpose((2, 3, 0, 1)) * -1
-    l2new.bbbb += tmp252.transpose((3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp252, (2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp252, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp252, (2, 3, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp252, (3, 2, 0, 1))
     del tmp252
-    tmp204 = f.bb.ov.copy()
+    tmp204 = np.copy(f.bb.ov)
     tmp204 += tmp97
     del tmp97
     tmp204 += tmp203
@@ -1339,11 +1339,11 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp204
     tmp238 = einsum(tmp198, (0, 1, 2, 3), l2.bbbb, (4, 2, 5, 0), (1, 5, 3, 4))
     del tmp198
-    l2new.bbbb += tmp238.transpose((3, 2, 0, 1)) * -2
-    l2new.bbbb += tmp238.transpose((3, 2, 1, 0)) * 2
-    l2new.bbbb += tmp238.transpose((2, 3, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp238, (3, 2, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp238, (3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp238, (2, 3, 0, 1)) * 2
     del tmp238
-    tmp234 = v.bbbb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp234 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 1, 3)))
     tmp234 += v.bbbb.oovv * -1
     tmp234 += tmp194
     del tmp194
@@ -1360,62 +1360,62 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.abab += einsum(tmp222, (0, 1), l1.aa, (2, 3), (2, 1, 3, 0)) * -1
     del tmp222
     tmp242 = einsum(tmp138, (0, 1, 2, 3), v.bbbb.ovov, (2, 4, 3, 5), (0, 1, 4, 5)) * 0.5
-    l2new.bbbb += tmp242.transpose((3, 2, 1, 0))
-    l2new.bbbb += tmp242.transpose((3, 2, 1, 0))
-    l2new.bbbb += tmp242.transpose((3, 2, 1, 0))
-    l2new.bbbb += tmp242.transpose((3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp242, (3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp242, (3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp242, (3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp242, (3, 2, 1, 0))
     del tmp242
     tmp236 = einsum(tmp121, (0, 1), l2.bbbb, (2, 3, 4, 0), (4, 1, 2, 3)) * -2
     del tmp121
-    l2new.bbbb += tmp236.transpose((3, 2, 1, 0))
-    l2new.bbbb += tmp236.transpose((3, 2, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp236, (3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp236, (3, 2, 0, 1)) * -1
     del tmp236
     tmp250 = einsum(tmp95, (0, 1, 2, 3), tmp39, (4, 0, 1, 5), (4, 2, 5, 3))
-    l2new.bbbb += tmp250.transpose((2, 3, 1, 0)) * -2
-    l2new.bbbb += tmp250.transpose((3, 2, 1, 0)) * 2
-    l2new.bbbb += tmp250.transpose((2, 3, 0, 1)) * 2
-    l2new.bbbb += tmp250.transpose((3, 2, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp250, (2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp250, (3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp250, (2, 3, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp250, (3, 2, 0, 1)) * -2
     del tmp250
     tmp233 = einsum(tmp51, (0, 1, 2, 3), tmp4, (0, 1, 4, 5), (2, 4, 3, 5))
-    l2new.bbbb += tmp233.transpose((2, 3, 1, 0))
-    l2new.bbbb += tmp233.transpose((2, 3, 0, 1)) * -1
-    l2new.bbbb += tmp233.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += tmp233.transpose((3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp233, (2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp233, (2, 3, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp233, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp233, (3, 2, 0, 1))
     del tmp233
-    tmp248 = v.bbbb.oooo.copy()
-    tmp248 += tmp107.transpose((1, 3, 2, 0))
+    tmp248 = np.copy(v.bbbb.oooo)
+    tmp248 += np.transpose(tmp107, (1, 3, 2, 0))
     del tmp107
-    tmp248 += tmp108.transpose((0, 2, 3, 1))
+    tmp248 += np.transpose(tmp108, (0, 2, 3, 1))
     del tmp108
     l2new.bbbb += einsum(tmp248, (0, 1, 2, 3), l2.bbbb, (4, 5, 0, 3), (4, 5, 2, 1)) * -2
     del tmp248
     tmp228 = einsum(tmp227, (0, 1, 2, 3), l1.bb, (4, 0), (1, 2, 3, 4))
     del tmp227
-    l2new.bbbb += tmp228.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += tmp228.transpose((3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp228, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp228, (3, 2, 0, 1))
     del tmp228
-    tmp226 = v.bbbb.ooov.copy()
-    tmp226 += tmp95.transpose((0, 2, 1, 3))
+    tmp226 = np.copy(v.bbbb.ooov)
+    tmp226 += np.transpose(tmp95, (0, 2, 1, 3))
     l2new.bbbb += einsum(l1.bb, (0, 1), tmp226, (1, 2, 3, 4), (4, 0, 3, 2)) * -1
     del tmp226
     tmp254 = einsum(tmp59, (0, 1), v.bbbb.ovov, (2, 3, 1, 4), (2, 0, 4, 3)) * 2
     del tmp59
-    l2new.bbbb += tmp254.transpose((3, 2, 0, 1)) * -1
-    l2new.bbbb += tmp254.transpose((2, 3, 0, 1))
+    l2new.bbbb += np.transpose(tmp254, (3, 2, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp254, (2, 3, 0, 1))
     del tmp254
     tmp232 = einsum(tmp39, (0, 1, 2, 3), tmp95, (0, 4, 2, 5), (1, 4, 3, 5)) * -1
     del tmp95
-    l2new.bbbb += tmp232.transpose((2, 3, 1, 0)) * 2
-    l2new.bbbb += tmp232.transpose((2, 3, 0, 1)) * -2
-    l2new.bbbb += tmp232.transpose((3, 2, 1, 0)) * -2
-    l2new.bbbb += tmp232.transpose((3, 2, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp232, (2, 3, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp232, (2, 3, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp232, (3, 2, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp232, (3, 2, 0, 1)) * 2
     del tmp232
     tmp225 = einsum(v.bbbb.ovov, (0, 1, 2, 3), tmp224, (4, 1), (0, 2, 4, 3))
     del tmp224
-    l2new.bbbb += tmp225.transpose((2, 3, 1, 0))
-    l2new.bbbb += tmp225.transpose((3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp225, (2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp225, (3, 2, 1, 0)) * -1
     del tmp225
-    tmp235 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp235 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp235 += tmp199
     del tmp199
     tmp235 += tmp200 * 2
@@ -1426,10 +1426,10 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp235
     tmp247 = einsum(tmp109, (0, 1, 2, 3), l2.bbbb, (4, 5, 0, 1), (2, 3, 4, 5))
     del tmp109
-    l2new.bbbb += tmp247.transpose((2, 3, 1, 0)) * 2
-    l2new.bbbb += tmp247.transpose((2, 3, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp247, (2, 3, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp247, (2, 3, 0, 1)) * -2
     del tmp247
-    tmp169 = f.aa.ov.copy()
+    tmp169 = np.copy(f.aa.ov)
     tmp169 += tmp162
     tmp169 += tmp6
     l2new.abab += einsum(tmp169, (0, 1), l1.bb, (2, 3), (1, 2, 0, 3))
@@ -1437,20 +1437,20 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.aaaa += einsum(tmp169, (0, 1), l1.aa, (2, 3), (2, 1, 3, 0))
     l2new.aaaa += einsum(tmp169, (0, 1), l1.aa, (2, 3), (1, 2, 0, 3))
     del tmp169
-    tmp185 = tmp27.copy() * 2
+    tmp185 = np.copy(tmp27) * 2
     tmp185 += tmp28
     l2new.abab += einsum(tmp185, (0, 1), v.aabb.ovov, (2, 1, 3, 4), (0, 4, 2, 3)) * -1
     l2new.aaaa += einsum(v.aaaa.ovov, (0, 1, 2, 3), tmp185, (4, 1), (4, 3, 0, 2)) * -1
     del tmp185
-    tmp221 = tmp126.copy()
+    tmp221 = np.copy(tmp126)
     tmp221 += tmp127
     l2new.abab += einsum(tmp221, (0, 1, 2, 3), v.aaaa.ovov, (4, 2, 0, 5), (5, 3, 4, 1)) * -2
     del tmp221
     tmp220 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (4, 2, 1, 5), (0, 4, 3, 5))
     l2new.abab += einsum(tmp220, (0, 1, 2, 3), l2.abab, (4, 2, 0, 5), (4, 3, 1, 5))
     del tmp220
-    tmp209 = f.aa.vv.copy() * -1
-    tmp209 += tmp92.transpose((1, 0)) * -1
+    tmp209 = np.copy(f.aa.vv) * -1
+    tmp209 += np.transpose(tmp92, (1, 0)) * -1
     tmp209 += tmp173 * 2
     del tmp173
     tmp209 += tmp174
@@ -1459,23 +1459,23 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp208
     l2new.abab += einsum(l2.abab, (0, 1, 2, 3), tmp209, (0, 4), (4, 1, 2, 3)) * -1
     del tmp209
-    tmp205 = v.aabb.vvoo.transpose((2, 3, 0, 1)).copy()
-    tmp205 += tmp101.transpose((0, 1, 3, 2))
+    tmp205 = np.copy(np.transpose(v.aabb.vvoo, (2, 3, 0, 1)))
+    tmp205 += np.transpose(tmp101, (0, 1, 3, 2))
     del tmp101
     l2new.abab += einsum(tmp205, (0, 1, 2, 3), l2.abab, (2, 4, 5, 0), (3, 4, 5, 1)) * -1
     del tmp205
-    tmp223 = tmp73.copy()
+    tmp223 = np.copy(tmp73)
     tmp223 += tmp74
     l2new.abab += einsum(v.bbbb.ovov, (0, 1, 2, 3), tmp223, (4, 2, 5, 1), (5, 3, 4, 0)) * -2
     del tmp223
     tmp219 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (0, 4, 5, 3), (1, 5, 2, 4))
     l2new.abab += einsum(l2.abab, (0, 1, 2, 3), tmp219, (3, 4, 0, 5), (5, 1, 2, 4))
     del tmp219
-    tmp218 = v.aabb.oovv.copy()
+    tmp218 = np.copy(v.aabb.oovv)
     tmp218 += einsum(v.aabb.ovvv, (0, 1, 2, 3), t1.aa, (4, 1), (4, 0, 2, 3))
     l2new.abab += einsum(tmp218, (0, 1, 2, 3), l2.abab, (4, 2, 0, 5), (4, 3, 1, 5)) * -1
     del tmp218
-    tmp216 = v.aabb.ooov.copy()
+    tmp216 = np.copy(v.aabb.ooov)
     tmp216 += tmp4
     del tmp4
     l2new.abab += einsum(tmp216, (0, 1, 2, 3), tmp37, (0, 4, 2, 5), (5, 3, 1, 4))
@@ -1489,11 +1489,11 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.aaaa += einsum(tmp188, (0, 1), l1.aa, (2, 3), (1, 2, 3, 0))
     del tmp188
     tmp207 = einsum(v.aabb.ovov, (0, 1, 2, 3), tmp82, (4, 0, 5, 2), (4, 5, 1, 3)) * 0.5
-    l2new.abab += tmp207.transpose((2, 3, 0, 1))
-    l2new.abab += tmp207.transpose((2, 3, 0, 1))
+    l2new.abab += np.transpose(tmp207, (2, 3, 0, 1))
+    l2new.abab += np.transpose(tmp207, (2, 3, 0, 1))
     del tmp207
-    tmp217 = v.aabb.oooo.copy()
-    tmp217 += tmp12.transpose((1, 0, 2, 3))
+    tmp217 = np.copy(v.aabb.oooo)
+    tmp217 += np.transpose(tmp12, (1, 0, 2, 3))
     del tmp12
     tmp217 += tmp13
     del tmp13
@@ -1501,11 +1501,11 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.abab += einsum(l2.abab, (0, 1, 2, 3), tmp217, (2, 4, 3, 5), (0, 1, 4, 5))
     del tmp217
     tmp206 = einsum(l2.abab, (0, 1, 2, 3), v.aabb.vvvv, (4, 0, 5, 1), (2, 3, 4, 5))
-    l2new.abab += tmp206.transpose((2, 3, 0, 1)) * 0.5
-    l2new.abab += tmp206.transpose((2, 3, 0, 1)) * 0.5
+    l2new.abab += np.transpose(tmp206, (2, 3, 0, 1)) * 0.5
+    l2new.abab += np.transpose(tmp206, (2, 3, 0, 1)) * 0.5
     del tmp206
-    tmp212 = f.bb.vv.copy() * -1
-    tmp212 += tmp143.transpose((1, 0)) * -1
+    tmp212 = np.copy(f.bb.vv) * -1
+    tmp212 += np.transpose(tmp143, (1, 0)) * -1
     tmp212 += tmp210
     del tmp210
     tmp212 += tmp211 * 2
@@ -1514,12 +1514,12 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.abab += einsum(l2.abab, (0, 1, 2, 3), tmp212, (1, 4), (0, 4, 2, 3)) * -1
     del tmp212
     tmp153 = einsum(tmp49, (0, 1, 2, 3), v.aaaa.ovoo, (4, 5, 2, 0), (1, 4, 3, 5)) * -1
-    l2new.aaaa += tmp153.transpose((2, 3, 1, 0)) * 2
-    l2new.aaaa += tmp153.transpose((2, 3, 0, 1)) * -2
-    l2new.aaaa += tmp153.transpose((3, 2, 1, 0)) * -2
-    l2new.aaaa += tmp153.transpose((3, 2, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp153, (2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp153, (2, 3, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp153, (3, 2, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp153, (3, 2, 0, 1)) * 2
     del tmp153
-    tmp163 = f.aa.ov.copy()
+    tmp163 = np.copy(f.aa.ov)
     tmp163 += tmp162
     del tmp162
     tmp163 += tmp6
@@ -1528,14 +1528,14 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp163
     tmp161 = einsum(tmp67, (0, 1), l2.aaaa, (2, 3, 4, 0), (4, 1, 2, 3)) * -2
     del tmp67
-    l2new.aaaa += tmp161.transpose((3, 2, 1, 0))
-    l2new.aaaa += tmp161.transpose((3, 2, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp161, (3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp161, (3, 2, 0, 1)) * -1
     del tmp161
-    tmp184 = v.aaaa.ooov.copy()
-    tmp184 += tmp0.transpose((0, 2, 1, 3))
+    tmp184 = np.copy(v.aaaa.ooov)
+    tmp184 += np.transpose(tmp0, (0, 2, 1, 3))
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp184, (1, 2, 3, 4), (4, 0, 2, 3))
     del tmp184
-    tmp157 = v.aaaa.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp157 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 1, 3)))
     tmp157 += v.aaaa.oovv * -1
     tmp157 += tmp155 * 2
     del tmp155
@@ -1545,93 +1545,93 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.aaaa += einsum(tmp157, (0, 1, 2, 3), l2.aaaa, (4, 2, 5, 0), (3, 4, 5, 1)) * -2
     del tmp157
     tmp187 = einsum(tmp0, (0, 1, 2, 3), tmp49, (4, 0, 1, 5), (4, 2, 5, 3))
-    l2new.aaaa += tmp187.transpose((2, 3, 1, 0)) * -2
-    l2new.aaaa += tmp187.transpose((3, 2, 1, 0)) * 2
-    l2new.aaaa += tmp187.transpose((2, 3, 0, 1)) * 2
-    l2new.aaaa += tmp187.transpose((3, 2, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp187, (2, 3, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp187, (3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp187, (2, 3, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp187, (3, 2, 0, 1)) * -2
     del tmp187
     tmp149 = einsum(l1.aa, (0, 1), tmp148, (1, 2, 3, 4), (2, 3, 4, 0))
     del tmp148
-    l2new.aaaa += tmp149.transpose((3, 2, 1, 0)) * -1
-    l2new.aaaa += tmp149.transpose((3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp149, (3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp149, (3, 2, 0, 1))
     del tmp149
     tmp168 = einsum(l2.abab, (0, 1, 2, 3), tmp167, (4, 3, 5, 1), (4, 2, 5, 0))
     del tmp167
-    l2new.aaaa += tmp168.transpose((3, 2, 0, 1)) * -1
-    l2new.aaaa += tmp168.transpose((3, 2, 1, 0))
-    l2new.aaaa += tmp168.transpose((2, 3, 0, 1))
+    l2new.aaaa += np.transpose(tmp168, (3, 2, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp168, (3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp168, (2, 3, 0, 1))
     del tmp168
     tmp181 = einsum(tmp180, (0, 1), tmp49, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp180
-    l2new.aaaa += tmp181.transpose((3, 2, 1, 0))
-    l2new.aaaa += tmp181.transpose((3, 2, 1, 0))
-    l2new.aaaa += tmp181.transpose((2, 3, 1, 0)) * -1
-    l2new.aaaa += tmp181.transpose((2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp181, (3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp181, (3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp181, (2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp181, (2, 3, 1, 0)) * -1
     del tmp181
     tmp191 = einsum(tmp60, (0, 1), v.aaaa.ovov, (2, 3, 1, 4), (2, 0, 4, 3))
     del tmp60
-    l2new.aaaa += tmp191.transpose((3, 2, 1, 0))
-    l2new.aaaa += tmp191.transpose((2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp191, (3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp191, (2, 3, 1, 0)) * -1
     del tmp191
     tmp152 = einsum(tmp49, (0, 1, 2, 3), tmp0, (0, 4, 2, 5), (1, 4, 3, 5)) * -1
-    l2new.aaaa += tmp152.transpose((2, 3, 1, 0)) * 2
-    l2new.aaaa += tmp152.transpose((2, 3, 0, 1)) * -2
-    l2new.aaaa += tmp152.transpose((3, 2, 1, 0)) * -2
-    l2new.aaaa += tmp152.transpose((3, 2, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp152, (2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp152, (2, 3, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp152, (3, 2, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp152, (3, 2, 0, 1)) * 2
     del tmp152
     tmp146 = einsum(tmp145, (0, 1), v.aaaa.ovov, (2, 1, 3, 4), (2, 3, 0, 4)) * 2
     del tmp145
-    l2new.aaaa += tmp146.transpose((2, 3, 1, 0))
-    l2new.aaaa += tmp146.transpose((3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp146, (2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp146, (3, 2, 1, 0)) * -1
     del tmp146
     tmp186 = einsum(tmp49, (0, 1, 2, 3), v.aaaa.ooov, (4, 0, 2, 5), (1, 4, 3, 5)) * -1
-    l2new.aaaa += tmp186.transpose((2, 3, 1, 0)) * -2
-    l2new.aaaa += tmp186.transpose((3, 2, 1, 0)) * 2
-    l2new.aaaa += tmp186.transpose((2, 3, 0, 1)) * 2
-    l2new.aaaa += tmp186.transpose((3, 2, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp186, (2, 3, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp186, (3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp186, (2, 3, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp186, (3, 2, 0, 1)) * -2
     del tmp186
     tmp166 = einsum(tmp165, (0, 1, 2, 3), l2.aaaa, (4, 2, 5, 0), (1, 5, 3, 4))
     del tmp165
-    l2new.aaaa += tmp166.transpose((3, 2, 0, 1)) * -2
-    l2new.aaaa += tmp166.transpose((3, 2, 1, 0)) * 2
-    l2new.aaaa += tmp166.transpose((2, 3, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp166, (3, 2, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp166, (3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp166, (2, 3, 0, 1)) * 2
     del tmp166
     tmp192 = einsum(v.aaaa.ovov, (0, 1, 2, 3), tmp56, (4, 2), (0, 4, 3, 1)) * 2
-    l2new.aaaa += tmp192.transpose((3, 2, 0, 1)) * -1
-    l2new.aaaa += tmp192.transpose((2, 3, 0, 1))
+    l2new.aaaa += np.transpose(tmp192, (3, 2, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp192, (2, 3, 0, 1))
     del tmp192
     tmp177 = einsum(tmp176, (0, 1), l2.aaaa, (2, 1, 3, 4), (3, 4, 0, 2)) * -1
     del tmp176
-    l2new.aaaa += tmp177.transpose((3, 2, 1, 0)) * -1
-    l2new.aaaa += tmp177.transpose((3, 2, 1, 0)) * -1
-    l2new.aaaa += tmp177.transpose((2, 3, 1, 0))
-    l2new.aaaa += tmp177.transpose((2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp177, (3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp177, (3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp177, (2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp177, (2, 3, 1, 0))
     del tmp177
     tmp154 = einsum(v.aaaa.ovvv, (0, 1, 2, 3), l1.aa, (3, 4), (4, 0, 1, 2))
-    l2new.aaaa += tmp154.transpose((3, 2, 1, 0)) * -1
-    l2new.aaaa += tmp154.transpose((3, 2, 0, 1))
-    l2new.aaaa += tmp154.transpose((2, 3, 1, 0))
-    l2new.aaaa += tmp154.transpose((2, 3, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp154, (3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp154, (3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp154, (2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp154, (2, 3, 0, 1)) * -1
     del tmp154
-    tmp183 = v.aaaa.oooo.copy()
-    tmp183 += tmp21.transpose((1, 3, 2, 0))
+    tmp183 = np.copy(v.aaaa.oooo)
+    tmp183 += np.transpose(tmp21, (1, 3, 2, 0))
     del tmp21
-    tmp183 += tmp22.transpose((0, 2, 3, 1))
+    tmp183 += np.transpose(tmp22, (0, 2, 3, 1))
     del tmp22
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp183, (2, 4, 5, 3), (0, 1, 5, 4)) * -2
     del tmp183
     tmp150 = einsum(tmp37, (0, 1, 2, 3), v.aabb.ovoo, (4, 5, 2, 1), (0, 4, 3, 5))
-    l2new.aaaa += tmp150.transpose((2, 3, 1, 0))
-    l2new.aaaa += tmp150.transpose((2, 3, 0, 1)) * -1
-    l2new.aaaa += tmp150.transpose((3, 2, 1, 0)) * -1
-    l2new.aaaa += tmp150.transpose((3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp150, (2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp150, (2, 3, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp150, (3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp150, (3, 2, 0, 1))
     del tmp150
-    tmp147 = v.aaaa.ooov.copy()
-    tmp147 += tmp0.transpose((0, 2, 1, 3))
+    tmp147 = np.copy(v.aaaa.ooov)
+    tmp147 += np.transpose(tmp0, (0, 2, 1, 3))
     del tmp0
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp147, (1, 2, 3, 4), (4, 0, 3, 2)) * -1
     del tmp147
-    tmp160 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy() * 0.5
+    tmp160 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3))) * 0.5
     tmp160 += tmp10 * 0.5
     del tmp10
     tmp160 += tmp158 * 0.5
@@ -1641,45 +1641,45 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.aaaa += einsum(tmp160, (0, 1, 2, 3), l2.abab, (4, 3, 5, 1), (2, 4, 5, 0)) * -2
     del tmp160
     tmp172 = einsum(tmp87, (0, 1, 2, 3), v.aaaa.ovov, (2, 4, 3, 5), (0, 1, 4, 5)) * 0.5
-    l2new.aaaa += tmp172.transpose((3, 2, 1, 0))
-    l2new.aaaa += tmp172.transpose((3, 2, 1, 0))
-    l2new.aaaa += tmp172.transpose((3, 2, 1, 0))
-    l2new.aaaa += tmp172.transpose((3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp172, (3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp172, (3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp172, (3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp172, (3, 2, 1, 0))
     del tmp172
     tmp171 = einsum(tmp49, (0, 1, 2, 3), v.aaaa.ovvv, (2, 4, 5, 3), (1, 0, 4, 5))
-    l2new.aaaa += tmp171.transpose((3, 2, 1, 0)) * -1
-    l2new.aaaa += tmp171.transpose((3, 2, 1, 0)) * -1
-    l2new.aaaa += tmp171.transpose((2, 3, 1, 0))
-    l2new.aaaa += tmp171.transpose((2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp171, (3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp171, (3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp171, (2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp171, (2, 3, 1, 0))
     del tmp171
     tmp182 = einsum(tmp23, (0, 1, 2, 3), l2.aaaa, (4, 5, 0, 1), (2, 3, 4, 5))
     del tmp23
-    l2new.aaaa += tmp182.transpose((2, 3, 1, 0)) * 2
-    l2new.aaaa += tmp182.transpose((2, 3, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp182, (2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp182, (2, 3, 0, 1)) * -2
     del tmp182
     tmp170 = einsum(l2.aaaa, (0, 1, 2, 3), v.aaaa.vvvv, (4, 1, 5, 0), (2, 3, 4, 5)) * -1
-    l2new.aaaa += tmp170.transpose((3, 2, 1, 0)) * 0.5
-    l2new.aaaa += tmp170.transpose((3, 2, 1, 0)) * 0.5
-    l2new.aaaa += tmp170.transpose((3, 2, 1, 0)) * 0.5
-    l2new.aaaa += tmp170.transpose((3, 2, 1, 0)) * 0.5
+    l2new.aaaa += np.transpose(tmp170, (3, 2, 1, 0)) * 0.5
+    l2new.aaaa += np.transpose(tmp170, (3, 2, 1, 0)) * 0.5
+    l2new.aaaa += np.transpose(tmp170, (3, 2, 1, 0)) * 0.5
+    l2new.aaaa += np.transpose(tmp170, (3, 2, 1, 0)) * 0.5
     del tmp170
     tmp190 = einsum(v.aaaa.ovov, (0, 1, 2, 3), tmp189, (4, 2, 5, 1), (4, 0, 5, 3))
     del tmp189
-    l2new.aaaa += tmp190.transpose((2, 3, 1, 0))
-    l2new.aaaa += tmp190.transpose((3, 2, 1, 0)) * -1
-    l2new.aaaa += tmp190.transpose((2, 3, 0, 1)) * -1
-    l2new.aaaa += tmp190.transpose((3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp190, (2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp190, (3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp190, (2, 3, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp190, (3, 2, 0, 1))
     del tmp190
     tmp151 = einsum(tmp2, (0, 1, 2, 3), tmp37, (4, 1, 2, 5), (4, 0, 5, 3))
-    l2new.aaaa += tmp151.transpose((2, 3, 1, 0))
-    l2new.aaaa += tmp151.transpose((2, 3, 0, 1)) * -1
-    l2new.aaaa += tmp151.transpose((3, 2, 1, 0)) * -1
-    l2new.aaaa += tmp151.transpose((3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp151, (2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp151, (2, 3, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp151, (3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp151, (3, 2, 0, 1))
     del tmp151
     tmp123 = einsum(t1.bb, (0, 1), v.bbbb.vvvv, (2, 3, 4, 1), (0, 2, 3, 4))
     l1new.bb += einsum(tmp123, (0, 1, 2, 3), l2.bbbb, (2, 3, 4, 0), (1, 4)) * 2
     del tmp123
-    tmp114 = l1.bb.transpose((1, 0)).copy() * -0.5
+    tmp114 = np.copy(np.transpose(l1.bb, (1, 0))) * -0.5
     tmp114 += t1.bb * -0.5
     tmp114 += tmp35 * -0.5
     tmp114 += tmp36 * -1
@@ -1692,7 +1692,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp122 = einsum(v.aabb.vvvv, (0, 1, 2, 3), t1.aa, (4, 1), (4, 0, 2, 3))
     l1new.bb += einsum(l2.abab, (0, 1, 2, 3), tmp122, (2, 0, 4, 1), (4, 3))
     del tmp122
-    tmp113 = tmp26.copy() * 0.5
+    tmp113 = np.copy(tmp26) * 0.5
     tmp113 += tmp27
     tmp113 += tmp28 * 0.5
     l1new.bb += einsum(v.aabb.vvov, (0, 1, 2, 3), tmp113, (1, 0), (3, 2)) * 2
@@ -1705,7 +1705,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp133 += einsum(t1.aa, (0, 1), tmp82, (0, 2, 3, 4), (2, 3, 4, 1)) * -1
     l1new.bb += einsum(v.aabb.ovov, (0, 1, 2, 3), tmp133, (0, 4, 2, 1), (3, 4)) * -1
     del tmp133
-    tmp142 = t1.bb.copy() * -1
+    tmp142 = np.copy(t1.bb) * -1
     tmp142 += tmp35 * -1
     tmp142 += tmp36 * -2
     tmp142 += tmp38
@@ -1713,7 +1713,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp142 += tmp45
     l1new.bb += einsum(v.bbbb.ovov, (0, 1, 2, 3), tmp142, (2, 1), (3, 0))
     del tmp142
-    tmp128 = l2.abab.transpose((2, 3, 0, 1)).copy()
+    tmp128 = np.copy(np.transpose(l2.abab, (2, 3, 0, 1)))
     tmp128 += tmp126 * 2
     del tmp126
     tmp128 += einsum(t1.aa, (0, 1), tmp51, (0, 2, 3, 4), (2, 3, 1, 4)) * -1
@@ -1721,7 +1721,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp127
     l1new.bb += einsum(v.aabb.ovvv, (0, 1, 2, 3), tmp128, (0, 4, 1, 3), (2, 4))
     del tmp128
-    tmp111 = v.bbbb.ooov.copy() * -1
+    tmp111 = np.copy(v.bbbb.ooov) * -1
     tmp111 += einsum(v.bbbb.ovvv, (0, 1, 2, 3), t2.bbbb, (4, 5, 1, 3), (0, 4, 5, 2)) * -1
     tmp111 += einsum(tmp104, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (2, 4, 0, 5)) * 2
     del tmp104
@@ -1734,7 +1734,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp110
     l1new.bb += einsum(l2.bbbb, (0, 1, 2, 3), tmp111, (4, 2, 3, 1), (0, 4)) * 2
     del tmp111
-    tmp34 = tmp31.copy()
+    tmp34 = np.copy(tmp31)
     del tmp31
     tmp34 += tmp32
     del tmp32
@@ -1744,11 +1744,11 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp112
     l1new.aa += einsum(v.aabb.ovvv, (0, 1, 2, 3), tmp34, (3, 2), (1, 0))
     del tmp34
-    tmp134 = l2.bbbb.transpose((2, 3, 0, 1)).copy() * -1
+    tmp134 = np.copy(np.transpose(l2.bbbb, (2, 3, 0, 1))) * -1
     tmp134 += einsum(t1.bb, (0, 1), tmp39, (2, 0, 3, 4), (2, 3, 4, 1))
     l1new.bb += einsum(v.bbbb.ovvv, (0, 1, 2, 3), tmp134, (4, 0, 3, 1), (2, 4)) * -2
     del tmp134
-    tmp103 = v.aabb.ovoo.transpose((0, 2, 3, 1)).copy()
+    tmp103 = np.copy(np.transpose(v.aabb.ovoo, (0, 2, 3, 1)))
     tmp103 += tmp2
     del tmp2
     tmp103 += einsum(t2.abab, (0, 1, 2, 3), v.aabb.vvov, (4, 2, 5, 3), (0, 1, 5, 4))
@@ -1763,8 +1763,8 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp103 += einsum(t1.aa, (0, 1), tmp16, (0, 2, 3, 4), (2, 4, 3, 1)) * -1
     l1new.bb += einsum(tmp103, (0, 1, 2, 3), l2.abab, (3, 4, 0, 1), (4, 2)) * -1
     del tmp103
-    tmp144 = f.bb.vv.copy()
-    tmp144 += tmp143.transpose((1, 0))
+    tmp144 = np.copy(f.bb.vv)
+    tmp144 += np.transpose(tmp143, (1, 0))
     del tmp143
     tmp144 += einsum(t1.bb, (0, 1), tmp129, (0, 2, 1, 3), (3, 2)) * -1
     del tmp129
@@ -1775,11 +1775,11 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l1new.bb += einsum(v.aabb.vvov, (0, 1, 2, 3), tmp135, (4, 2, 0, 1), (3, 4)) * -1
     del tmp135
     tmp140 = einsum(l1.bb, (0, 1), t2.bbbb, (2, 3, 4, 0), (1, 2, 3, 4))
-    tmp140 += tmp136.transpose((0, 2, 1, 3)) * 0.5
-    tmp140 += tmp137.transpose((0, 2, 1, 3)) * 2
+    tmp140 += np.transpose(tmp136, (0, 2, 1, 3)) * 0.5
+    tmp140 += np.transpose(tmp137, (0, 2, 1, 3)) * 2
     l1new.bb += einsum(tmp140, (0, 1, 2, 3), v.bbbb.ovov, (1, 4, 2, 3), (4, 0)) * 2
     del tmp140
-    tmp58 = l1.aa.transpose((1, 0)).copy() * -1
+    tmp58 = np.copy(np.transpose(l1.aa, (1, 0))) * -1
     tmp58 += t1.aa * -1
     tmp58 += tmp47 * -2
     tmp58 += tmp48 * -1
@@ -1790,21 +1790,21 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l1new.bb += einsum(v.aabb.ovov, (0, 1, 2, 3), tmp58, (0, 1), (3, 2)) * -1
     l1new.aa += einsum(tmp58, (0, 1), v.aaaa.ovov, (2, 3, 0, 1), (3, 2)) * -1
     del tmp58
-    tmp141 = tmp80.copy()
-    tmp141 += tmp81.transpose((1, 0, 2, 3))
+    tmp141 = np.copy(tmp80)
+    tmp141 += np.transpose(tmp81, (1, 0, 2, 3))
     l1new.bb += einsum(tmp141, (0, 1, 2, 3), v.aabb.ooov, (0, 1, 3, 4), (4, 2))
     del tmp141
-    tmp139 = tmp39.transpose((1, 0, 2, 3)).copy() * -1
+    tmp139 = np.copy(np.transpose(tmp39, (1, 0, 2, 3))) * -1
     del tmp39
-    tmp139 += tmp136.transpose((2, 0, 1, 3)) * 0.5
+    tmp139 += np.transpose(tmp136, (2, 0, 1, 3)) * 0.5
     del tmp136
-    tmp139 += tmp137.transpose((2, 0, 1, 3)) * 2
+    tmp139 += np.transpose(tmp137, (2, 0, 1, 3)) * 2
     del tmp137
     tmp139 += einsum(tmp138, (0, 1, 2, 3), t1.bb, (0, 4), (3, 1, 2, 4))
     del tmp138
     l1new.bb += einsum(v.bbbb.ovov, (0, 1, 2, 3), tmp139, (0, 4, 2, 1), (3, 4)) * -2
     del tmp139
-    tmp46 = l1.bb.transpose((1, 0)).copy() * -1
+    tmp46 = np.copy(np.transpose(l1.bb, (1, 0))) * -1
     tmp46 += t1.bb * -1
     tmp46 += tmp35 * -1
     del tmp35
@@ -1818,7 +1818,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp45
     l1new.aa += einsum(tmp46, (0, 1), v.aabb.ovov, (2, 3, 0, 1), (3, 2)) * -1
     del tmp46
-    tmp25 = v.aaaa.ooov.copy() * -0.5
+    tmp25 = np.copy(v.aaaa.ooov) * -0.5
     tmp25 += einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovvv, (4, 2, 5, 3), (4, 0, 1, 5)) * -0.5
     tmp25 += einsum(t2.aaaa, (0, 1, 2, 3), tmp18, (4, 5, 1, 3), (5, 0, 4, 2))
     del tmp18
@@ -1835,7 +1835,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp84 += einsum(t1.bb, (0, 1), tmp51, (2, 3, 0, 4), (2, 3, 1, 4))
     l1new.aa += einsum(v.aabb.ovvv, (0, 1, 2, 3), tmp84, (4, 0, 3, 2), (1, 4)) * -1
     del tmp84
-    tmp17 = v.aabb.ooov.copy()
+    tmp17 = np.copy(v.aabb.ooov)
     tmp17 += einsum(t1.bb, (0, 1), v.aabb.oovv, (2, 3, 4, 1), (2, 3, 0, 4))
     tmp17 += einsum(v.aabb.ovvv, (0, 1, 2, 3), t2.abab, (4, 5, 1, 3), (4, 0, 5, 2))
     tmp17 += einsum(t2.abab, (0, 1, 2, 3), tmp1, (0, 4, 5, 2), (4, 5, 1, 3))
@@ -1855,12 +1855,12 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp69 = einsum(v.aaaa.vvvv, (0, 1, 2, 3), t1.aa, (4, 3), (4, 0, 1, 2))
     l1new.aa += einsum(l2.aaaa, (0, 1, 2, 3), tmp69, (3, 4, 1, 0), (4, 2)) * -2
     del tmp69
-    tmp79 = tmp76.copy()
+    tmp79 = np.copy(tmp76)
     tmp79 += einsum(tmp49, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3)) * -0.5
     tmp79 += tmp77 * 0.25
     l1new.aa += einsum(tmp79, (0, 1, 2, 3), v.aaaa.ovvv, (1, 4, 3, 2), (4, 0)) * -4
     del tmp79
-    tmp91 = t1.aa.copy() * -0.5
+    tmp91 = np.copy(t1.aa) * -0.5
     tmp91 += tmp47 * -1
     del tmp47
     tmp91 += tmp48 * -0.5
@@ -1873,14 +1873,14 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp56
     l1new.aa += einsum(tmp91, (0, 1), v.aaaa.ovov, (2, 1, 0, 3), (3, 2)) * 2
     del tmp91
-    tmp88 = tmp49.transpose((1, 0, 2, 3)).copy() * -0.5
-    tmp88 += tmp85.transpose((2, 0, 1, 3))
-    tmp88 += tmp86.transpose((2, 0, 1, 3)) * 0.25
+    tmp88 = np.copy(np.transpose(tmp49, (1, 0, 2, 3))) * -0.5
+    tmp88 += np.transpose(tmp85, (2, 0, 1, 3))
+    tmp88 += np.transpose(tmp86, (2, 0, 1, 3)) * 0.25
     tmp88 += einsum(tmp87, (0, 1, 2, 3), t1.aa, (0, 4), (3, 1, 2, 4)) * 0.5
     del tmp87
     l1new.aa += einsum(v.aaaa.ovov, (0, 1, 2, 3), tmp88, (0, 4, 2, 1), (3, 4)) * -4
     del tmp88
-    tmp75 = l2.abab.transpose((2, 3, 0, 1)).copy()
+    tmp75 = np.copy(np.transpose(l2.abab, (2, 3, 0, 1)))
     tmp75 += tmp73 * 2
     del tmp73
     tmp75 += tmp74 * 2
@@ -1891,7 +1891,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp72 = einsum(t1.aa, (0, 1), v.aaaa.ovvv, (2, 1, 3, 4), (0, 2, 3, 4))
     l1new.aa += einsum(tmp72, (0, 1, 2, 3), tmp49, (4, 0, 1, 3), (2, 4)) * -2
     del tmp72
-    tmp29 = tmp26.copy()
+    tmp29 = np.copy(tmp26)
     del tmp26
     tmp29 += tmp27 * 2
     del tmp27
@@ -1900,29 +1900,29 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l1new.aa += einsum(tmp29, (0, 1), tmp30, (2, 3, 1, 0), (3, 2)) * -1
     del tmp30, tmp29
     tmp89 = einsum(l1.aa, (0, 1), t2.aaaa, (2, 3, 4, 0), (1, 2, 3, 4)) * 0.5
-    tmp89 += tmp85.transpose((0, 2, 1, 3))
+    tmp89 += np.transpose(tmp85, (0, 2, 1, 3))
     del tmp85
-    tmp89 += tmp86.transpose((0, 2, 1, 3)) * 0.25
+    tmp89 += np.transpose(tmp86, (0, 2, 1, 3)) * 0.25
     del tmp86
     l1new.aa += einsum(tmp89, (0, 1, 2, 3), v.aaaa.ovov, (1, 4, 2, 3), (4, 0)) * 4
     del tmp89
-    tmp78 = l2.aaaa.transpose((2, 3, 0, 1)).copy()
+    tmp78 = np.copy(np.transpose(l2.aaaa, (2, 3, 0, 1)))
     tmp78 += tmp76 * 2
     del tmp76
     tmp78 += tmp77 * 0.5
     del tmp77
     l1new.aa += einsum(v.aaaa.ovvv, (0, 1, 2, 3), tmp78, (4, 0, 3, 1), (2, 4)) * 2
     del tmp78
-    tmp94 = f.aa.vv.copy()
-    tmp94 += tmp92.transpose((1, 0))
+    tmp94 = np.copy(f.aa.vv)
+    tmp94 += np.transpose(tmp92, (1, 0))
     del tmp92
     tmp94 += einsum(t1.aa, (0, 1), tmp93, (0, 1, 2, 3), (3, 2)) * -1
     del tmp93
     l1new.aa += einsum(l1.aa, (0, 1), tmp94, (0, 2), (2, 1))
     del tmp94
-    tmp90 = tmp80.copy()
+    tmp90 = np.copy(tmp80)
     del tmp80
-    tmp90 += tmp81.transpose((0, 1, 3, 2))
+    tmp90 += np.transpose(tmp81, (0, 1, 3, 2))
     del tmp81
     l1new.aa += einsum(tmp90, (0, 1, 2, 3), v.aabb.ovoo, (1, 4, 3, 2), (4, 0))
     del tmp90
@@ -1942,16 +1942,16 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l1new.aa += einsum(tmp83, (0, 1, 2, 3), v.aabb.ovov, (1, 4, 2, 3), (4, 0)) * -1
     del tmp83
     l1new.aa += einsum(v.aaaa.oovv, (0, 1, 2, 3), l1.aa, (3, 1), (2, 0)) * -1
-    l1new.aa += f.aa.ov.transpose((1, 0))
+    l1new.aa += np.transpose(f.aa.ov, (1, 0))
     l1new.bb += einsum(v.bbbb.oovv, (0, 1, 2, 3), l1.bb, (3, 1), (2, 0)) * -1
-    l1new.bb += f.bb.ov.transpose((1, 0))
-    l2new.aaaa += v.aaaa.ovov.transpose((1, 3, 0, 2))
-    l2new.aaaa += v.aaaa.ovov.transpose((3, 1, 0, 2)) * -1
-    l2new.abab += v.aabb.ovov.transpose((1, 3, 0, 2))
+    l1new.bb += np.transpose(f.bb.ov, (1, 0))
+    l2new.aaaa += np.transpose(v.aaaa.ovov, (1, 3, 0, 2))
+    l2new.aaaa += np.transpose(v.aaaa.ovov, (3, 1, 0, 2)) * -1
+    l2new.abab += np.transpose(v.aabb.ovov, (1, 3, 0, 2))
     l2new.abab += einsum(v.aabb.ovvv, (0, 1, 2, 3), l1.bb, (3, 4), (1, 2, 0, 4))
     l2new.abab += einsum(v.aabb.vvov, (0, 1, 2, 3), l1.aa, (1, 4), (0, 3, 4, 2))
-    l2new.bbbb += v.bbbb.ovov.transpose((1, 3, 0, 2))
-    l2new.bbbb += v.bbbb.ovov.transpose((3, 1, 0, 2)) * -1
+    l2new.bbbb += np.transpose(v.bbbb.ovov, (1, 3, 0, 2))
+    l2new.bbbb += np.transpose(v.bbbb.ovov, (3, 1, 0, 2)) * -1
 
     return {f"l1new": l1new, f"l2new": l2new}
 
@@ -1984,18 +1984,18 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
         bb=Namespace(oo=np.eye(t2.bbbb.shape[0]), vv=np.eye(t2.bbbb.shape[-1])),
     )
     tmp4 = einsum(l1.bb, (0, 1), t1.bb, (2, 0), (1, 2))
-    rdm1.bb.oo = tmp4.transpose((1, 0)).copy() * -1
+    rdm1.bb.oo = np.copy(np.transpose(tmp4, (1, 0))) * -1
     tmp5 = einsum(l2.bbbb, (0, 1, 2, 3), t2.bbbb, (4, 3, 0, 1), (2, 4))
-    rdm1.bb.oo += tmp5.transpose((1, 0)) * -2
+    rdm1.bb.oo += np.transpose(tmp5, (1, 0)) * -2
     tmp3 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 3, 0, 4), (4, 1))
-    rdm1.bb.oo += tmp3.transpose((1, 0)) * -1
+    rdm1.bb.oo += np.transpose(tmp3, (1, 0)) * -1
     tmp2 = einsum(l1.aa, (0, 1), t1.aa, (2, 0), (1, 2))
-    rdm1.aa.oo = tmp2.transpose((1, 0)).copy() * -1
+    rdm1.aa.oo = np.copy(np.transpose(tmp2, (1, 0))) * -1
     tmp1 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (2, 3, 4, 1), (4, 0))
-    rdm1.aa.oo += tmp1.transpose((1, 0)) * -2
+    rdm1.aa.oo += np.transpose(tmp1, (1, 0)) * -2
     tmp0 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 3, 4, 1), (4, 0))
-    rdm1.aa.oo += tmp0.transpose((1, 0)) * -1
-    tmp11 = tmp4.copy()
+    rdm1.aa.oo += np.transpose(tmp0, (1, 0)) * -1
+    tmp11 = np.copy(tmp4)
     del tmp4
     tmp11 += tmp3
     del tmp3
@@ -2015,7 +2015,7 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp6 = einsum(t1.aa, (0, 1), l2.aaaa, (2, 1, 3, 4), (3, 4, 0, 2))
     rdm1.aa.ov += einsum(tmp6, (0, 1, 2, 3), t2.aaaa, (1, 0, 4, 3), (2, 4)) * -2
     del tmp6
-    tmp8 = tmp2.copy()
+    tmp8 = np.copy(tmp2)
     del tmp2
     tmp8 += tmp1 * 2
     del tmp1
@@ -2032,8 +2032,8 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm1.bb.ov += einsum(l1.aa, (0, 1), t2.abab, (1, 2, 0, 3), (2, 3))
     rdm1.bb.ov += t1.bb
     rdm1.bb.ov += einsum(t2.bbbb, (0, 1, 2, 3), l1.bb, (3, 1), (0, 2)) * 2
-    rdm1.aa.vo = l1.aa.copy()
-    rdm1.bb.vo = l1.bb.copy()
+    rdm1.aa.vo = np.copy(l1.aa)
+    rdm1.bb.vo = np.copy(l1.bb)
     rdm1.aa.vv = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (4, 3, 0, 1), (4, 2))
     rdm1.aa.vv += einsum(l1.aa, (0, 1), t1.aa, (1, 2), (0, 2))
     rdm1.aa.vv += einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (2, 3, 4, 1), (0, 4)) * 2
@@ -2078,47 +2078,47 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp9 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 3, 0, 4), (4, 1))
     tmp8 = einsum(l1.bb, (0, 1), t1.bb, (2, 0), (1, 2))
     tmp19 = einsum(t1.bb, (0, 1), l2.bbbb, (2, 1, 3, 4), (3, 4, 0, 2))
-    rdm2.bbbb.vooo = tmp19.transpose((3, 2, 1, 0)).copy()
-    rdm2.bbbb.vooo += tmp19.transpose((3, 2, 1, 0))
-    rdm2.bbbb.ovoo = tmp19.transpose((2, 3, 1, 0)).copy() * -1
-    rdm2.bbbb.ovoo += tmp19.transpose((2, 3, 1, 0)) * -1
+    rdm2.bbbb.vooo = np.copy(np.transpose(tmp19, (3, 2, 1, 0)))
+    rdm2.bbbb.vooo += np.transpose(tmp19, (3, 2, 1, 0))
+    rdm2.bbbb.ovoo = np.copy(np.transpose(tmp19, (2, 3, 1, 0))) * -1
+    rdm2.bbbb.ovoo += np.transpose(tmp19, (2, 3, 1, 0)) * -1
     tmp14 = einsum(t1.bb, (0, 1), l2.abab, (2, 1, 3, 4), (3, 4, 0, 2))
     rdm2.abab.vovv = einsum(tmp14, (0, 1, 2, 3), t2.abab, (0, 1, 4, 5), (3, 2, 4, 5)) * -1
     rdm2.abab.vovo = einsum(tmp14, (0, 1, 2, 3), t1.aa, (0, 4), (3, 2, 4, 1)) * -1
-    rdm2.abab.vooo = tmp14.transpose((3, 2, 0, 1)).copy() * -1
+    rdm2.abab.vooo = np.copy(np.transpose(tmp14, (3, 2, 0, 1))) * -1
     tmp2 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 3, 4, 1), (4, 0))
     tmp1 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (2, 3, 4, 1), (4, 0))
     tmp0 = einsum(l1.aa, (0, 1), t1.aa, (2, 0), (1, 2))
     tmp6 = einsum(t1.aa, (0, 1), l2.aaaa, (2, 1, 3, 4), (3, 4, 0, 2))
-    rdm2.aaaa.vooo = tmp6.transpose((3, 2, 1, 0)).copy()
-    rdm2.aaaa.vooo += tmp6.transpose((3, 2, 1, 0))
-    rdm2.aaaa.ovoo = tmp6.transpose((2, 3, 1, 0)).copy() * -1
-    rdm2.aaaa.ovoo += tmp6.transpose((2, 3, 1, 0)) * -1
+    rdm2.aaaa.vooo = np.copy(np.transpose(tmp6, (3, 2, 1, 0)))
+    rdm2.aaaa.vooo += np.transpose(tmp6, (3, 2, 1, 0))
+    rdm2.aaaa.ovoo = np.copy(np.transpose(tmp6, (2, 3, 1, 0))) * -1
+    rdm2.aaaa.ovoo += np.transpose(tmp6, (2, 3, 1, 0)) * -1
     tmp27 = einsum(t1.aa, (0, 1), l2.abab, (1, 2, 3, 4), (3, 0, 4, 2))
     rdm2.abab.ovvv = einsum(t2.abab, (0, 1, 2, 3), tmp27, (0, 4, 1, 5), (4, 5, 2, 3)) * -1
     rdm2.abab.ovov = einsum(t1.bb, (0, 1), tmp27, (2, 3, 0, 4), (3, 4, 2, 1)) * -1
-    rdm2.abab.ovoo = tmp27.transpose((1, 3, 0, 2)).copy() * -1
+    rdm2.abab.ovoo = np.copy(np.transpose(tmp27, (1, 3, 0, 2))) * -1
     tmp88 = einsum(t2.bbbb, (0, 1, 2, 3), l2.bbbb, (4, 3, 5, 1), (5, 0, 4, 2))
-    rdm2.bbbb.vovo = tmp88.transpose((2, 1, 3, 0)).copy() * -4
-    rdm2.bbbb.voov = tmp88.transpose((2, 1, 0, 3)).copy() * 4
-    rdm2.bbbb.ovvo = tmp88.transpose((1, 2, 3, 0)).copy() * 4
-    rdm2.bbbb.ovov = tmp88.transpose((1, 2, 0, 3)).copy() * -4
+    rdm2.bbbb.vovo = np.copy(np.transpose(tmp88, (2, 1, 3, 0))) * -4
+    rdm2.bbbb.voov = np.copy(np.transpose(tmp88, (2, 1, 0, 3))) * 4
+    rdm2.bbbb.ovvo = np.copy(np.transpose(tmp88, (1, 2, 3, 0))) * 4
+    rdm2.bbbb.ovov = np.copy(np.transpose(tmp88, (1, 2, 0, 3))) * -4
     tmp107 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 4, 0, 5), (3, 4, 1, 5))
-    rdm2.bbbb.vovo += tmp107.transpose((2, 1, 3, 0)) * -1
-    rdm2.bbbb.voov += tmp107.transpose((2, 1, 0, 3))
-    rdm2.bbbb.ovvo += tmp107.transpose((1, 2, 3, 0))
-    rdm2.bbbb.ovov += tmp107.transpose((1, 2, 0, 3)) * -1
+    rdm2.bbbb.vovo += np.transpose(tmp107, (2, 1, 3, 0)) * -1
+    rdm2.bbbb.voov += np.transpose(tmp107, (2, 1, 0, 3))
+    rdm2.bbbb.ovvo += np.transpose(tmp107, (1, 2, 3, 0))
+    rdm2.bbbb.ovov += np.transpose(tmp107, (1, 2, 0, 3)) * -1
     tmp69 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 3, 5, 1), (2, 4, 0, 5))
-    rdm2.aaaa.vovo = tmp69.transpose((2, 1, 3, 0)).copy() * -1
-    rdm2.aaaa.voov = tmp69.transpose((2, 1, 0, 3)).copy()
-    rdm2.aaaa.ovvo = tmp69.transpose((1, 2, 3, 0)).copy()
-    rdm2.aaaa.ovov = tmp69.transpose((1, 2, 0, 3)).copy() * -1
+    rdm2.aaaa.vovo = np.copy(np.transpose(tmp69, (2, 1, 3, 0))) * -1
+    rdm2.aaaa.voov = np.copy(np.transpose(tmp69, (2, 1, 0, 3)))
+    rdm2.aaaa.ovvo = np.copy(np.transpose(tmp69, (1, 2, 3, 0)))
+    rdm2.aaaa.ovov = np.copy(np.transpose(tmp69, (1, 2, 0, 3))) * -1
     tmp67 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (4, 3, 5, 1), (5, 0, 4, 2))
-    rdm2.aaaa.vovo += tmp67.transpose((2, 1, 3, 0)) * -4
-    rdm2.aaaa.voov += tmp67.transpose((2, 1, 0, 3)) * 4
-    rdm2.aaaa.ovvo += tmp67.transpose((1, 2, 3, 0)) * 4
-    rdm2.aaaa.ovov += tmp67.transpose((1, 2, 0, 3)) * -4
-    tmp17 = tmp8.copy()
+    rdm2.aaaa.vovo += np.transpose(tmp67, (2, 1, 3, 0)) * -4
+    rdm2.aaaa.voov += np.transpose(tmp67, (2, 1, 0, 3)) * 4
+    rdm2.aaaa.ovvo += np.transpose(tmp67, (1, 2, 3, 0)) * 4
+    rdm2.aaaa.ovov += np.transpose(tmp67, (1, 2, 0, 3)) * -4
+    tmp17 = np.copy(tmp8)
     tmp17 += tmp9
     tmp17 += tmp10 * 2
     rdm2.abab.oovv = einsum(t2.abab, (0, 1, 2, 3), tmp17, (1, 4), (0, 4, 2, 3)) * -1
@@ -2129,52 +2129,52 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.bbbb.ooov += einsum(t1.bb, (0, 1), tmp17, (2, 3), (3, 0, 2, 1)) * -1
     rdm2.bbbb.oooo = einsum(delta.bb.oo, (0, 1), tmp17, (2, 3), (0, 3, 2, 1))
     tmp51 = einsum(t2.bbbb, (0, 1, 2, 3), tmp19, (4, 1, 5, 3), (4, 5, 0, 2)) * -1
-    rdm2.bbbb.oovo += tmp51.transpose((2, 1, 3, 0)) * -4
-    rdm2.bbbb.oovo += tmp51.transpose((1, 2, 3, 0)) * 4
-    rdm2.bbbb.ooov += tmp51.transpose((2, 1, 0, 3)) * 4
-    rdm2.bbbb.ooov += tmp51.transpose((1, 2, 0, 3)) * -4
+    rdm2.bbbb.oovo += np.transpose(tmp51, (2, 1, 3, 0)) * -4
+    rdm2.bbbb.oovo += np.transpose(tmp51, (1, 2, 3, 0)) * 4
+    rdm2.bbbb.ooov += np.transpose(tmp51, (2, 1, 0, 3)) * 4
+    rdm2.bbbb.ooov += np.transpose(tmp51, (1, 2, 0, 3)) * -4
     tmp50 = einsum(t2.abab, (0, 1, 2, 3), tmp14, (0, 4, 5, 2), (4, 5, 1, 3))
-    rdm2.bbbb.oovo += tmp50.transpose((2, 1, 3, 0)) * -1
-    rdm2.bbbb.oovo += tmp50.transpose((1, 2, 3, 0))
-    rdm2.bbbb.ooov += tmp50.transpose((2, 1, 0, 3))
-    rdm2.bbbb.ooov += tmp50.transpose((1, 2, 0, 3)) * -1
+    rdm2.bbbb.oovo += np.transpose(tmp50, (2, 1, 3, 0)) * -1
+    rdm2.bbbb.oovo += np.transpose(tmp50, (1, 2, 3, 0))
+    rdm2.bbbb.ooov += np.transpose(tmp50, (2, 1, 0, 3))
+    rdm2.bbbb.ooov += np.transpose(tmp50, (1, 2, 0, 3)) * -1
     tmp18 = einsum(t2.bbbb, (0, 1, 2, 3), l2.bbbb, (2, 3, 4, 5), (4, 5, 0, 1))
-    rdm2.bbbb.oooo += tmp18.transpose((3, 2, 1, 0))
-    rdm2.bbbb.oooo += tmp18.transpose((3, 2, 1, 0))
+    rdm2.bbbb.oooo += np.transpose(tmp18, (3, 2, 1, 0))
+    rdm2.bbbb.oooo += np.transpose(tmp18, (3, 2, 1, 0))
     tmp20 = einsum(tmp19, (0, 1, 2, 3), t1.bb, (4, 3), (0, 1, 4, 2))
-    rdm2.bbbb.oooo += tmp20.transpose((2, 3, 1, 0)) * -1
-    rdm2.bbbb.oooo += tmp20.transpose((2, 3, 1, 0)) * -1
+    rdm2.bbbb.oooo += np.transpose(tmp20, (2, 3, 1, 0)) * -1
+    rdm2.bbbb.oooo += np.transpose(tmp20, (2, 3, 1, 0)) * -1
     tmp15 = einsum(t1.aa, (0, 1), tmp14, (2, 3, 4, 1), (2, 0, 3, 4))
-    rdm2.abab.oooo = tmp15.transpose((1, 3, 0, 2)).copy()
+    rdm2.abab.oooo = np.copy(np.transpose(tmp15, (1, 3, 0, 2)))
     tmp13 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 5, 0, 1), (2, 4, 3, 5))
-    rdm2.abab.oooo += tmp13.transpose((1, 3, 0, 2))
-    tmp4 = tmp0.copy() * 0.5
+    rdm2.abab.oooo += np.transpose(tmp13, (1, 3, 0, 2))
+    tmp4 = np.copy(tmp0) * 0.5
     tmp4 += tmp1
     tmp4 += tmp2 * 0.5
     rdm2.aaaa.oooo = einsum(delta.aa.oo, (0, 1), tmp4, (2, 3), (0, 3, 2, 1)) * 2
     rdm2.aaaa.oooo += einsum(tmp4, (0, 1), delta.aa.oo, (2, 3), (1, 2, 0, 3)) * -2
     tmp7 = einsum(tmp6, (0, 1, 2, 3), t1.aa, (4, 3), (0, 1, 4, 2))
-    rdm2.aaaa.oooo += tmp7.transpose((2, 3, 1, 0)) * -1
-    rdm2.aaaa.oooo += tmp7.transpose((2, 3, 1, 0)) * -1
+    rdm2.aaaa.oooo += np.transpose(tmp7, (2, 3, 1, 0)) * -1
+    rdm2.aaaa.oooo += np.transpose(tmp7, (2, 3, 1, 0)) * -1
     tmp5 = einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (4, 5, 0, 1), (2, 3, 4, 5))
-    rdm2.aaaa.oooo += tmp5.transpose((3, 2, 1, 0))
-    rdm2.aaaa.oooo += tmp5.transpose((3, 2, 1, 0))
+    rdm2.aaaa.oooo += np.transpose(tmp5, (3, 2, 1, 0))
+    rdm2.aaaa.oooo += np.transpose(tmp5, (3, 2, 1, 0))
     tmp31 = einsum(t2.abab, (0, 1, 2, 3), tmp27, (4, 5, 1, 3), (4, 5, 0, 2))
-    rdm2.aaaa.oovo = tmp31.transpose((2, 1, 3, 0)).copy() * -1
-    rdm2.aaaa.oovo += tmp31.transpose((1, 2, 3, 0))
-    rdm2.aaaa.ooov = tmp31.transpose((2, 1, 0, 3)).copy()
-    rdm2.aaaa.ooov += tmp31.transpose((1, 2, 0, 3)) * -1
+    rdm2.aaaa.oovo = np.copy(np.transpose(tmp31, (2, 1, 3, 0))) * -1
+    rdm2.aaaa.oovo += np.transpose(tmp31, (1, 2, 3, 0))
+    rdm2.aaaa.ooov = np.copy(np.transpose(tmp31, (2, 1, 0, 3)))
+    rdm2.aaaa.ooov += np.transpose(tmp31, (1, 2, 0, 3)) * -1
     tmp32 = einsum(tmp6, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (0, 2, 4, 5)) * -1
-    rdm2.aaaa.oovo += tmp32.transpose((2, 1, 3, 0)) * -4
-    rdm2.aaaa.oovo += tmp32.transpose((1, 2, 3, 0)) * 4
-    rdm2.aaaa.ooov += tmp32.transpose((2, 1, 0, 3)) * 4
-    rdm2.aaaa.ooov += tmp32.transpose((1, 2, 0, 3)) * -4
+    rdm2.aaaa.oovo += np.transpose(tmp32, (2, 1, 3, 0)) * -4
+    rdm2.aaaa.oovo += np.transpose(tmp32, (1, 2, 3, 0)) * 4
+    rdm2.aaaa.ooov += np.transpose(tmp32, (2, 1, 0, 3)) * 4
+    rdm2.aaaa.ooov += np.transpose(tmp32, (1, 2, 0, 3)) * -4
     tmp108 = einsum(tmp19, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 3, 4))
-    rdm2.bbbb.vovo += tmp108.transpose((2, 1, 3, 0)) * 2
-    rdm2.bbbb.voov += tmp108.transpose((2, 1, 0, 3)) * -2
-    rdm2.bbbb.ovvo += tmp108.transpose((1, 2, 3, 0)) * -2
-    rdm2.bbbb.ovov += tmp108.transpose((1, 2, 0, 3)) * 2
-    tmp121 = tmp107.copy()
+    rdm2.bbbb.vovo += np.transpose(tmp108, (2, 1, 3, 0)) * 2
+    rdm2.bbbb.voov += np.transpose(tmp108, (2, 1, 0, 3)) * -2
+    rdm2.bbbb.ovvo += np.transpose(tmp108, (1, 2, 3, 0)) * -2
+    rdm2.bbbb.ovov += np.transpose(tmp108, (1, 2, 0, 3)) * 2
+    tmp121 = np.copy(tmp107)
     tmp121 += tmp88 * 4
     tmp80 = einsum(l2.bbbb, (0, 1, 2, 3), t2.bbbb, (2, 3, 4, 1), (0, 4))
     tmp79 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 4, 0, 1), (4, 3))
@@ -2183,39 +2183,39 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp102 = einsum(l1.aa, (0, 1), t1.aa, (1, 2), (0, 2))
     tmp63 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (4, 3, 0, 1), (4, 2))
     tmp90 = einsum(l2.aaaa, (0, 1, 2, 3), t2.abab, (3, 4, 1, 5), (2, 4, 0, 5))
-    rdm2.abab.voov = tmp90.transpose((2, 1, 0, 3)).copy() * 2
+    rdm2.abab.voov = np.copy(np.transpose(tmp90, (2, 1, 0, 3))) * 2
     tmp92 = einsum(t2.bbbb, (0, 1, 2, 3), l2.abab, (4, 3, 5, 1), (5, 0, 4, 2))
-    rdm2.abab.voov += tmp92.transpose((2, 1, 0, 3)) * 2
+    rdm2.abab.voov += np.transpose(tmp92, (2, 1, 0, 3)) * 2
     tmp104 = einsum(tmp6, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 3, 4))
-    rdm2.aaaa.vovo += tmp104.transpose((2, 1, 3, 0)) * 2
-    rdm2.aaaa.voov += tmp104.transpose((2, 1, 0, 3)) * -2
-    rdm2.aaaa.ovvo += tmp104.transpose((1, 2, 3, 0)) * -2
-    rdm2.aaaa.ovov += tmp104.transpose((1, 2, 0, 3)) * 2
-    tmp84 = tmp67.copy() * 4
+    rdm2.aaaa.vovo += np.transpose(tmp104, (2, 1, 3, 0)) * 2
+    rdm2.aaaa.voov += np.transpose(tmp104, (2, 1, 0, 3)) * -2
+    rdm2.aaaa.ovvo += np.transpose(tmp104, (1, 2, 3, 0)) * -2
+    rdm2.aaaa.ovov += np.transpose(tmp104, (1, 2, 0, 3)) * 2
+    tmp84 = np.copy(tmp67) * 4
     tmp84 += tmp69
     rdm2.abab.oovv += einsum(tmp84, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5))
     tmp65 = einsum(l2.bbbb, (0, 1, 2, 3), t2.abab, (4, 3, 5, 1), (4, 2, 5, 0))
-    rdm2.abab.ovvo = tmp65.transpose((0, 3, 2, 1)).copy() * 2
+    rdm2.abab.ovvo = np.copy(np.transpose(tmp65, (0, 3, 2, 1))) * 2
     tmp82 = einsum(l2.abab, (0, 1, 2, 3), t2.aaaa, (4, 2, 5, 0), (4, 3, 5, 1))
-    rdm2.abab.ovvo += tmp82.transpose((0, 3, 2, 1)) * 2
+    rdm2.abab.ovvo += np.transpose(tmp82, (0, 3, 2, 1)) * 2
     tmp39 = einsum(tmp14, (0, 1, 2, 3), t2.abab, (0, 1, 3, 4), (2, 4))
     tmp40 = einsum(t2.bbbb, (0, 1, 2, 3), tmp19, (1, 0, 4, 3), (4, 2))
     tmp60 = einsum(t1.bb, (0, 1), tmp17, (0, 2), (2, 1)) * 0.5
     tmp36 = einsum(t2.bbbb, (0, 1, 2, 3), l1.bb, (3, 1), (0, 2))
     tmp35 = einsum(l1.aa, (0, 1), t2.abab, (1, 2, 0, 3), (2, 3))
     tmp49 = einsum(t2.bbbb, (0, 1, 2, 3), l1.bb, (3, 4), (4, 0, 1, 2))
-    rdm2.bbbb.oovo += tmp49.transpose((2, 1, 3, 0)) * 2
-    rdm2.bbbb.ooov += tmp49.transpose((2, 1, 0, 3)) * -2
-    tmp100 = tmp50.copy()
+    rdm2.bbbb.oovo += np.transpose(tmp49, (2, 1, 3, 0)) * 2
+    rdm2.bbbb.ooov += np.transpose(tmp49, (2, 1, 0, 3)) * -2
+    tmp100 = np.copy(tmp50)
     del tmp50
     tmp100 += tmp51 * 4
     del tmp51
     tmp41 = einsum(t1.bb, (0, 1), tmp17, (0, 2), (2, 1))
-    tmp52 = tmp18.transpose((1, 0, 3, 2)).copy()
+    tmp52 = np.copy(np.transpose(tmp18, (1, 0, 3, 2)))
     del tmp18
-    tmp52 += tmp20.transpose((0, 1, 3, 2)) * -1
+    tmp52 += np.transpose(tmp20, (0, 1, 3, 2)) * -1
     del tmp20
-    tmp45 = tmp13.copy()
+    tmp45 = np.copy(tmp13)
     del tmp13
     tmp45 += tmp15
     del tmp15
@@ -2224,17 +2224,17 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp21 = einsum(l1.aa, (0, 1), t2.aaaa, (2, 1, 3, 0), (2, 3))
     tmp22 = einsum(l1.bb, (0, 1), t2.abab, (2, 1, 3, 0), (2, 3))
     tmp43 = einsum(t2.abab, (0, 1, 2, 3), tmp6, (4, 0, 5, 2), (4, 5, 1, 3)) * -1
-    rdm2.abab.ooov = tmp43.transpose((1, 2, 0, 3)).copy() * -2
+    rdm2.abab.ooov = np.copy(np.transpose(tmp43, (1, 2, 0, 3))) * -2
     tmp44 = einsum(t2.bbbb, (0, 1, 2, 3), tmp27, (4, 5, 1, 3), (4, 5, 0, 2))
-    rdm2.abab.ooov += tmp44.transpose((1, 2, 0, 3)) * -2
+    rdm2.abab.ooov += np.transpose(tmp44, (1, 2, 0, 3)) * -2
     tmp28 = einsum(t2.abab, (0, 1, 2, 3), tmp27, (0, 4, 1, 3), (4, 2))
     tmp26 = einsum(tmp6, (0, 1, 2, 3), t2.aaaa, (1, 0, 4, 3), (2, 4))
     tmp29 = einsum(tmp4, (0, 1), t1.aa, (0, 2), (1, 2)) * 2
     tmp58 = einsum(tmp19, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 2, 5)) * -1
-    rdm2.abab.oovo += tmp58.transpose((0, 2, 3, 1)) * -2
+    rdm2.abab.oovo += np.transpose(tmp58, (0, 2, 3, 1)) * -2
     tmp57 = einsum(tmp14, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 3), (4, 1, 2, 5))
-    rdm2.abab.oovo += tmp57.transpose((0, 2, 3, 1)) * -2
-    tmp12 = tmp0.copy()
+    rdm2.abab.oovo += np.transpose(tmp57, (0, 2, 3, 1)) * -2
+    tmp12 = np.copy(tmp0)
     tmp12 += tmp1 * 2
     tmp12 += tmp2
     rdm2.abab.oovv += einsum(tmp12, (0, 1), t2.abab, (0, 2, 3, 4), (1, 2, 3, 4)) * -1
@@ -2244,59 +2244,59 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.aaaa.ooov += einsum(t1.aa, (0, 1), tmp12, (2, 3), (0, 3, 2, 1))
     rdm2.aaaa.ooov += einsum(tmp12, (0, 1), t1.aa, (2, 3), (1, 2, 0, 3)) * -1
     rdm2.abab.oooo += einsum(tmp12, (0, 1), delta.bb.oo, (2, 3), (1, 2, 0, 3)) * -1
-    tmp33 = tmp5.transpose((1, 0, 3, 2)).copy()
+    tmp33 = np.copy(np.transpose(tmp5, (1, 0, 3, 2)))
     del tmp5
-    tmp33 += tmp7.transpose((0, 1, 3, 2)) * -1
+    tmp33 += np.transpose(tmp7, (0, 1, 3, 2)) * -1
     del tmp7
-    tmp77 = tmp32.copy() * 4
+    tmp77 = np.copy(tmp32) * 4
     del tmp32
     tmp77 += tmp31
     del tmp31
     tmp25 = einsum(t2.aaaa, (0, 1, 2, 3), l1.aa, (3, 4), (4, 0, 1, 2))
-    rdm2.aaaa.oovo += tmp25.transpose((2, 1, 3, 0)) * 2
-    rdm2.aaaa.ooov += tmp25.transpose((2, 1, 0, 3)) * -2
+    rdm2.aaaa.oovo += np.transpose(tmp25, (2, 1, 3, 0)) * 2
+    rdm2.aaaa.ooov += np.transpose(tmp25, (2, 1, 0, 3)) * -2
     tmp54 = einsum(tmp4, (0, 1), t1.aa, (0, 2), (1, 2))
     del tmp4
     tmp130 = einsum(t2.bbbb, (0, 1, 2, 3), l2.bbbb, (4, 5, 0, 1), (4, 5, 2, 3))
-    rdm2.bbbb.vvvv = tmp130.transpose((1, 0, 3, 2)).copy()
-    rdm2.bbbb.vvvv += tmp130.transpose((1, 0, 3, 2))
+    rdm2.bbbb.vvvv = np.copy(np.transpose(tmp130, (1, 0, 3, 2)))
+    rdm2.bbbb.vvvv += np.transpose(tmp130, (1, 0, 3, 2))
     del tmp130
     tmp128 = einsum(t1.bb, (0, 1), l2.bbbb, (2, 3, 4, 0), (4, 2, 3, 1))
     rdm2.bbbb.vvvv += einsum(t1.bb, (0, 1), tmp128, (0, 2, 3, 4), (2, 3, 1, 4)) * 2
-    rdm2.bbbb.vvvo = tmp128.transpose((2, 1, 3, 0)).copy() * 2
-    rdm2.bbbb.vvov = tmp128.transpose((2, 1, 0, 3)).copy() * -2
+    rdm2.bbbb.vvvo = np.copy(np.transpose(tmp128, (2, 1, 3, 0))) * 2
+    rdm2.bbbb.vvov = np.copy(np.transpose(tmp128, (2, 1, 0, 3))) * -2
     del tmp128
     tmp127 = einsum(t1.bb, (0, 1), l2.abab, (2, 3, 4, 0), (4, 2, 3, 1))
     rdm2.abab.vvvv = einsum(tmp127, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3))
-    rdm2.abab.vvov = tmp127.transpose((1, 2, 0, 3)).copy()
+    rdm2.abab.vvov = np.copy(np.transpose(tmp127, (1, 2, 0, 3)))
     del tmp127
     tmp126 = einsum(t1.aa, (0, 1), l2.aaaa, (2, 3, 4, 0), (4, 2, 3, 1))
     rdm2.aaaa.vvvv = einsum(t1.aa, (0, 1), tmp126, (0, 2, 3, 4), (2, 3, 1, 4)) * 2
-    rdm2.aaaa.vvvo = tmp126.transpose((2, 1, 3, 0)).copy() * 2
-    rdm2.aaaa.vvov = tmp126.transpose((2, 1, 0, 3)).copy() * -2
+    rdm2.aaaa.vvvo = np.copy(np.transpose(tmp126, (2, 1, 3, 0))) * 2
+    rdm2.aaaa.vvov = np.copy(np.transpose(tmp126, (2, 1, 0, 3))) * -2
     del tmp126
     tmp129 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (4, 5, 0, 1), (4, 5, 2, 3))
-    rdm2.aaaa.vvvv += tmp129.transpose((1, 0, 3, 2))
-    rdm2.aaaa.vvvv += tmp129.transpose((1, 0, 3, 2))
+    rdm2.aaaa.vvvv += np.transpose(tmp129, (1, 0, 3, 2))
+    rdm2.aaaa.vvvv += np.transpose(tmp129, (1, 0, 3, 2))
     del tmp129
     tmp124 = einsum(t1.bb, (0, 1), tmp108, (0, 2, 3, 4), (2, 3, 4, 1)) * -1
     del tmp108
-    rdm2.bbbb.vovv = tmp124.transpose((1, 0, 3, 2)).copy() * 2
-    rdm2.bbbb.ovvv = tmp124.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.bbbb.vovv = np.copy(np.transpose(tmp124, (1, 0, 3, 2))) * 2
+    rdm2.bbbb.ovvv = np.copy(np.transpose(tmp124, (0, 1, 3, 2))) * -2
     del tmp124
     tmp122 = einsum(t1.bb, (0, 1), tmp121, (0, 2, 3, 4), (2, 1, 3, 4))
     del tmp121
-    rdm2.bbbb.vovv += tmp122.transpose((2, 0, 3, 1)) * -1
-    rdm2.bbbb.vovv += tmp122.transpose((2, 0, 1, 3))
-    rdm2.bbbb.ovvv += tmp122.transpose((0, 2, 3, 1))
+    rdm2.bbbb.vovv += np.transpose(tmp122, (2, 0, 3, 1)) * -1
+    rdm2.bbbb.vovv += np.transpose(tmp122, (2, 0, 1, 3))
+    rdm2.bbbb.ovvv += np.transpose(tmp122, (0, 2, 3, 1))
     del tmp122
     tmp118 = einsum(t2.bbbb, (0, 1, 2, 3), l1.bb, (4, 1), (0, 4, 2, 3))
-    rdm2.bbbb.vovv += tmp118.transpose((1, 0, 3, 2))
-    rdm2.bbbb.vovv += tmp118.transpose((1, 0, 3, 2))
-    rdm2.bbbb.ovvv += tmp118.transpose((0, 1, 3, 2)) * -1
-    rdm2.bbbb.ovvv += tmp118.transpose((0, 1, 3, 2)) * -1
+    rdm2.bbbb.vovv += np.transpose(tmp118, (1, 0, 3, 2))
+    rdm2.bbbb.vovv += np.transpose(tmp118, (1, 0, 3, 2))
+    rdm2.bbbb.ovvv += np.transpose(tmp118, (0, 1, 3, 2)) * -1
+    rdm2.bbbb.ovvv += np.transpose(tmp118, (0, 1, 3, 2)) * -1
     del tmp118
-    tmp106 = tmp105.copy()
+    tmp106 = np.copy(tmp105)
     tmp106 += tmp79
     tmp106 += tmp80 * 2
     rdm2.bbbb.vovv += einsum(tmp106, (0, 1), t1.bb, (2, 3), (0, 2, 3, 1)) * -1
@@ -2308,7 +2308,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.bbbb.ovov += einsum(tmp106, (0, 1), delta.bb.oo, (2, 3), (2, 0, 3, 1))
     rdm2.abab.ovov += einsum(tmp106, (0, 1), delta.aa.oo, (2, 3), (2, 0, 3, 1))
     del tmp106
-    tmp119 = tmp105.copy() * 0.5
+    tmp119 = np.copy(tmp105) * 0.5
     del tmp105
     tmp119 += tmp79 * 0.5
     tmp119 += tmp80
@@ -2317,12 +2317,12 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp119
     tmp123 = einsum(t2.bbbb, (0, 1, 2, 3), tmp19, (1, 0, 4, 5), (4, 5, 2, 3)) * -1
     del tmp19
-    rdm2.bbbb.vovv += tmp123.transpose((1, 0, 3, 2))
-    rdm2.bbbb.vovv += tmp123.transpose((1, 0, 3, 2))
-    rdm2.bbbb.ovvv += tmp123.transpose((0, 1, 3, 2)) * -1
-    rdm2.bbbb.ovvv += tmp123.transpose((0, 1, 3, 2)) * -1
+    rdm2.bbbb.vovv += np.transpose(tmp123, (1, 0, 3, 2))
+    rdm2.bbbb.vovv += np.transpose(tmp123, (1, 0, 3, 2))
+    rdm2.bbbb.ovvv += np.transpose(tmp123, (0, 1, 3, 2)) * -1
+    rdm2.bbbb.ovvv += np.transpose(tmp123, (0, 1, 3, 2)) * -1
     del tmp123
-    tmp103 = tmp102.copy()
+    tmp103 = np.copy(tmp102)
     tmp103 += tmp62 * 2
     tmp103 += tmp63
     rdm2.abab.vovv += einsum(t1.bb, (0, 1), tmp103, (2, 3), (2, 0, 3, 1))
@@ -2332,19 +2332,19 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.aaaa.voov += einsum(tmp103, (0, 1), delta.aa.oo, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.aaaa.ovov += einsum(tmp103, (0, 1), delta.aa.oo, (2, 3), (2, 0, 3, 1))
     del tmp103
-    tmp125 = tmp90.copy()
+    tmp125 = np.copy(tmp90)
     tmp125 += tmp92
     rdm2.abab.vovv += einsum(tmp125, (0, 1, 2, 3), t1.aa, (0, 4), (2, 1, 4, 3)) * 2
     del tmp125
     tmp112 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 4, 5, 1), (3, 4, 0, 5))
     rdm2.abab.vovv += einsum(t1.bb, (0, 1), tmp112, (0, 2, 3, 4), (3, 2, 4, 1)) * -1
-    rdm2.abab.vovo += tmp112.transpose((2, 1, 3, 0)) * -1
+    rdm2.abab.vovo += np.transpose(tmp112, (2, 1, 3, 0)) * -1
     del tmp112
     tmp111 = einsum(tmp14, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 3, 4))
     rdm2.abab.vovv += einsum(tmp111, (0, 1, 2, 3), t1.aa, (0, 4), (2, 1, 4, 3)) * -1
-    rdm2.abab.voov += tmp111.transpose((2, 1, 0, 3)) * -1
+    rdm2.abab.voov += np.transpose(tmp111, (2, 1, 0, 3)) * -1
     del tmp111
-    tmp109 = tmp102.copy() * 0.5
+    tmp109 = np.copy(tmp102) * 0.5
     del tmp102
     tmp109 += tmp62
     tmp109 += tmp63 * 0.5
@@ -2354,54 +2354,54 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.aaaa.ovvo += einsum(tmp109, (0, 1), delta.aa.oo, (2, 3), (2, 0, 1, 3)) * -2
     del tmp109
     tmp113 = einsum(l1.aa, (0, 1), t2.aaaa, (2, 1, 3, 4), (2, 0, 3, 4))
-    rdm2.aaaa.vovv += tmp113.transpose((1, 0, 3, 2))
-    rdm2.aaaa.vovv += tmp113.transpose((1, 0, 3, 2))
-    rdm2.aaaa.ovvv += tmp113.transpose((0, 1, 3, 2)) * -1
-    rdm2.aaaa.ovvv += tmp113.transpose((0, 1, 3, 2)) * -1
+    rdm2.aaaa.vovv += np.transpose(tmp113, (1, 0, 3, 2))
+    rdm2.aaaa.vovv += np.transpose(tmp113, (1, 0, 3, 2))
+    rdm2.aaaa.ovvv += np.transpose(tmp113, (0, 1, 3, 2)) * -1
+    rdm2.aaaa.ovvv += np.transpose(tmp113, (0, 1, 3, 2)) * -1
     del tmp113
     tmp117 = einsum(t1.aa, (0, 1), tmp104, (0, 2, 3, 4), (2, 3, 4, 1)) * -1
     del tmp104
-    rdm2.aaaa.vovv += tmp117.transpose((1, 0, 3, 2)) * 2
-    rdm2.aaaa.ovvv += tmp117.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.vovv += np.transpose(tmp117, (1, 0, 3, 2)) * 2
+    rdm2.aaaa.ovvv += np.transpose(tmp117, (0, 1, 3, 2)) * -2
     del tmp117
     tmp115 = einsum(tmp84, (0, 1, 2, 3), t1.aa, (0, 4), (1, 4, 2, 3))
     del tmp84
-    rdm2.aaaa.vovv += tmp115.transpose((2, 0, 3, 1)) * -1
-    rdm2.aaaa.vovv += tmp115.transpose((2, 0, 1, 3))
-    rdm2.aaaa.ovvv += tmp115.transpose((0, 2, 3, 1))
+    rdm2.aaaa.vovv += np.transpose(tmp115, (2, 0, 3, 1)) * -1
+    rdm2.aaaa.vovv += np.transpose(tmp115, (2, 0, 1, 3))
+    rdm2.aaaa.ovvv += np.transpose(tmp115, (0, 2, 3, 1))
     del tmp115
     tmp116 = einsum(tmp6, (0, 1, 2, 3), t2.aaaa, (1, 0, 4, 5), (2, 3, 4, 5)) * -1
     del tmp6
-    rdm2.aaaa.vovv += tmp116.transpose((1, 0, 3, 2))
-    rdm2.aaaa.vovv += tmp116.transpose((1, 0, 3, 2))
-    rdm2.aaaa.ovvv += tmp116.transpose((0, 1, 3, 2)) * -1
-    rdm2.aaaa.ovvv += tmp116.transpose((0, 1, 3, 2)) * -1
+    rdm2.aaaa.vovv += np.transpose(tmp116, (1, 0, 3, 2))
+    rdm2.aaaa.vovv += np.transpose(tmp116, (1, 0, 3, 2))
+    rdm2.aaaa.ovvv += np.transpose(tmp116, (0, 1, 3, 2)) * -1
+    rdm2.aaaa.ovvv += np.transpose(tmp116, (0, 1, 3, 2)) * -1
     del tmp116
-    tmp120 = tmp107.copy()
+    tmp120 = np.copy(tmp107)
     del tmp107
     tmp120 += tmp88 * 4
     rdm2.bbbb.ovvv += einsum(t1.bb, (0, 1), tmp120, (0, 2, 3, 4), (2, 3, 1, 4)) * -1
     del tmp120
     tmp85 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 4, 5, 1), (5, 0, 4, 3))
     rdm2.abab.ovvv += einsum(tmp85, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3)) * -1
-    rdm2.abab.ovov += tmp85.transpose((1, 2, 0, 3)) * -1
+    rdm2.abab.ovov += np.transpose(tmp85, (1, 2, 0, 3)) * -1
     rdm2.abab.oovv += einsum(t2.abab, (0, 1, 2, 3), tmp85, (0, 4, 3, 5), (4, 1, 2, 5))
     del tmp85
     tmp110 = einsum(t1.aa, (0, 1), tmp27, (0, 2, 3, 4), (2, 3, 1, 4))
     rdm2.abab.ovvv += einsum(t1.bb, (0, 1), tmp110, (2, 0, 3, 4), (2, 4, 3, 1)) * -1
-    rdm2.abab.ovvo += tmp110.transpose((0, 3, 2, 1)) * -1
+    rdm2.abab.ovvo += np.transpose(tmp110, (0, 3, 2, 1)) * -1
     del tmp110
-    tmp83 = tmp82.copy()
+    tmp83 = np.copy(tmp82)
     del tmp82
     tmp83 += tmp65
     rdm2.abab.ovvv += einsum(t1.bb, (0, 1), tmp83, (2, 0, 3, 4), (2, 4, 3, 1)) * 2
     rdm2.abab.oovv += einsum(t2.bbbb, (0, 1, 2, 3), tmp83, (4, 1, 5, 3), (4, 0, 5, 2)) * 4
     del tmp83
-    tmp114 = tmp67.copy()
+    tmp114 = np.copy(tmp67)
     tmp114 += tmp69 * 0.25
     rdm2.aaaa.ovvv += einsum(t1.aa, (0, 1), tmp114, (0, 2, 3, 4), (2, 3, 1, 4)) * -4
     del tmp114
-    tmp61 = tmp39.copy() * 0.5
+    tmp61 = np.copy(tmp39) * 0.5
     tmp61 += tmp40
     tmp61 += tmp60
     del tmp60
@@ -2410,7 +2410,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.abab.oovv += einsum(t1.aa, (0, 1), tmp61, (2, 3), (0, 2, 1, 3)) * -2
     rdm2.bbbb.oovo += einsum(delta.bb.oo, (0, 1), tmp61, (2, 3), (2, 0, 3, 1)) * -2
     del tmp61
-    tmp37 = t1.bb.copy()
+    tmp37 = np.copy(t1.bb)
     tmp37 += tmp35
     tmp37 += tmp36 * 2
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp37, (2, 3), (0, 2, 1, 3))
@@ -2419,29 +2419,29 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.bbbb.ooov += einsum(delta.bb.oo, (0, 1), tmp37, (2, 3), (0, 2, 1, 3))
     rdm2.abab.ooov += einsum(delta.aa.oo, (0, 1), tmp37, (2, 3), (0, 2, 1, 3))
     del tmp37
-    tmp81 = tmp79.copy() * 0.5
+    tmp81 = np.copy(tmp79) * 0.5
     tmp81 += tmp80
     rdm2.bbbb.oovv += einsum(t2.bbbb, (0, 1, 2, 3), tmp81, (3, 4), (0, 1, 2, 4)) * -4
     rdm2.abab.oovv += einsum(tmp81, (0, 1), t2.abab, (2, 3, 4, 0), (2, 3, 4, 1)) * -2
     del tmp81
     tmp95 = einsum(tmp49, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 4, 3))
     del tmp49
-    rdm2.bbbb.oovv += tmp95.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp95, (0, 1, 3, 2)) * -2
     rdm2.bbbb.oovv += tmp95 * 2
     del tmp95
     tmp101 = einsum(tmp100, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 4, 3))
     del tmp100
-    rdm2.bbbb.oovv += tmp101.transpose((0, 1, 3, 2))
-    rdm2.bbbb.oovv += tmp101.transpose((1, 0, 3, 2)) * -1
+    rdm2.bbbb.oovv += np.transpose(tmp101, (0, 1, 3, 2))
+    rdm2.bbbb.oovv += np.transpose(tmp101, (1, 0, 3, 2)) * -1
     rdm2.bbbb.oovv += tmp101 * -1
-    rdm2.bbbb.oovv += tmp101.transpose((1, 0, 2, 3))
+    rdm2.bbbb.oovv += np.transpose(tmp101, (1, 0, 2, 3))
     del tmp101
-    tmp94 = tmp35.copy()
+    tmp94 = np.copy(tmp35)
     tmp94 += tmp36 * 2
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp94, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp94, (2, 3), (2, 0, 3, 1))
     del tmp94
-    tmp42 = tmp39.copy()
+    tmp42 = np.copy(tmp39)
     del tmp39
     tmp42 += tmp40 * 2
     del tmp40
@@ -2455,10 +2455,10 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.abab.ooov += einsum(tmp42, (0, 1), delta.aa.oo, (2, 3), (2, 0, 3, 1)) * -1
     del tmp42
     tmp98 = einsum(t2.bbbb, (0, 1, 2, 3), tmp52, (0, 1, 4, 5), (4, 5, 2, 3))
-    rdm2.bbbb.oovv += tmp98.transpose((1, 0, 3, 2))
-    rdm2.bbbb.oovv += tmp98.transpose((1, 0, 3, 2))
+    rdm2.bbbb.oovv += np.transpose(tmp98, (1, 0, 3, 2))
+    rdm2.bbbb.oovv += np.transpose(tmp98, (1, 0, 3, 2))
     del tmp98
-    tmp48 = t1.bb.copy()
+    tmp48 = np.copy(t1.bb)
     tmp48 += tmp35
     del tmp35
     tmp48 += tmp36 * 2
@@ -2467,7 +2467,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.bbbb.oovo += einsum(tmp48, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3))
     rdm2.bbbb.ooov += einsum(tmp48, (0, 1), delta.bb.oo, (2, 3), (0, 2, 3, 1)) * -1
     del tmp48
-    tmp96 = tmp79.copy()
+    tmp96 = np.copy(tmp79)
     del tmp79
     tmp96 += tmp80 * 2
     del tmp80
@@ -2476,26 +2476,26 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp89 = einsum(t2.bbbb, (0, 1, 2, 3), tmp88, (1, 4, 3, 5), (0, 4, 2, 5))
     del tmp88
     rdm2.bbbb.oovv += tmp89 * 8
-    rdm2.bbbb.oovv += tmp89.transpose((0, 1, 3, 2)) * -8
+    rdm2.bbbb.oovv += np.transpose(tmp89, (0, 1, 3, 2)) * -8
     del tmp89
     tmp97 = einsum(tmp17, (0, 1), t2.bbbb, (2, 0, 3, 4), (2, 1, 3, 4)) * -1
     del tmp17
-    rdm2.bbbb.oovv += tmp97.transpose((1, 0, 3, 2))
-    rdm2.bbbb.oovv += tmp97.transpose((1, 0, 3, 2))
-    rdm2.bbbb.oovv += tmp97.transpose((0, 1, 3, 2)) * -1
-    rdm2.bbbb.oovv += tmp97.transpose((0, 1, 3, 2)) * -1
+    rdm2.bbbb.oovv += np.transpose(tmp97, (1, 0, 3, 2))
+    rdm2.bbbb.oovv += np.transpose(tmp97, (1, 0, 3, 2))
+    rdm2.bbbb.oovv += np.transpose(tmp97, (0, 1, 3, 2)) * -1
+    rdm2.bbbb.oovv += np.transpose(tmp97, (0, 1, 3, 2)) * -1
     del tmp97
     tmp91 = einsum(tmp90, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5))
     del tmp90
-    rdm2.bbbb.oovv += tmp91.transpose((1, 0, 3, 2)) * 2
-    rdm2.bbbb.oovv += tmp91.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp91, (1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp91, (0, 1, 3, 2)) * -2
     del tmp91
     tmp93 = einsum(tmp92, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (4, 1, 5, 3))
     del tmp92
-    rdm2.bbbb.oovv += tmp93.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp93, (1, 0, 3, 2)) * 2
     rdm2.bbbb.oovv += tmp93 * 2
-    rdm2.bbbb.oovv += tmp93.transpose((1, 0, 2, 3)) * -2
-    rdm2.bbbb.oovv += tmp93.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp93, (1, 0, 2, 3)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp93, (0, 1, 3, 2)) * -2
     del tmp93
     tmp99 = einsum(tmp52, (0, 1, 2, 3), t1.bb, (0, 4), (1, 3, 2, 4))
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp99, (0, 2, 3, 4), (2, 3, 1, 4)) * 2
@@ -2503,40 +2503,40 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp46 = einsum(tmp45, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 3, 4))
     del tmp45
     rdm2.abab.oovv += einsum(t1.aa, (0, 1), tmp46, (0, 2, 3, 4), (2, 3, 1, 4))
-    rdm2.abab.ooov += tmp46.transpose((1, 2, 0, 3))
+    rdm2.abab.ooov += np.transpose(tmp46, (1, 2, 0, 3))
     del tmp46
     tmp47 = einsum(tmp14, (0, 1, 2, 3), t2.abab, (4, 1, 3, 5), (0, 4, 2, 5))
     del tmp14
     rdm2.abab.oovv += einsum(t1.aa, (0, 1), tmp47, (0, 2, 3, 4), (2, 3, 1, 4))
-    rdm2.abab.ooov += tmp47.transpose((1, 2, 0, 3))
+    rdm2.abab.ooov += np.transpose(tmp47, (1, 2, 0, 3))
     del tmp47
     tmp59 = einsum(tmp27, (0, 1, 2, 3), t2.abab, (0, 4, 5, 3), (1, 2, 4, 5))
     del tmp27
     rdm2.abab.oovv += einsum(tmp59, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 3, 4))
-    rdm2.abab.oovo += tmp59.transpose((0, 2, 3, 1))
+    rdm2.abab.oovo += np.transpose(tmp59, (0, 2, 3, 1))
     del tmp59
     tmp56 = einsum(t2.abab, (0, 1, 2, 3), l1.bb, (3, 4), (0, 4, 1, 2))
     rdm2.abab.oovv += einsum(tmp56, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 3, 4)) * -1
-    rdm2.abab.oovo += tmp56.transpose((0, 2, 3, 1)) * -1
+    rdm2.abab.oovo += np.transpose(tmp56, (0, 2, 3, 1)) * -1
     del tmp56
-    tmp71 = tmp21.copy() * 2
+    tmp71 = np.copy(tmp21) * 2
     tmp71 += tmp22
     rdm2.abab.oovv += einsum(t1.bb, (0, 1), tmp71, (2, 3), (2, 0, 3, 1))
     rdm2.aaaa.oovv = einsum(tmp71, (0, 1), t1.aa, (2, 3), (2, 0, 1, 3)) * -1
     rdm2.aaaa.oovv += einsum(t1.aa, (0, 1), tmp71, (2, 3), (2, 0, 3, 1))
     del tmp71
-    tmp86 = tmp43.copy()
+    tmp86 = np.copy(tmp43)
     del tmp43
     tmp86 += tmp44
     del tmp44
     rdm2.abab.oovv += einsum(t1.aa, (0, 1), tmp86, (0, 2, 3, 4), (2, 3, 1, 4)) * -2
     del tmp86
-    tmp73 = tmp62.copy() * 2
+    tmp73 = np.copy(tmp62) * 2
     tmp73 += tmp63
     rdm2.abab.oovv += einsum(t2.abab, (0, 1, 2, 3), tmp73, (2, 4), (0, 1, 4, 3)) * -1
     rdm2.aaaa.oovv += einsum(tmp73, (0, 1), t2.aaaa, (2, 3, 4, 0), (2, 3, 1, 4)) * 2
     del tmp73
-    tmp30 = tmp26.copy() * 2
+    tmp30 = np.copy(tmp26) * 2
     tmp30 += tmp28
     tmp30 += tmp29
     del tmp29
@@ -2549,15 +2549,15 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp30
     tmp38 = einsum(t2.abab, (0, 1, 2, 3), l1.aa, (2, 4), (4, 0, 1, 3))
     rdm2.abab.oovv += einsum(t1.aa, (0, 1), tmp38, (0, 2, 3, 4), (2, 3, 1, 4)) * -1
-    rdm2.abab.ooov += tmp38.transpose((1, 2, 0, 3)) * -1
+    rdm2.abab.ooov += np.transpose(tmp38, (1, 2, 0, 3)) * -1
     del tmp38
-    tmp87 = tmp57.copy()
+    tmp87 = np.copy(tmp57)
     del tmp57
     tmp87 += tmp58
     del tmp58
     rdm2.abab.oovv += einsum(tmp87, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 3, 4)) * -2
     del tmp87
-    tmp64 = tmp62.copy()
+    tmp64 = np.copy(tmp62)
     del tmp62
     tmp64 += tmp63 * 0.5
     del tmp63
@@ -2565,34 +2565,34 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp64
     tmp70 = einsum(t2.aaaa, (0, 1, 2, 3), tmp69, (1, 4, 3, 5), (0, 4, 2, 5))
     del tmp69
-    rdm2.aaaa.oovv += tmp70.transpose((1, 0, 3, 2)) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp70, (1, 0, 3, 2)) * 2
     rdm2.aaaa.oovv += tmp70 * 2
-    rdm2.aaaa.oovv += tmp70.transpose((1, 0, 2, 3)) * -2
-    rdm2.aaaa.oovv += tmp70.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp70, (1, 0, 2, 3)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp70, (0, 1, 3, 2)) * -2
     del tmp70
     tmp66 = einsum(tmp65, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp65
     rdm2.aaaa.oovv += tmp66 * 2
-    rdm2.aaaa.oovv += tmp66.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp66, (0, 1, 3, 2)) * -2
     del tmp66
     tmp74 = einsum(tmp12, (0, 1), t2.aaaa, (2, 0, 3, 4), (1, 2, 3, 4)) * -1
     del tmp12
-    rdm2.aaaa.oovv += tmp74.transpose((0, 1, 3, 2))
-    rdm2.aaaa.oovv += tmp74.transpose((0, 1, 3, 2))
-    rdm2.aaaa.oovv += tmp74.transpose((1, 0, 3, 2)) * -1
-    rdm2.aaaa.oovv += tmp74.transpose((1, 0, 3, 2)) * -1
+    rdm2.aaaa.oovv += np.transpose(tmp74, (0, 1, 3, 2))
+    rdm2.aaaa.oovv += np.transpose(tmp74, (0, 1, 3, 2))
+    rdm2.aaaa.oovv += np.transpose(tmp74, (1, 0, 3, 2)) * -1
+    rdm2.aaaa.oovv += np.transpose(tmp74, (1, 0, 3, 2)) * -1
     del tmp74
     tmp76 = einsum(tmp33, (0, 1, 2, 3), t1.aa, (0, 4), (1, 3, 2, 4))
     rdm2.aaaa.oovv += einsum(tmp76, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3)) * 2
     del tmp76
     tmp78 = einsum(tmp77, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3))
     del tmp77
-    rdm2.aaaa.oovv += tmp78.transpose((0, 1, 3, 2))
-    rdm2.aaaa.oovv += tmp78.transpose((1, 0, 3, 2)) * -1
+    rdm2.aaaa.oovv += np.transpose(tmp78, (0, 1, 3, 2))
+    rdm2.aaaa.oovv += np.transpose(tmp78, (1, 0, 3, 2)) * -1
     rdm2.aaaa.oovv += tmp78 * -1
-    rdm2.aaaa.oovv += tmp78.transpose((1, 0, 2, 3))
+    rdm2.aaaa.oovv += np.transpose(tmp78, (1, 0, 2, 3))
     del tmp78
-    tmp24 = t1.aa.copy()
+    tmp24 = np.copy(t1.aa)
     tmp24 += tmp21 * 2
     tmp24 += tmp22
     rdm2.aaaa.oovv += einsum(tmp24, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
@@ -2602,9 +2602,9 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp68 = einsum(t2.aaaa, (0, 1, 2, 3), tmp67, (1, 4, 3, 5), (0, 4, 2, 5))
     del tmp67
     rdm2.aaaa.oovv += tmp68 * 8
-    rdm2.aaaa.oovv += tmp68.transpose((0, 1, 3, 2)) * -8
+    rdm2.aaaa.oovv += np.transpose(tmp68, (0, 1, 3, 2)) * -8
     del tmp68
-    tmp23 = t1.aa.copy()
+    tmp23 = np.copy(t1.aa)
     tmp23 += tmp21 * 2
     del tmp21
     tmp23 += tmp22
@@ -2615,15 +2615,15 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.aaaa.ooov += einsum(tmp23, (0, 1), delta.aa.oo, (2, 3), (0, 2, 3, 1)) * -1
     del tmp23
     tmp75 = einsum(t2.aaaa, (0, 1, 2, 3), tmp33, (0, 1, 4, 5), (4, 5, 2, 3))
-    rdm2.aaaa.oovv += tmp75.transpose((1, 0, 3, 2))
-    rdm2.aaaa.oovv += tmp75.transpose((1, 0, 3, 2))
+    rdm2.aaaa.oovv += np.transpose(tmp75, (1, 0, 3, 2))
+    rdm2.aaaa.oovv += np.transpose(tmp75, (1, 0, 3, 2))
     del tmp75
     tmp72 = einsum(tmp25, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3))
     del tmp25
-    rdm2.aaaa.oovv += tmp72.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp72, (0, 1, 3, 2)) * -2
     rdm2.aaaa.oovv += tmp72 * 2
     del tmp72
-    tmp55 = tmp26.copy()
+    tmp55 = np.copy(tmp26)
     del tmp26
     tmp55 += tmp28 * 0.5
     del tmp28
@@ -2636,20 +2636,20 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp55
     tmp53 = einsum(tmp52, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 3, 4)) * 2
     del tmp52
-    rdm2.bbbb.oovo += tmp53.transpose((2, 1, 3, 0)) * -1
-    rdm2.bbbb.ooov += tmp53.transpose((2, 1, 0, 3))
+    rdm2.bbbb.oovo += np.transpose(tmp53, (2, 1, 3, 0)) * -1
+    rdm2.bbbb.ooov += np.transpose(tmp53, (2, 1, 0, 3))
     del tmp53
     tmp34 = einsum(t1.aa, (0, 1), tmp33, (0, 2, 3, 4), (2, 3, 4, 1)) * 2
     del tmp33
-    rdm2.aaaa.oovo += tmp34.transpose((2, 1, 3, 0)) * -1
-    rdm2.aaaa.ooov += tmp34.transpose((2, 1, 0, 3))
+    rdm2.aaaa.oovo += np.transpose(tmp34, (2, 1, 3, 0)) * -1
+    rdm2.aaaa.ooov += np.transpose(tmp34, (2, 1, 0, 3))
     del tmp34
-    tmp16 = tmp8.copy() * 0.5
+    tmp16 = np.copy(tmp8) * 0.5
     tmp16 += tmp9 * 0.5
     tmp16 += tmp10
     rdm2.bbbb.oooo += einsum(tmp16, (0, 1), delta.bb.oo, (2, 3), (1, 2, 0, 3)) * -2
     del tmp16
-    tmp11 = delta.bb.oo.copy() * -1
+    tmp11 = np.copy(delta.bb.oo) * -1
     tmp11 += tmp8
     del tmp8
     tmp11 += tmp9
@@ -2660,7 +2660,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.bbbb.oooo += einsum(tmp11, (0, 1), delta.bb.oo, (2, 3), (2, 1, 3, 0)) * -1
     rdm2.abab.oooo += einsum(tmp11, (0, 1), delta.aa.oo, (2, 3), (2, 1, 3, 0)) * -1
     del tmp11
-    tmp3 = delta.aa.oo.copy() * -1
+    tmp3 = np.copy(delta.aa.oo) * -1
     tmp3 += tmp0
     del tmp0
     tmp3 += tmp1 * 2
@@ -2696,10 +2696,10 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.bbbb.voov += einsum(t1.bb, (0, 1), l1.bb, (2, 3), (2, 0, 3, 1))
     rdm2.aaaa.vovo += einsum(l1.aa, (0, 1), t1.aa, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.bbbb.vovo += einsum(t1.bb, (0, 1), l1.bb, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.aaaa.vvoo = l2.aaaa.copy()
+    rdm2.aaaa.vvoo = np.copy(l2.aaaa)
     rdm2.aaaa.vvoo += l2.aaaa
-    rdm2.abab.vvoo = l2.abab.copy()
-    rdm2.bbbb.vvoo = l2.bbbb.copy()
+    rdm2.abab.vvoo = np.copy(l2.abab)
+    rdm2.bbbb.vvoo = np.copy(l2.bbbb)
     rdm2.bbbb.vvoo += l2.bbbb
     rdm2.abab.ovvv += einsum(l1.bb, (0, 1), t2.abab, (2, 1, 3, 4), (2, 0, 3, 4))
     rdm2.abab.vovv += einsum(t2.abab, (0, 1, 2, 3), l1.aa, (4, 0), (4, 1, 2, 3))
@@ -2709,9 +2709,9 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.abab = pack_2e(rdm2.abab.oooo, rdm2.abab.ooov, rdm2.abab.oovo, rdm2.abab.ovoo, rdm2.abab.vooo, rdm2.abab.oovv, rdm2.abab.ovov, rdm2.abab.ovvo, rdm2.abab.voov, rdm2.abab.vovo, rdm2.abab.vvoo, rdm2.abab.ovvv, rdm2.abab.vovv, rdm2.abab.vvov, rdm2.abab.vvvo, rdm2.abab.vvvv)
     rdm2.bbbb = pack_2e(rdm2.bbbb.oooo, rdm2.bbbb.ooov, rdm2.bbbb.oovo, rdm2.bbbb.ovoo, rdm2.bbbb.vooo, rdm2.bbbb.oovv, rdm2.bbbb.ovov, rdm2.bbbb.ovvo, rdm2.bbbb.voov, rdm2.bbbb.vovo, rdm2.bbbb.vvoo, rdm2.bbbb.ovvv, rdm2.bbbb.vovv, rdm2.bbbb.vvov, rdm2.bbbb.vvvo, rdm2.bbbb.vvvv)
     rdm2 = Namespace(
-        aaaa=rdm2.aaaa.transpose(0, 2, 1, 3),
-        aabb=rdm2.abab.transpose(0, 2, 1, 3),
-        bbbb=rdm2.bbbb.transpose(0, 2, 1, 3),
+        aaaa=np.transpose(rdm2.aaaa, (0, 2, 1, 3)),
+        aabb=np.transpose(rdm2.abab, (0, 2, 1, 3)),
+        bbbb=np.transpose(rdm2.bbbb, (0, 2, 1, 3)),
     )
 
     return rdm2
@@ -3176,14 +3176,14 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     ints = kwargs["ints"]
     r1new = Namespace()
     r2new = Namespace()
-    tmp75 = ints.tmp37.copy() * -1
-    tmp75 += ints.tmp37.transpose((0, 2, 1, 3))
-    tmp77 = v.bbbb.ooov.copy() * -1
-    tmp77 += v.bbbb.ooov.transpose((0, 2, 1, 3))
-    tmp16 = ints.tmp16.copy()
-    tmp16 += ints.tmp16.transpose((0, 2, 1, 3)) * -1
-    tmp18 = v.aaaa.ooov.copy()
-    tmp18 += v.aaaa.ovoo.transpose((0, 2, 3, 1)) * -1
+    tmp75 = np.copy(ints.tmp37) * -1
+    tmp75 += np.transpose(ints.tmp37, (0, 2, 1, 3))
+    tmp77 = np.copy(v.bbbb.ooov) * -1
+    tmp77 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3))
+    tmp16 = np.copy(ints.tmp16)
+    tmp16 += np.transpose(ints.tmp16, (0, 2, 1, 3)) * -1
+    tmp18 = np.copy(v.aaaa.ooov)
+    tmp18 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1)) * -1
     tmp74 = einsum(v.aabb.ovoo, (0, 1, 2, 3), r2.aba, (0, 4, 1), (4, 2, 3))
     tmp76 = einsum(r2.bbb, (0, 1, 2), tmp75, (3, 1, 4, 2), (0, 3, 4)) * -1
     del tmp75
@@ -3196,98 +3196,98 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp19 = einsum(r2.aaa, (0, 1, 2), tmp18, (1, 3, 4, 2), (0, 3, 4)) * -1
     del tmp18
     tmp14 = einsum(v.aabb.ooov, (0, 1, 2, 3), r2.bab, (2, 4, 3), (4, 0, 1)) * -1
-    tmp2 = f.bb.ov.copy()
+    tmp2 = np.copy(f.bb.ov)
     tmp2 += ints.tmp12
     tmp2 += ints.tmp15
     tmp2 += ints.tmp11 * -1
     r1new.b = einsum(tmp2, (0, 1), r2.bbb, (2, 0, 1), (2,)) * 2
     r1new.a = einsum(tmp2, (0, 1), r2.bab, (0, 2, 1), (2,)) * -1
-    tmp71 = ints.tmp279.copy()
+    tmp71 = np.copy(ints.tmp279)
     tmp71 += ints.tmp283 * 0.5
-    tmp71 += ints.tmp318.transpose((0, 1, 3, 2)) * 0.5
-    tmp81 = ints.tmp367.copy()
+    tmp71 += np.transpose(ints.tmp318, (0, 1, 3, 2)) * 0.5
+    tmp81 = np.copy(ints.tmp367)
     tmp81 += ints.tmp37
     tmp81 += ints.tmp394 * 2
     tmp81 += ints.tmp433 * 2
     tmp81 += ints.tmp437
-    tmp81 += ints.tmp441.transpose((0, 2, 1, 3))
-    tmp81 += v.bbbb.ooov.transpose((0, 2, 1, 3))
-    tmp83 = ints.tmp41.copy() * 2
+    tmp81 += np.transpose(ints.tmp441, (0, 2, 1, 3))
+    tmp81 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3))
+    tmp83 = np.copy(ints.tmp41) * 2
     tmp83 += ints.tmp43
     tmp83 += ints.tmp31 * -1
     tmp83 += ints.tmp45 * -1
-    tmp79 = tmp73.copy() * 0.5
+    tmp79 = np.copy(tmp73) * 0.5
     del tmp73
-    tmp79 += tmp74.transpose((0, 2, 1)) * -0.5
+    tmp79 += np.transpose(tmp74, (0, 2, 1)) * -0.5
     del tmp74
-    tmp79 += tmp76.transpose((1, 2, 0)) * -1
+    tmp79 += np.transpose(tmp76, (1, 2, 0)) * -1
     del tmp76
-    tmp79 += tmp78.transpose((0, 2, 1))
+    tmp79 += np.transpose(tmp78, (0, 2, 1))
     del tmp78
-    tmp89 = ints.tmp317.copy()
+    tmp89 = np.copy(ints.tmp317)
     tmp89 += ints.tmp277 * 2
-    tmp93 = ints.tmp371.copy()
-    tmp93 += ints.tmp383.transpose((0, 2, 1, 3))
+    tmp93 = np.copy(ints.tmp371)
+    tmp93 += np.transpose(ints.tmp383, (0, 2, 1, 3))
     tmp93 += ints.tmp398
     tmp93 += ints.tmp427
     tmp93 += ints.tmp439
     tmp93 += ints.tmp396 * 2
     tmp93 += ints.tmp435 * 2
-    tmp87 = ints.tmp275.copy()
+    tmp87 = np.copy(ints.tmp275)
     tmp87 += ints.tmp319
     tmp87 += ints.tmp281 * 2
-    tmp91 = f.bb.oo.copy()
+    tmp91 = np.copy(f.bb.oo)
     tmp91 += ints.tmp28
-    tmp91 += ints.tmp32.transpose((1, 0))
-    tmp91 += ints.tmp33.transpose((1, 0))
-    tmp91 += ints.tmp46.transpose((1, 0))
-    tmp91 += ints.tmp47.transpose((1, 0))
-    tmp3 = f.aa.ov.copy()
+    tmp91 += np.transpose(ints.tmp32, (1, 0))
+    tmp91 += np.transpose(ints.tmp33, (1, 0))
+    tmp91 += np.transpose(ints.tmp46, (1, 0))
+    tmp91 += np.transpose(ints.tmp47, (1, 0))
+    tmp3 = np.copy(f.aa.ov)
     tmp3 += ints.tmp13
     tmp3 += ints.tmp9
     tmp3 += ints.tmp7 * -1
     r1new.b += einsum(tmp3, (0, 1), r2.aba, (0, 2, 1), (2,)) * -1
     r1new.a += einsum(r2.aaa, (0, 1, 2), tmp3, (1, 2), (0,)) * 2
-    tmp32 = f.aa.oo.copy()
+    tmp32 = np.copy(f.aa.oo)
     tmp32 += ints.tmp1
-    tmp32 += ints.tmp25.transpose((1, 0))
-    tmp32 += ints.tmp26.transpose((1, 0))
-    tmp32 += ints.tmp5.transpose((1, 0))
-    tmp32 += ints.tmp6.transpose((1, 0))
-    tmp30 = ints.tmp59.copy()
+    tmp32 += np.transpose(ints.tmp25, (1, 0))
+    tmp32 += np.transpose(ints.tmp26, (1, 0))
+    tmp32 += np.transpose(ints.tmp5, (1, 0))
+    tmp32 += np.transpose(ints.tmp6, (1, 0))
+    tmp30 = np.copy(ints.tmp59)
     tmp30 += ints.tmp112 * 2
-    tmp34 = ints.tmp106.copy()
+    tmp34 = np.copy(ints.tmp106)
     tmp34 += ints.tmp156
     tmp34 += ints.tmp172
     tmp34 += ints.tmp74
-    tmp34 += ints.tmp89.transpose((0, 2, 1, 3))
+    tmp34 += np.transpose(ints.tmp89, (0, 2, 1, 3))
     tmp34 += ints.tmp104 * 2
     tmp34 += ints.tmp166 * 2
-    tmp10 = ints.tmp114.copy()
+    tmp10 = np.copy(ints.tmp114)
     tmp10 += ints.tmp120 * 0.5
-    tmp10 += ints.tmp61.transpose((0, 1, 3, 2)) * 0.5
-    tmp24 = ints.tmp20.copy() * 2
+    tmp10 += np.transpose(ints.tmp61, (0, 1, 3, 2)) * 0.5
+    tmp24 = np.copy(ints.tmp20) * 2
     tmp24 += ints.tmp22
     tmp24 += ints.tmp24 * -1
     tmp24 += ints.tmp4 * -1
-    tmp20 = tmp14.transpose((0, 2, 1)).copy() * 0.5
+    tmp20 = np.copy(np.transpose(tmp14, (0, 2, 1))) * 0.5
     del tmp14
     tmp20 += tmp15 * -0.5
     del tmp15
-    tmp20 += tmp17.transpose((1, 2, 0)) * -1
+    tmp20 += np.transpose(tmp17, (1, 2, 0)) * -1
     del tmp17
-    tmp20 += tmp19.transpose((0, 2, 1))
+    tmp20 += np.transpose(tmp19, (0, 2, 1))
     del tmp19
-    tmp12 = ints.tmp118.copy()
+    tmp12 = np.copy(ints.tmp118)
     tmp12 += ints.tmp122 * 2
     tmp12 += ints.tmp63
-    tmp22 = ints.tmp102.copy()
+    tmp22 = np.copy(ints.tmp102)
     tmp22 += ints.tmp164
     tmp22 += ints.tmp168 * 0.5
     tmp22 += ints.tmp16 * 0.5
-    tmp22 += ints.tmp174.transpose((0, 2, 1, 3)) * 0.5
+    tmp22 += np.transpose(ints.tmp174, (0, 2, 1, 3)) * 0.5
     tmp22 += ints.tmp70 * 0.5
-    tmp22 += v.aaaa.ooov.transpose((0, 2, 1, 3)) * 0.5
+    tmp22 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3)) * 0.5
     tmp60 = einsum(t1.bb, (0, 1), tmp2, (0, 2), (2, 1))
     del tmp2
     tmp72 = einsum(tmp71, (0, 1, 2, 3), r2.bbb, (4, 1, 3), (4, 0, 2)) * -4
@@ -3313,21 +3313,21 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp91
     tmp53 = einsum(v.aabb.ovov, (0, 1, 2, 3), r2.aba, (0, 2, 1), (3,))
     tmp54 = einsum(v.bbbb.ovov, (0, 1, 2, 3), r2.bbb, (0, 2, 3), (1,))
-    tmp51 = ints.tmp39.copy()
-    tmp51 += v.aabb.ovoo.transpose((0, 2, 3, 1))
-    tmp1 = ints.tmp18.copy()
+    tmp51 = np.copy(ints.tmp39)
+    tmp51 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
+    tmp1 = np.copy(ints.tmp18)
     tmp1 += v.aabb.ooov
     r1new.a += einsum(tmp1, (0, 1, 2, 3), r2.bab, (2, 1, 3), (0,))
-    tmp63 = ints.tmp37.copy()
-    tmp63 += ints.tmp37.transpose((0, 2, 1, 3)) * -1
+    tmp63 = np.copy(ints.tmp37)
+    tmp63 += np.transpose(ints.tmp37, (0, 2, 1, 3)) * -1
     tmp63 += v.bbbb.ooov * -1
-    tmp63 += v.bbbb.ooov.transpose((0, 2, 1, 3))
+    tmp63 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3))
     tmp40 = einsum(v.aaaa.ovov, (0, 1, 2, 3), r2.aaa, (0, 2, 1), (3,)) * -1
     tmp41 = einsum(v.aabb.ovov, (0, 1, 2, 3), r2.bab, (2, 0, 3), (1,)) * -1
-    tmp50 = ints.tmp16.copy()
-    tmp50 += ints.tmp16.transpose((0, 2, 1, 3)) * -1
+    tmp50 = np.copy(ints.tmp16)
+    tmp50 += np.transpose(ints.tmp16, (0, 2, 1, 3)) * -1
     tmp50 += v.aaaa.ooov * -1
-    tmp50 += v.aaaa.ooov.transpose((0, 2, 1, 3))
+    tmp50 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3))
     tmp38 = einsum(tmp3, (0, 1), t1.aa, (0, 2), (1, 2))
     del tmp3
     tmp28 = einsum(ints.tmp116, (0, 1, 2, 3), r2.bab, (1, 4, 3), (0, 4, 2)) * -1
@@ -3351,26 +3351,26 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp12
     tmp23 = einsum(tmp22, (0, 1, 2, 3), r1.a, (2,), (0, 1, 3)) * 2
     del tmp22
-    tmp61 = ints.tmp256.copy()
-    tmp61 += ints.tmp300.transpose((1, 0)) * 2
-    tmp61 += ints.tmp302.transpose((1, 0))
+    tmp61 = np.copy(ints.tmp256)
+    tmp61 += np.transpose(ints.tmp300, (1, 0)) * 2
+    tmp61 += np.transpose(ints.tmp302, (1, 0))
     tmp61 += f.bb.vv * -1
-    tmp61 += ints.tmp255.transpose((1, 0)) * -1
-    tmp61 += ints.tmp257.transpose((1, 0)) * -1
+    tmp61 += np.transpose(ints.tmp255, (1, 0)) * -1
+    tmp61 += np.transpose(ints.tmp257, (1, 0)) * -1
     tmp61 += tmp60
     del tmp60
     r2new.bbb = einsum(r2.bbb, (0, 1, 2), tmp61, (2, 3), (0, 1, 3)) * -2
     r2new.bab = einsum(r2.bab, (0, 1, 2), tmp61, (2, 3), (0, 1, 3)) * -1
     del tmp61
-    tmp97 = ints.tmp377.copy()
-    tmp97 += ints.tmp414.transpose((1, 2, 0, 3))
+    tmp97 = np.copy(ints.tmp377)
+    tmp97 += np.transpose(ints.tmp414, (1, 2, 0, 3))
     tmp97 += ints.tmp420
     tmp97 += ints.tmp422
     tmp97 += ints.tmp373 * -1
     tmp97 += ints.tmp418 * -1
     r2new.bbb += einsum(r1.b, (0,), tmp97, (1, 2, 0, 3), (2, 1, 3)) * -2
     del tmp97
-    tmp66 = ints.tmp284.copy()
+    tmp66 = np.copy(ints.tmp284)
     tmp66 += ints.tmp286 * 2
     tmp66 += ints.tmp290
     tmp66 += ints.tmp297 * 2
@@ -3406,7 +3406,7 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r2new.bbb += einsum(tmp66, (0, 1), r1.b, (2,), (2, 0, 1)) * -1
     r2new.bab += einsum(r1.a, (0,), tmp66, (1, 2), (1, 0, 2))
     del tmp66
-    tmp85 = tmp67.copy()
+    tmp85 = np.copy(tmp67)
     del tmp67
     tmp85 += tmp68
     del tmp68
@@ -3414,47 +3414,47 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp69
     tmp85 += tmp70 * 2
     del tmp70
-    tmp85 += tmp72.transpose((1, 0, 2)) * -1
+    tmp85 += np.transpose(tmp72, (1, 0, 2)) * -1
     del tmp72
     tmp85 += tmp80
     del tmp80
     tmp85 += tmp82
     del tmp82
-    tmp85 += tmp84.transpose((1, 0, 2))
+    tmp85 += np.transpose(tmp84, (1, 0, 2))
     del tmp84
-    r2new.bbb += tmp85.transpose((1, 0, 2))
+    r2new.bbb += np.transpose(tmp85, (1, 0, 2))
     r2new.bbb += tmp85 * -1
     del tmp85
-    tmp95 = tmp86.copy() * 2
+    tmp95 = np.copy(tmp86) * 2
     del tmp86
-    tmp95 += tmp88.transpose((1, 0, 2))
+    tmp95 += np.transpose(tmp88, (1, 0, 2))
     del tmp88
-    tmp95 += tmp90.transpose((1, 0, 2)) * -2
+    tmp95 += np.transpose(tmp90, (1, 0, 2)) * -2
     del tmp90
-    tmp95 += tmp92.transpose((1, 0, 2)) * -2
+    tmp95 += np.transpose(tmp92, (1, 0, 2)) * -2
     del tmp92
     tmp95 += tmp94
     del tmp94
-    r2new.bbb += tmp95.transpose((1, 0, 2)) * -1
+    r2new.bbb += np.transpose(tmp95, (1, 0, 2)) * -1
     r2new.bbb += tmp95
     del tmp95
-    tmp96 = ints.tmp369.copy()
+    tmp96 = np.copy(ints.tmp369)
     tmp96 += ints.tmp375
-    tmp96 += v.bbbb.oooo.transpose((0, 2, 1, 3))
+    tmp96 += np.transpose(v.bbbb.oooo, (0, 2, 1, 3))
     r2new.bbb += einsum(tmp96, (0, 1, 2, 3), r2.bbb, (3, 2, 4), (0, 1, 4)) * -2
     del tmp96
-    tmp55 = tmp53.copy() * -0.5
+    tmp55 = np.copy(tmp53) * -0.5
     del tmp53
     tmp55 += tmp54
     del tmp54
     r2new.bbb += einsum(tmp55, (0,), t2.bbbb, (1, 2, 3, 0), (1, 2, 3)) * 4
     r2new.aba = einsum(t2.abab, (0, 1, 2, 3), tmp55, (3,), (0, 1, 2)) * 2
     del tmp55
-    tmp62 = ints.tmp18.copy()
+    tmp62 = np.copy(ints.tmp18)
     tmp62 += ints.tmp259
     tmp62 += ints.tmp270
     tmp62 += ints.tmp271 * 2
-    tmp62 += ints.tmp292.transpose((1, 0, 2, 3))
+    tmp62 += np.transpose(ints.tmp292, (1, 0, 2, 3))
     tmp62 += ints.tmp308
     tmp62 += ints.tmp309
     tmp62 += ints.tmp326
@@ -3471,45 +3471,45 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp62 += ints.tmp334 * -1
     tmp62 += ints.tmp337 * -1
     tmp62 += ints.tmp346 * -1
-    tmp62 += ints.tmp349.transpose((1, 0, 2, 3)) * -1
+    tmp62 += np.transpose(ints.tmp349, (1, 0, 2, 3)) * -1
     r2new.bab += einsum(r1.a, (0,), tmp62, (1, 0, 2, 3), (2, 1, 3))
     del tmp62
-    tmp7 = f.bb.oo.copy()
+    tmp7 = np.copy(f.bb.oo)
     tmp7 += ints.tmp28
-    tmp7 += ints.tmp32.transpose((1, 0))
-    tmp7 += ints.tmp33.transpose((1, 0))
-    tmp7 += ints.tmp41.transpose((1, 0)) * 2
-    tmp7 += ints.tmp43.transpose((1, 0))
-    tmp7 += ints.tmp46.transpose((1, 0))
-    tmp7 += ints.tmp47.transpose((1, 0))
-    tmp7 += ints.tmp31.transpose((1, 0)) * -1
-    tmp7 += ints.tmp45.transpose((1, 0)) * -1
+    tmp7 += np.transpose(ints.tmp32, (1, 0))
+    tmp7 += np.transpose(ints.tmp33, (1, 0))
+    tmp7 += np.transpose(ints.tmp41, (1, 0)) * 2
+    tmp7 += np.transpose(ints.tmp43, (1, 0))
+    tmp7 += np.transpose(ints.tmp46, (1, 0))
+    tmp7 += np.transpose(ints.tmp47, (1, 0))
+    tmp7 += np.transpose(ints.tmp31, (1, 0)) * -1
+    tmp7 += np.transpose(ints.tmp45, (1, 0)) * -1
     r2new.bab += einsum(tmp7, (0, 1), r2.bab, (0, 2, 3), (1, 2, 3)) * -1
     r2new.aba += einsum(tmp7, (0, 1), r2.aba, (2, 0, 3), (2, 1, 3)) * -1
     r1new.b += einsum(tmp7, (0, 1), r1.b, (0,), (1,)) * -1
     del tmp7
-    tmp4 = f.aa.oo.copy()
+    tmp4 = np.copy(f.aa.oo)
     tmp4 += ints.tmp1
-    tmp4 += ints.tmp20.transpose((1, 0)) * 2
-    tmp4 += ints.tmp22.transpose((1, 0))
-    tmp4 += ints.tmp25.transpose((1, 0))
-    tmp4 += ints.tmp26.transpose((1, 0))
-    tmp4 += ints.tmp5.transpose((1, 0))
-    tmp4 += ints.tmp6.transpose((1, 0))
-    tmp4 += ints.tmp24.transpose((1, 0)) * -1
-    tmp4 += ints.tmp4.transpose((1, 0)) * -1
+    tmp4 += np.transpose(ints.tmp20, (1, 0)) * 2
+    tmp4 += np.transpose(ints.tmp22, (1, 0))
+    tmp4 += np.transpose(ints.tmp25, (1, 0))
+    tmp4 += np.transpose(ints.tmp26, (1, 0))
+    tmp4 += np.transpose(ints.tmp5, (1, 0))
+    tmp4 += np.transpose(ints.tmp6, (1, 0))
+    tmp4 += np.transpose(ints.tmp24, (1, 0)) * -1
+    tmp4 += np.transpose(ints.tmp4, (1, 0)) * -1
     r2new.bab += einsum(tmp4, (0, 1), r2.bab, (2, 0, 3), (2, 1, 3)) * -1
     r2new.aba += einsum(r2.aba, (0, 1, 2), tmp4, (0, 3), (3, 1, 2)) * -1
     r1new.a += einsum(tmp4, (0, 1), r1.a, (0,), (1,)) * -1
     del tmp4
-    tmp57 = ints.tmp275.copy()
+    tmp57 = np.copy(ints.tmp275)
     tmp57 += ints.tmp281 * 2
     tmp57 += ints.tmp319
-    tmp57 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp57 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp57 += ints.tmp273 * -1
     r2new.bab += einsum(r2.aaa, (0, 1, 2), tmp57, (1, 3, 2, 4), (3, 0, 4)) * -2
     del tmp57
-    tmp58 = ints.tmp258.copy()
+    tmp58 = np.copy(ints.tmp258)
     tmp58 += v.aabb.oovv
     tmp58 += ints.tmp304 * -1
     r2new.bab += einsum(tmp58, (0, 1, 2, 3), r2.bab, (4, 1, 3), (4, 0, 2)) * -1
@@ -3520,21 +3520,21 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp64 += einsum(tmp1, (0, 1, 2, 3), r2.bab, (4, 1, 3), (0, 4, 2))
     r2new.bab += einsum(t1.bb, (0, 1), tmp64, (2, 3, 0), (3, 2, 1))
     del tmp64
-    tmp65 = tmp40.copy() * 2
+    tmp65 = np.copy(tmp40) * 2
     tmp65 += tmp41
     r2new.bab += einsum(tmp65, (0,), t2.abab, (1, 2, 0, 3), (2, 1, 3))
     del tmp65
-    tmp59 = ints.tmp192.copy()
+    tmp59 = np.copy(ints.tmp192)
     tmp59 += ints.tmp230
     tmp59 += ints.tmp233
     tmp59 += ints.tmp244
     tmp59 += v.aabb.oooo
     r2new.bab += einsum(r2.bab, (0, 1, 2), tmp59, (3, 1, 4, 0), (4, 3, 2))
     del tmp59
-    tmp56 = ints.tmp279.copy() * 2
+    tmp56 = np.copy(ints.tmp279) * 2
     tmp56 += ints.tmp283
-    tmp56 += ints.tmp318.transpose((0, 1, 3, 2))
-    tmp56 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp56 += np.transpose(ints.tmp318, (0, 1, 3, 2))
+    tmp56 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp56 += ints.tmp277 * -2
     tmp56 += ints.tmp317 * -1
     tmp56 += v.bbbb.oovv * -1
@@ -3548,14 +3548,14 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp1
     r2new.aba += einsum(t1.aa, (0, 1), tmp52, (2, 0, 3), (2, 3, 1))
     del tmp52
-    tmp46 = ints.tmp118.copy()
+    tmp46 = np.copy(ints.tmp118)
     tmp46 += ints.tmp122 * 2
     tmp46 += ints.tmp63
-    tmp46 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp46 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp46 += ints.tmp116 * -1
     r2new.aba += einsum(tmp46, (0, 1, 2, 3), r2.bbb, (4, 1, 3), (0, 4, 2)) * -2
     del tmp46
-    tmp44 = ints.tmp100.copy() * 2
+    tmp44 = np.copy(ints.tmp100) * 2
     tmp44 += ints.tmp101
     tmp44 += ints.tmp124 * 2
     tmp44 += ints.tmp126
@@ -3591,10 +3591,10 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r2new.aaa = einsum(r1.a, (0,), tmp44, (1, 2), (1, 0, 2))
     r2new.aaa += einsum(r1.a, (0,), tmp44, (1, 2), (0, 1, 2)) * -1
     del tmp44
-    tmp49 = ints.tmp190.copy()
+    tmp49 = np.copy(ints.tmp190)
     tmp49 += ints.tmp200
     tmp49 += ints.tmp201 * 2
-    tmp49 += ints.tmp209.transpose((0, 2, 1, 3))
+    tmp49 += np.transpose(ints.tmp209, (0, 2, 1, 3))
     tmp49 += ints.tmp223
     tmp49 += ints.tmp224
     tmp49 += ints.tmp229
@@ -3602,7 +3602,7 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp49 += ints.tmp239 * 2
     tmp49 += ints.tmp243
     tmp49 += ints.tmp39
-    tmp49 += v.aabb.ovoo.transpose((0, 2, 3, 1))
+    tmp49 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
     tmp49 += ints.tmp194 * -1
     tmp49 += ints.tmp197 * -1
     tmp49 += ints.tmp199 * -1
@@ -3612,101 +3612,101 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp49 += ints.tmp238 * -1
     tmp49 += ints.tmp241 * -1
     tmp49 += ints.tmp248 * -1
-    tmp49 += ints.tmp249.transpose((0, 2, 1, 3)) * -1
+    tmp49 += np.transpose(ints.tmp249, (0, 2, 1, 3)) * -1
     r2new.aba += einsum(tmp49, (0, 1, 2, 3), r1.b, (2,), (0, 1, 3))
     del tmp49
-    tmp45 = ints.tmp114.copy() * 2
+    tmp45 = np.copy(ints.tmp114) * 2
     tmp45 += ints.tmp120
-    tmp45 += ints.tmp61.transpose((0, 1, 3, 2))
-    tmp45 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp45 += np.transpose(ints.tmp61, (0, 1, 3, 2))
+    tmp45 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp45 += ints.tmp112 * -2
     tmp45 += ints.tmp59 * -1
     tmp45 += v.aaaa.oovv * -1
     r2new.aba += einsum(tmp45, (0, 1, 2, 3), r2.aba, (1, 4, 3), (0, 4, 2))
     del tmp45
-    tmp48 = ints.tmp192.copy()
+    tmp48 = np.copy(ints.tmp192)
     tmp48 += ints.tmp230
     tmp48 += ints.tmp233
     tmp48 += ints.tmp244
     tmp48 += v.aabb.oooo
     r2new.aba += einsum(tmp48, (0, 1, 2, 3), r2.aba, (1, 3, 4), (0, 2, 4))
     del tmp48
-    tmp39 = ints.tmp108.transpose((1, 0)).copy() * 2
-    tmp39 += ints.tmp110.transpose((1, 0))
+    tmp39 = np.copy(np.transpose(ints.tmp108, (1, 0))) * 2
+    tmp39 += np.transpose(ints.tmp110, (1, 0))
     tmp39 += ints.tmp55
     tmp39 += f.aa.vv * -1
-    tmp39 += ints.tmp53.transpose((1, 0)) * -1
-    tmp39 += ints.tmp57.transpose((1, 0)) * -1
+    tmp39 += np.transpose(ints.tmp53, (1, 0)) * -1
+    tmp39 += np.transpose(ints.tmp57, (1, 0)) * -1
     tmp39 += tmp38
     del tmp38
     r2new.aba += einsum(tmp39, (0, 1), r2.aba, (2, 3, 0), (2, 3, 1)) * -1
     r2new.aaa += einsum(tmp39, (0, 1), r2.aaa, (2, 3, 0), (2, 3, 1)) * -2
     del tmp39
-    tmp47 = ints.tmp189.copy()
-    tmp47 += v.aabb.vvoo.transpose((2, 3, 0, 1))
+    tmp47 = np.copy(ints.tmp189)
+    tmp47 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1))
     tmp47 += ints.tmp217 * -1
     r2new.aba += einsum(r2.aba, (0, 1, 2), tmp47, (3, 1, 4, 2), (0, 3, 4)) * -1
     del tmp47
-    tmp37 = ints.tmp72.copy()
+    tmp37 = np.copy(ints.tmp72)
     tmp37 += ints.tmp78
-    tmp37 += v.aaaa.oooo.transpose((0, 2, 1, 3))
+    tmp37 += np.transpose(v.aaaa.oooo, (0, 2, 1, 3))
     r2new.aaa += einsum(r2.aaa, (0, 1, 2), tmp37, (3, 4, 1, 0), (3, 4, 2)) * -2
     del tmp37
-    tmp43 = ints.tmp139.copy()
-    tmp43 += ints.tmp147.transpose((2, 0, 1, 3))
-    tmp43 += ints.tmp149.transpose((2, 0, 1, 3))
-    tmp43 += ints.tmp80.transpose((2, 0, 1, 3))
-    tmp43 += ints.tmp145.transpose((2, 0, 1, 3)) * -1
-    tmp43 += ints.tmp76.transpose((2, 0, 1, 3)) * -1
+    tmp43 = np.copy(ints.tmp139)
+    tmp43 += np.transpose(ints.tmp147, (2, 0, 1, 3))
+    tmp43 += np.transpose(ints.tmp149, (2, 0, 1, 3))
+    tmp43 += np.transpose(ints.tmp80, (2, 0, 1, 3))
+    tmp43 += np.transpose(ints.tmp145, (2, 0, 1, 3)) * -1
+    tmp43 += np.transpose(ints.tmp76, (2, 0, 1, 3)) * -1
     r2new.aaa += einsum(r1.a, (0,), tmp43, (0, 1, 2, 3), (2, 1, 3)) * -2
     del tmp43
-    tmp42 = tmp40.copy()
+    tmp42 = np.copy(tmp40)
     del tmp40
     tmp42 += tmp41 * 0.5
     del tmp41
     r2new.aaa += einsum(tmp42, (0,), t2.aaaa, (1, 2, 3, 0), (1, 2, 3)) * 4
     del tmp42
-    tmp36 = tmp27.copy() * 2
+    tmp36 = np.copy(tmp27) * 2
     del tmp27
     tmp36 += tmp28
     del tmp28
     tmp36 += tmp29
     del tmp29
-    tmp36 += tmp31.transpose((1, 0, 2)) * -2
+    tmp36 += np.transpose(tmp31, (1, 0, 2)) * -2
     del tmp31
-    tmp36 += tmp33.transpose((1, 0, 2)) * -2
+    tmp36 += np.transpose(tmp33, (1, 0, 2)) * -2
     del tmp33
     tmp36 += tmp35
     del tmp35
-    r2new.aaa += tmp36.transpose((1, 0, 2)) * -1
+    r2new.aaa += np.transpose(tmp36, (1, 0, 2)) * -1
     r2new.aaa += tmp36
     del tmp36
-    tmp26 = tmp8.copy() * 2
+    tmp26 = np.copy(tmp8) * 2
     del tmp8
     tmp26 += tmp9 * 2
     del tmp9
-    tmp26 += tmp11.transpose((1, 0, 2)) * -1
+    tmp26 += np.transpose(tmp11, (1, 0, 2)) * -1
     del tmp11
-    tmp26 += tmp13.transpose((1, 0, 2))
+    tmp26 += np.transpose(tmp13, (1, 0, 2))
     del tmp13
     tmp26 += tmp21
     del tmp21
     tmp26 += tmp23
     del tmp23
-    tmp26 += tmp25.transpose((1, 0, 2))
+    tmp26 += np.transpose(tmp25, (1, 0, 2))
     del tmp25
-    r2new.aaa += tmp26.transpose((1, 0, 2))
+    r2new.aaa += np.transpose(tmp26, (1, 0, 2))
     r2new.aaa += tmp26 * -1
     del tmp26
-    tmp5 = ints.tmp37.copy()
+    tmp5 = np.copy(ints.tmp37)
     tmp5 += v.bbbb.ooov * -1
     r1new.b += einsum(r2.bbb, (0, 1, 2), tmp5, (3, 0, 1, 2), (3,)) * 2
     del tmp5
-    tmp6 = ints.tmp39.copy()
-    tmp6 += v.aabb.ovoo.transpose((0, 2, 3, 1))
+    tmp6 = np.copy(ints.tmp39)
+    tmp6 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
     r1new.b += einsum(tmp6, (0, 1, 2, 3), r2.aba, (0, 2, 3), (1,))
     del tmp6
-    tmp0 = ints.tmp16.copy()
+    tmp0 = np.copy(ints.tmp16)
     tmp0 += v.aaaa.ooov * -1
     r1new.a += einsum(tmp0, (0, 1, 2, 3), r2.aaa, (1, 2, 3), (0,)) * 2
     del tmp0
@@ -4053,38 +4053,38 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     ints = kwargs["ints"]
     r1new = Namespace()
     r2new = Namespace()
-    tmp130 = ints.tmp291.copy()
-    tmp130 += ints.tmp360.transpose((0, 1, 3, 2))
-    tmp130 += ints.tmp356.transpose((0, 1, 3, 2)) * 2
+    tmp130 = np.copy(ints.tmp291)
+    tmp130 += np.transpose(ints.tmp360, (0, 1, 3, 2))
+    tmp130 += np.transpose(ints.tmp356, (0, 1, 3, 2)) * 2
     tmp126 = einsum(r1.b, (0,), ints.tmp315, (1, 2, 3, 0), (1, 2, 3))
-    tmp128 = ints.tmp315.copy()
-    tmp128 += v.bbbb.ooov.transpose((0, 2, 1, 3))
+    tmp128 = np.copy(ints.tmp315)
+    tmp128 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3))
     tmp99 = einsum(v.bbbb.ooov, (0, 1, 2, 3), r1.b, (3,), (0, 1, 2))
-    tmp102 = ints.tmp315.copy()
-    tmp102 += v.bbbb.ooov.transpose((0, 2, 1, 3))
-    tmp88 = ints.tmp300.copy()
-    tmp88 += v.aabb.ovoo.transpose((0, 2, 3, 1))
-    tmp104 = f.bb.ov.copy()
+    tmp102 = np.copy(ints.tmp315)
+    tmp102 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3))
+    tmp88 = np.copy(ints.tmp300)
+    tmp88 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
+    tmp104 = np.copy(f.bb.ov)
     tmp104 += ints.tmp12
     tmp104 += ints.tmp15
-    tmp106 = ints.tmp290.copy()
+    tmp106 = np.copy(ints.tmp290)
     tmp106 += ints.tmp354 * 2
-    tmp27 = ints.tmp146.copy()
+    tmp27 = np.copy(ints.tmp146)
     tmp27 += ints.tmp67 * 2
     tmp19 = einsum(v.aaaa.ooov, (0, 1, 2, 3), r1.a, (3,), (0, 1, 2))
-    tmp25 = f.aa.ov.copy()
+    tmp25 = np.copy(f.aa.ov)
     tmp25 += ints.tmp13
     tmp25 += ints.tmp9
-    tmp23 = ints.tmp160.copy()
+    tmp23 = np.copy(ints.tmp160)
     tmp23 += v.aabb.ooov
-    tmp21 = ints.tmp158.copy()
-    tmp21 += v.aaaa.ooov.transpose((0, 2, 1, 3))
-    tmp51 = ints.tmp148.copy()
-    tmp51 += ints.tmp75.transpose((0, 1, 3, 2))
-    tmp51 += ints.tmp69.transpose((0, 1, 3, 2)) * 2
+    tmp21 = np.copy(ints.tmp158)
+    tmp21 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3))
+    tmp51 = np.copy(ints.tmp148)
+    tmp51 += np.transpose(ints.tmp75, (0, 1, 3, 2))
+    tmp51 += np.transpose(ints.tmp69, (0, 1, 3, 2)) * 2
     tmp47 = einsum(ints.tmp158, (0, 1, 2, 3), r1.a, (3,), (0, 1, 2))
-    tmp49 = ints.tmp158.copy()
-    tmp49 += v.aaaa.ooov.transpose((0, 2, 1, 3))
+    tmp49 = np.copy(ints.tmp158)
+    tmp49 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3))
     tmp131 = einsum(r1.b, (0,), tmp130, (1, 2, 0, 3), (1, 2, 3))
     del tmp130
     tmp127 = einsum(tmp126, (0, 1, 2), t1.bb, (1, 3), (0, 2, 3))
@@ -4121,90 +4121,90 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp47
     tmp50 = einsum(r2.aaa, (0, 1, 2), tmp49, (3, 4, 2, 1), (3, 4, 0)) * -1
     del tmp49
-    tmp0 = f.bb.ov.copy()
+    tmp0 = np.copy(f.bb.ov)
     tmp0 += ints.tmp12
     tmp0 += ints.tmp15
     tmp0 += ints.tmp11 * -1
     r1new.b = einsum(r2.bbb, (0, 1, 2), tmp0, (2, 1), (0,)) * 2
     r1new.a = einsum(tmp0, (0, 1), r2.bab, (1, 2, 0), (2,)) * -1
-    tmp123 = ints.tmp290.copy()
+    tmp123 = np.copy(ints.tmp290)
     tmp123 += ints.tmp354 * 2
-    tmp121 = ints.tmp292.copy()
+    tmp121 = np.copy(ints.tmp292)
     tmp121 += ints.tmp352
     tmp121 += ints.tmp358 * 2
-    tmp132 = tmp125.copy() * 2
+    tmp132 = np.copy(tmp125) * 2
     del tmp125
-    tmp132 += tmp127.transpose((1, 0, 2))
+    tmp132 += np.transpose(tmp127, (1, 0, 2))
     del tmp127
-    tmp132 += tmp129.transpose((1, 0, 2)) * -2
+    tmp132 += np.transpose(tmp129, (1, 0, 2)) * -2
     del tmp129
-    tmp132 += tmp131.transpose((1, 0, 2))
+    tmp132 += np.transpose(tmp131, (1, 0, 2))
     del tmp131
-    tmp134 = ints.tmp440.copy()
+    tmp134 = np.copy(ints.tmp440)
     tmp134 += ints.tmp385 * 2
     tmp119 = einsum(r1.b, (0,), v.bbbb.oovv, (1, 2, 3, 0), (1, 2, 3))
-    tmp108 = tmp100.transpose((1, 0, 2)).copy()
+    tmp108 = np.copy(np.transpose(tmp100, (1, 0, 2)))
     del tmp100
-    tmp108 += tmp101.transpose((1, 0, 2)) * -1
+    tmp108 += np.transpose(tmp101, (1, 0, 2)) * -1
     del tmp101
-    tmp108 += tmp103.transpose((1, 0, 2)) * -1
+    tmp108 += np.transpose(tmp103, (1, 0, 2)) * -1
     del tmp103
     tmp108 += tmp105 * -1
     del tmp105
-    tmp108 += tmp107.transpose((1, 0, 2))
+    tmp108 += np.transpose(tmp107, (1, 0, 2))
     del tmp107
-    tmp114 = tmp112.copy()
+    tmp114 = np.copy(tmp112)
     del tmp112
     tmp114 += tmp113 * 2
     del tmp113
-    tmp97 = f.bb.vv.copy() * 0.5
-    tmp97 += ints.tmp31.transpose((1, 0)) * 0.5
-    tmp97 += ints.tmp33.transpose((1, 0)) * 0.5
-    tmp97 += ints.tmp41.transpose((1, 0)) * -1
-    tmp97 += ints.tmp43.transpose((1, 0)) * -0.5
-    tmp95 = ints.tmp291.copy()
-    tmp95 += ints.tmp356.transpose((0, 1, 3, 2)) * 2
-    tmp95 += ints.tmp360.transpose((0, 1, 3, 2))
-    tmp110 = ints.tmp383.copy()
+    tmp97 = np.copy(f.bb.vv) * 0.5
+    tmp97 += np.transpose(ints.tmp31, (1, 0)) * 0.5
+    tmp97 += np.transpose(ints.tmp33, (1, 0)) * 0.5
+    tmp97 += np.transpose(ints.tmp41, (1, 0)) * -1
+    tmp97 += np.transpose(ints.tmp43, (1, 0)) * -0.5
+    tmp95 = np.copy(ints.tmp291)
+    tmp95 += np.transpose(ints.tmp356, (0, 1, 3, 2)) * 2
+    tmp95 += np.transpose(ints.tmp360, (0, 1, 3, 2))
+    tmp110 = np.copy(ints.tmp383)
     tmp110 += ints.tmp387 * 0.5
     tmp110 += v.bbbb.ovvv * 0.5
-    tmp1 = f.aa.ov.copy()
+    tmp1 = np.copy(f.aa.ov)
     tmp1 += ints.tmp13
     tmp1 += ints.tmp9
     tmp1 += ints.tmp7 * -1
     r1new.b += einsum(tmp1, (0, 1), r2.aba, (1, 2, 0), (2,)) * -1
     r1new.a += einsum(tmp1, (0, 1), r2.aaa, (2, 1, 0), (2,)) * 2
-    tmp17 = f.aa.vv.copy() * 0.5
-    tmp17 += ints.tmp4.transpose((1, 0)) * 0.5
-    tmp17 += ints.tmp6.transpose((1, 0)) * 0.5
-    tmp17 += ints.tmp20.transpose((1, 0)) * -1
-    tmp17 += ints.tmp22.transpose((1, 0)) * -0.5
-    tmp15 = ints.tmp150.copy()
+    tmp17 = np.copy(f.aa.vv) * 0.5
+    tmp17 += np.transpose(ints.tmp4, (1, 0)) * 0.5
+    tmp17 += np.transpose(ints.tmp6, (1, 0)) * 0.5
+    tmp17 += np.transpose(ints.tmp20, (1, 0)) * -1
+    tmp17 += np.transpose(ints.tmp22, (1, 0)) * -0.5
+    tmp15 = np.copy(ints.tmp150)
     tmp15 += ints.tmp73
     tmp15 += ints.tmp77 * 2
-    tmp35 = tmp33.copy()
+    tmp35 = np.copy(tmp33)
     del tmp33
     tmp35 += tmp34 * 2
     del tmp34
-    tmp31 = ints.tmp59.copy()
+    tmp31 = np.copy(ints.tmp59)
     tmp31 += ints.tmp63 * 0.5
     tmp31 += v.aaaa.ovvv * 0.5
-    tmp13 = ints.tmp148.copy()
-    tmp13 += ints.tmp69.transpose((0, 1, 3, 2)) * 2
-    tmp13 += ints.tmp75.transpose((0, 1, 3, 2))
-    tmp29 = tmp20.transpose((1, 0, 2)).copy() * 0.5
+    tmp13 = np.copy(ints.tmp148)
+    tmp13 += np.transpose(ints.tmp69, (0, 1, 3, 2)) * 2
+    tmp13 += np.transpose(ints.tmp75, (0, 1, 3, 2))
+    tmp29 = np.copy(np.transpose(tmp20, (1, 0, 2))) * 0.5
     del tmp20
-    tmp29 += tmp22.transpose((1, 0, 2)) * -1
+    tmp29 += np.transpose(tmp22, (1, 0, 2)) * -1
     del tmp22
-    tmp29 += tmp24.transpose((1, 0, 2))
+    tmp29 += np.transpose(tmp24, (1, 0, 2))
     del tmp24
-    tmp29 += tmp26.transpose((1, 0, 2)) * -1
+    tmp29 += np.transpose(tmp26, (1, 0, 2)) * -1
     del tmp26
-    tmp29 += tmp28.transpose((1, 0, 2))
+    tmp29 += np.transpose(tmp28, (1, 0, 2))
     del tmp28
-    tmp44 = ints.tmp146.copy()
+    tmp44 = np.copy(ints.tmp146)
     tmp44 += ints.tmp67 * 2
-    tmp53 = tmp46.transpose((1, 0, 2)).copy() * 2
+    tmp53 = np.copy(np.transpose(tmp46, (1, 0, 2))) * 2
     del tmp46
     tmp53 += tmp48
     del tmp48
@@ -4213,7 +4213,7 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp53 += tmp52
     del tmp52
     tmp40 = einsum(v.aaaa.oovv, (0, 1, 2, 3), r1.a, (3,), (0, 1, 2))
-    tmp55 = ints.tmp141.copy()
+    tmp55 = np.copy(ints.tmp141)
     tmp55 += ints.tmp61 * 2
     tmp10 = einsum(r1.b, (0,), tmp0, (1, 0), (1,))
     tmp9 = einsum(v.bbbb.ovov, (0, 1, 2, 3), r2.bbb, (3, 1, 2), (0,)) * -1
@@ -4246,24 +4246,24 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp4 = einsum(v.aabb.ovov, (0, 1, 2, 3), r2.bab, (3, 1, 2), (0,)) * -1
     tmp5 = einsum(tmp1, (0, 1), r1.a, (1,), (0,))
     tmp3 = einsum(r2.aaa, (0, 1, 2), v.aaaa.ovov, (3, 0, 2, 1), (3,))
-    tmp78 = ints.tmp315.copy()
-    tmp78 += ints.tmp315.transpose((0, 2, 1, 3)) * -1
+    tmp78 = np.copy(ints.tmp315)
+    tmp78 += np.transpose(ints.tmp315, (0, 2, 1, 3)) * -1
     tmp78 += v.bbbb.ooov * -1
-    tmp78 += v.bbbb.ooov.transpose((0, 2, 1, 3))
+    tmp78 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3))
     tmp70 = einsum(tmp1, (0, 1), t1.aa, (0, 2), (2, 1))
     del tmp1
-    tmp87 = r2.aaa.transpose((2, 0, 1)).copy()
+    tmp87 = np.copy(np.transpose(r2.aaa, (2, 0, 1)))
     tmp87 += einsum(r1.a, (0,), t1.aa, (1, 2), (1, 0, 2)) * 0.5
     tmp77 = einsum(v.aabb.ovov, (0, 1, 2, 3), r2.bab, (3, 1, 4), (0, 4, 2)) * -1
     r2new.bab = einsum(tmp77, (0, 1, 2), t2.abab, (0, 2, 3, 4), (4, 3, 1)) * -1
-    tmp74 = r2.bbb.transpose((2, 0, 1)).copy()
+    tmp74 = np.copy(np.transpose(r2.bbb, (2, 0, 1)))
     tmp74 += einsum(t1.bb, (0, 1), r1.b, (2,), (0, 2, 1)) * 0.5
     tmp63 = einsum(r2.aba, (0, 1, 2), v.aabb.ovov, (3, 0, 4, 1), (2, 3, 4))
     r2new.aba = einsum(t2.abab, (0, 1, 2, 3), tmp63, (4, 0, 1), (2, 3, 4))
-    tmp64 = ints.tmp158.copy()
-    tmp64 += ints.tmp158.transpose((0, 2, 1, 3)) * -1
+    tmp64 = np.copy(ints.tmp158)
+    tmp64 += np.transpose(ints.tmp158, (0, 2, 1, 3)) * -1
     tmp64 += v.aaaa.ooov * -1
-    tmp64 += v.aaaa.ooov.transpose((0, 2, 1, 3))
+    tmp64 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3))
     tmp18 = einsum(r2.aaa, (0, 1, 2), tmp17, (1, 3), (2, 0, 3)) * -4
     del tmp17
     tmp12 = einsum(r2.aaa, (0, 1, 2), v.aaaa.oovv, (3, 2, 4, 1), (3, 0, 4))
@@ -4289,7 +4289,7 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp39 = einsum(r2.aaa, (0, 1, 2), v.aaaa.ovov, (3, 4, 2, 1), (3, 0, 4))
     tmp56 = einsum(r1.a, (0,), tmp55, (1, 2, 0, 3), (1, 2, 3))
     del tmp55
-    tmp11 = tmp8.copy() * -1
+    tmp11 = np.copy(tmp8) * -1
     del tmp8
     tmp11 += tmp9 * 2
     del tmp9
@@ -4300,24 +4300,24 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r1new.b += einsum(t1.bb, (0, 1), tmp11, (0,), (1,)) * -1
     del tmp11
     tmp138 = einsum(v.bbbb.ovov, (0, 1, 2, 3), r2.bbb, (3, 1, 4), (4, 0, 2)) * -1
-    tmp137 = ints.tmp423.copy()
+    tmp137 = np.copy(ints.tmp423)
     tmp137 += ints.tmp450 * -1
     r2new.bbb += einsum(r1.b, (0,), tmp137, (1, 2, 3, 0), (3, 2, 1)) * 2
     del tmp137
-    tmp86 = f.bb.oo.copy()
-    tmp86 += ints.tmp273.transpose((1, 0))
-    tmp86 += ints.tmp274.transpose((1, 0))
+    tmp86 = np.copy(f.bb.oo)
+    tmp86 += np.transpose(ints.tmp273, (1, 0))
+    tmp86 += np.transpose(ints.tmp274, (1, 0))
     tmp86 += ints.tmp287
-    tmp86 += ints.tmp296.transpose((1, 0)) * 2
-    tmp86 += ints.tmp298.transpose((1, 0))
-    tmp86 += ints.tmp308.transpose((1, 0))
-    tmp86 += ints.tmp309.transpose((1, 0))
-    tmp86 += ints.tmp272.transpose((1, 0)) * -1
-    tmp86 += ints.tmp307.transpose((1, 0)) * -1
+    tmp86 += np.transpose(ints.tmp296, (1, 0)) * 2
+    tmp86 += np.transpose(ints.tmp298, (1, 0))
+    tmp86 += np.transpose(ints.tmp308, (1, 0))
+    tmp86 += np.transpose(ints.tmp309, (1, 0))
+    tmp86 += np.transpose(ints.tmp272, (1, 0)) * -1
+    tmp86 += np.transpose(ints.tmp307, (1, 0)) * -1
     r2new.bbb += einsum(tmp86, (0, 1), r2.bbb, (2, 3, 0), (2, 3, 1)) * -2
     r2new.bab += einsum(r2.bab, (0, 1, 2), tmp86, (2, 3), (0, 1, 3)) * -1
     del tmp86
-    tmp136 = tmp117.copy() * 2
+    tmp136 = np.copy(tmp117) * 2
     del tmp117
     tmp136 += tmp118 * 2
     del tmp118
@@ -4331,10 +4331,10 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp133
     tmp136 += tmp135
     del tmp135
-    r2new.bbb += tmp136.transpose((2, 1, 0)) * -1
-    r2new.bbb += tmp136.transpose((1, 2, 0))
+    r2new.bbb += np.transpose(tmp136, (2, 1, 0)) * -1
+    r2new.bbb += np.transpose(tmp136, (1, 2, 0))
     del tmp136
-    tmp116 = tmp92.copy()
+    tmp116 = np.copy(tmp92)
     del tmp92
     tmp116 += tmp93
     del tmp93
@@ -4348,16 +4348,16 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp109
     tmp116 += tmp111
     del tmp111
-    tmp116 += tmp115.transpose((0, 2, 1))
+    tmp116 += np.transpose(tmp115, (0, 2, 1))
     del tmp115
-    r2new.bbb += tmp116.transpose((2, 1, 0))
-    r2new.bbb += tmp116.transpose((1, 2, 0)) * -1
+    r2new.bbb += np.transpose(tmp116, (2, 1, 0))
+    r2new.bbb += np.transpose(tmp116, (1, 2, 0)) * -1
     del tmp116
-    tmp139 = t2.bbbb.copy()
+    tmp139 = np.copy(t2.bbbb)
     tmp139 += einsum(t1.bb, (0, 1), t1.bb, (2, 3), (2, 0, 3, 1))
     r2new.bbb += einsum(tmp138, (0, 1, 2), tmp139, (1, 2, 3, 4), (4, 3, 0)) * -2
     del tmp138, tmp139
-    tmp91 = ints.tmp271.copy()
+    tmp91 = np.copy(ints.tmp271)
     tmp91 += ints.tmp294 * 2
     tmp91 += ints.tmp304
     tmp91 += ints.tmp313
@@ -4397,7 +4397,7 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp90 += einsum(r2.bab, (0, 1, 2), tmp88, (3, 4, 2, 1), (3, 4, 0)) * -1
     r2new.bab += einsum(t1.aa, (0, 1), tmp90, (0, 2, 3), (3, 1, 2)) * -1
     del tmp90
-    tmp6 = tmp3.copy() * 2
+    tmp6 = np.copy(tmp3) * 2
     del tmp3
     tmp6 += tmp4
     del tmp4
@@ -4407,19 +4407,19 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r2new.aaa = einsum(tmp6, (0,), t2.aaaa, (1, 0, 2, 3), (2, 3, 1)) * 2
     r1new.a += einsum(tmp6, (0,), t1.aa, (0, 1), (1,)) * -1
     del tmp6
-    tmp84 = ints.tmp32.copy() * 0.5
-    tmp84 += ints.tmp41.transpose((1, 0))
-    tmp84 += ints.tmp43.transpose((1, 0)) * 0.5
+    tmp84 = np.copy(ints.tmp32) * 0.5
+    tmp84 += np.transpose(ints.tmp41, (1, 0))
+    tmp84 += np.transpose(ints.tmp43, (1, 0)) * 0.5
     tmp84 += f.bb.vv * -0.5
-    tmp84 += ints.tmp31.transpose((1, 0)) * -0.5
-    tmp84 += ints.tmp33.transpose((1, 0)) * -0.5
+    tmp84 += np.transpose(ints.tmp31, (1, 0)) * -0.5
+    tmp84 += np.transpose(ints.tmp33, (1, 0)) * -0.5
     tmp84 += einsum(t1.bb, (0, 1), tmp0, (0, 2), (2, 1)) * 0.5
     r2new.bab += einsum(r2.bab, (0, 1, 2), tmp84, (0, 3), (3, 1, 2)) * -2
     del tmp84
-    tmp79 = ints.tmp291.transpose((0, 1, 3, 2)).copy()
+    tmp79 = np.copy(np.transpose(ints.tmp291, (0, 1, 3, 2)))
     tmp79 += ints.tmp356 * 2
     tmp79 += ints.tmp360
-    tmp79 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp79 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp79 += ints.tmp290 * -1
     tmp79 += ints.tmp354 * -2
     tmp79 += v.bbbb.oovv * -1
@@ -4427,33 +4427,33 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp78
     r2new.bab += einsum(r2.bab, (0, 1, 2), tmp79, (3, 2, 4, 0), (4, 1, 3))
     del tmp79
-    tmp71 = ints.tmp20.transpose((1, 0)).copy() * 2
-    tmp71 += ints.tmp22.transpose((1, 0))
+    tmp71 = np.copy(np.transpose(ints.tmp20, (1, 0))) * 2
+    tmp71 += np.transpose(ints.tmp22, (1, 0))
     tmp71 += ints.tmp5
     tmp71 += f.aa.vv * -1
-    tmp71 += ints.tmp4.transpose((1, 0)) * -1
-    tmp71 += ints.tmp6.transpose((1, 0)) * -1
-    tmp71 += tmp70.transpose((1, 0))
+    tmp71 += np.transpose(ints.tmp4, (1, 0)) * -1
+    tmp71 += np.transpose(ints.tmp6, (1, 0)) * -1
+    tmp71 += np.transpose(tmp70, (1, 0))
     del tmp70
     r2new.bab += einsum(tmp71, (0, 1), r2.bab, (2, 0, 3), (2, 1, 3)) * -1
     r2new.aba += einsum(tmp71, (0, 1), r2.aba, (0, 2, 3), (1, 2, 3)) * -1
     del tmp71
-    tmp85 = ints.tmp276.copy()
+    tmp85 = np.copy(ints.tmp276)
     tmp85 += ints.tmp289
     tmp85 += ints.tmp301
     tmp85 += ints.tmp344
     tmp85 += ints.tmp346 * 2
-    tmp85 += v.aabb.vvov.transpose((2, 0, 1, 3))
+    tmp85 += np.transpose(v.aabb.vvov, (2, 0, 1, 3))
     tmp85 += ints.tmp263 * -1
-    tmp85 += ints.tmp345.transpose((0, 2, 1, 3)) * -1
+    tmp85 += np.transpose(ints.tmp345, (0, 2, 1, 3)) * -1
     r2new.bab += einsum(r1.a, (0,), tmp85, (1, 2, 0, 3), (3, 2, 1)) * -1
     del tmp85
-    tmp80 = r2.aaa.transpose((2, 0, 1)).copy() * 2
+    tmp80 = np.copy(np.transpose(r2.aaa, (2, 0, 1))) * 2
     tmp80 += einsum(r1.a, (0,), t1.aa, (1, 2), (1, 0, 2))
-    tmp81 = ints.tmp292.copy()
+    tmp81 = np.copy(ints.tmp292)
     tmp81 += ints.tmp352
     tmp81 += ints.tmp358 * 2
-    tmp81 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp81 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp81 += ints.tmp350 * -1
     r2new.bab += einsum(tmp80, (0, 1, 2), tmp81, (0, 3, 1, 4), (4, 2, 3))
     del tmp80, tmp81
@@ -4464,19 +4464,19 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp88, tmp87
     r2new.bab += einsum(tmp89, (0, 1, 2), t1.bb, (1, 3), (3, 2, 0))
     del tmp89
-    tmp82 = r2.bab.transpose((2, 1, 0)).copy() * -1
+    tmp82 = np.copy(np.transpose(r2.bab, (2, 1, 0))) * -1
     tmp82 += einsum(t1.bb, (0, 1), r1.a, (2,), (0, 2, 1))
-    tmp83 = ints.tmp314.copy()
-    tmp83 += v.aabb.vvoo.transpose((2, 3, 0, 1))
+    tmp83 = np.copy(ints.tmp314)
+    tmp83 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1))
     tmp83 += ints.tmp266 * -1
     r2new.bab += einsum(tmp82, (0, 1, 2), tmp83, (3, 0, 4, 1), (2, 4, 3))
     del tmp82, tmp83
-    tmp67 = ints.tmp150.copy()
+    tmp67 = np.copy(ints.tmp150)
     tmp67 += ints.tmp73
     tmp67 += ints.tmp77 * 2
-    tmp67 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp67 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp67 += ints.tmp71 * -1
-    tmp62 = ints.tmp101.copy()
+    tmp62 = np.copy(ints.tmp101)
     tmp62 += ints.tmp116 * 2
     tmp62 += ints.tmp117
     tmp62 += ints.tmp128
@@ -4512,7 +4512,7 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r2new.aaa += einsum(tmp62, (0, 1), r1.a, (2,), (1, 2, 0))
     r2new.aaa += einsum(tmp62, (0, 1), r1.a, (2,), (2, 1, 0)) * -1
     del tmp62
-    tmp69 = ints.tmp226.copy()
+    tmp69 = np.copy(ints.tmp226)
     tmp69 += v.aabb.oovv
     tmp69 += ints.tmp199 * -1
     tmp75 = einsum(v.aabb.ovvv, (0, 1, 2, 3), r2.aba, (1, 3, 4), (4, 0, 2)) * -1
@@ -4522,34 +4522,34 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp74
     r2new.aba += einsum(t1.aa, (0, 1), tmp75, (2, 0, 3), (1, 3, 2))
     del tmp75
-    tmp72 = ints.tmp32.copy()
-    tmp72 += ints.tmp41.transpose((1, 0)) * 2
-    tmp72 += ints.tmp43.transpose((1, 0))
+    tmp72 = np.copy(ints.tmp32)
+    tmp72 += np.transpose(ints.tmp41, (1, 0)) * 2
+    tmp72 += np.transpose(ints.tmp43, (1, 0))
     tmp72 += f.bb.vv * -1
-    tmp72 += ints.tmp31.transpose((1, 0)) * -1
-    tmp72 += ints.tmp33.transpose((1, 0)) * -1
+    tmp72 += np.transpose(ints.tmp31, (1, 0)) * -1
+    tmp72 += np.transpose(ints.tmp33, (1, 0)) * -1
     tmp72 += einsum(t1.bb, (0, 1), tmp0, (0, 2), (2, 1))
     del tmp0
     r2new.aba += einsum(r2.aba, (0, 1, 2), tmp72, (1, 3), (0, 3, 2)) * -1
     del tmp72
-    tmp66 = r2.bbb.transpose((2, 0, 1)).copy() * 2
+    tmp66 = np.copy(np.transpose(r2.bbb, (2, 0, 1))) * 2
     tmp66 += einsum(t1.bb, (0, 1), r1.b, (2,), (0, 2, 1))
     r2new.aba += einsum(tmp67, (0, 1, 2, 3), tmp66, (1, 3, 4), (2, 4, 0))
     del tmp67, tmp66
-    tmp73 = ints.tmp205.copy()
+    tmp73 = np.copy(ints.tmp205)
     tmp73 += ints.tmp216
     tmp73 += ints.tmp220
     tmp73 += ints.tmp240
     tmp73 += ints.tmp242 * 2
     tmp73 += v.aabb.ovvv
     tmp73 += ints.tmp196 * -1
-    tmp73 += ints.tmp241.transpose((0, 1, 3, 2)) * -1
+    tmp73 += np.transpose(ints.tmp241, (0, 1, 3, 2)) * -1
     r2new.aba += einsum(tmp73, (0, 1, 2, 3), r1.b, (3,), (1, 2, 0)) * -1
     del tmp73
-    tmp65 = ints.tmp148.transpose((0, 1, 3, 2)).copy()
+    tmp65 = np.copy(np.transpose(ints.tmp148, (0, 1, 3, 2)))
     tmp65 += ints.tmp69 * 2
     tmp65 += ints.tmp75
-    tmp65 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp65 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp65 += ints.tmp146 * -1
     tmp65 += ints.tmp67 * -2
     tmp65 += v.aaaa.oovv * -1
@@ -4557,16 +4557,16 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp64
     r2new.aba += einsum(tmp65, (0, 1, 2, 3), r2.aba, (3, 4, 1), (2, 4, 0))
     del tmp65
-    tmp58 = f.aa.oo.copy()
-    tmp58 += ints.tmp106.transpose((1, 0))
-    tmp58 += ints.tmp108.transpose((1, 0))
+    tmp58 = np.copy(f.aa.oo)
+    tmp58 += np.transpose(ints.tmp106, (1, 0))
+    tmp58 += np.transpose(ints.tmp108, (1, 0))
     tmp58 += ints.tmp137
-    tmp58 += ints.tmp154.transpose((1, 0)) * 2
-    tmp58 += ints.tmp156.transpose((1, 0))
-    tmp58 += ints.tmp175.transpose((1, 0))
-    tmp58 += ints.tmp177.transpose((1, 0))
-    tmp58 += ints.tmp104.transpose((1, 0)) * -1
-    tmp58 += ints.tmp173.transpose((1, 0)) * -1
+    tmp58 += np.transpose(ints.tmp154, (1, 0)) * 2
+    tmp58 += np.transpose(ints.tmp156, (1, 0))
+    tmp58 += np.transpose(ints.tmp175, (1, 0))
+    tmp58 += np.transpose(ints.tmp177, (1, 0))
+    tmp58 += np.transpose(ints.tmp104, (1, 0)) * -1
+    tmp58 += np.transpose(ints.tmp173, (1, 0)) * -1
     r2new.aba += einsum(r2.aba, (0, 1, 2), tmp58, (2, 3), (0, 1, 3)) * -1
     r2new.aaa += einsum(r2.aaa, (0, 1, 2), tmp58, (2, 3), (0, 1, 3)) * -2
     del tmp58
@@ -4575,30 +4575,30 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp23
     r2new.aba += einsum(t1.bb, (0, 1), tmp76, (2, 0, 3), (3, 1, 2))
     del tmp76
-    tmp68 = r2.aba.transpose((2, 0, 1)).copy()
+    tmp68 = np.copy(np.transpose(r2.aba, (2, 0, 1)))
     tmp68 += einsum(r1.b, (0,), t1.aa, (1, 2), (1, 2, 0)) * -1
     r2new.aba += einsum(tmp69, (0, 1, 2, 3), tmp68, (1, 4, 3), (4, 2, 0)) * -1
     del tmp69, tmp68
-    tmp61 = t2.aaaa.copy()
+    tmp61 = np.copy(t2.aaaa)
     tmp61 += einsum(t1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
-    tmp37 = tmp12.copy() * 2
+    tmp37 = np.copy(tmp12) * 2
     del tmp12
-    tmp37 += tmp14.transpose((0, 2, 1)) * -1
+    tmp37 += np.transpose(tmp14, (0, 2, 1)) * -1
     del tmp14
-    tmp37 += tmp16.transpose((0, 2, 1))
+    tmp37 += np.transpose(tmp16, (0, 2, 1))
     del tmp16
-    tmp37 += tmp18.transpose((0, 2, 1)) * -1
+    tmp37 += np.transpose(tmp18, (0, 2, 1)) * -1
     del tmp18
-    tmp37 += tmp30.transpose((0, 2, 1))
+    tmp37 += np.transpose(tmp30, (0, 2, 1))
     del tmp30
     tmp37 += tmp32
     del tmp32
     tmp37 += tmp36
     del tmp36
-    r2new.aaa += tmp37.transpose((2, 1, 0))
-    r2new.aaa += tmp37.transpose((1, 2, 0)) * -1
+    r2new.aaa += np.transpose(tmp37, (2, 1, 0))
+    r2new.aaa += np.transpose(tmp37, (1, 2, 0)) * -1
     del tmp37
-    tmp57 = tmp38.copy() * 2
+    tmp57 = np.copy(tmp38) * 2
     del tmp38
     tmp57 += tmp39 * 2
     del tmp39
@@ -4608,36 +4608,36 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp42
     tmp57 += tmp43
     del tmp43
-    tmp57 += tmp45.transpose((0, 2, 1)) * -2
+    tmp57 += np.transpose(tmp45, (0, 2, 1)) * -2
     del tmp45
-    tmp57 += tmp54.transpose((0, 2, 1))
+    tmp57 += np.transpose(tmp54, (0, 2, 1))
     del tmp54
     tmp57 += tmp56
     del tmp56
-    r2new.aaa += tmp57.transpose((2, 1, 0)) * -1
-    r2new.aaa += tmp57.transpose((1, 2, 0))
+    r2new.aaa += np.transpose(tmp57, (2, 1, 0)) * -1
+    r2new.aaa += np.transpose(tmp57, (1, 2, 0))
     del tmp57
     tmp60 = einsum(r2.aaa, (0, 1, 2), v.aaaa.ovov, (3, 0, 4, 1), (2, 3, 4))
     r2new.aaa += einsum(tmp60, (0, 1, 2), tmp61, (1, 2, 3, 4), (4, 3, 0)) * -2
     del tmp60, tmp61
-    tmp59 = ints.tmp118.copy()
+    tmp59 = np.copy(ints.tmp118)
     tmp59 += ints.tmp162 * -1
     r2new.aaa += einsum(r1.a, (0,), tmp59, (1, 2, 3, 0), (3, 2, 1)) * 2
     del tmp59
-    tmp7 = ints.tmp32.copy()
-    tmp7 += ints.tmp41.transpose((1, 0)) * 2
-    tmp7 += ints.tmp43.transpose((1, 0))
+    tmp7 = np.copy(ints.tmp32)
+    tmp7 += np.transpose(ints.tmp41, (1, 0)) * 2
+    tmp7 += np.transpose(ints.tmp43, (1, 0))
     tmp7 += f.bb.vv * -1
-    tmp7 += ints.tmp31.transpose((1, 0)) * -1
-    tmp7 += ints.tmp33.transpose((1, 0)) * -1
+    tmp7 += np.transpose(ints.tmp31, (1, 0)) * -1
+    tmp7 += np.transpose(ints.tmp33, (1, 0)) * -1
     r1new.b += einsum(r1.b, (0,), tmp7, (0, 1), (1,)) * -1
     del tmp7
-    tmp2 = ints.tmp20.transpose((1, 0)).copy() * 2
-    tmp2 += ints.tmp22.transpose((1, 0))
+    tmp2 = np.copy(np.transpose(ints.tmp20, (1, 0))) * 2
+    tmp2 += np.transpose(ints.tmp22, (1, 0))
     tmp2 += ints.tmp5
     tmp2 += f.aa.vv * -1
-    tmp2 += ints.tmp4.transpose((1, 0)) * -1
-    tmp2 += ints.tmp6.transpose((1, 0)) * -1
+    tmp2 += np.transpose(ints.tmp4, (1, 0)) * -1
+    tmp2 += np.transpose(ints.tmp6, (1, 0)) * -1
     r1new.a += einsum(tmp2, (0, 1), r1.a, (0,), (1,)) * -1
     del tmp2
     r1new.a += einsum(v.aabb.vvov, (0, 1, 2, 3), r2.bab, (3, 1, 2), (0,)) * -1
@@ -5171,40 +5171,40 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp83 = einsum(v.aaaa.ooov, (0, 1, 2, 3), r1.aa, (4, 3), (4, 0, 1, 2))
     tmp4 = einsum(r1.bb, (0, 1), v.aabb.ovov, (2, 3, 0, 1), (2, 3))
     tmp50 = einsum(r1.aa, (0, 1), v.aaaa.ovov, (2, 3, 0, 1), (2, 3))
-    tmp239 = v.bbbb.ovvv.copy()
-    tmp239 += v.bbbb.ovvv.transpose((0, 2, 1, 3)) * -1
-    tmp247 = tmp8.copy()
+    tmp239 = np.copy(v.bbbb.ovvv)
+    tmp239 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3)) * -1
+    tmp247 = np.copy(tmp8)
     tmp247 += tmp246
     del tmp246
-    tmp185 = ints.tmp95.copy()
+    tmp185 = np.copy(ints.tmp95)
     tmp185 += ints.tmp467 * 2
-    tmp230 = f.bb.ov.copy()
+    tmp230 = np.copy(f.bb.ov)
     tmp230 += ints.tmp15
     tmp230 += ints.tmp18
-    tmp205 = tmp203.copy()
+    tmp205 = np.copy(tmp203)
     del tmp203
-    tmp205 += tmp204.transpose((0, 2, 3, 1))
+    tmp205 += np.transpose(tmp204, (0, 2, 3, 1))
     del tmp204
-    tmp201 = ints.tmp469.copy()
+    tmp201 = np.copy(ints.tmp469)
     tmp201 += ints.tmp473 * 0.5
-    tmp201 += ints.tmp96.transpose((0, 1, 3, 2)) * 0.5
-    tmp108 = ints.tmp45.copy()
+    tmp201 += np.transpose(ints.tmp96, (0, 1, 3, 2)) * 0.5
+    tmp108 = np.copy(ints.tmp45)
     tmp108 += ints.tmp269 * 2
-    tmp62 = f.aa.ov.copy()
+    tmp62 = np.copy(f.aa.ov)
     tmp62 += ints.tmp12
     tmp62 += ints.tmp16
-    tmp80 = ints.tmp271.copy()
+    tmp80 = np.copy(ints.tmp271)
     tmp80 += ints.tmp277 * 0.5
-    tmp80 += ints.tmp46.transpose((0, 1, 3, 2)) * 0.5
-    tmp84 = tmp82.copy()
+    tmp80 += np.transpose(ints.tmp46, (0, 1, 3, 2)) * 0.5
+    tmp84 = np.copy(tmp82)
     del tmp82
-    tmp84 += tmp83.transpose((0, 2, 3, 1))
+    tmp84 += np.transpose(tmp83, (0, 2, 3, 1))
     del tmp83
-    tmp51 = tmp50.copy()
+    tmp51 = np.copy(tmp50)
     del tmp50
     tmp51 += tmp4
-    tmp39 = v.aaaa.ovvv.copy() * -1
-    tmp39 += v.aaaa.ovvv.transpose((0, 2, 3, 1))
+    tmp39 = np.copy(v.aaaa.ovvv) * -1
+    tmp39 += np.transpose(v.aaaa.ovvv, (0, 2, 3, 1))
     tmp165 = einsum(r2.bbbb, (0, 1, 2, 3), v.bbbb.ovov, (0, 4, 1, 3), (2, 4))
     tmp164 = einsum(v.aabb.ovov, (0, 1, 2, 3), r2.abab, (0, 2, 1, 4), (4, 3))
     tmp163 = einsum(v.aabb.ovvv, (0, 1, 2, 3), r1.aa, (0, 1), (2, 3))
@@ -5231,7 +5231,7 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp202 = einsum(tmp201, (0, 1, 2, 3), r1.bb, (4, 3), (0, 1, 4, 2)) * 2
     del tmp201
     tmp200 = einsum(v.bbbb.ooov, (0, 1, 2, 3), r2.bbbb, (4, 2, 5, 3), (4, 0, 1, 5))
-    tmp266 = f.bb.ov.copy()
+    tmp266 = np.copy(f.bb.ov)
     tmp266 += ints.tmp15
     tmp266 += ints.tmp18
     tmp263 = einsum(r1.bb, (0, 1), v.bbbb.ovov, (2, 1, 0, 3), (2, 3))
@@ -5239,17 +5239,17 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp259 = einsum(v.bbbb.ooov, (0, 1, 2, 3), r1.bb, (2, 3), (0, 1))
     tmp254 = einsum(r1.bb, (0, 1), ints.tmp14, (2, 1), (2, 0))
     tmp255 = einsum(ints.tmp98, (0, 1, 2, 3), r1.bb, (2, 3), (0, 1))
-    tmp5 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp5 += v.aaaa.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp9 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp9 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp5 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1)))
+    tmp5 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3)) * -1
+    tmp9 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp9 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
     tmp109 = einsum(tmp108, (0, 1, 2, 3), r1.aa, (4, 3), (4, 0, 1, 2))
     del tmp108
     tmp106 = einsum(v.aaaa.ooov, (0, 1, 2, 3), r2.aaaa, (4, 1, 5, 3), (4, 0, 2, 5))
     tmp107 = einsum(ints.tmp50, (0, 1, 2, 3), r2.abab, (4, 2, 5, 3), (0, 1, 4, 5))
     tmp105 = einsum(ints.tmp48, (0, 1, 2, 3), r2.aaaa, (4, 1, 5, 3), (0, 2, 4, 5))
     tmp125 = einsum(r1.aa, (0, 1), v.aaaa.ovov, (2, 1, 0, 3), (2, 3))
-    tmp128 = f.aa.ov.copy()
+    tmp128 = np.copy(f.aa.ov)
     tmp128 += ints.tmp12
     tmp128 += ints.tmp16
     tmp61 = einsum(r1.bb, (0, 1), ints.tmp50, (2, 3, 0, 1), (2, 3))
@@ -5277,87 +5277,87 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp40 = einsum(tmp39, (0, 1, 2, 3), r1.aa, (0, 1), (2, 3))
     del tmp39
     tmp38 = einsum(v.aabb.vvov, (0, 1, 2, 3), r1.bb, (2, 3), (0, 1))
-    tmp221 = ints.tmp551.copy()
+    tmp221 = np.copy(ints.tmp551)
     tmp221 += ints.tmp678
     tmp221 += ints.tmp682 * -1
-    tmp219 = ints.tmp79.copy() * 2
+    tmp219 = np.copy(ints.tmp79) * 2
     tmp219 += ints.tmp81
-    tmp219 += ints.tmp93.transpose((1, 0))
-    tmp243 = tmp164.copy() * 0.5
+    tmp219 += np.transpose(ints.tmp93, (1, 0))
+    tmp243 = np.copy(tmp164) * 0.5
     tmp243 += tmp165
     tmp237 = einsum(ints.tmp14, (0, 1), r2.bbbb, (2, 3, 4, 1), (0, 2, 3, 4))
-    tmp241 = tmp163.transpose((1, 0)).copy()
+    tmp241 = np.copy(np.transpose(tmp163, (1, 0)))
     tmp241 += tmp240 * -1
     del tmp240
-    tmp249 = tmp245.transpose((1, 0, 2, 3)).copy() * -1
+    tmp249 = np.copy(np.transpose(tmp245, (1, 0, 2, 3))) * -1
     del tmp245
-    tmp249 += tmp248.transpose((2, 1, 0, 3)) * -1
+    tmp249 += np.transpose(tmp248, (2, 1, 0, 3)) * -1
     del tmp248
-    tmp216 = ints.tmp539.copy()
-    tmp216 += ints.tmp553.transpose((2, 0, 1, 3))
-    tmp216 += ints.tmp555.transpose((2, 0, 1, 3))
-    tmp214 = f.bb.vv.copy()
-    tmp214 += ints.tmp92.transpose((1, 0))
-    tmp214 += ints.tmp94.transpose((1, 0))
-    tmp180 = ints.tmp536.copy()
+    tmp216 = np.copy(ints.tmp539)
+    tmp216 += np.transpose(ints.tmp553, (2, 0, 1, 3))
+    tmp216 += np.transpose(ints.tmp555, (2, 0, 1, 3))
+    tmp214 = np.copy(f.bb.vv)
+    tmp214 += np.transpose(ints.tmp92, (1, 0))
+    tmp214 += np.transpose(ints.tmp94, (1, 0))
+    tmp180 = np.copy(ints.tmp536)
     tmp180 += ints.tmp532 * 2
-    tmp176 = ints.tmp473.copy()
-    tmp176 += ints.tmp96.transpose((0, 1, 3, 2))
+    tmp176 = np.copy(ints.tmp473)
+    tmp176 += np.transpose(ints.tmp96, (0, 1, 3, 2))
     tmp176 += ints.tmp469 * 2
-    tmp174 = ints.tmp465.copy()
+    tmp174 = np.copy(ints.tmp465)
     tmp174 += ints.tmp97
     tmp174 += ints.tmp471 * 2
     tmp172 = einsum(v.bbbb.oovv, (0, 1, 2, 3), r1.bb, (4, 3), (4, 0, 1, 2))
-    tmp187 = tmp182.copy()
+    tmp187 = np.copy(tmp182)
     del tmp182
     tmp187 += tmp183 * 2
     del tmp183
-    tmp187 += tmp184.transpose((0, 2, 1, 3)) * 2
+    tmp187 += np.transpose(tmp184, (0, 2, 1, 3)) * 2
     del tmp184
     tmp187 += tmp186
     del tmp186
-    tmp178 = ints.tmp613.copy()
-    tmp178 += ints.tmp633.transpose((0, 2, 1, 3))
+    tmp178 = np.copy(ints.tmp613)
+    tmp178 += np.transpose(ints.tmp633, (0, 2, 1, 3))
     tmp178 += ints.tmp671
     tmp178 += ints.tmp98
     tmp178 += ints.tmp609 * 2
     tmp178 += ints.tmp651 * 2
-    tmp232 = tmp228.copy() * 0.5
+    tmp232 = np.copy(tmp228) * 0.5
     del tmp228
     tmp232 += tmp229 * 0.5
     del tmp229
     tmp232 += tmp28 * 0.5
     tmp232 += tmp29
-    tmp232 += tmp231.transpose((1, 0))
+    tmp232 += np.transpose(tmp231, (1, 0))
     del tmp231
-    tmp226 = f.bb.oo.copy()
-    tmp226 += ints.tmp102.transpose((1, 0)) * 2
-    tmp226 += ints.tmp104.transpose((1, 0))
-    tmp226 += ints.tmp107.transpose((1, 0))
-    tmp226 += ints.tmp108.transpose((1, 0))
-    tmp226 += ints.tmp67.transpose((1, 0))
-    tmp226 += ints.tmp68.transpose((1, 0))
+    tmp226 = np.copy(f.bb.oo)
+    tmp226 += np.transpose(ints.tmp102, (1, 0)) * 2
+    tmp226 += np.transpose(ints.tmp104, (1, 0))
+    tmp226 += np.transpose(ints.tmp107, (1, 0))
+    tmp226 += np.transpose(ints.tmp108, (1, 0))
+    tmp226 += np.transpose(ints.tmp67, (1, 0))
+    tmp226 += np.transpose(ints.tmp68, (1, 0))
     tmp226 += ints.tmp89
-    tmp234 = ints.tmp577.copy()
+    tmp234 = np.copy(ints.tmp577)
     tmp234 += ints.tmp626 * -1
     tmp224 = einsum(v.bbbb.ooov, (0, 1, 2, 3), r1.bb, (1, 3), (0, 2))
-    tmp196 = ints.tmp467.copy() * 2
+    tmp196 = np.copy(ints.tmp467) * 2
     tmp196 += ints.tmp95
-    tmp209 = ints.tmp566.copy()
-    tmp209 += ints.tmp611.transpose((0, 2, 1, 3)) * 2
-    tmp209 += ints.tmp620.transpose((0, 2, 1, 3))
-    tmp209 += ints.tmp631.transpose((0, 2, 1, 3))
-    tmp209 += ints.tmp653.transpose((0, 2, 1, 3)) * 2
-    tmp209 += ints.tmp655.transpose((0, 2, 1, 3))
-    tmp209 += ints.tmp675.transpose((0, 2, 1, 3))
-    tmp211 = ints.tmp534.copy()
+    tmp209 = np.copy(ints.tmp566)
+    tmp209 += np.transpose(ints.tmp611, (0, 2, 1, 3)) * 2
+    tmp209 += np.transpose(ints.tmp620, (0, 2, 1, 3))
+    tmp209 += np.transpose(ints.tmp631, (0, 2, 1, 3))
+    tmp209 += np.transpose(ints.tmp653, (0, 2, 1, 3)) * 2
+    tmp209 += np.transpose(ints.tmp655, (0, 2, 1, 3))
+    tmp209 += np.transpose(ints.tmp675, (0, 2, 1, 3))
+    tmp211 = np.copy(ints.tmp534)
     tmp211 += ints.tmp669 * 0.5
     tmp194 = einsum(v.bbbb.ovov, (0, 1, 2, 3), r1.bb, (4, 3), (4, 0, 2, 1))
-    tmp207 = tmp198.transpose((0, 2, 1, 3)).copy()
+    tmp207 = np.copy(np.transpose(tmp198, (0, 2, 1, 3)))
     del tmp198
     tmp207 += tmp199 * 2
     del tmp199
-    tmp207 += tmp200.transpose((0, 2, 1, 3)) * 2
+    tmp207 += np.transpose(tmp200, (0, 2, 1, 3)) * 2
     del tmp200
     tmp207 += tmp202
     del tmp202
@@ -5367,13 +5367,13 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp266
     tmp264 = einsum(t2.bbbb, (0, 1, 2, 3), tmp263, (4, 3), (0, 1, 4, 2))
     del tmp263
-    tmp252 = ints.tmp106.copy()
+    tmp252 = np.copy(ints.tmp106)
     tmp252 += ints.tmp66
-    tmp260 = tmp258.transpose((1, 0)).copy()
+    tmp260 = np.copy(np.transpose(tmp258, (1, 0)))
     del tmp258
-    tmp260 += tmp259.transpose((1, 0))
+    tmp260 += np.transpose(tmp259, (1, 0))
     del tmp259
-    tmp256 = tmp254.transpose((1, 0)).copy()
+    tmp256 = np.copy(np.transpose(tmp254, (1, 0)))
     del tmp254
     tmp256 += tmp255
     del tmp255
@@ -5383,56 +5383,56 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp9
     tmp143 = einsum(v.aabb.ovov, (0, 1, 2, 3), r2.abab, (4, 5, 1, 3), (4, 0, 5, 2))
     r2new.abab = einsum(tmp143, (0, 1, 2, 3), t2.abab, (1, 3, 4, 5), (0, 2, 4, 5))
-    tmp1 = ints.tmp50.copy()
+    tmp1 = np.copy(ints.tmp50)
     tmp1 += v.aabb.ooov
     r1new.aa = einsum(r2.abab, (0, 1, 2, 3), tmp1, (4, 0, 1, 3), (4, 2)) * -1
-    tmp24 = ints.tmp100.copy()
-    tmp24 += v.aabb.ovoo.transpose((0, 2, 3, 1))
+    tmp24 = np.copy(ints.tmp100)
+    tmp24 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
     r1new.bb = einsum(tmp24, (0, 1, 2, 3), r2.abab, (0, 2, 3, 4), (1, 4)) * -1
-    tmp3 = f.bb.ov.copy()
+    tmp3 = np.copy(f.bb.ov)
     tmp3 += ints.tmp15
     tmp3 += ints.tmp18
     tmp3 += ints.tmp14 * -1
     r1new.bb += einsum(r2.bbbb, (0, 1, 2, 3), tmp3, (1, 3), (0, 2)) * 2
     r1new.aa += einsum(r2.abab, (0, 1, 2, 3), tmp3, (1, 3), (0, 2))
-    tmp30 = ints.tmp98.copy() * -1
-    tmp30 += ints.tmp98.transpose((0, 2, 1, 3))
+    tmp30 = np.copy(ints.tmp98) * -1
+    tmp30 += np.transpose(ints.tmp98, (0, 2, 1, 3))
     tmp30 += v.bbbb.ooov
-    tmp30 += v.bbbb.ooov.transpose((0, 2, 1, 3)) * -1
-    tmp17 = ints.tmp48.copy()
-    tmp17 += ints.tmp48.transpose((0, 2, 1, 3)) * -1
+    tmp30 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3)) * -1
+    tmp17 = np.copy(ints.tmp48)
+    tmp17 += np.transpose(ints.tmp48, (0, 2, 1, 3)) * -1
     tmp17 += v.aaaa.ooov * -1
-    tmp17 += v.aaaa.ooov.transpose((0, 2, 1, 3))
-    tmp2 = f.aa.ov.copy()
+    tmp17 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3))
+    tmp2 = np.copy(f.aa.ov)
     tmp2 += ints.tmp12
     tmp2 += ints.tmp16
     tmp2 += ints.tmp10 * -1
     r1new.bb += einsum(r2.abab, (0, 1, 2, 3), tmp2, (0, 2), (1, 3))
     r1new.aa += einsum(r2.aaaa, (0, 1, 2, 3), tmp2, (1, 3), (0, 2)) * 2
-    tmp132 = ints.tmp23.copy() * 2
+    tmp132 = np.copy(ints.tmp23) * 2
     tmp132 += ints.tmp25
-    tmp132 += ints.tmp43.transpose((1, 0))
-    tmp134 = ints.tmp302.copy()
+    tmp132 += np.transpose(ints.tmp43, (1, 0))
+    tmp134 = np.copy(ints.tmp302)
     tmp134 += ints.tmp306 * -1
-    tmp99 = ints.tmp275.copy()
+    tmp99 = np.copy(ints.tmp275)
     tmp99 += ints.tmp47
     tmp99 += ints.tmp279 * 2
-    tmp103 = ints.tmp120.copy()
+    tmp103 = np.copy(ints.tmp120)
     tmp103 += ints.tmp116 * 2
     tmp94 = einsum(v.aaaa.oovv, (0, 1, 2, 3), r1.aa, (4, 3), (4, 0, 1, 2))
-    tmp97 = ints.tmp277.copy()
-    tmp97 += ints.tmp46.transpose((0, 1, 3, 2))
+    tmp97 = np.copy(ints.tmp277)
+    tmp97 += np.transpose(ints.tmp46, (0, 1, 3, 2))
     tmp97 += ints.tmp271 * 2
-    tmp110 = tmp105.copy() * 2
+    tmp110 = np.copy(tmp105) * 2
     del tmp105
-    tmp110 += tmp106.transpose((0, 2, 1, 3)) * 2
+    tmp110 += np.transpose(tmp106, (0, 2, 1, 3)) * 2
     del tmp106
     tmp110 += tmp107
     del tmp107
-    tmp110 += tmp109.transpose((1, 2, 0, 3))
+    tmp110 += np.transpose(tmp109, (1, 2, 0, 3))
     del tmp109
-    tmp101 = ints.tmp211.copy()
-    tmp101 += ints.tmp239.transpose((0, 2, 1, 3))
+    tmp101 = np.copy(ints.tmp211)
+    tmp101 += np.transpose(ints.tmp239, (0, 2, 1, 3))
     tmp101 += ints.tmp295
     tmp101 += ints.tmp48
     tmp101 += ints.tmp207 * 2
@@ -5441,7 +5441,7 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp125
     tmp129 = einsum(r2.aaaa, (0, 1, 2, 3), tmp128, (4, 3), (0, 1, 4, 2)) * -1
     del tmp128
-    tmp64 = tmp60.copy()
+    tmp64 = np.copy(tmp60)
     del tmp60
     tmp64 += tmp61
     del tmp61
@@ -5449,62 +5449,62 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp64 += tmp16
     tmp64 += tmp63
     del tmp63
-    tmp66 = ints.tmp169.copy()
+    tmp66 = np.copy(ints.tmp169)
     tmp66 += ints.tmp230 * -1
-    tmp58 = f.aa.oo.copy()
+    tmp58 = np.copy(f.aa.oo)
     tmp58 += ints.tmp39
-    tmp58 += ints.tmp52.transpose((1, 0)) * 2
-    tmp58 += ints.tmp54.transpose((1, 0))
-    tmp58 += ints.tmp57.transpose((1, 0))
-    tmp58 += ints.tmp58.transpose((1, 0))
-    tmp58 += ints.tmp5.transpose((1, 0))
-    tmp58 += ints.tmp6.transpose((1, 0))
+    tmp58 += np.transpose(ints.tmp52, (1, 0)) * 2
+    tmp58 += np.transpose(ints.tmp54, (1, 0))
+    tmp58 += np.transpose(ints.tmp57, (1, 0))
+    tmp58 += np.transpose(ints.tmp58, (1, 0))
+    tmp58 += np.transpose(ints.tmp5, (1, 0))
+    tmp58 += np.transpose(ints.tmp6, (1, 0))
     tmp56 = einsum(r1.aa, (0, 1), v.aaaa.ooov, (2, 0, 3, 1), (2, 3))
-    tmp113 = ints.tmp4.copy()
+    tmp113 = np.copy(ints.tmp4)
     tmp113 += ints.tmp56
-    tmp121 = tmp119.transpose((1, 0)).copy()
+    tmp121 = np.copy(np.transpose(tmp119, (1, 0)))
     del tmp119
-    tmp121 += tmp120.transpose((1, 0))
+    tmp121 += np.transpose(tmp120, (1, 0))
     del tmp120
-    tmp117 = tmp115.transpose((1, 0)).copy()
+    tmp117 = np.copy(np.transpose(tmp115, (1, 0)))
     del tmp115
     tmp117 += tmp116
     del tmp116
-    tmp88 = ints.tmp156.copy()
-    tmp88 += ints.tmp209.transpose((0, 2, 1, 3)) * 2
-    tmp88 += ints.tmp222.transpose((0, 2, 1, 3))
-    tmp88 += ints.tmp237.transpose((0, 2, 1, 3))
-    tmp88 += ints.tmp265.transpose((0, 2, 1, 3)) * 2
-    tmp88 += ints.tmp267.transpose((0, 2, 1, 3))
-    tmp88 += ints.tmp299.transpose((0, 2, 1, 3))
-    tmp75 = ints.tmp269.copy() * 2
+    tmp88 = np.copy(ints.tmp156)
+    tmp88 += np.transpose(ints.tmp209, (0, 2, 1, 3)) * 2
+    tmp88 += np.transpose(ints.tmp222, (0, 2, 1, 3))
+    tmp88 += np.transpose(ints.tmp237, (0, 2, 1, 3))
+    tmp88 += np.transpose(ints.tmp265, (0, 2, 1, 3)) * 2
+    tmp88 += np.transpose(ints.tmp267, (0, 2, 1, 3))
+    tmp88 += np.transpose(ints.tmp299, (0, 2, 1, 3))
+    tmp75 = np.copy(ints.tmp269) * 2
     tmp75 += ints.tmp45
-    tmp86 = tmp77.copy() * 2
+    tmp86 = np.copy(tmp77) * 2
     del tmp77
-    tmp86 += tmp78.transpose((0, 2, 1, 3)) * 2
+    tmp86 += np.transpose(tmp78, (0, 2, 1, 3)) * 2
     del tmp78
-    tmp86 += tmp79.transpose((0, 2, 1, 3))
+    tmp86 += np.transpose(tmp79, (0, 2, 1, 3))
     del tmp79
-    tmp86 += tmp81.transpose((1, 2, 0, 3))
+    tmp86 += np.transpose(tmp81, (1, 2, 0, 3))
     del tmp81
     tmp86 += tmp85
     del tmp85
-    tmp90 = ints.tmp118.copy()
+    tmp90 = np.copy(ints.tmp118)
     tmp90 += ints.tmp293 * 0.5
     tmp72 = einsum(r1.aa, (0, 1), v.aaaa.ovov, (2, 3, 4, 1), (0, 2, 4, 3))
-    tmp45 = tmp43.copy() * 2
+    tmp45 = np.copy(tmp43) * 2
     tmp45 += tmp44
     tmp36 = einsum(r2.aaaa, (0, 1, 2, 3), ints.tmp10, (4, 3), (4, 0, 1, 2))
-    tmp53 = tmp49.transpose((1, 0, 2, 3)).copy() * -1
+    tmp53 = np.copy(np.transpose(tmp49, (1, 0, 2, 3))) * -1
     del tmp49
-    tmp53 += tmp52.transpose((1, 0, 2, 3)) * -1
+    tmp53 += np.transpose(tmp52, (1, 0, 2, 3)) * -1
     del tmp52
-    tmp41 = tmp38.transpose((1, 0)).copy()
-    tmp41 += tmp40.transpose((1, 0)) * -1
+    tmp41 = np.copy(np.transpose(tmp38, (1, 0)))
+    tmp41 += np.transpose(tmp40, (1, 0)) * -1
     del tmp40
-    tmp47 = ints.tmp123.copy()
-    tmp47 += ints.tmp142.transpose((2, 0, 1, 3))
-    tmp47 += ints.tmp144.transpose((2, 0, 1, 3))
+    tmp47 = np.copy(ints.tmp123)
+    tmp47 += np.transpose(ints.tmp142, (2, 0, 1, 3))
+    tmp47 += np.transpose(ints.tmp144, (2, 0, 1, 3))
     tmp222 = einsum(tmp221, (0, 1, 2, 3), r1.bb, (2, 4), (0, 1, 3, 4)) * 2
     del tmp221
     tmp220 = einsum(tmp219, (0, 1), r2.bbbb, (2, 3, 4, 1), (2, 3, 0, 4)) * -2
@@ -5567,58 +5567,58 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp260
     tmp257 = einsum(tmp256, (0, 1), t2.bbbb, (2, 1, 3, 4), (0, 2, 3, 4)) * -1
     del tmp256
-    tmp7 = tmp4.copy()
+    tmp7 = np.copy(tmp4)
     del tmp4
     tmp7 += tmp6 * -1
     del tmp6
     r1new.bb += einsum(tmp7, (0, 1), t2.abab, (0, 2, 1, 3), (2, 3))
     r1new.aa += einsum(tmp7, (0, 1), t2.aaaa, (2, 0, 3, 1), (2, 3)) * 2
-    tmp157 = ints.tmp465.copy()
+    tmp157 = np.copy(ints.tmp465)
     tmp157 += ints.tmp471 * 2
     tmp157 += ints.tmp97
-    tmp157 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp157 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp157 += ints.tmp463 * -1
-    tmp148 = ints.tmp515.copy()
+    tmp148 = np.copy(ints.tmp515)
     tmp148 += v.aabb.oovv
     tmp148 += ints.tmp491 * -1
     r2new.abab += einsum(r2.abab, (0, 1, 2, 3), tmp148, (4, 0, 5, 3), (4, 1, 2, 5)) * -1
-    tmp11 = tmp8.copy()
+    tmp11 = np.copy(tmp8)
     del tmp8
     tmp11 += tmp10 * -1
     del tmp10
     r1new.bb += einsum(tmp11, (0, 1), t2.bbbb, (2, 0, 3, 1), (2, 3)) * 2
     r1new.aa += einsum(t2.abab, (0, 1, 2, 3), tmp11, (1, 3), (0, 2))
-    tmp154 = ints.tmp275.copy()
+    tmp154 = np.copy(ints.tmp275)
     tmp154 += ints.tmp279 * 2
     tmp154 += ints.tmp47
-    tmp154 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp154 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp154 += ints.tmp273 * -1
-    tmp153 = ints.tmp98.copy()
-    tmp153 += ints.tmp98.transpose((0, 2, 1, 3)) * -1
+    tmp153 = np.copy(ints.tmp98)
+    tmp153 += np.transpose(ints.tmp98, (0, 2, 1, 3)) * -1
     tmp153 += v.bbbb.ooov * -1
-    tmp153 += v.bbbb.ooov.transpose((0, 2, 1, 3))
-    tmp155 = tmp143.transpose((1, 0, 2, 3)).copy()
+    tmp153 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3))
+    tmp155 = np.copy(np.transpose(tmp143, (1, 0, 2, 3)))
     del tmp143
     tmp155 += einsum(r1.aa, (0, 1), tmp24, (2, 3, 4, 1), (2, 0, 3, 4))
     tmp155 += einsum(r1.bb, (0, 1), tmp1, (2, 3, 4, 1), (3, 2, 0, 4))
-    tmp149 = ints.tmp498.copy()
-    tmp149 += v.aabb.vvoo.transpose((2, 3, 0, 1))
+    tmp149 = np.copy(ints.tmp498)
+    tmp149 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1))
     tmp149 += ints.tmp495 * -1
     r2new.abab += einsum(r2.abab, (0, 1, 2, 3), tmp149, (4, 1, 5, 2), (0, 4, 5, 3)) * -1
     tmp33 = einsum(r1.bb, (0, 1), tmp3, (2, 1), (0, 2))
     tmp31 = einsum(r1.bb, (0, 1), tmp30, (2, 0, 3, 1), (2, 3))
     del tmp30
     tmp32 = einsum(tmp24, (0, 1, 2, 3), r1.aa, (0, 3), (1, 2))
-    tmp166 = v.bbbb.ovvv.copy() * -1
-    tmp166 += v.bbbb.ovvv.transpose((0, 2, 1, 3))
+    tmp166 = np.copy(v.bbbb.ovvv) * -1
+    tmp166 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3))
     tmp18 = einsum(r1.aa, (0, 1), tmp17, (2, 3, 0, 1), (2, 3))
     tmp19 = einsum(r1.bb, (0, 1), tmp1, (2, 3, 0, 1), (2, 3))
     tmp20 = einsum(tmp2, (0, 1), r1.aa, (2, 1), (2, 0))
-    tmp161 = v.aaaa.ovvv.copy() * -1
-    tmp161 += v.aaaa.ovvv.transpose((0, 2, 1, 3))
-    tmp137 = f.aa.vv.copy()
-    tmp137 += ints.tmp42.transpose((1, 0))
-    tmp137 += ints.tmp44.transpose((1, 0))
+    tmp161 = np.copy(v.aaaa.ovvv) * -1
+    tmp161 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3))
+    tmp137 = np.copy(f.aa.vv)
+    tmp137 += np.transpose(ints.tmp42, (1, 0))
+    tmp137 += np.transpose(ints.tmp44, (1, 0))
     tmp133 = einsum(r2.aaaa, (0, 1, 2, 3), tmp132, (4, 3), (0, 1, 2, 4)) * -2
     del tmp132
     tmp135 = einsum(r1.aa, (0, 1), tmp134, (2, 3, 0, 4), (2, 3, 1, 4)) * 2
@@ -5680,33 +5680,33 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp41
     tmp48 = einsum(r1.aa, (0, 1), tmp47, (0, 2, 3, 4), (2, 3, 1, 4)) * 2
     del tmp47
-    tmp223 = tmp220.transpose((1, 0, 2, 3)).copy() * -1
+    tmp223 = np.copy(np.transpose(tmp220, (1, 0, 2, 3))) * -1
     del tmp220
     tmp223 += tmp222 * -1
     del tmp222
-    r2new.bbbb = tmp223.transpose((1, 0, 3, 2)).copy() * -1
-    r2new.bbbb += tmp223.transpose((1, 0, 2, 3))
+    r2new.bbbb = np.copy(np.transpose(tmp223, (1, 0, 3, 2))) * -1
+    r2new.bbbb += np.transpose(tmp223, (1, 0, 2, 3))
     del tmp223
     tmp271 = einsum(v.bbbb.ovov, (0, 1, 2, 3), r2.bbbb, (4, 5, 3, 1), (4, 5, 0, 2)) * -1
-    tmp251 = tmp238.copy() * 2
+    tmp251 = np.copy(tmp238) * 2
     del tmp238
-    tmp251 += tmp242.transpose((1, 0, 3, 2))
+    tmp251 += np.transpose(tmp242, (1, 0, 3, 2))
     del tmp242
-    tmp251 += tmp244.transpose((1, 0, 2, 3))
+    tmp251 += np.transpose(tmp244, (1, 0, 2, 3))
     del tmp244
-    tmp251 += tmp250.transpose((1, 0, 3, 2))
+    tmp251 += np.transpose(tmp250, (1, 0, 3, 2))
     del tmp250
-    r2new.bbbb += tmp251.transpose((0, 1, 3, 2)) * -1
+    r2new.bbbb += np.transpose(tmp251, (0, 1, 3, 2)) * -1
     r2new.bbbb += tmp251
     del tmp251
-    tmp218 = tmp215.transpose((1, 0, 2, 3)).copy()
+    tmp218 = np.copy(np.transpose(tmp215, (1, 0, 2, 3)))
     del tmp215
     tmp218 += tmp217
     del tmp217
-    r2new.bbbb += tmp218.transpose((1, 0, 3, 2)) * -2
-    r2new.bbbb += tmp218.transpose((1, 0, 2, 3)) * 2
+    r2new.bbbb += np.transpose(tmp218, (1, 0, 3, 2)) * -2
+    r2new.bbbb += np.transpose(tmp218, (1, 0, 2, 3)) * 2
     del tmp218
-    tmp189 = tmp170.copy()
+    tmp189 = np.copy(tmp170)
     del tmp170
     tmp189 += tmp171 * 2
     del tmp171
@@ -5722,27 +5722,27 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp181
     tmp189 += tmp188
     del tmp188
-    r2new.bbbb += tmp189.transpose((1, 0, 3, 2))
-    r2new.bbbb += tmp189.transpose((1, 0, 2, 3)) * -1
-    r2new.bbbb += tmp189.transpose((0, 1, 3, 2)) * -1
+    r2new.bbbb += np.transpose(tmp189, (1, 0, 3, 2))
+    r2new.bbbb += np.transpose(tmp189, (1, 0, 2, 3)) * -1
+    r2new.bbbb += np.transpose(tmp189, (0, 1, 3, 2)) * -1
     r2new.bbbb += tmp189
     del tmp189
-    tmp236 = tmp225.transpose((0, 1, 3, 2)).copy() * -2
+    tmp236 = np.copy(np.transpose(tmp225, (0, 1, 3, 2))) * -2
     del tmp225
-    tmp236 += tmp227.transpose((0, 1, 3, 2))
+    tmp236 += np.transpose(tmp227, (0, 1, 3, 2))
     del tmp227
-    tmp236 += tmp233.transpose((0, 1, 3, 2))
+    tmp236 += np.transpose(tmp233, (0, 1, 3, 2))
     del tmp233
-    tmp236 += tmp235.transpose((0, 1, 3, 2)) * -1
+    tmp236 += np.transpose(tmp235, (0, 1, 3, 2)) * -1
     del tmp235
-    r2new.bbbb += tmp236.transpose((1, 0, 2, 3)) * -1
+    r2new.bbbb += np.transpose(tmp236, (1, 0, 2, 3)) * -1
     r2new.bbbb += tmp236
     del tmp236
-    tmp272 = t2.bbbb.copy()
+    tmp272 = np.copy(t2.bbbb)
     tmp272 += einsum(t1.bb, (0, 1), t1.bb, (2, 3), (2, 0, 3, 1))
     r2new.bbbb += einsum(tmp271, (0, 1, 2, 3), tmp272, (2, 3, 4, 5), (1, 0, 5, 4)) * 2
     del tmp271, tmp272
-    tmp169 = ints.tmp331.copy()
+    tmp169 = np.copy(ints.tmp331)
     tmp169 += ints.tmp337 * 2
     tmp169 += ints.tmp338
     tmp169 += ints.tmp344
@@ -5780,14 +5780,14 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r2new.bbbb += einsum(r1.bb, (0, 1), tmp169, (2, 3), (2, 0, 3, 1)) * -1
     r2new.abab += einsum(tmp169, (0, 1), r1.aa, (2, 3), (2, 0, 3, 1)) * -1
     del tmp169
-    tmp270 = ints.tmp673.copy()
+    tmp270 = np.copy(ints.tmp673)
     tmp270 += ints.tmp680
-    tmp270 += v.bbbb.oooo.transpose((0, 2, 1, 3))
+    tmp270 += np.transpose(v.bbbb.oooo, (0, 2, 1, 3))
     tmp270 += ints.tmp622 * -1
-    tmp270 += ints.tmp622.transpose((1, 0, 2, 3))
+    tmp270 += np.transpose(ints.tmp622, (1, 0, 2, 3))
     r2new.bbbb += einsum(r2.bbbb, (0, 1, 2, 3), tmp270, (4, 5, 0, 1), (4, 5, 2, 3)) * 2
     del tmp270
-    tmp213 = tmp190.copy()
+    tmp213 = np.copy(tmp190)
     del tmp190
     tmp213 += tmp191
     del tmp191
@@ -5805,46 +5805,46 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp210
     tmp213 += tmp212
     del tmp212
-    r2new.bbbb += tmp213.transpose((1, 0, 3, 2)) * -1
-    r2new.bbbb += tmp213.transpose((1, 0, 2, 3))
-    r2new.bbbb += tmp213.transpose((0, 1, 3, 2))
+    r2new.bbbb += np.transpose(tmp213, (1, 0, 3, 2)) * -1
+    r2new.bbbb += np.transpose(tmp213, (1, 0, 2, 3))
+    r2new.bbbb += np.transpose(tmp213, (0, 1, 3, 2))
     r2new.bbbb += tmp213 * -1
     del tmp213
-    tmp269 = tmp265.copy()
+    tmp269 = np.copy(tmp265)
     del tmp265
-    tmp269 += tmp268.transpose((1, 0, 2, 3)) * -1
+    tmp269 += np.transpose(tmp268, (1, 0, 2, 3)) * -1
     del tmp268
-    r2new.bbbb += tmp269.transpose((0, 1, 3, 2)) * 2
+    r2new.bbbb += np.transpose(tmp269, (0, 1, 3, 2)) * 2
     r2new.bbbb += tmp269 * -2
     del tmp269
-    tmp262 = tmp253.transpose((0, 1, 3, 2)).copy()
+    tmp262 = np.copy(np.transpose(tmp253, (0, 1, 3, 2)))
     del tmp253
-    tmp262 += tmp257.transpose((0, 1, 3, 2))
+    tmp262 += np.transpose(tmp257, (0, 1, 3, 2))
     del tmp257
-    tmp262 += tmp261.transpose((1, 0, 3, 2))
+    tmp262 += np.transpose(tmp261, (1, 0, 3, 2))
     del tmp261
-    r2new.bbbb += tmp262.transpose((1, 0, 2, 3)) * 2
+    r2new.bbbb += np.transpose(tmp262, (1, 0, 2, 3)) * 2
     r2new.bbbb += tmp262 * -2
     del tmp262
-    tmp27 = ints.tmp79.transpose((1, 0)).copy() * 2
-    tmp27 += ints.tmp81.transpose((1, 0))
+    tmp27 = np.copy(np.transpose(ints.tmp79, (1, 0))) * 2
+    tmp27 += np.transpose(ints.tmp81, (1, 0))
     tmp27 += ints.tmp93
     tmp27 += f.bb.vv * -1
-    tmp27 += ints.tmp92.transpose((1, 0)) * -1
-    tmp27 += ints.tmp94.transpose((1, 0)) * -1
+    tmp27 += np.transpose(ints.tmp92, (1, 0)) * -1
+    tmp27 += np.transpose(ints.tmp94, (1, 0)) * -1
     r2new.abab += einsum(r2.abab, (0, 1, 2, 3), tmp27, (3, 4), (0, 1, 2, 4)) * -1
     r1new.bb += einsum(tmp27, (0, 1), r1.bb, (2, 0), (2, 1)) * -1
     del tmp27
-    tmp168 = f.bb.oo.copy()
-    tmp168 += ints.tmp102.transpose((1, 0)) * 2
-    tmp168 += ints.tmp104.transpose((1, 0))
-    tmp168 += ints.tmp107.transpose((1, 0))
-    tmp168 += ints.tmp108.transpose((1, 0))
-    tmp168 += ints.tmp67.transpose((1, 0))
-    tmp168 += ints.tmp68.transpose((1, 0))
+    tmp168 = np.copy(f.bb.oo)
+    tmp168 += np.transpose(ints.tmp102, (1, 0)) * 2
+    tmp168 += np.transpose(ints.tmp104, (1, 0))
+    tmp168 += np.transpose(ints.tmp107, (1, 0))
+    tmp168 += np.transpose(ints.tmp108, (1, 0))
+    tmp168 += np.transpose(ints.tmp67, (1, 0))
+    tmp168 += np.transpose(ints.tmp68, (1, 0))
     tmp168 += ints.tmp89
-    tmp168 += ints.tmp106.transpose((1, 0)) * -1
-    tmp168 += ints.tmp66.transpose((1, 0)) * -1
+    tmp168 += np.transpose(ints.tmp106, (1, 0)) * -1
+    tmp168 += np.transpose(ints.tmp66, (1, 0)) * -1
     r2new.abab += einsum(tmp168, (0, 1), r2.abab, (2, 0, 3, 4), (2, 1, 3, 4)) * -1
     del tmp168
     tmp158 = einsum(r2.abab, (0, 1, 2, 3), v.aabb.ovvv, (4, 2, 5, 3), (4, 0, 1, 5)) * 0.5
@@ -5862,10 +5862,10 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp148
     r2new.abab += einsum(t1.aa, (0, 1), tmp158, (0, 2, 3, 4), (2, 3, 1, 4)) * -2
     del tmp158
-    tmp145 = ints.tmp469.copy() * 2
+    tmp145 = np.copy(ints.tmp469) * 2
     tmp145 += ints.tmp473
-    tmp145 += ints.tmp96.transpose((0, 1, 3, 2))
-    tmp145 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp145 += np.transpose(ints.tmp96, (0, 1, 3, 2))
+    tmp145 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp145 += ints.tmp467 * -2
     tmp145 += ints.tmp95 * -1
     tmp145 += v.bbbb.oovv * -1
@@ -5890,7 +5890,7 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp155
     r2new.abab += einsum(tmp156, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 3, 4)) * -1
     del tmp156
-    tmp142 = ints.tmp153.copy()
+    tmp142 = np.copy(ints.tmp153)
     tmp142 += ints.tmp167 * 2
     tmp142 += ints.tmp168
     tmp142 += ints.tmp180
@@ -5928,127 +5928,127 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r2new.aaaa += einsum(tmp142, (0, 1), r1.aa, (2, 3), (2, 0, 3, 1)) * -1
     r2new.aaaa += einsum(r1.aa, (0, 1), tmp142, (2, 3), (2, 0, 3, 1)) * -1
     del tmp142
-    tmp152 = ints.tmp327.copy()
+    tmp152 = np.copy(ints.tmp327)
     tmp152 += ints.tmp329 * 2
     tmp152 += ints.tmp351
     tmp152 += ints.tmp437
     tmp152 += ints.tmp497
     tmp152 += v.aabb.ovvv
-    tmp152 += ints.tmp328.transpose((0, 1, 3, 2)) * -1
+    tmp152 += np.transpose(ints.tmp328, (0, 1, 3, 2)) * -1
     tmp152 += ints.tmp525 * -1
     r2new.abab += einsum(tmp152, (0, 1, 2, 3), r1.bb, (4, 3), (0, 4, 1, 2))
     del tmp152
-    tmp146 = ints.tmp465.copy() * 0.5
+    tmp146 = np.copy(ints.tmp465) * 0.5
     tmp146 += ints.tmp471
     tmp146 += ints.tmp97 * 0.5
-    tmp146 += v.aabb.ovov.transpose((0, 2, 1, 3)) * 0.5
+    tmp146 += np.transpose(v.aabb.ovov, (0, 2, 1, 3)) * 0.5
     tmp146 += ints.tmp463 * -0.5
     r2new.abab += einsum(r2.aaaa, (0, 1, 2, 3), tmp146, (1, 4, 3, 5), (0, 4, 2, 5)) * 4
     del tmp146
-    tmp14 = ints.tmp23.transpose((1, 0)).copy() * 2
-    tmp14 += ints.tmp25.transpose((1, 0))
+    tmp14 = np.copy(np.transpose(ints.tmp23, (1, 0))) * 2
+    tmp14 += np.transpose(ints.tmp25, (1, 0))
     tmp14 += ints.tmp43
     tmp14 += f.aa.vv * -1
-    tmp14 += ints.tmp42.transpose((1, 0)) * -1
-    tmp14 += ints.tmp44.transpose((1, 0)) * -1
+    tmp14 += np.transpose(ints.tmp42, (1, 0)) * -1
+    tmp14 += np.transpose(ints.tmp44, (1, 0)) * -1
     r2new.abab += einsum(r2.abab, (0, 1, 2, 3), tmp14, (2, 4), (0, 1, 4, 3)) * -1
     r1new.aa += einsum(tmp14, (0, 1), r1.aa, (2, 0), (2, 1)) * -1
     del tmp14
-    tmp34 = tmp28.transpose((1, 0)).copy()
+    tmp34 = np.copy(np.transpose(tmp28, (1, 0)))
     del tmp28
-    tmp34 += tmp29.transpose((1, 0)) * 2
+    tmp34 += np.transpose(tmp29, (1, 0)) * 2
     del tmp29
-    tmp34 += tmp31.transpose((1, 0)) * -1
+    tmp34 += np.transpose(tmp31, (1, 0)) * -1
     del tmp31
-    tmp34 += tmp32.transpose((1, 0))
+    tmp34 += np.transpose(tmp32, (1, 0))
     del tmp32
-    tmp34 += tmp33.transpose((1, 0))
+    tmp34 += np.transpose(tmp33, (1, 0))
     del tmp33
     r2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp34, (1, 4), (0, 4, 2, 3)) * -1
     r1new.bb += einsum(t1.bb, (0, 1), tmp34, (0, 2), (2, 1)) * -1
     del tmp34
-    tmp167 = tmp163.transpose((1, 0)).copy() * -0.5
+    tmp167 = np.copy(np.transpose(tmp163, (1, 0))) * -0.5
     del tmp163
-    tmp167 += tmp164.transpose((1, 0)) * 0.5
+    tmp167 += np.transpose(tmp164, (1, 0)) * 0.5
     del tmp164
-    tmp167 += tmp165.transpose((1, 0))
+    tmp167 += np.transpose(tmp165, (1, 0))
     del tmp165
     tmp167 += einsum(tmp166, (0, 1, 2, 3), r1.bb, (0, 2), (1, 3)) * -0.5
     del tmp166
     r2new.abab += einsum(tmp167, (0, 1), t2.abab, (2, 3, 4, 0), (2, 3, 4, 1)) * -2
     del tmp167
-    tmp144 = ints.tmp271.copy() * 2
+    tmp144 = np.copy(ints.tmp271) * 2
     tmp144 += ints.tmp277
-    tmp144 += ints.tmp46.transpose((0, 1, 3, 2))
-    tmp144 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp144 += np.transpose(ints.tmp46, (0, 1, 3, 2))
+    tmp144 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp144 += ints.tmp269 * -2
     tmp144 += ints.tmp45 * -1
     tmp144 += v.aaaa.oovv * -1
     r2new.abab += einsum(r2.abab, (0, 1, 2, 3), tmp144, (4, 0, 5, 2), (4, 1, 5, 3))
     del tmp144
-    tmp150 = ints.tmp412.copy()
+    tmp150 = np.copy(ints.tmp412)
     tmp150 += ints.tmp433
     tmp150 += ints.tmp500
     tmp150 += ints.tmp509
     tmp150 += v.aabb.oooo
     r2new.abab += einsum(tmp150, (0, 1, 2, 3), r2.abab, (1, 3, 4, 5), (0, 2, 4, 5))
     del tmp150
-    tmp21 = tmp15.transpose((1, 0)).copy() * 2
+    tmp21 = np.copy(np.transpose(tmp15, (1, 0))) * 2
     del tmp15
-    tmp21 += tmp16.transpose((1, 0))
+    tmp21 += np.transpose(tmp16, (1, 0))
     del tmp16
-    tmp21 += tmp18.transpose((1, 0)) * -1
+    tmp21 += np.transpose(tmp18, (1, 0)) * -1
     del tmp18
-    tmp21 += tmp19.transpose((1, 0))
+    tmp21 += np.transpose(tmp19, (1, 0))
     del tmp19
-    tmp21 += tmp20.transpose((1, 0))
+    tmp21 += np.transpose(tmp20, (1, 0))
     del tmp20
     r2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp21, (0, 4), (4, 1, 2, 3)) * -1
     r1new.aa += einsum(t1.aa, (0, 1), tmp21, (0, 2), (2, 1)) * -1
     del tmp21
-    tmp147 = ints.tmp275.copy() * 0.5
+    tmp147 = np.copy(ints.tmp275) * 0.5
     tmp147 += ints.tmp279
     tmp147 += ints.tmp47 * 0.5
-    tmp147 += v.aabb.ovov.transpose((0, 2, 1, 3)) * 0.5
+    tmp147 += np.transpose(v.aabb.ovov, (0, 2, 1, 3)) * 0.5
     tmp147 += ints.tmp273 * -0.5
     r2new.abab += einsum(tmp147, (0, 1, 2, 3), r2.bbbb, (4, 1, 5, 3), (0, 4, 2, 5)) * 4
     del tmp147
-    tmp160 = ints.tmp308.copy()
-    tmp160 += ints.tmp320.transpose((1, 0, 2, 3))
-    tmp160 += ints.tmp321.transpose((1, 0, 2, 3))
-    tmp160 += ints.tmp394.transpose((1, 0, 2, 3))
-    tmp160 += ints.tmp396.transpose((1, 0, 2, 3)) * 2
-    tmp160 += ints.tmp460.transpose((1, 0, 2, 3))
-    tmp160 += ints.tmp461.transpose((1, 0, 2, 3)) * 2
-    tmp160 += ints.tmp50.transpose((1, 0, 2, 3))
-    tmp160 += ints.tmp518.transpose((1, 0, 2, 3))
-    tmp160 += ints.tmp521.transpose((1, 0, 2, 3))
-    tmp160 += ints.tmp526.transpose((1, 0, 2, 3))
+    tmp160 = np.copy(ints.tmp308)
+    tmp160 += np.transpose(ints.tmp320, (1, 0, 2, 3))
+    tmp160 += np.transpose(ints.tmp321, (1, 0, 2, 3))
+    tmp160 += np.transpose(ints.tmp394, (1, 0, 2, 3))
+    tmp160 += np.transpose(ints.tmp396, (1, 0, 2, 3)) * 2
+    tmp160 += np.transpose(ints.tmp460, (1, 0, 2, 3))
+    tmp160 += np.transpose(ints.tmp461, (1, 0, 2, 3)) * 2
+    tmp160 += np.transpose(ints.tmp50, (1, 0, 2, 3))
+    tmp160 += np.transpose(ints.tmp518, (1, 0, 2, 3))
+    tmp160 += np.transpose(ints.tmp521, (1, 0, 2, 3))
+    tmp160 += np.transpose(ints.tmp526, (1, 0, 2, 3))
     tmp160 += v.aabb.ooov
-    tmp160 += ints.tmp319.transpose((1, 0, 2, 3)) * -1
-    tmp160 += ints.tmp349.transpose((1, 0, 2, 3)) * -1
-    tmp160 += ints.tmp395.transpose((1, 0, 2, 3)) * -1
+    tmp160 += np.transpose(ints.tmp319, (1, 0, 2, 3)) * -1
+    tmp160 += np.transpose(ints.tmp349, (1, 0, 2, 3)) * -1
+    tmp160 += np.transpose(ints.tmp395, (1, 0, 2, 3)) * -1
     tmp160 += ints.tmp422 * -1
-    tmp160 += ints.tmp439.transpose((1, 0, 2, 3)) * -1
-    tmp160 += ints.tmp459.transpose((1, 0, 2, 3)) * -1
-    tmp160 += ints.tmp490.transpose((1, 0, 2, 3)) * -1
-    tmp160 += ints.tmp502.transpose((1, 0, 2, 3)) * -1
-    tmp160 += ints.tmp503.transpose((1, 0, 2, 3)) * -1
-    tmp160 += ints.tmp511.transpose((1, 0, 2, 3)) * -1
+    tmp160 += np.transpose(ints.tmp439, (1, 0, 2, 3)) * -1
+    tmp160 += np.transpose(ints.tmp459, (1, 0, 2, 3)) * -1
+    tmp160 += np.transpose(ints.tmp490, (1, 0, 2, 3)) * -1
+    tmp160 += np.transpose(ints.tmp502, (1, 0, 2, 3)) * -1
+    tmp160 += np.transpose(ints.tmp503, (1, 0, 2, 3)) * -1
+    tmp160 += np.transpose(ints.tmp511, (1, 0, 2, 3)) * -1
     r2new.abab += einsum(r1.aa, (0, 1), tmp160, (0, 2, 3, 4), (2, 3, 1, 4)) * -1
     del tmp160
-    tmp162 = tmp38.transpose((1, 0)).copy() * -1
+    tmp162 = np.copy(np.transpose(tmp38, (1, 0))) * -1
     del tmp38
-    tmp162 += tmp43.transpose((1, 0)) * 2
+    tmp162 += np.transpose(tmp43, (1, 0)) * 2
     del tmp43
-    tmp162 += tmp44.transpose((1, 0))
+    tmp162 += np.transpose(tmp44, (1, 0))
     del tmp44
     tmp162 += einsum(tmp161, (0, 1, 2, 3), r1.aa, (0, 2), (1, 3)) * -1
     del tmp161
     r2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp162, (2, 4), (0, 1, 4, 3)) * -1
     del tmp162
-    tmp159 = ints.tmp100.copy()
-    tmp159 += ints.tmp366.transpose((0, 2, 1, 3))
+    tmp159 = np.copy(ints.tmp100)
+    tmp159 += np.transpose(ints.tmp366, (0, 2, 1, 3))
     tmp159 += ints.tmp378
     tmp159 += ints.tmp379
     tmp159 += ints.tmp403
@@ -6058,11 +6058,11 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp159 += ints.tmp446 * 2
     tmp159 += ints.tmp499
     tmp159 += ints.tmp507
-    tmp159 += v.aabb.ovoo.transpose((0, 2, 3, 1))
+    tmp159 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
     tmp159 += ints.tmp377 * -1
     tmp159 += ints.tmp404 * -1
     tmp159 += ints.tmp444 * -1
-    tmp159 += ints.tmp484.transpose((0, 2, 1, 3)) * -1
+    tmp159 += np.transpose(ints.tmp484, (0, 2, 1, 3)) * -1
     tmp159 += ints.tmp494 * -1
     tmp159 += ints.tmp513 * -1
     tmp159 += ints.tmp516 * -1
@@ -6071,104 +6071,104 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp159 += ints.tmp527 * -1
     r2new.abab += einsum(r1.bb, (0, 1), tmp159, (2, 3, 0, 4), (2, 3, 4, 1)) * -1
     del tmp159
-    tmp151 = ints.tmp313.copy()
+    tmp151 = np.copy(ints.tmp313)
     tmp151 += ints.tmp315 * 2
     tmp151 += ints.tmp339
     tmp151 += ints.tmp418
     tmp151 += ints.tmp506
-    tmp151 += v.aabb.vvov.transpose((2, 0, 1, 3))
-    tmp151 += ints.tmp314.transpose((0, 2, 1, 3)) * -1
+    tmp151 += np.transpose(v.aabb.vvov, (2, 0, 1, 3))
+    tmp151 += np.transpose(ints.tmp314, (0, 2, 1, 3)) * -1
     tmp151 += ints.tmp369 * -1
     r2new.abab += einsum(tmp151, (0, 1, 2, 3), r1.aa, (4, 2), (4, 0, 1, 3))
     del tmp151
-    tmp22 = f.aa.oo.copy()
+    tmp22 = np.copy(f.aa.oo)
     tmp22 += ints.tmp39
-    tmp22 += ints.tmp52.transpose((1, 0)) * 2
-    tmp22 += ints.tmp54.transpose((1, 0))
-    tmp22 += ints.tmp57.transpose((1, 0))
-    tmp22 += ints.tmp58.transpose((1, 0))
-    tmp22 += ints.tmp5.transpose((1, 0))
-    tmp22 += ints.tmp6.transpose((1, 0))
-    tmp22 += ints.tmp4.transpose((1, 0)) * -1
-    tmp22 += ints.tmp56.transpose((1, 0)) * -1
+    tmp22 += np.transpose(ints.tmp52, (1, 0)) * 2
+    tmp22 += np.transpose(ints.tmp54, (1, 0))
+    tmp22 += np.transpose(ints.tmp57, (1, 0))
+    tmp22 += np.transpose(ints.tmp58, (1, 0))
+    tmp22 += np.transpose(ints.tmp5, (1, 0))
+    tmp22 += np.transpose(ints.tmp6, (1, 0))
+    tmp22 += np.transpose(ints.tmp4, (1, 0)) * -1
+    tmp22 += np.transpose(ints.tmp56, (1, 0)) * -1
     r2new.abab += einsum(r2.abab, (0, 1, 2, 3), tmp22, (0, 4), (4, 1, 2, 3)) * -1
     r1new.aa += einsum(r1.aa, (0, 1), tmp22, (0, 2), (2, 1)) * -1
     del tmp22
     tmp140 = einsum(r2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 3, 5, 2), (0, 1, 4, 5)) * -1
-    tmp141 = t2.aaaa.copy()
+    tmp141 = np.copy(t2.aaaa)
     tmp141 += einsum(t1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
     r2new.aaaa += einsum(tmp141, (0, 1, 2, 3), tmp140, (4, 5, 0, 1), (5, 4, 3, 2)) * 2
     del tmp141, tmp140
     tmp138 = einsum(tmp137, (0, 1), r2.aaaa, (2, 3, 4, 0), (2, 3, 4, 1)) * -1
     del tmp137
-    r2new.aaaa += tmp138.transpose((1, 0, 2, 3)) * 2
-    r2new.aaaa += tmp138.transpose((1, 0, 3, 2)) * -2
+    r2new.aaaa += np.transpose(tmp138, (1, 0, 2, 3)) * 2
+    r2new.aaaa += np.transpose(tmp138, (1, 0, 3, 2)) * -2
     del tmp138
-    tmp136 = tmp133.transpose((1, 0, 3, 2)).copy() * -1
+    tmp136 = np.copy(np.transpose(tmp133, (1, 0, 3, 2))) * -1
     del tmp133
-    tmp136 += tmp135.transpose((0, 1, 3, 2)) * -1
+    tmp136 += np.transpose(tmp135, (0, 1, 3, 2)) * -1
     del tmp135
-    r2new.aaaa += tmp136.transpose((1, 0, 3, 2)) * -1
-    r2new.aaaa += tmp136.transpose((1, 0, 2, 3))
+    r2new.aaaa += np.transpose(tmp136, (1, 0, 3, 2)) * -1
+    r2new.aaaa += np.transpose(tmp136, (1, 0, 2, 3))
     del tmp136
-    tmp112 = tmp93.copy() * 2
+    tmp112 = np.copy(tmp93) * 2
     del tmp93
     tmp112 += tmp95
     del tmp95
     tmp112 += tmp96
     del tmp96
-    tmp112 += tmp98.transpose((1, 0, 3, 2)) * 2
+    tmp112 += np.transpose(tmp98, (1, 0, 3, 2)) * 2
     del tmp98
-    tmp112 += tmp100.transpose((1, 0, 3, 2))
+    tmp112 += np.transpose(tmp100, (1, 0, 3, 2))
     del tmp100
-    tmp112 += tmp102.transpose((0, 1, 3, 2))
+    tmp112 += np.transpose(tmp102, (0, 1, 3, 2))
     del tmp102
-    tmp112 += tmp104.transpose((1, 0, 2, 3))
+    tmp112 += np.transpose(tmp104, (1, 0, 2, 3))
     del tmp104
-    tmp112 += tmp111.transpose((0, 1, 3, 2))
+    tmp112 += np.transpose(tmp111, (0, 1, 3, 2))
     del tmp111
-    r2new.aaaa += tmp112.transpose((1, 0, 3, 2))
-    r2new.aaaa += tmp112.transpose((1, 0, 2, 3)) * -1
-    r2new.aaaa += tmp112.transpose((0, 1, 3, 2)) * -1
+    r2new.aaaa += np.transpose(tmp112, (1, 0, 3, 2))
+    r2new.aaaa += np.transpose(tmp112, (1, 0, 2, 3)) * -1
+    r2new.aaaa += np.transpose(tmp112, (0, 1, 3, 2)) * -1
     r2new.aaaa += tmp112
     del tmp112
-    tmp131 = tmp124.copy() * -1
+    tmp131 = np.copy(tmp124) * -1
     del tmp124
     tmp131 += tmp127
     del tmp127
-    tmp131 += tmp130.transpose((1, 0, 3, 2)) * -1
+    tmp131 += np.transpose(tmp130, (1, 0, 3, 2)) * -1
     del tmp130
-    r2new.aaaa += tmp131.transpose((0, 1, 3, 2)) * 2
+    r2new.aaaa += np.transpose(tmp131, (0, 1, 3, 2)) * 2
     r2new.aaaa += tmp131 * -2
     del tmp131
-    tmp68 = tmp57.transpose((0, 1, 3, 2)).copy() * -2
+    tmp68 = np.copy(np.transpose(tmp57, (0, 1, 3, 2))) * -2
     del tmp57
-    tmp68 += tmp59.transpose((1, 0, 3, 2))
+    tmp68 += np.transpose(tmp59, (1, 0, 3, 2))
     del tmp59
-    tmp68 += tmp65.transpose((1, 0, 3, 2))
+    tmp68 += np.transpose(tmp65, (1, 0, 3, 2))
     del tmp65
-    tmp68 += tmp67.transpose((1, 0, 3, 2)) * -1
+    tmp68 += np.transpose(tmp67, (1, 0, 3, 2)) * -1
     del tmp67
-    r2new.aaaa += tmp68.transpose((1, 0, 2, 3)) * -1
+    r2new.aaaa += np.transpose(tmp68, (1, 0, 2, 3)) * -1
     r2new.aaaa += tmp68
     del tmp68
-    tmp139 = ints.tmp297.copy()
+    tmp139 = np.copy(ints.tmp297)
     tmp139 += ints.tmp304
-    tmp139 += v.aaaa.oooo.transpose((0, 2, 1, 3))
+    tmp139 += np.transpose(v.aaaa.oooo, (0, 2, 1, 3))
     tmp139 += ints.tmp224 * -1
-    tmp139 += ints.tmp224.transpose((1, 0, 2, 3))
+    tmp139 += np.transpose(ints.tmp224, (1, 0, 2, 3))
     r2new.aaaa += einsum(r2.aaaa, (0, 1, 2, 3), tmp139, (4, 5, 1, 0), (4, 5, 2, 3)) * -2
     del tmp139
-    tmp123 = tmp114.transpose((1, 0, 3, 2)).copy()
+    tmp123 = np.copy(np.transpose(tmp114, (1, 0, 3, 2)))
     del tmp114
-    tmp123 += tmp118.transpose((1, 0, 3, 2))
+    tmp123 += np.transpose(tmp118, (1, 0, 3, 2))
     del tmp118
-    tmp123 += tmp122.transpose((0, 1, 3, 2))
+    tmp123 += np.transpose(tmp122, (0, 1, 3, 2))
     del tmp122
-    r2new.aaaa += tmp123.transpose((1, 0, 2, 3)) * 2
+    r2new.aaaa += np.transpose(tmp123, (1, 0, 2, 3)) * 2
     r2new.aaaa += tmp123 * -2
     del tmp123
-    tmp92 = tmp69.copy()
+    tmp92 = np.copy(tmp69)
     del tmp69
     tmp92 += tmp70
     del tmp70
@@ -6178,70 +6178,70 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp73
     tmp92 += tmp74
     del tmp74
-    tmp92 += tmp76.transpose((1, 0, 3, 2))
+    tmp92 += np.transpose(tmp76, (1, 0, 3, 2))
     del tmp76
-    tmp92 += tmp87.transpose((0, 1, 3, 2))
+    tmp92 += np.transpose(tmp87, (0, 1, 3, 2))
     del tmp87
-    tmp92 += tmp89.transpose((0, 1, 3, 2))
+    tmp92 += np.transpose(tmp89, (0, 1, 3, 2))
     del tmp89
-    tmp92 += tmp91.transpose((1, 0, 2, 3))
+    tmp92 += np.transpose(tmp91, (1, 0, 2, 3))
     del tmp91
-    r2new.aaaa += tmp92.transpose((1, 0, 3, 2)) * -1
-    r2new.aaaa += tmp92.transpose((1, 0, 2, 3))
-    r2new.aaaa += tmp92.transpose((0, 1, 3, 2))
+    r2new.aaaa += np.transpose(tmp92, (1, 0, 3, 2)) * -1
+    r2new.aaaa += np.transpose(tmp92, (1, 0, 2, 3))
+    r2new.aaaa += np.transpose(tmp92, (0, 1, 3, 2))
     r2new.aaaa += tmp92 * -1
     del tmp92
-    tmp55 = tmp37.copy() * -2
+    tmp55 = np.copy(tmp37) * -2
     del tmp37
-    tmp55 += tmp42.transpose((1, 0, 2, 3)) * -1
+    tmp55 += np.transpose(tmp42, (1, 0, 2, 3)) * -1
     del tmp42
-    tmp55 += tmp46.transpose((1, 0, 3, 2)) * -1
+    tmp55 += np.transpose(tmp46, (1, 0, 3, 2)) * -1
     del tmp46
-    tmp55 += tmp48.transpose((0, 1, 3, 2))
+    tmp55 += np.transpose(tmp48, (0, 1, 3, 2))
     del tmp48
-    tmp55 += tmp54.transpose((1, 0, 2, 3)) * -1
+    tmp55 += np.transpose(tmp54, (1, 0, 2, 3)) * -1
     del tmp54
-    r2new.aaaa += tmp55.transpose((0, 1, 3, 2))
+    r2new.aaaa += np.transpose(tmp55, (0, 1, 3, 2))
     r2new.aaaa += tmp55 * -1
     del tmp55
-    tmp25 = ints.tmp95.copy()
+    tmp25 = np.copy(ints.tmp95)
     tmp25 += v.bbbb.oovv
-    tmp25 += ints.tmp96.transpose((0, 1, 3, 2)) * -1
-    tmp25 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp25 += np.transpose(ints.tmp96, (0, 1, 3, 2)) * -1
+    tmp25 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
     r1new.bb += einsum(r1.bb, (0, 1), tmp25, (2, 0, 3, 1), (2, 3)) * -1
     del tmp25
-    tmp23 = ints.tmp98.copy()
+    tmp23 = np.copy(ints.tmp98)
     tmp23 += v.bbbb.ooov * -1
     r1new.bb += einsum(r2.bbbb, (0, 1, 2, 3), tmp23, (4, 0, 1, 3), (4, 2)) * 2
     del tmp23
-    tmp35 = f.bb.oo.copy() * 0.5
-    tmp35 += ints.tmp102.transpose((1, 0))
-    tmp35 += ints.tmp104.transpose((1, 0)) * 0.5
-    tmp35 += ints.tmp107.transpose((1, 0)) * 0.5
-    tmp35 += ints.tmp108.transpose((1, 0)) * 0.5
-    tmp35 += ints.tmp67.transpose((1, 0)) * 0.5
-    tmp35 += ints.tmp68.transpose((1, 0)) * 0.5
+    tmp35 = np.copy(f.bb.oo) * 0.5
+    tmp35 += np.transpose(ints.tmp102, (1, 0))
+    tmp35 += np.transpose(ints.tmp104, (1, 0)) * 0.5
+    tmp35 += np.transpose(ints.tmp107, (1, 0)) * 0.5
+    tmp35 += np.transpose(ints.tmp108, (1, 0)) * 0.5
+    tmp35 += np.transpose(ints.tmp67, (1, 0)) * 0.5
+    tmp35 += np.transpose(ints.tmp68, (1, 0)) * 0.5
     tmp35 += ints.tmp89 * 0.5
-    tmp35 += ints.tmp106.transpose((1, 0)) * -0.5
-    tmp35 += ints.tmp66.transpose((1, 0)) * -0.5
+    tmp35 += np.transpose(ints.tmp106, (1, 0)) * -0.5
+    tmp35 += np.transpose(ints.tmp66, (1, 0)) * -0.5
     r1new.bb += einsum(r1.bb, (0, 1), tmp35, (0, 2), (2, 1)) * -2
     del tmp35
-    tmp26 = ints.tmp97.copy()
-    tmp26 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp26 = np.copy(ints.tmp97)
+    tmp26 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     r1new.bb += einsum(tmp26, (0, 1, 2, 3), r1.aa, (0, 2), (1, 3))
     del tmp26
-    tmp12 = ints.tmp45.copy()
+    tmp12 = np.copy(ints.tmp45)
     tmp12 += v.aaaa.oovv
-    tmp12 += ints.tmp46.transpose((0, 1, 3, 2)) * -1
-    tmp12 += v.aaaa.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp12 += np.transpose(ints.tmp46, (0, 1, 3, 2)) * -1
+    tmp12 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3)) * -1
     r1new.aa += einsum(r1.aa, (0, 1), tmp12, (2, 0, 3, 1), (2, 3)) * -1
     del tmp12
-    tmp0 = ints.tmp48.copy()
+    tmp0 = np.copy(ints.tmp48)
     tmp0 += v.aaaa.ooov * -1
     r1new.aa += einsum(tmp0, (0, 1, 2, 3), r2.aaaa, (1, 2, 4, 3), (0, 4)) * 2
     del tmp0
-    tmp13 = ints.tmp47.copy()
-    tmp13 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp13 = np.copy(ints.tmp47)
+    tmp13 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     r1new.aa += einsum(r1.bb, (0, 1), tmp13, (2, 0, 3, 1), (2, 3))
     del tmp13
     r1new.aa += einsum(v.aabb.vvov, (0, 1, 2, 3), r2.abab, (4, 2, 1, 3), (4, 0))
@@ -6716,66 +6716,66 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     r2new = Namespace()
     tmp53 = einsum(t2.bbbb, (0, 1, 2, 3), r2.bbb, (0, 1, 3), (2,))
     tmp52 = einsum(r2.aba, (0, 1, 2), t2.abab, (0, 1, 2, 3), (3,))
-    tmp87 = ints.tmp426.copy()
+    tmp87 = np.copy(ints.tmp426)
     tmp87 += ints.tmp432
     tmp87 += ints.tmp436 * 2
-    tmp91 = f.bb.oo.copy()
+    tmp91 = np.copy(f.bb.oo)
     tmp91 += ints.tmp163
     tmp91 += ints.tmp167
     tmp91 += ints.tmp205
     tmp91 += ints.tmp209
-    tmp91 += ints.tmp21.transpose((1, 0))
-    tmp89 = ints.tmp425.copy()
-    tmp89 += ints.tmp430.transpose((0, 1, 3, 2)) * 2
-    tmp62 = f.bb.ov.copy()
+    tmp91 += np.transpose(ints.tmp21, (1, 0))
+    tmp89 = np.copy(ints.tmp425)
+    tmp89 += np.transpose(ints.tmp430, (0, 1, 3, 2)) * 2
+    tmp62 = np.copy(f.bb.ov)
     tmp62 += ints.tmp36
     tmp62 += ints.tmp38
     tmp62 += ints.tmp89 * -1
-    tmp74 = ints.tmp324.copy()
-    tmp74 += ints.tmp434.transpose((0, 1, 3, 2)) * 2
-    tmp74 += ints.tmp438.transpose((0, 1, 3, 2))
+    tmp74 = np.copy(ints.tmp324)
+    tmp74 += np.transpose(ints.tmp434, (0, 1, 3, 2)) * 2
+    tmp74 += np.transpose(ints.tmp438, (0, 1, 3, 2))
     tmp47 = einsum(r2.aba, (0, 1, 2), t1.aa, (3, 2), (0, 3, 1))
-    tmp82 = ints.tmp140.copy() * 2
+    tmp82 = np.copy(ints.tmp140) * 2
     tmp82 += ints.tmp143
     tmp82 += ints.tmp161 * -1
     tmp82 += ints.tmp203 * -1
     tmp49 = einsum(r2.bbb, (0, 1, 2), t1.bb, (3, 2), (0, 1, 3))
-    tmp78 = v.bbbb.ooov.copy()
-    tmp78 += v.bbbb.ooov.transpose((0, 2, 1, 3)) * -1
-    tmp76 = ints.tmp119.copy() * -1
-    tmp76 += ints.tmp119.transpose((0, 2, 1, 3))
-    tmp80 = tmp52.copy() * -0.5
+    tmp78 = np.copy(v.bbbb.ooov)
+    tmp78 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3)) * -1
+    tmp76 = np.copy(ints.tmp119) * -1
+    tmp76 += np.transpose(ints.tmp119, (0, 2, 1, 3))
+    tmp80 = np.copy(tmp52) * -0.5
     tmp80 += tmp53
-    tmp40 = f.aa.ov.copy()
+    tmp40 = np.copy(f.aa.ov)
     tmp40 += ints.tmp32
     tmp40 += ints.tmp39
     tmp40 += ints.tmp82 * -1
     tmp11 = einsum(r2.bab, (0, 1, 2), t1.bb, (3, 2), (1, 0, 3)) * -1
-    tmp25 = ints.tmp47.copy() * 2
+    tmp25 = np.copy(ints.tmp47) * 2
     tmp25 += ints.tmp49
     tmp25 += ints.tmp154 * -1
     tmp25 += ints.tmp25 * -1
     tmp20 = einsum(t1.aa, (0, 1), r2.aaa, (2, 3, 1), (2, 3, 0))
-    tmp23 = v.aaaa.ooov.copy() * -1
-    tmp23 += v.aaaa.ooov.transpose((0, 2, 1, 3))
-    tmp21 = ints.tmp41.copy() * -1
-    tmp21 += ints.tmp41.transpose((0, 2, 1, 3))
-    tmp18 = ints.tmp349.copy()
+    tmp23 = np.copy(v.aaaa.ooov) * -1
+    tmp23 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3))
+    tmp21 = np.copy(ints.tmp41) * -1
+    tmp21 += np.transpose(ints.tmp41, (0, 2, 1, 3))
+    tmp18 = np.copy(ints.tmp349)
     tmp18 += ints.tmp357
     tmp18 += ints.tmp361 * 2
     tmp14 = einsum(t2.aaaa, (0, 1, 2, 3), r2.aaa, (0, 1, 3), (2,))
-    tmp16 = ints.tmp193.copy()
-    tmp16 += ints.tmp355.transpose((0, 1, 3, 2)) * 2
-    tmp16 += ints.tmp359.transpose((0, 1, 3, 2))
-    tmp36 = f.aa.oo.copy()
+    tmp16 = np.copy(ints.tmp193)
+    tmp16 += np.transpose(ints.tmp355, (0, 1, 3, 2)) * 2
+    tmp16 += np.transpose(ints.tmp359, (0, 1, 3, 2))
+    tmp36 = np.copy(f.aa.oo)
     tmp36 += ints.tmp155
     tmp36 += ints.tmp156
-    tmp36 += ints.tmp1.transpose((1, 0))
+    tmp36 += np.transpose(ints.tmp1, (1, 0))
     tmp36 += ints.tmp26
     tmp36 += ints.tmp27
     tmp32 = einsum(r2.bab, (0, 1, 2), t2.abab, (1, 0, 3, 2), (3,)) * -1
-    tmp34 = ints.tmp346.copy()
-    tmp34 += ints.tmp351.transpose((0, 1, 3, 2)) * 2
+    tmp34 = np.copy(ints.tmp346)
+    tmp34 += np.transpose(ints.tmp351, (0, 1, 3, 2)) * 2
     tmp88 = einsum(r2.aba, (0, 1, 2), tmp87, (0, 3, 2, 4), (1, 3, 4))
     del tmp87
     tmp92 = einsum(r2.bbb, (0, 1, 2), tmp91, (1, 3), (0, 3, 2)) * -1
@@ -6828,17 +6828,17 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp35 = einsum(r2.aaa, (0, 1, 2), tmp34, (1, 3, 4, 2), (0, 3, 4)) * -1
     del tmp34
     tmp28 = einsum(r1.a, (0,), ints.tmp41, (0, 1, 2, 3), (1, 2, 3))
-    tmp93 = tmp85.copy()
+    tmp93 = np.copy(tmp85)
     del tmp85
     tmp93 += tmp86 * 2
     del tmp86
-    tmp93 += tmp88.transpose((1, 0, 2))
+    tmp93 += np.transpose(tmp88, (1, 0, 2))
     del tmp88
-    tmp93 += tmp90.transpose((1, 0, 2)) * -2
+    tmp93 += np.transpose(tmp90, (1, 0, 2)) * -2
     del tmp90
-    tmp93 += tmp92.transpose((1, 0, 2)) * -2
+    tmp93 += np.transpose(tmp92, (1, 0, 2)) * -2
     del tmp92
-    tmp64 = ints.tmp186.transpose((1, 0)).copy()
+    tmp64 = np.copy(np.transpose(ints.tmp186, (1, 0)))
     tmp64 += ints.tmp449 * 2
     tmp64 += ints.tmp451
     tmp64 += f.bb.vv * -1
@@ -6846,10 +6846,10 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp64 += ints.tmp188 * -1
     tmp64 += tmp63
     del tmp63
-    tmp94 = ints.tmp306.copy()
+    tmp94 = np.copy(ints.tmp306)
     tmp94 += ints.tmp333
-    tmp94 += v.bbbb.oooo.transpose((0, 2, 3, 1)) * -1
-    tmp84 = tmp67.copy()
+    tmp94 += np.transpose(v.bbbb.oooo, (0, 2, 3, 1)) * -1
+    tmp84 = np.copy(tmp67)
     del tmp67
     tmp84 += tmp68
     del tmp68
@@ -6863,103 +6863,103 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp72
     tmp84 += tmp73 * -1
     del tmp73
-    tmp84 += tmp75.transpose((1, 0, 2)) * -1
+    tmp84 += np.transpose(tmp75, (1, 0, 2)) * -1
     del tmp75
-    tmp84 += tmp77.transpose((1, 0, 2))
+    tmp84 += np.transpose(tmp77, (1, 0, 2))
     del tmp77
     tmp84 += tmp79
     del tmp79
-    tmp84 += tmp81.transpose((1, 0, 2)) * -1
+    tmp84 += np.transpose(tmp81, (1, 0, 2)) * -1
     del tmp81
-    tmp84 += tmp83.transpose((1, 0, 2))
+    tmp84 += np.transpose(tmp83, (1, 0, 2))
     del tmp83
-    tmp56 = ints.tmp426.copy()
+    tmp56 = np.copy(ints.tmp426)
     tmp56 += ints.tmp432
     tmp56 += ints.tmp436 * 2
-    tmp56 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp56 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp56 += ints.tmp428 * -1
-    tmp60 = ints.tmp45.copy()
+    tmp60 = np.copy(ints.tmp45)
     tmp60 += v.aabb.ooov
-    tmp66 = tmp14.copy()
+    tmp66 = np.copy(tmp14)
     del tmp14
     tmp66 += tmp32 * 0.5
     del tmp32
-    tmp61 = ints.tmp45.copy()
+    tmp61 = np.copy(ints.tmp45)
     tmp61 += v.aabb.ooov
-    tmp58 = ints.tmp151.copy()
+    tmp58 = np.copy(ints.tmp151)
     tmp58 += ints.tmp174
-    tmp58 += ints.tmp176.transpose((1, 0, 2, 3))
+    tmp58 += np.transpose(ints.tmp176, (1, 0, 2, 3))
     tmp58 += ints.tmp214
     tmp58 += v.aabb.oooo
-    tmp55 = ints.tmp324.copy()
-    tmp55 += ints.tmp434.transpose((0, 1, 3, 2)) * 2
-    tmp55 += ints.tmp438.transpose((0, 1, 3, 2))
-    tmp55 += v.bbbb.ovov.transpose((0, 2, 3, 1))
+    tmp55 = np.copy(ints.tmp324)
+    tmp55 += np.transpose(ints.tmp434, (0, 1, 3, 2)) * 2
+    tmp55 += np.transpose(ints.tmp438, (0, 1, 3, 2))
+    tmp55 += np.transpose(v.bbbb.ovov, (0, 2, 3, 1))
     tmp55 += ints.tmp425 * -1
-    tmp55 += ints.tmp430.transpose((0, 1, 3, 2)) * -2
+    tmp55 += np.transpose(ints.tmp430, (0, 1, 3, 2)) * -2
     tmp55 += v.bbbb.oovv * -1
-    tmp65 = f.bb.oo.copy()
+    tmp65 = np.copy(f.bb.oo)
     tmp65 += ints.tmp140 * 2
     tmp65 += ints.tmp143
     tmp65 += ints.tmp163
     tmp65 += ints.tmp167
     tmp65 += ints.tmp205
     tmp65 += ints.tmp209
-    tmp65 += ints.tmp21.transpose((1, 0))
+    tmp65 += np.transpose(ints.tmp21, (1, 0))
     tmp65 += ints.tmp161 * -1
     tmp65 += ints.tmp203 * -1
-    tmp57 = ints.tmp196.copy()
+    tmp57 = np.copy(ints.tmp196)
     tmp57 += v.aabb.oovv
     tmp57 += ints.tmp453 * -1
-    tmp59 = ints.tmp119.copy() * -1
-    tmp59 += ints.tmp119.transpose((0, 2, 1, 3))
+    tmp59 = np.copy(ints.tmp119) * -1
+    tmp59 += np.transpose(ints.tmp119, (0, 2, 1, 3))
     tmp59 += v.bbbb.ooov
-    tmp59 += v.bbbb.ooov.transpose((0, 2, 1, 3)) * -1
-    tmp4 = f.aa.oo.copy()
+    tmp59 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3)) * -1
+    tmp4 = np.copy(f.aa.oo)
     tmp4 += ints.tmp155
     tmp4 += ints.tmp156
-    tmp4 += ints.tmp1.transpose((1, 0))
-    tmp4 += ints.tmp26.transpose((1, 0))
-    tmp4 += ints.tmp27.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp1, (1, 0))
+    tmp4 += np.transpose(ints.tmp26, (1, 0))
+    tmp4 += np.transpose(ints.tmp27, (1, 0))
     tmp4 += ints.tmp47 * 2
     tmp4 += ints.tmp49
     tmp4 += ints.tmp154 * -1
     tmp4 += ints.tmp25 * -1
-    tmp45 = ints.tmp327.copy()
-    tmp45 += v.aabb.vvoo.transpose((2, 3, 0, 1))
+    tmp45 = np.copy(ints.tmp327)
+    tmp45 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1))
     tmp45 += ints.tmp422 * -1
-    tmp50 = ints.tmp124.copy()
-    tmp50 += v.aabb.ovoo.transpose((0, 2, 3, 1))
-    tmp51 = f.aa.oo.copy()
+    tmp50 = np.copy(ints.tmp124)
+    tmp50 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
+    tmp51 = np.copy(f.aa.oo)
     tmp51 += ints.tmp155
     tmp51 += ints.tmp156
-    tmp51 += ints.tmp1.transpose((1, 0))
+    tmp51 += np.transpose(ints.tmp1, (1, 0))
     tmp51 += ints.tmp26
     tmp51 += ints.tmp27
     tmp51 += ints.tmp47 * 2
     tmp51 += ints.tmp49
     tmp51 += ints.tmp154 * -1
     tmp51 += ints.tmp25 * -1
-    tmp7 = f.bb.oo.copy()
+    tmp7 = np.copy(f.bb.oo)
     tmp7 += ints.tmp140 * 2
     tmp7 += ints.tmp143
-    tmp7 += ints.tmp163.transpose((1, 0))
-    tmp7 += ints.tmp167.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp163, (1, 0))
+    tmp7 += np.transpose(ints.tmp167, (1, 0))
     tmp7 += ints.tmp205
     tmp7 += ints.tmp209
-    tmp7 += ints.tmp21.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp21, (1, 0))
     tmp7 += ints.tmp161 * -1
     tmp7 += ints.tmp203 * -1
-    tmp48 = ints.tmp41.copy() * -1
-    tmp48 += ints.tmp41.transpose((0, 2, 1, 3))
+    tmp48 = np.copy(ints.tmp41) * -1
+    tmp48 += np.transpose(ints.tmp41, (0, 2, 1, 3))
     tmp48 += v.aaaa.ooov
-    tmp48 += v.aaaa.ooov.transpose((0, 2, 1, 3)) * -1
-    tmp44 = ints.tmp349.copy()
+    tmp48 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3)) * -1
+    tmp44 = np.copy(ints.tmp349)
     tmp44 += ints.tmp357
     tmp44 += ints.tmp361 * 2
-    tmp44 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp44 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp44 += ints.tmp353 * -1
-    tmp42 = ints.tmp181.transpose((1, 0)).copy()
+    tmp42 = np.copy(np.transpose(ints.tmp181, (1, 0)))
     tmp42 += ints.tmp391 * 2
     tmp42 += ints.tmp393
     tmp42 += f.aa.vv * -1
@@ -6967,23 +6967,23 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp42 += ints.tmp190 * -1
     tmp42 += tmp41
     del tmp41
-    tmp46 = ints.tmp151.copy()
-    tmp46 += ints.tmp174.transpose((0, 1, 3, 2))
+    tmp46 = np.copy(ints.tmp151)
+    tmp46 += np.transpose(ints.tmp174, (0, 1, 3, 2))
     tmp46 += ints.tmp176
     tmp46 += ints.tmp214
     tmp46 += v.aabb.oooo
-    tmp43 = ints.tmp193.copy()
-    tmp43 += ints.tmp355.transpose((0, 1, 3, 2)) * 2
-    tmp43 += ints.tmp359.transpose((0, 1, 3, 2))
-    tmp43 += v.aaaa.ovov.transpose((0, 2, 3, 1))
+    tmp43 = np.copy(ints.tmp193)
+    tmp43 += np.transpose(ints.tmp355, (0, 1, 3, 2)) * 2
+    tmp43 += np.transpose(ints.tmp359, (0, 1, 3, 2))
+    tmp43 += np.transpose(v.aaaa.ovov, (0, 2, 3, 1))
     tmp43 += ints.tmp346 * -1
-    tmp43 += ints.tmp351.transpose((0, 1, 3, 2)) * -2
+    tmp43 += np.transpose(ints.tmp351, (0, 1, 3, 2)) * -2
     tmp43 += v.aaaa.oovv * -1
-    tmp54 = tmp52.copy() * -1
+    tmp54 = np.copy(tmp52) * -1
     del tmp52
     tmp54 += tmp53 * 2
     del tmp53
-    tmp27 = tmp8.copy()
+    tmp27 = np.copy(tmp8)
     del tmp8
     tmp27 += tmp9 * 2
     del tmp9
@@ -6995,17 +6995,17 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp13
     tmp27 += tmp15 * 2
     del tmp15
-    tmp27 += tmp17.transpose((1, 0, 2)) * -1
+    tmp27 += np.transpose(tmp17, (1, 0, 2)) * -1
     del tmp17
-    tmp27 += tmp19.transpose((1, 0, 2))
+    tmp27 += np.transpose(tmp19, (1, 0, 2))
     del tmp19
-    tmp27 += tmp22.transpose((1, 0, 2))
+    tmp27 += np.transpose(tmp22, (1, 0, 2))
     del tmp22
     tmp27 += tmp24
     del tmp24
-    tmp27 += tmp26.transpose((1, 0, 2))
+    tmp27 += np.transpose(tmp26, (1, 0, 2))
     del tmp26
-    tmp38 = tmp28.copy()
+    tmp38 = np.copy(tmp28)
     del tmp28
     tmp38 += tmp29 * 2
     del tmp29
@@ -7015,18 +7015,18 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp31
     tmp38 += tmp33
     del tmp33
-    tmp38 += tmp35.transpose((1, 0, 2)) * -2
+    tmp38 += np.transpose(tmp35, (1, 0, 2)) * -2
     del tmp35
-    tmp38 += tmp37.transpose((1, 0, 2)) * -2
+    tmp38 += np.transpose(tmp37, (1, 0, 2)) * -2
     del tmp37
-    tmp39 = ints.tmp148.copy()
+    tmp39 = np.copy(ints.tmp148)
     tmp39 += ints.tmp211
-    tmp39 += v.aaaa.oooo.transpose((0, 2, 3, 1)) * -1
-    tmp6 = ints.tmp225.transpose((1, 2, 0, 3)).copy() * 0.5
-    tmp6 += ints.tmp230.transpose((1, 2, 0, 3)) * 0.5
-    tmp6 += ints.tmp238.transpose((0, 2, 1, 3)) * 0.5
-    tmp6 += ints.tmp251.transpose((0, 2, 1, 3))
-    tmp6 += ints.tmp256.transpose((0, 2, 1, 3)) * 0.5
+    tmp39 += np.transpose(v.aaaa.oooo, (0, 2, 3, 1)) * -1
+    tmp6 = np.copy(np.transpose(ints.tmp225, (1, 2, 0, 3))) * 0.5
+    tmp6 += np.transpose(ints.tmp230, (1, 2, 0, 3)) * 0.5
+    tmp6 += np.transpose(ints.tmp238, (0, 2, 1, 3)) * 0.5
+    tmp6 += np.transpose(ints.tmp251, (0, 2, 1, 3))
+    tmp6 += np.transpose(ints.tmp256, (0, 2, 1, 3)) * 0.5
     tmp6 += ints.tmp281 * 0.5
     tmp6 += ints.tmp285 * 0.5
     tmp6 += ints.tmp295
@@ -7039,10 +7039,10 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp6 += ints.tmp277 * -0.5
     tmp6 += ints.tmp292 * -1
     tmp6 += ints.tmp299 * -0.5
-    tmp6 += ints.tmp317.transpose((0, 2, 1, 3)) * -0.5
+    tmp6 += np.transpose(ints.tmp317, (0, 2, 1, 3)) * -0.5
     tmp6 += ints.tmp325 * -0.5
-    tmp6 += v.bbbb.ooov.transpose((0, 2, 1, 3)) * -0.5
-    tmp3 = ints.tmp117.copy()
+    tmp6 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3)) * -0.5
+    tmp3 = np.copy(ints.tmp117)
     tmp3 += ints.tmp122 * 0.5
     tmp3 += ints.tmp138
     tmp3 += ints.tmp146 * 0.5
@@ -7074,19 +7074,19 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp3 += ints.tmp8 * -1
     tmp3 += ints.tmp94 * -0.5
     tmp3 += ints.tmp98 * -1
-    tmp5 = ints.tmp124.copy()
-    tmp5 += ints.tmp223.transpose((0, 2, 1, 3))
-    tmp5 += ints.tmp240.transpose((0, 2, 1, 3))
-    tmp5 += ints.tmp250.transpose((0, 2, 1, 3))
-    tmp5 += ints.tmp254.transpose((0, 2, 1, 3)) * 2
+    tmp5 = np.copy(ints.tmp124)
+    tmp5 += np.transpose(ints.tmp223, (0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp240, (0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp250, (0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp254, (0, 2, 1, 3)) * 2
     tmp5 += ints.tmp264
     tmp5 += ints.tmp279
     tmp5 += ints.tmp283
     tmp5 += ints.tmp291
     tmp5 += ints.tmp297 * 2
     tmp5 += ints.tmp328
-    tmp5 += v.aabb.ovoo.transpose((0, 2, 3, 1))
-    tmp5 += ints.tmp232.transpose((0, 2, 1, 3)) * -1
+    tmp5 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
+    tmp5 += np.transpose(ints.tmp232, (0, 2, 1, 3)) * -1
     tmp5 += ints.tmp247 * -1
     tmp5 += ints.tmp253 * -1
     tmp5 += ints.tmp275 * -1
@@ -7094,9 +7094,9 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp5 += ints.tmp301 * -1
     tmp5 += ints.tmp309 * -1
     tmp5 += ints.tmp319 * -1
-    tmp5 += ints.tmp320.transpose((0, 2, 1, 3)) * -1
+    tmp5 += np.transpose(ints.tmp320, (0, 2, 1, 3)) * -1
     tmp5 += ints.tmp336 * -1
-    tmp2 = ints.tmp120.copy()
+    tmp2 = np.copy(ints.tmp120)
     tmp2 += ints.tmp125 * 0.5
     tmp2 += ints.tmp141
     tmp2 += ints.tmp144 * 0.5
@@ -7128,36 +7128,36 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp2 += ints.tmp7 * -0.5
     tmp2 += ints.tmp88 * -0.5
     tmp2 += ints.tmp96 * -1
-    tmp1 = ints.tmp109.copy() * 0.5
+    tmp1 = np.copy(ints.tmp109) * 0.5
     tmp1 += ints.tmp113 * 0.5
     tmp1 += ints.tmp130
     tmp1 += ints.tmp149 * 0.5
-    tmp1 += ints.tmp15.transpose((1, 2, 0, 3)) * 0.5
+    tmp1 += np.transpose(ints.tmp15, (1, 2, 0, 3)) * 0.5
     tmp1 += ints.tmp170 * 0.5
     tmp1 += ints.tmp212 * 0.5
-    tmp1 += ints.tmp28.transpose((1, 2, 0, 3)) * 0.5
-    tmp1 += ints.tmp43.transpose((0, 2, 1, 3)) * 0.5
-    tmp1 += ints.tmp62.transpose((0, 2, 1, 3))
-    tmp1 += ints.tmp66.transpose((0, 2, 1, 3)) * 0.5
+    tmp1 += np.transpose(ints.tmp28, (1, 2, 0, 3)) * 0.5
+    tmp1 += np.transpose(ints.tmp43, (0, 2, 1, 3)) * 0.5
+    tmp1 += np.transpose(ints.tmp62, (0, 2, 1, 3))
+    tmp1 += np.transpose(ints.tmp66, (0, 2, 1, 3)) * 0.5
     tmp1 += ints.tmp105 * -0.5
     tmp1 += ints.tmp127 * -1
     tmp1 += ints.tmp133 * -0.5
-    tmp1 += ints.tmp172.transpose((0, 2, 1, 3)) * -0.5
+    tmp1 += np.transpose(ints.tmp172, (0, 2, 1, 3)) * -0.5
     tmp1 += ints.tmp194 * -0.5
     tmp1 += ints.tmp41 * -0.5
     tmp1 += ints.tmp59 * -1
     tmp1 += ints.tmp78 * -0.5
-    tmp1 += v.aaaa.ooov.transpose((0, 2, 1, 3)) * -0.5
-    tmp0 = ints.tmp111.copy()
+    tmp1 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3)) * -0.5
+    tmp0 = np.copy(ints.tmp111)
     tmp0 += ints.tmp115
     tmp0 += ints.tmp129
     tmp0 += ints.tmp135 * 2
-    tmp0 += ints.tmp17.transpose((1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp17, (1, 0, 2, 3))
     tmp0 += ints.tmp197
     tmp0 += ints.tmp45
-    tmp0 += ints.tmp46.transpose((1, 0, 2, 3))
-    tmp0 += ints.tmp64.transpose((1, 0, 2, 3))
-    tmp0 += ints.tmp68.transpose((1, 0, 2, 3)) * 2
+    tmp0 += np.transpose(ints.tmp46, (1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp64, (1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp68, (1, 0, 2, 3)) * 2
     tmp0 += ints.tmp80
     tmp0 += v.aabb.ooov
     tmp0 += ints.tmp107 * -1
@@ -7165,16 +7165,16 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp0 += ints.tmp137 * -1
     tmp0 += ints.tmp152 * -1
     tmp0 += ints.tmp175 * -1
-    tmp0 += ints.tmp177.transpose((1, 0, 2, 3)) * -1
+    tmp0 += np.transpose(ints.tmp177, (1, 0, 2, 3)) * -1
     tmp0 += ints.tmp215 * -1
-    tmp0 += ints.tmp30.transpose((1, 0, 2, 3)) * -1
+    tmp0 += np.transpose(ints.tmp30, (1, 0, 2, 3)) * -1
     tmp0 += ints.tmp61 * -1
     tmp0 += ints.tmp65 * -1
-    r2new.bbb = tmp84.copy() * -1
-    r2new.bbb += tmp84.transpose((1, 0, 2))
+    r2new.bbb = np.copy(tmp84) * -1
+    r2new.bbb += np.transpose(tmp84, (1, 0, 2))
     del tmp84
     r2new.bbb += tmp93
-    r2new.bbb += tmp93.transpose((1, 0, 2)) * -1
+    r2new.bbb += np.transpose(tmp93, (1, 0, 2)) * -1
     del tmp93
     r2new.bbb += einsum(tmp94, (0, 1, 2, 3), r2.bbb, (1, 0, 4), (2, 3, 4)) * -2
     del tmp94
@@ -7229,11 +7229,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     r2new.aba += einsum(tmp50, (0, 1, 2, 3), r1.b, (1,), (0, 2, 3))
     del tmp50
     r2new.aba += einsum(r1.b, (0,), tmp40, (1, 2), (1, 0, 2)) * -1
-    r2new.aaa = tmp27.copy() * -1
-    r2new.aaa += tmp27.transpose((1, 0, 2))
+    r2new.aaa = np.copy(tmp27) * -1
+    r2new.aaa += np.transpose(tmp27, (1, 0, 2))
     del tmp27
     r2new.aaa += tmp38
-    r2new.aaa += tmp38.transpose((1, 0, 2)) * -1
+    r2new.aaa += np.transpose(tmp38, (1, 0, 2)) * -1
     del tmp38
     r2new.aaa += einsum(r2.aaa, (0, 1, 2), tmp39, (0, 1, 3, 4), (3, 4, 2)) * 2
     del tmp39
@@ -7603,14 +7603,14 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     ints = kwargs["ints"]
     r1new = Namespace()
     r2new = Namespace()
-    tmp119 = f.bb.ov.copy()
+    tmp119 = np.copy(f.bb.ov)
     tmp119 += ints.tmp33
     tmp119 += ints.tmp35
-    tmp95 = ints.tmp114.copy() * -1
-    tmp95 += ints.tmp114.transpose((0, 2, 1, 3))
-    tmp44 = ints.tmp111.copy() * -1
-    tmp44 += ints.tmp111.transpose((0, 2, 1, 3))
-    tmp62 = f.aa.ov.copy()
+    tmp95 = np.copy(ints.tmp114) * -1
+    tmp95 += np.transpose(ints.tmp114, (0, 2, 1, 3))
+    tmp44 = np.copy(ints.tmp111) * -1
+    tmp44 += np.transpose(ints.tmp111, (0, 2, 1, 3))
+    tmp62 = np.copy(f.aa.ov)
     tmp62 += ints.tmp29
     tmp62 += ints.tmp36
     tmp120 = einsum(t1.bb, (0, 1), tmp119, (0, 2), (1, 2))
@@ -7630,76 +7630,76 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp62
     tmp15 = einsum(r1.a, (0,), t1.aa, (1, 0), (1,))
     tmp17 = einsum(r2.bab, (0, 1, 2), t2.abab, (3, 2, 1, 0), (3,)) * -1
-    tmp115 = ints.tmp284.copy()
+    tmp115 = np.copy(ints.tmp284)
     tmp115 += ints.tmp310
     tmp115 += ints.tmp290 * 2
-    tmp121 = ints.tmp175.copy()
-    tmp121 += tmp120.transpose((1, 0))
+    tmp121 = np.copy(ints.tmp175)
+    tmp121 += np.transpose(tmp120, (1, 0))
     del tmp120
     tmp34 = einsum(r1.b, (0,), t1.bb, (1, 0), (1,))
-    tmp117 = ints.tmp305.transpose((0, 1, 3, 2)).copy()
+    tmp117 = np.copy(np.transpose(ints.tmp305, (0, 1, 3, 2)))
     tmp117 += ints.tmp288 * 2
-    tmp102 = f.bb.vv.copy() * 0.5
+    tmp102 = np.copy(f.bb.vv) * 0.5
     tmp102 += ints.tmp173 * 0.5
     tmp102 += ints.tmp177 * 0.5
     tmp102 += ints.tmp230 * -1
     tmp102 += ints.tmp232 * -0.5
-    tmp102 += tmp101.transpose((1, 0)) * 0.5
+    tmp102 += np.transpose(tmp101, (1, 0)) * 0.5
     del tmp101
-    tmp110 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp110 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp110 += tmp109 * -1
     del tmp109
-    tmp104 = tmp35.copy() * -0.5
+    tmp104 = np.copy(tmp35) * -0.5
     tmp104 += tmp36
-    tmp97 = ints.tmp285.copy() * 2
+    tmp97 = np.copy(ints.tmp285) * 2
     tmp97 += ints.tmp292
-    tmp97 += ints.tmp307.transpose((0, 1, 3, 2))
+    tmp97 += np.transpose(ints.tmp307, (0, 1, 3, 2))
     tmp97 += tmp96 * -1
     del tmp96
     tmp22 = einsum(t1.bb, (0, 1), r2.bbb, (2, 1, 3), (3, 0, 2))
-    tmp99 = v.bbbb.ooov.copy() * -1
-    tmp99 += v.bbbb.ooov.transpose((0, 2, 1, 3))
-    tmp107 = ints.tmp287.copy()
+    tmp99 = np.copy(v.bbbb.ooov) * -1
+    tmp99 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3))
+    tmp107 = np.copy(ints.tmp287)
     tmp107 += tmp106
     del tmp106
-    tmp38 = f.bb.ov.copy()
+    tmp38 = np.copy(f.bb.ov)
     tmp38 += ints.tmp33
     tmp38 += ints.tmp35
     tmp38 += ints.tmp89 * -1
-    tmp19 = f.aa.ov.copy()
+    tmp19 = np.copy(f.aa.ov)
     tmp19 += ints.tmp29
     tmp19 += ints.tmp36
     tmp19 += ints.tmp82 * -1
-    tmp49 = ints.tmp141.copy() * 0.5
+    tmp49 = np.copy(ints.tmp141) * 0.5
     tmp49 += ints.tmp147
     tmp49 += ints.tmp186 * 0.5
     tmp49 += tmp48 * -0.5
     del tmp48
     tmp2 = einsum(t1.aa, (0, 1), r2.aaa, (2, 1, 3), (3, 0, 2))
-    tmp51 = v.aaaa.ooov.copy() * -1
-    tmp51 += v.aaaa.ooov.transpose((0, 2, 1, 3))
-    tmp54 = f.aa.vv.copy() * 0.5
+    tmp51 = np.copy(v.aaaa.ooov) * -1
+    tmp51 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3))
+    tmp54 = np.copy(f.aa.vv) * 0.5
     tmp54 += ints.tmp26 * 0.5
     tmp54 += ints.tmp28 * 0.5
     tmp54 += ints.tmp47 * -1
     tmp54 += ints.tmp49 * -0.5
-    tmp54 += tmp53.transpose((1, 0)) * 0.5
+    tmp54 += np.transpose(tmp53, (1, 0)) * 0.5
     del tmp53
     tmp6 = einsum(r2.bab, (0, 1, 2), t1.bb, (3, 0), (2, 3, 1)) * -1
-    tmp46 = ints.tmp139.copy() * 2
+    tmp46 = np.copy(ints.tmp139) * 2
     tmp46 += ints.tmp145
-    tmp46 += ints.tmp183.transpose((0, 1, 3, 2))
+    tmp46 += np.transpose(ints.tmp183, (0, 1, 3, 2))
     tmp46 += tmp45 * -1
     del tmp45
     tmp16 = einsum(r2.aaa, (0, 1, 2), t2.aaaa, (3, 2, 0, 1), (3,))
-    tmp60 = ints.tmp181.transpose((0, 1, 3, 2)).copy()
+    tmp60 = np.copy(np.transpose(ints.tmp181, (0, 1, 3, 2)))
     tmp60 += ints.tmp142 * 2
-    tmp64 = ints.tmp27.copy()
-    tmp64 += tmp63.transpose((1, 0))
+    tmp64 = np.copy(ints.tmp27)
+    tmp64 += np.transpose(tmp63, (1, 0))
     del tmp63
-    tmp66 = tmp15.copy()
+    tmp66 = np.copy(tmp15)
     tmp66 += tmp17
-    tmp124 = t2.bbbb.copy()
+    tmp124 = np.copy(t2.bbbb)
     tmp124 += einsum(t1.bb, (0, 1), t1.bb, (2, 3), (2, 0, 3, 1))
     tmp116 = einsum(tmp115, (0, 1, 2, 3), r2.aba, (2, 4, 0), (1, 4, 3))
     del tmp115
@@ -7725,22 +7725,22 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp108 = einsum(tmp107, (0, 1, 2, 3), r2.aba, (2, 4, 0), (1, 4, 3))
     del tmp107
     tmp81 = einsum(t1.bb, (0, 1), tmp38, (0, 2), (1, 2))
-    tmp87 = t2.abab.copy()
+    tmp87 = np.copy(t2.abab)
     tmp87 += einsum(t1.aa, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3))
-    tmp30 = ints.tmp117.copy()
+    tmp30 = np.copy(ints.tmp117)
     tmp30 += v.aabb.ooov
     tmp79 = einsum(t1.aa, (0, 1), tmp19, (0, 2), (1, 2))
-    tmp74 = ints.tmp120.copy()
-    tmp74 += v.aabb.ovoo.transpose((0, 2, 3, 1))
-    tmp83 = ints.tmp114.copy() * -1
-    tmp83 += ints.tmp114.transpose((0, 2, 1, 3))
+    tmp74 = np.copy(ints.tmp120)
+    tmp74 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
+    tmp83 = np.copy(ints.tmp114) * -1
+    tmp83 += np.transpose(ints.tmp114, (0, 2, 1, 3))
     tmp83 += v.bbbb.ooov
-    tmp83 += v.bbbb.ooov.transpose((0, 2, 1, 3)) * -1
-    tmp72 = ints.tmp111.copy() * -1
-    tmp72 += ints.tmp111.transpose((0, 2, 1, 3))
+    tmp83 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3)) * -1
+    tmp72 = np.copy(ints.tmp111) * -1
+    tmp72 += np.transpose(ints.tmp111, (0, 2, 1, 3))
     tmp72 += v.aaaa.ooov
-    tmp72 += v.aaaa.ooov.transpose((0, 2, 1, 3)) * -1
-    tmp77 = t2.abab.copy()
+    tmp72 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3)) * -1
+    tmp77 = np.copy(t2.abab)
     tmp77 += einsum(t1.aa, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3))
     tmp50 = einsum(r2.bab, (0, 1, 2), tmp49, (3, 2, 4, 0), (3, 1, 4)) * -2
     del tmp49
@@ -7755,7 +7755,7 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp46
     tmp43 = einsum(tmp16, (0,), v.aaaa.ovov, (1, 2, 0, 3), (1, 2, 3)) * -1
     tmp39 = einsum(r1.a, (0,), v.aaaa.ovvv, (1, 2, 3, 0), (1, 2, 3))
-    tmp69 = t2.aaaa.copy()
+    tmp69 = np.copy(t2.aaaa)
     tmp69 += einsum(t1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
     tmp59 = einsum(r2.bab, (0, 1, 2), v.aabb.ovov, (3, 4, 2, 0), (3, 1, 4)) * -1
     tmp61 = einsum(tmp60, (0, 1, 2, 3), r2.aaa, (4, 2, 0), (1, 4, 3)) * -1
@@ -7769,46 +7769,46 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp26 = einsum(r2.aba, (0, 1, 2), t1.aa, (3, 0), (2, 3, 1))
     tmp125 = einsum(r2.bbb, (0, 1, 2), tmp124, (3, 4, 0, 1), (2, 4, 3)) * -1
     del tmp124
-    tmp123 = tmp113.copy() * 2
+    tmp123 = np.copy(tmp113) * 2
     del tmp113
     tmp123 += tmp114
     del tmp114
-    tmp123 += tmp116.transpose((0, 2, 1))
+    tmp123 += np.transpose(tmp116, (0, 2, 1))
     del tmp116
-    tmp123 += tmp118.transpose((0, 2, 1)) * -2
+    tmp123 += np.transpose(tmp118, (0, 2, 1)) * -2
     del tmp118
-    tmp123 += tmp122.transpose((0, 2, 1)) * -2
+    tmp123 += np.transpose(tmp122, (0, 2, 1)) * -2
     del tmp122
-    tmp112 = tmp92.copy()
+    tmp112 = np.copy(tmp92)
     del tmp92
     tmp112 += tmp93 * 2
     del tmp93
     tmp112 += tmp94 * 2
     del tmp94
-    tmp112 += tmp98.transpose((0, 2, 1)) * -1
+    tmp112 += np.transpose(tmp98, (0, 2, 1)) * -1
     del tmp98
     tmp112 += tmp100 * -1
     del tmp100
-    tmp112 += tmp103.transpose((0, 2, 1)) * -1
+    tmp112 += np.transpose(tmp103, (0, 2, 1)) * -1
     del tmp103
-    tmp112 += tmp105.transpose((0, 2, 1)) * -1
+    tmp112 += np.transpose(tmp105, (0, 2, 1)) * -1
     del tmp105
-    tmp112 += tmp108.transpose((0, 2, 1))
+    tmp112 += np.transpose(tmp108, (0, 2, 1))
     del tmp108
     tmp112 += tmp111
     del tmp111
-    tmp91 = f.bb.oo.copy()
+    tmp91 = np.copy(f.bb.oo)
     tmp91 += ints.tmp130 * 2
     tmp91 += ints.tmp133
     tmp91 += ints.tmp158
     tmp91 += ints.tmp163
     tmp91 += ints.tmp195
     tmp91 += ints.tmp200
-    tmp91 += ints.tmp22.transpose((1, 0))
+    tmp91 += np.transpose(ints.tmp22, (1, 0))
     tmp91 += ints.tmp156 * -1
     tmp91 += ints.tmp193 * -1
     tmp4 = einsum(r2.bab, (0, 1, 2), t1.aa, (3, 1), (3, 2, 0)) * -1
-    tmp89 = ints.tmp175.transpose((1, 0)).copy()
+    tmp89 = np.copy(np.transpose(ints.tmp175, (1, 0)))
     tmp89 += ints.tmp230 * 2
     tmp89 += ints.tmp232
     tmp89 += f.bb.vv * -1
@@ -7817,39 +7817,39 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp89 += tmp81
     tmp88 = einsum(r2.bab, (0, 1, 2), tmp87, (3, 4, 1, 0), (3, 2, 4)) * -1
     del tmp87
-    tmp85 = ints.tmp284.copy()
+    tmp85 = np.copy(ints.tmp284)
     tmp85 += ints.tmp290 * 2
     tmp85 += ints.tmp310
-    tmp85 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp85 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp85 += ints.tmp287 * -1
     tmp85 += einsum(tmp30, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3)) * -1
-    tmp18 = tmp15.copy()
+    tmp18 = np.copy(tmp15)
     del tmp15
     tmp18 += tmp16 * 2
     del tmp16
     tmp18 += tmp17
     del tmp17
-    tmp90 = ints.tmp27.transpose((1, 0)).copy()
+    tmp90 = np.copy(np.transpose(ints.tmp27, (1, 0)))
     tmp90 += ints.tmp47 * 2
     tmp90 += ints.tmp49
     tmp90 += f.aa.vv * -1
-    tmp90 += ints.tmp26.transpose((1, 0)) * -1
-    tmp90 += ints.tmp28.transpose((1, 0)) * -1
+    tmp90 += np.transpose(ints.tmp26, (1, 0)) * -1
+    tmp90 += np.transpose(ints.tmp28, (1, 0)) * -1
     tmp90 += tmp79
-    tmp86 = ints.tmp149.copy()
-    tmp86 += ints.tmp185.transpose((0, 1, 3, 2)) * -1
-    tmp86 += v.aabb.vvoo.transpose((2, 3, 0, 1)) * -1
+    tmp86 = np.copy(ints.tmp149)
+    tmp86 += np.transpose(ints.tmp185, (0, 1, 3, 2)) * -1
+    tmp86 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1)) * -1
     tmp86 += einsum(t1.aa, (0, 1), tmp74, (0, 2, 3, 4), (2, 3, 1, 4))
-    tmp84 = ints.tmp285.copy() * 2
+    tmp84 = np.copy(ints.tmp285) * 2
     tmp84 += ints.tmp292
-    tmp84 += ints.tmp307.transpose((0, 1, 3, 2))
-    tmp84 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp84 += np.transpose(ints.tmp307, (0, 1, 3, 2))
+    tmp84 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp84 += ints.tmp288 * -2
-    tmp84 += ints.tmp305.transpose((0, 1, 3, 2)) * -1
+    tmp84 += np.transpose(ints.tmp305, (0, 1, 3, 2)) * -1
     tmp84 += v.bbbb.oovv * -1
     tmp84 += einsum(tmp83, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 4, 3)) * -1
     del tmp83
-    tmp80 = ints.tmp27.transpose((1, 0)).copy()
+    tmp80 = np.copy(np.transpose(ints.tmp27, (1, 0)))
     tmp80 += ints.tmp47 * 2
     tmp80 += ints.tmp49
     tmp80 += f.aa.vv * -1
@@ -7857,54 +7857,54 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp80 += ints.tmp28 * -1
     tmp80 += tmp79
     del tmp79
-    tmp75 = ints.tmp141.copy()
+    tmp75 = np.copy(ints.tmp141)
     tmp75 += ints.tmp147 * 2
     tmp75 += ints.tmp186
-    tmp75 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp75 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp75 += ints.tmp144 * -1
     tmp75 += einsum(t1.bb, (0, 1), tmp74, (2, 3, 0, 4), (2, 3, 4, 1)) * -1
     del tmp74
-    tmp71 = f.aa.oo.copy()
+    tmp71 = np.copy(f.aa.oo)
     tmp71 += ints.tmp127 * 2
     tmp71 += ints.tmp136
     tmp71 += ints.tmp153
     tmp71 += ints.tmp160
     tmp71 += ints.tmp190
     tmp71 += ints.tmp197
-    tmp71 += ints.tmp19.transpose((1, 0))
+    tmp71 += np.transpose(ints.tmp19, (1, 0))
     tmp71 += ints.tmp150 * -1
     tmp71 += ints.tmp187 * -1
-    tmp73 = ints.tmp139.copy() * 2
+    tmp73 = np.copy(ints.tmp139) * 2
     tmp73 += ints.tmp145
-    tmp73 += ints.tmp183.transpose((0, 1, 3, 2))
-    tmp73 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp73 += np.transpose(ints.tmp183, (0, 1, 3, 2))
+    tmp73 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp73 += ints.tmp142 * -2
-    tmp73 += ints.tmp181.transpose((0, 1, 3, 2)) * -1
+    tmp73 += np.transpose(ints.tmp181, (0, 1, 3, 2)) * -1
     tmp73 += v.aaaa.oovv * -1
     tmp73 += einsum(t1.aa, (0, 1), tmp72, (2, 0, 3, 4), (2, 3, 1, 4)) * -1
     del tmp72
     tmp24 = einsum(t1.bb, (0, 1), r2.aba, (2, 1, 3), (3, 0, 2))
-    tmp76 = ints.tmp294.copy()
-    tmp76 += ints.tmp309.transpose((0, 1, 3, 2)) * -1
+    tmp76 = np.copy(ints.tmp294)
+    tmp76 += np.transpose(ints.tmp309, (0, 1, 3, 2)) * -1
     tmp76 += v.aabb.oovv * -1
     tmp76 += einsum(t1.bb, (0, 1), tmp30, (2, 3, 0, 4), (2, 3, 1, 4))
-    tmp82 = ints.tmp175.transpose((1, 0)).copy()
+    tmp82 = np.copy(np.transpose(ints.tmp175, (1, 0)))
     tmp82 += ints.tmp230 * 2
     tmp82 += ints.tmp232
     tmp82 += f.bb.vv * -1
-    tmp82 += ints.tmp173.transpose((1, 0)) * -1
-    tmp82 += ints.tmp177.transpose((1, 0)) * -1
+    tmp82 += np.transpose(ints.tmp173, (1, 0)) * -1
+    tmp82 += np.transpose(ints.tmp177, (1, 0)) * -1
     tmp82 += tmp81
     del tmp81
     tmp78 = einsum(tmp77, (0, 1, 2, 3), r2.aba, (2, 3, 4), (4, 0, 1))
     del tmp77
-    tmp37 = tmp34.copy()
+    tmp37 = np.copy(tmp34)
     del tmp34
     tmp37 += tmp35 * -1
     del tmp35
     tmp37 += tmp36 * 2
     del tmp36
-    tmp56 = tmp39.copy()
+    tmp56 = np.copy(tmp39)
     del tmp39
     tmp56 += tmp40 * 2
     del tmp40
@@ -7914,49 +7914,49 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp42
     tmp56 += tmp43 * 2
     del tmp43
-    tmp56 += tmp47.transpose((0, 2, 1)) * -1
+    tmp56 += np.transpose(tmp47, (0, 2, 1)) * -1
     del tmp47
-    tmp56 += tmp50.transpose((0, 2, 1))
+    tmp56 += np.transpose(tmp50, (0, 2, 1))
     del tmp50
     tmp56 += tmp52 * -1
     del tmp52
-    tmp56 += tmp55.transpose((0, 2, 1)) * -1
+    tmp56 += np.transpose(tmp55, (0, 2, 1)) * -1
     del tmp55
     tmp70 = einsum(tmp69, (0, 1, 2, 3), r2.aaa, (2, 3, 4), (4, 1, 0)) * -1
     del tmp69
-    tmp68 = tmp57.copy() * 2
+    tmp68 = np.copy(tmp57) * 2
     del tmp57
     tmp68 += tmp58
     del tmp58
     tmp68 += tmp59
     del tmp59
-    tmp68 += tmp61.transpose((0, 2, 1)) * -2
+    tmp68 += np.transpose(tmp61, (0, 2, 1)) * -2
     del tmp61
-    tmp68 += tmp65.transpose((0, 2, 1)) * -2
+    tmp68 += np.transpose(tmp65, (0, 2, 1)) * -2
     del tmp65
-    tmp68 += tmp67.transpose((0, 2, 1))
+    tmp68 += np.transpose(tmp67, (0, 2, 1))
     del tmp67
     tmp31 = einsum(t1.bb, (0, 1), tmp22, (2, 3, 1), (2, 3, 0)) * -1
-    tmp32 = ints.tmp114.copy()
+    tmp32 = np.copy(ints.tmp114)
     tmp32 += v.bbbb.ooov * -1
-    tmp21 = ints.tmp238.transpose((0, 3, 1, 2)).copy() * 0.5
-    tmp21 += ints.tmp247.transpose((0, 2, 1, 3))
-    tmp21 += ints.tmp254.transpose((0, 2, 1, 3)) * 0.5
-    tmp21 += v.bbbb.ovvv.transpose((0, 2, 1, 3)) * 0.5
+    tmp21 = np.copy(np.transpose(ints.tmp238, (0, 3, 1, 2))) * 0.5
+    tmp21 += np.transpose(ints.tmp247, (0, 2, 1, 3))
+    tmp21 += np.transpose(ints.tmp254, (0, 2, 1, 3)) * 0.5
+    tmp21 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3)) * 0.5
     tmp21 += ints.tmp226 * -0.5
-    tmp21 += ints.tmp250.transpose((0, 2, 1, 3)) * -1
-    tmp21 += ints.tmp276.transpose((0, 3, 1, 2)) * -0.5
-    tmp27 = ints.tmp309.transpose((0, 1, 3, 2)).copy()
+    tmp21 += np.transpose(ints.tmp250, (0, 2, 1, 3)) * -1
+    tmp21 += np.transpose(ints.tmp276, (0, 3, 1, 2)) * -0.5
+    tmp27 = np.copy(np.transpose(ints.tmp309, (0, 1, 3, 2)))
     tmp27 += v.aabb.oovv
     tmp27 += ints.tmp294 * -1
     tmp29 = einsum(t1.bb, (0, 1), tmp26, (2, 3, 1), (2, 3, 0))
-    tmp33 = ints.tmp175.transpose((1, 0)).copy()
+    tmp33 = np.copy(np.transpose(ints.tmp175, (1, 0)))
     tmp33 += ints.tmp230 * 2
     tmp33 += ints.tmp232
     tmp33 += f.bb.vv * -1
-    tmp33 += ints.tmp173.transpose((1, 0)) * -1
-    tmp33 += ints.tmp177.transpose((1, 0)) * -1
-    tmp28 = ints.tmp112.copy() * 2
+    tmp33 += np.transpose(ints.tmp173, (1, 0)) * -1
+    tmp33 += np.transpose(ints.tmp177, (1, 0)) * -1
+    tmp28 = np.copy(ints.tmp112) * 2
     tmp28 += ints.tmp118
     tmp28 += ints.tmp128 * 2
     tmp28 += ints.tmp137
@@ -7988,27 +7988,27 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp28 += ints.tmp8 * -2
     tmp28 += ints.tmp94 * -1
     tmp28 += ints.tmp98 * -2
-    tmp23 = ints.tmp285.copy() * 2
+    tmp23 = np.copy(ints.tmp285) * 2
     tmp23 += ints.tmp292
-    tmp23 += ints.tmp307.transpose((0, 1, 3, 2))
-    tmp23 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp23 += np.transpose(ints.tmp307, (0, 1, 3, 2))
+    tmp23 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp23 += ints.tmp288 * -2
-    tmp23 += ints.tmp305.transpose((0, 1, 3, 2)) * -1
+    tmp23 += np.transpose(ints.tmp305, (0, 1, 3, 2)) * -1
     tmp23 += v.bbbb.oovv * -1
-    tmp20 = ints.tmp228.copy()
-    tmp20 += ints.tmp240.transpose((0, 1, 3, 2))
+    tmp20 = np.copy(ints.tmp228)
+    tmp20 += np.transpose(ints.tmp240, (0, 1, 3, 2))
     tmp20 += ints.tmp246
     tmp20 += ints.tmp252 * 2
-    tmp20 += ints.tmp278.transpose((0, 1, 3, 2))
+    tmp20 += np.transpose(ints.tmp278, (0, 1, 3, 2))
     tmp20 += v.aabb.ovvv
     tmp20 += ints.tmp249 * -1
-    tmp20 += ints.tmp256.transpose((0, 1, 3, 2)) * -1
-    tmp25 = ints.tmp284.copy()
+    tmp20 += np.transpose(ints.tmp256, (0, 1, 3, 2)) * -1
+    tmp25 = np.copy(ints.tmp284)
     tmp25 += ints.tmp290 * 2
     tmp25 += ints.tmp310
-    tmp25 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp25 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp25 += ints.tmp287 * -1
-    tmp9 = ints.tmp115.copy() * 2
+    tmp9 = np.copy(ints.tmp115) * 2
     tmp9 += ints.tmp121
     tmp9 += ints.tmp131 * 2
     tmp9 += ints.tmp134
@@ -8041,25 +8041,25 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp9 += ints.tmp88 * -1
     tmp9 += ints.tmp96 * -2
     tmp10 = einsum(tmp6, (0, 1, 2), t1.aa, (3, 2), (3, 0, 1))
-    tmp5 = ints.tmp141.copy()
+    tmp5 = np.copy(ints.tmp141)
     tmp5 += ints.tmp147 * 2
     tmp5 += ints.tmp186
-    tmp5 += v.aabb.ovov.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     tmp5 += ints.tmp144 * -1
-    tmp0 = ints.tmp125.copy()
-    tmp0 += ints.tmp45.transpose((0, 2, 1, 3))
+    tmp0 = np.copy(ints.tmp125)
+    tmp0 += np.transpose(ints.tmp45, (0, 2, 1, 3))
     tmp0 += ints.tmp61
-    tmp0 += ints.tmp73.transpose((0, 2, 1, 3))
-    tmp0 += ints.tmp79.transpose((0, 2, 1, 3)) * 2
-    tmp0 += v.aabb.vvov.transpose((2, 0, 1, 3))
-    tmp0 += ints.tmp76.transpose((0, 2, 1, 3)) * -1
+    tmp0 += np.transpose(ints.tmp73, (0, 2, 1, 3))
+    tmp0 += np.transpose(ints.tmp79, (0, 2, 1, 3)) * 2
+    tmp0 += np.transpose(v.aabb.vvov, (2, 0, 1, 3))
+    tmp0 += np.transpose(ints.tmp76, (0, 2, 1, 3)) * -1
     tmp0 += ints.tmp81 * -1
-    tmp11 = ints.tmp120.copy()
-    tmp11 += v.aabb.ovoo.transpose((0, 2, 3, 1))
-    tmp7 = ints.tmp185.transpose((0, 1, 3, 2)).copy()
-    tmp7 += v.aabb.vvoo.transpose((2, 3, 0, 1))
+    tmp11 = np.copy(ints.tmp120)
+    tmp11 += np.transpose(v.aabb.ovoo, (0, 2, 3, 1))
+    tmp7 = np.copy(np.transpose(ints.tmp185, (0, 1, 3, 2)))
+    tmp7 += np.transpose(v.aabb.vvoo, (2, 3, 0, 1))
     tmp7 += ints.tmp149 * -1
-    tmp8 = ints.tmp112.copy()
+    tmp8 = np.copy(ints.tmp112)
     tmp8 += ints.tmp118 * 0.5
     tmp8 += ints.tmp128
     tmp8 += ints.tmp137 * 0.5
@@ -8091,35 +8091,35 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp8 += ints.tmp8 * -1
     tmp8 += ints.tmp94 * -0.5
     tmp8 += ints.tmp98 * -1
-    tmp14 = ints.tmp27.transpose((1, 0)).copy()
+    tmp14 = np.copy(np.transpose(ints.tmp27, (1, 0)))
     tmp14 += ints.tmp47 * 2
     tmp14 += ints.tmp49
     tmp14 += f.aa.vv * -1
-    tmp14 += ints.tmp26.transpose((1, 0)) * -1
-    tmp14 += ints.tmp28.transpose((1, 0)) * -1
-    tmp3 = ints.tmp139.copy() * 2
+    tmp14 += np.transpose(ints.tmp26, (1, 0)) * -1
+    tmp14 += np.transpose(ints.tmp28, (1, 0)) * -1
+    tmp3 = np.copy(ints.tmp139) * 2
     tmp3 += ints.tmp145
-    tmp3 += ints.tmp183.transpose((0, 1, 3, 2))
-    tmp3 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp3 += np.transpose(ints.tmp183, (0, 1, 3, 2))
+    tmp3 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp3 += ints.tmp142 * -2
-    tmp3 += ints.tmp181.transpose((0, 1, 3, 2)) * -1
+    tmp3 += np.transpose(ints.tmp181, (0, 1, 3, 2)) * -1
     tmp3 += v.aaaa.oovv * -1
-    tmp13 = ints.tmp111.copy()
+    tmp13 = np.copy(ints.tmp111)
     tmp13 += v.aaaa.ooov * -1
-    tmp1 = ints.tmp59.copy() * 0.5
-    tmp1 += ints.tmp71.transpose((0, 1, 3, 2))
-    tmp1 += ints.tmp77.transpose((0, 1, 3, 2)) * 0.5
+    tmp1 = np.copy(ints.tmp59) * 0.5
+    tmp1 += np.transpose(ints.tmp71, (0, 1, 3, 2))
+    tmp1 += np.transpose(ints.tmp77, (0, 1, 3, 2)) * 0.5
     tmp1 += v.aaaa.ovvv * 0.5
     tmp1 += ints.tmp123 * -0.5
-    tmp1 += ints.tmp43.transpose((0, 2, 3, 1)) * -0.5
-    tmp1 += ints.tmp74.transpose((0, 1, 3, 2)) * -1
+    tmp1 += np.transpose(ints.tmp43, (0, 2, 3, 1)) * -0.5
+    tmp1 += np.transpose(ints.tmp74, (0, 1, 3, 2)) * -1
     tmp12 = einsum(t1.aa, (0, 1), tmp2, (2, 3, 1), (2, 3, 0)) * -1
     r2new.bbb = einsum(v.bbbb.vvvv, (0, 1, 2, 3), r2.bbb, (1, 3, 4), (0, 2, 4)) * 2
-    r2new.bbb += tmp112.transpose((1, 2, 0)) * -1
-    r2new.bbb += tmp112.transpose((2, 1, 0))
+    r2new.bbb += np.transpose(tmp112, (1, 2, 0)) * -1
+    r2new.bbb += np.transpose(tmp112, (2, 1, 0))
     del tmp112
-    r2new.bbb += tmp123.transpose((1, 2, 0))
-    r2new.bbb += tmp123.transpose((2, 1, 0)) * -1
+    r2new.bbb += np.transpose(tmp123, (1, 2, 0))
+    r2new.bbb += np.transpose(tmp123, (2, 1, 0)) * -1
     del tmp123
     r2new.bbb += einsum(v.bbbb.ovov, (0, 1, 2, 3), tmp125, (4, 0, 2), (3, 1, 4)) * -2
     del tmp125
@@ -8166,11 +8166,11 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     r2new.aba += einsum(v.aabb.ovov, (0, 1, 2, 3), tmp37, (2,), (1, 3, 0))
     r2new.aba += einsum(r1.b, (0,), tmp19, (1, 2), (2, 0, 1)) * -1
     r2new.aaa = einsum(r2.aaa, (0, 1, 2), v.aaaa.vvvv, (3, 1, 4, 0), (3, 4, 2)) * -2
-    r2new.aaa += tmp56.transpose((1, 2, 0)) * -1
-    r2new.aaa += tmp56.transpose((2, 1, 0))
+    r2new.aaa += np.transpose(tmp56, (1, 2, 0)) * -1
+    r2new.aaa += np.transpose(tmp56, (2, 1, 0))
     del tmp56
-    r2new.aaa += tmp68.transpose((1, 2, 0))
-    r2new.aaa += tmp68.transpose((2, 1, 0)) * -1
+    r2new.aaa += np.transpose(tmp68, (1, 2, 0))
+    r2new.aaa += np.transpose(tmp68, (2, 1, 0)) * -1
     del tmp68
     r2new.aaa += einsum(v.aaaa.ovov, (0, 1, 2, 3), tmp70, (4, 0, 2), (3, 1, 4)) * -2
     del tmp70

--- a/ebcc/codegen/UCCSDT.py
+++ b/ebcc/codegen/UCCSDT.py
@@ -9138,9 +9138,9 @@ def make_rdm2_f(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, t3=None,
     rdm2_f_abab = pack_2e(rdm2_f_abab_oooo, rdm2_f_abab_ooov, rdm2_f_abab_oovo, rdm2_f_abab_ovoo, rdm2_f_abab_vooo, rdm2_f_abab_oovv, rdm2_f_abab_ovov, rdm2_f_abab_ovvo, rdm2_f_abab_voov, rdm2_f_abab_vovo, rdm2_f_abab_vvoo, rdm2_f_abab_ovvv, rdm2_f_abab_vovv, rdm2_f_abab_vvov, rdm2_f_abab_vvvo, rdm2_f_abab_vvvv)
     rdm2_f_bbbb = pack_2e(rdm2_f_bbbb_oooo, rdm2_f_bbbb_ooov, rdm2_f_bbbb_oovo, rdm2_f_bbbb_ovoo, rdm2_f_bbbb_vooo, rdm2_f_bbbb_oovv, rdm2_f_bbbb_ovov, rdm2_f_bbbb_ovvo, rdm2_f_bbbb_voov, rdm2_f_bbbb_vovo, rdm2_f_bbbb_vvoo, rdm2_f_bbbb_ovvv, rdm2_f_bbbb_vovv, rdm2_f_bbbb_vvov, rdm2_f_bbbb_vvvo, rdm2_f_bbbb_vvvv)
 
-    rdm2_f_aaaa = rdm2_f_aaaa.swapaxes(1, 2)
-    rdm2_f_aabb = rdm2_f_abab.swapaxes(1, 2)
-    rdm2_f_bbbb = rdm2_f_bbbb.swapaxes(1, 2)
+    rdm2_f_aaaa = rdm2_f_aaaa.transpose(0, 2, 1, 3)
+    rdm2_f_aabb = rdm2_f_abab.transpose(0, 2, 1, 3)
+    rdm2_f_bbbb = rdm2_f_bbbb.transpose(0, 2, 1, 3)
 
     rdm2_f.aaaa = rdm2_f_aaaa
     rdm2_f.aabb = rdm2_f_aabb

--- a/ebcc/codegen/UCCSDT.py
+++ b/ebcc/codegen/UCCSDT.py
@@ -9138,9 +9138,9 @@ def make_rdm2_f(f=None, v=None, nocc=None, nvir=None, t1=None, t2=None, t3=None,
     rdm2_f_abab = pack_2e(rdm2_f_abab_oooo, rdm2_f_abab_ooov, rdm2_f_abab_oovo, rdm2_f_abab_ovoo, rdm2_f_abab_vooo, rdm2_f_abab_oovv, rdm2_f_abab_ovov, rdm2_f_abab_ovvo, rdm2_f_abab_voov, rdm2_f_abab_vovo, rdm2_f_abab_vvoo, rdm2_f_abab_ovvv, rdm2_f_abab_vovv, rdm2_f_abab_vvov, rdm2_f_abab_vvvo, rdm2_f_abab_vvvv)
     rdm2_f_bbbb = pack_2e(rdm2_f_bbbb_oooo, rdm2_f_bbbb_ooov, rdm2_f_bbbb_oovo, rdm2_f_bbbb_ovoo, rdm2_f_bbbb_vooo, rdm2_f_bbbb_oovv, rdm2_f_bbbb_ovov, rdm2_f_bbbb_ovvo, rdm2_f_bbbb_voov, rdm2_f_bbbb_vovo, rdm2_f_bbbb_vvoo, rdm2_f_bbbb_ovvv, rdm2_f_bbbb_vovv, rdm2_f_bbbb_vvov, rdm2_f_bbbb_vvvo, rdm2_f_bbbb_vvvv)
 
-    rdm2_f_aaaa = rdm2_f_aaaa.transpose(0, 2, 1, 3)
-    rdm2_f_aabb = rdm2_f_abab.transpose(0, 2, 1, 3)
-    rdm2_f_bbbb = rdm2_f_bbbb.transpose(0, 2, 1, 3)
+    rdm2_f_aaaa = np.transpose(rdm2_f_aaaa, (0, 2, 1, 3))
+    rdm2_f_aabb = np.transpose(rdm2_f_abab, (0, 2, 1, 3))
+    rdm2_f_bbbb = np.transpose(rdm2_f_bbbb, (0, 2, 1, 3))
 
     rdm2_f.aaaa = rdm2_f_aaaa
     rdm2_f.aabb = rdm2_f_aabb

--- a/ebcc/codegen/UCCSD_SD_1_1.py
+++ b/ebcc/codegen/UCCSD_SD_1_1.py
@@ -51,16 +51,16 @@ def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -1496,16 +1496,16 @@ def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -3880,16 +3880,16 @@ def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -4048,16 +4048,16 @@ def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -5664,16 +5664,16 @@ def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None,
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -5694,16 +5694,16 @@ def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -5722,16 +5722,16 @@ def make_eb_coup_rdm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=Non
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 

--- a/ebcc/codegen/UCCSD_SD_1_2.py
+++ b/ebcc/codegen/UCCSD_SD_1_2.py
@@ -52,16 +52,16 @@ def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -1833,16 +1833,16 @@ def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -4678,16 +4678,16 @@ def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -4866,16 +4866,16 @@ def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -6853,16 +6853,16 @@ def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None,
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -6885,16 +6885,16 @@ def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -6915,16 +6915,16 @@ def make_eb_coup_rdm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=Non
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 

--- a/ebcc/codegen/UCCSD_S_1_1.py
+++ b/ebcc/codegen/UCCSD_S_1_1.py
@@ -51,16 +51,16 @@ def update_amps(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -1444,16 +1444,16 @@ def update_lams(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -3792,16 +3792,16 @@ def make_rdm1_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -3960,16 +3960,16 @@ def make_rdm2_f(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -5546,16 +5546,16 @@ def make_sing_b_dm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None,
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -5575,16 +5575,16 @@ def make_rdm1_b(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=None, nb
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 
@@ -5602,16 +5602,16 @@ def make_eb_coup_rdm(f=None, v=None, w=None, g=None, G=None, nocc=None, nvir=Non
     # Get boson coupling creation array:
     gc = Namespace(
         aa = Namespace(
-            boo=g.aa.boo.transpose(0, 2, 1),
-            bov=g.aa.bvo.transpose(0, 2, 1),
-            bvo=g.aa.bov.transpose(0, 2, 1),
-            bvv=g.aa.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.aa.boo, (0, 2, 1)),
+            bov=np.transpose(g.aa.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.aa.bov, (0, 2, 1)),
+            bvv=np.transpose(g.aa.bvv, (0, 2, 1)),
         ),
         bb = Namespace(
-            boo=g.bb.boo.transpose(0, 2, 1),
-            bov=g.bb.bvo.transpose(0, 2, 1),
-            bvo=g.bb.bov.transpose(0, 2, 1),
-            bvv=g.bb.bvv.transpose(0, 2, 1),
+            boo=np.transpose(g.bb.boo, (0, 2, 1)),
+            bov=np.transpose(g.bb.bvo, (0, 2, 1)),
+            bvo=np.transpose(g.bb.bov, (0, 2, 1)),
+            bvv=np.transpose(g.bb.bvv, (0, 2, 1)),
         ),
     )
 

--- a/ebcc/codegen/UCCSDtp.py
+++ b/ebcc/codegen/UCCSDtp.py
@@ -41,10 +41,10 @@ def update_amps(f=None, v=None, space=None, t1=None, t2=None, t3=None, **kwargs)
     nvir = (space[0].ncvir, space[1].ncvir)
     naocc = (space[0].naocc, space[1].naocc)
     navir = (space[0].navir, space[1].navir)
-    soa = np.ones((nocc[0],), dtype=bool)
-    sva = np.ones((nvir[0],), dtype=bool)
-    sob = np.ones((nocc[1],), dtype=bool)
-    svb = np.ones((nvir[1],), dtype=bool)
+    soa = np.ones((nocc[0],), dtype=np.bool_)
+    sva = np.ones((nvir[0],), dtype=np.bool_)
+    sob = np.ones((nocc[1],), dtype=np.bool_)
+    svb = np.ones((nvir[1],), dtype=np.bool_)
     sOa = space[0].active[space[0].correlated][space[0].occupied[space[0].correlated]]
     sVa = space[0].active[space[0].correlated][space[0].virtual[space[0].correlated]]
     sOb = space[1].active[space[1].correlated][space[1].occupied[space[1].correlated]]

--- a/ebcc/codegen/UDCD.py
+++ b/ebcc/codegen/UDCD.py
@@ -71,113 +71,113 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp15 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.abab, (4, 2, 5, 3), (4, 0, 5, 1))
     tmp12 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 5, 1, 3), (0, 4, 2, 5))
     tmp35 = einsum(t2.bbbb, (0, 1, 2, 3), v.aabb.ovov, (4, 5, 1, 3), (4, 0, 5, 2))
-    tmp37 = f.bb.oo.copy()
+    tmp37 = np.copy(f.bb.oo)
     tmp37 += tmp21 * 0.5
     tmp37 += tmp22
-    tmp41 = f.bb.vv.copy() * -1
+    tmp41 = np.copy(f.bb.vv) * -1
     tmp41 += tmp26 * 0.5
     tmp41 += tmp27
-    tmp46 = v.bbbb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp46 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 1, 3)))
     tmp46 += tmp32
-    tmp44 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp44 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3))) * 2
     tmp44 += tmp34
-    tmp48 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp48 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp48 += tmp34 * 0.5
     tmp7 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (0, 4, 1, 3), (2, 4))
     tmp6 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (0, 3, 1, 4), (2, 4)) * -1
     tmp10 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (4, 2, 5, 3), (4, 0, 5, 1))
-    tmp2 = f.aa.oo.copy()
+    tmp2 = np.copy(f.aa.oo)
     tmp2 += tmp0
     tmp2 += tmp1 * 0.5
-    tmp18 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp18 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp18 += tmp15 * 0.5
-    tmp13 = v.aaaa.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp13 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 1, 3)))
     tmp13 += tmp12
-    tmp16 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp16 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3))) * 2
     tmp16 += tmp15
     tmp43 = einsum(tmp35, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (4, 1, 5, 3))
-    t2new.bbbb = tmp43.transpose((1, 0, 2, 3)).copy() * -1
-    t2new.bbbb += tmp43.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp43.transpose((1, 0, 3, 2))
+    t2new.bbbb = np.copy(np.transpose(tmp43, (1, 0, 2, 3))) * -1
+    t2new.bbbb += np.transpose(tmp43, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp43, (1, 0, 3, 2))
     t2new.bbbb += tmp43
-    t2new.bbbb += tmp43.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp43.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp43.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp43, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp43, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp43, (1, 0, 3, 2))
     t2new.bbbb += tmp43
     del tmp43
     tmp38 = einsum(tmp37, (0, 1), t2.bbbb, (2, 1, 3, 4), (0, 2, 3, 4)) * -1
     del tmp37
-    t2new.bbbb += tmp38.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp38.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp38.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp38.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp38, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp38, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp38, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp38, (1, 0, 3, 2)) * -1
     del tmp38
     tmp40 = einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.oovv, (4, 1, 5, 3), (0, 4, 2, 5))
-    t2new.bbbb += tmp40.transpose((0, 1, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp40, (0, 1, 3, 2)) * 2
     t2new.bbbb += tmp40 * -2
-    t2new.bbbb += tmp40.transpose((1, 0, 2, 3)) * 2
-    t2new.bbbb += tmp40.transpose((1, 0, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp40, (1, 0, 2, 3)) * 2
+    t2new.bbbb += np.transpose(tmp40, (1, 0, 3, 2)) * -2
     del tmp40
     tmp42 = einsum(tmp41, (0, 1), t2.bbbb, (2, 3, 4, 1), (2, 3, 0, 4)) * -2
     del tmp41
-    t2new.bbbb += tmp42.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp42.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp42, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp42, (1, 0, 2, 3))
     del tmp42
     tmp47 = einsum(t2.bbbb, (0, 1, 2, 3), tmp46, (4, 1, 5, 3), (4, 0, 5, 2)) * 2
     del tmp46
-    t2new.bbbb += tmp47.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp47.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp47.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp47, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp47, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp47, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp47
     del tmp47
     tmp39 = einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.oooo, (4, 1, 5, 0), (4, 5, 2, 3)) * -1
-    t2new.bbbb += tmp39.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp39.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp39, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp39, (1, 0, 3, 2))
     del tmp39
     tmp45 = einsum(tmp44, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5)) * 0.5
     del tmp44
-    t2new.bbbb += tmp45.transpose((1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp45, (1, 0, 2, 3)) * -1
     t2new.bbbb += tmp45
     del tmp45
     tmp50 = einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.vvvv, (4, 3, 5, 2), (0, 1, 4, 5)) * -1
-    t2new.bbbb += tmp50.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp50.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp50, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp50, (1, 0, 3, 2))
     del tmp50
     tmp49 = einsum(tmp48, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5))
     del tmp48
-    t2new.bbbb += tmp49.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp49.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp49, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp49, (0, 1, 3, 2)) * -1
     del tmp49
-    tmp25 = f.aa.vv.copy() * -1
-    tmp25 += tmp6.transpose((1, 0))
-    tmp25 += tmp7.transpose((1, 0)) * 0.5
+    tmp25 = np.copy(f.aa.vv) * -1
+    tmp25 += np.transpose(tmp6, (1, 0))
+    tmp25 += np.transpose(tmp7, (1, 0)) * 0.5
     t2new.abab = einsum(t2.abab, (0, 1, 2, 3), tmp25, (2, 4), (0, 1, 4, 3)) * -1
     del tmp25
-    tmp24 = f.aa.oo.copy()
-    tmp24 += tmp0.transpose((1, 0))
+    tmp24 = np.copy(f.aa.oo)
+    tmp24 += np.transpose(tmp0, (1, 0))
     del tmp0
-    tmp24 += tmp1.transpose((1, 0)) * 0.5
+    tmp24 += np.transpose(tmp1, (1, 0)) * 0.5
     del tmp1
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp24, (0, 4), (4, 1, 2, 3)) * -1
     del tmp24
-    tmp36 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp36 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp36 += tmp34 * 0.5
     del tmp34
     tmp36 += tmp35
     del tmp35
     t2new.abab += einsum(t2.aaaa, (0, 1, 2, 3), tmp36, (1, 4, 3, 5), (0, 4, 2, 5)) * 2
     del tmp36
-    tmp23 = f.bb.oo.copy()
-    tmp23 += tmp21.transpose((1, 0)) * 0.5
+    tmp23 = np.copy(f.bb.oo)
+    tmp23 += np.transpose(tmp21, (1, 0)) * 0.5
     del tmp21
-    tmp23 += tmp22.transpose((1, 0))
+    tmp23 += np.transpose(tmp22, (1, 0))
     del tmp22
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp23, (1, 4), (0, 4, 2, 3)) * -1
     del tmp23
-    tmp28 = f.bb.vv.copy() * -1
-    tmp28 += tmp26.transpose((1, 0)) * 0.5
+    tmp28 = np.copy(f.bb.vv) * -1
+    tmp28 += np.transpose(tmp26, (1, 0)) * 0.5
     del tmp26
-    tmp28 += tmp27.transpose((1, 0))
+    tmp28 += np.transpose(tmp27, (1, 0))
     del tmp27
     t2new.abab += einsum(tmp28, (0, 1), t2.abab, (2, 3, 4, 0), (2, 3, 4, 1)) * -1
     del tmp28
@@ -185,74 +185,74 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     t2new.abab += tmp31 * 0.5
     t2new.abab += tmp31 * 0.5
     del tmp31
-    tmp30 = v.aaaa.ovov.transpose((0, 2, 1, 3)).copy()
-    tmp30 += tmp12.transpose((1, 0, 3, 2))
+    tmp30 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 1, 3)))
+    tmp30 += np.transpose(tmp12, (1, 0, 3, 2))
     del tmp12
-    tmp30 += tmp10.transpose((1, 0, 3, 2)) * 0.5
+    tmp30 += np.transpose(tmp10, (1, 0, 3, 2)) * 0.5
     t2new.abab += einsum(tmp30, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5))
     del tmp30
-    tmp33 = v.bbbb.ovov.transpose((0, 2, 1, 3)).copy() * 2
+    tmp33 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 1, 3))) * 2
     tmp33 += einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (0, 4, 1, 5), (2, 4, 3, 5))
-    tmp33 += tmp32.transpose((1, 0, 3, 2)) * 2
+    tmp33 += np.transpose(tmp32, (1, 0, 3, 2)) * 2
     del tmp32
     t2new.abab += einsum(tmp33, (0, 1, 2, 3), t2.abab, (4, 0, 5, 2), (4, 1, 5, 3)) * 0.5
     del tmp33
-    tmp29 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp29 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp29 += einsum(v.aabb.ovov, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 1), (4, 2, 5, 3))
     tmp29 += tmp15 * 0.5
     del tmp15
     t2new.abab += einsum(tmp29, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (0, 4, 2, 5)) * 2
     del tmp29
     tmp4 = einsum(v.aaaa.oooo, (0, 1, 2, 3), t2.aaaa, (3, 1, 4, 5), (0, 2, 4, 5)) * -1
-    t2new.aaaa = tmp4.transpose((1, 0, 3, 2)).copy()
-    t2new.aaaa += tmp4.transpose((1, 0, 3, 2))
+    t2new.aaaa = np.copy(np.transpose(tmp4, (1, 0, 3, 2)))
+    t2new.aaaa += np.transpose(tmp4, (1, 0, 3, 2))
     del tmp4
     tmp11 = einsum(t2.aaaa, (0, 1, 2, 3), tmp10, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp10
-    t2new.aaaa += tmp11.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp11.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp11.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp11, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp11, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp11, (1, 0, 3, 2))
     t2new.aaaa += tmp11
-    t2new.aaaa += tmp11.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp11.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp11.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp11, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp11, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp11, (1, 0, 3, 2))
     t2new.aaaa += tmp11
     del tmp11
     tmp3 = einsum(tmp2, (0, 1), t2.aaaa, (2, 1, 3, 4), (2, 0, 3, 4)) * -1
     del tmp2
-    t2new.aaaa += tmp3.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp3.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp3.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp3.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp3, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp3, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp3, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp3, (0, 1, 3, 2)) * -1
     del tmp3
     tmp20 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.vvvv, (4, 3, 5, 2), (0, 1, 4, 5)) * -1
-    t2new.aaaa += tmp20.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp20.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp20, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp20, (1, 0, 3, 2))
     del tmp20
     tmp5 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.oovv, (4, 1, 5, 3), (0, 4, 2, 5))
-    t2new.aaaa += tmp5.transpose((0, 1, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp5, (0, 1, 3, 2)) * 2
     t2new.aaaa += tmp5 * -2
-    t2new.aaaa += tmp5.transpose((1, 0, 2, 3)) * 2
-    t2new.aaaa += tmp5.transpose((1, 0, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp5, (1, 0, 2, 3)) * 2
+    t2new.aaaa += np.transpose(tmp5, (1, 0, 3, 2)) * -2
     del tmp5
     tmp19 = einsum(t2.abab, (0, 1, 2, 3), tmp18, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp18
     t2new.aaaa += tmp19
-    t2new.aaaa += tmp19.transpose((1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp19, (1, 0, 2, 3)) * -1
     del tmp19
     tmp14 = einsum(tmp13, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (4, 0, 5, 2)) * 2
     del tmp13
-    t2new.aaaa += tmp14.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp14, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp14
-    t2new.aaaa += tmp14.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp14.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp14, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp14, (1, 0, 3, 2))
     del tmp14
-    tmp9 = f.aa.vv.copy() * -2
+    tmp9 = np.copy(f.aa.vv) * -2
     tmp9 += tmp6 * 2
     tmp9 += tmp7
     t2new.aaaa += einsum(tmp9, (0, 1), t2.aaaa, (2, 3, 4, 1), (2, 3, 4, 0)) * -1
     del tmp9
-    tmp8 = f.aa.vv.copy() * -1
+    tmp8 = np.copy(f.aa.vv) * -1
     tmp8 += tmp6
     del tmp6
     tmp8 += tmp7 * 0.5
@@ -261,19 +261,19 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     del tmp8
     tmp17 = einsum(t2.abab, (0, 1, 2, 3), tmp16, (4, 1, 5, 3), (0, 4, 2, 5)) * 0.5
     del tmp16
-    t2new.aaaa += tmp17.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp17.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp17, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp17, (1, 0, 3, 2))
     del tmp17
-    t2new.aaaa += v.aaaa.ovov.transpose((0, 2, 1, 3))
-    t2new.aaaa += v.aaaa.ovov.transpose((0, 2, 3, 1)) * -1
+    t2new.aaaa += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
+    t2new.aaaa += np.transpose(v.aaaa.ovov, (0, 2, 3, 1)) * -1
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), v.aabb.oooo, (4, 0, 5, 1), (4, 5, 2, 3))
     t2new.abab += einsum(v.aaaa.oovv, (0, 1, 2, 3), t2.abab, (1, 4, 3, 5), (0, 4, 2, 5)) * -1
     t2new.abab += einsum(v.aabb.oovv, (0, 1, 2, 3), t2.abab, (1, 4, 5, 3), (0, 4, 5, 2)) * -1
-    t2new.abab += v.aabb.ovov.transpose((0, 2, 1, 3))
+    t2new.abab += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     t2new.abab += einsum(v.bbbb.oovv, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 5, 2)) * -1
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), v.aabb.vvoo, (4, 2, 5, 1), (0, 5, 4, 3)) * -1
-    t2new.bbbb += v.bbbb.ovov.transpose((0, 2, 1, 3))
-    t2new.bbbb += v.bbbb.ovov.transpose((0, 2, 3, 1)) * -1
+    t2new.bbbb += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
+    t2new.bbbb += np.transpose(v.bbbb.ovov, (0, 2, 3, 1)) * -1
 
     return {f"t2new": t2new}
 

--- a/ebcc/codegen/UDCSD.py
+++ b/ebcc/codegen/UDCSD.py
@@ -37,17 +37,17 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
         Coupled cluster energy.
     """
 
-    tmp0 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp0 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp2 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp2 += v.aaaa.ovov.transpose((0, 2, 1, 3))
-    tmp1 = f.bb.ov.copy() * 2
+    tmp0 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp0 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
+    tmp2 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1))) * -1
+    tmp2 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
+    tmp1 = np.copy(f.bb.ov) * 2
     tmp1 += einsum(t1.aa, (0, 1), v.aabb.ovov, (0, 1, 2, 3), (2, 3)) * 2
     tmp1 += einsum(t1.bb, (0, 1), tmp0, (0, 2, 1, 3), (2, 3)) * -1
     del tmp0
     e_cc = einsum(tmp1, (0, 1), t1.bb, (0, 1), ()) * 0.5
     del tmp1
-    tmp3 = f.aa.ov.copy() * 2
+    tmp3 = np.copy(f.aa.ov) * 2
     tmp3 += einsum(t1.aa, (0, 1), tmp2, (0, 2, 3, 1), (2, 3)) * -1
     del tmp2
     e_cc += einsum(t1.aa, (0, 1), tmp3, (0, 1), ()) * 0.5
@@ -83,68 +83,68 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
 
     t1new = Namespace()
     t2new = Namespace()
-    tmp14 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp14 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp7 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp7 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp14 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp14 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
+    tmp7 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1))) * -1
+    tmp7 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp21 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t1.bb, (4, 3), (4, 0, 2, 1))
     t1new.bb = einsum(tmp21, (0, 1, 2, 3), t2.bbbb, (1, 2, 4, 3), (0, 4)) * 2
     tmp15 = einsum(t1.bb, (0, 1), tmp14, (0, 2, 1, 3), (2, 3))
     del tmp14
     tmp13 = einsum(t1.aa, (0, 1), v.aabb.ovov, (0, 1, 2, 3), (2, 3))
     t1new.bb += tmp13
-    tmp154 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp154 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp154 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp154 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
     tmp0 = einsum(v.aabb.ovov, (0, 1, 2, 3), t1.bb, (2, 3), (0, 1))
-    t1new.aa = tmp0.copy()
+    t1new.aa = np.copy(tmp0)
     tmp8 = einsum(t1.aa, (0, 1), tmp7, (0, 2, 3, 1), (2, 3))
     del tmp7
-    tmp54 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp54 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp54 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1))) * -1
+    tmp54 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp1 = einsum(v.aaaa.ovov, (0, 1, 2, 3), t1.aa, (4, 3), (4, 0, 2, 1))
     t1new.aa += einsum(tmp1, (0, 1, 2, 3), t2.aaaa, (1, 2, 4, 3), (0, 4)) * 2
     tmp22 = einsum(v.aabb.ovov, (0, 1, 2, 3), t1.bb, (4, 3), (0, 4, 2, 1))
     t1new.bb += einsum(tmp22, (0, 1, 2, 3), t2.abab, (0, 2, 3, 4), (1, 4)) * -1
-    tmp165 = v.bbbb.ovvv.copy() * -1
-    tmp165 += v.bbbb.ovvv.transpose((0, 2, 1, 3))
-    tmp167 = tmp21.copy() * -1
-    tmp167 += tmp21.transpose((0, 2, 1, 3))
-    tmp30 = v.bbbb.ooov.copy()
-    tmp30 += v.bbbb.ovoo.transpose((0, 2, 3, 1)) * -1
-    tmp174 = v.bbbb.ooov.copy() * -1
-    tmp174 += v.bbbb.ovoo.transpose((0, 2, 3, 1))
-    tmp16 = f.bb.ov.copy()
+    tmp165 = np.copy(v.bbbb.ovvv) * -1
+    tmp165 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3))
+    tmp167 = np.copy(tmp21) * -1
+    tmp167 += np.transpose(tmp21, (0, 2, 1, 3))
+    tmp30 = np.copy(v.bbbb.ooov)
+    tmp30 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1)) * -1
+    tmp174 = np.copy(v.bbbb.ooov) * -1
+    tmp174 += np.transpose(v.bbbb.ovoo, (0, 2, 3, 1))
+    tmp16 = np.copy(f.bb.ov)
     tmp16 += tmp13
     tmp16 += tmp15 * -1
     del tmp15
     t1new.bb += einsum(t2.bbbb, (0, 1, 2, 3), tmp16, (1, 3), (0, 2)) * 2
     t1new.aa += einsum(tmp16, (0, 1), t2.abab, (2, 0, 3, 1), (2, 3))
-    tmp105 = v.bbbb.ovvv.copy() * -1
-    tmp105 += v.bbbb.ovvv.transpose((0, 2, 1, 3))
+    tmp105 = np.copy(v.bbbb.ovvv) * -1
+    tmp105 += np.transpose(v.bbbb.ovvv, (0, 2, 1, 3))
     tmp155 = einsum(t1.bb, (0, 1), tmp154, (0, 2, 1, 3), (2, 3))
     del tmp154
-    tmp18 = v.aaaa.ooov.copy() * -1
-    tmp18 += v.aaaa.ooov.transpose((0, 2, 1, 3))
-    tmp9 = f.aa.ov.copy()
+    tmp18 = np.copy(v.aaaa.ooov) * -1
+    tmp18 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3))
+    tmp9 = np.copy(f.aa.ov)
     tmp9 += tmp0
     tmp9 += tmp8 * -1
     del tmp8
     t1new.bb += einsum(t2.abab, (0, 1, 2, 3), tmp9, (0, 2), (1, 3))
     t1new.aa += einsum(tmp9, (0, 1), t2.aaaa, (2, 0, 3, 1), (2, 3)) * 2
-    tmp43 = v.aaaa.ovvv.copy()
-    tmp43 += v.aaaa.ovvv.transpose((0, 2, 3, 1)) * -1
+    tmp43 = np.copy(v.aaaa.ovvv)
+    tmp43 += np.transpose(v.aaaa.ovvv, (0, 2, 3, 1)) * -1
     tmp55 = einsum(t1.aa, (0, 1), tmp54, (0, 2, 3, 1), (2, 3))
     del tmp54
     tmp2 = einsum(t1.aa, (0, 1), v.aabb.ovov, (2, 1, 3, 4), (0, 2, 3, 4))
     t1new.aa += einsum(t2.abab, (0, 1, 2, 3), tmp2, (4, 0, 1, 3), (4, 2)) * -1
-    tmp78 = v.aaaa.ooov.copy() * -1
-    tmp78 += v.aaaa.ovoo.transpose((0, 2, 3, 1))
-    tmp70 = tmp1.copy() * -1
-    tmp70 += tmp1.transpose((0, 2, 1, 3))
-    tmp68 = v.aaaa.ovvv.copy() * -1
-    tmp68 += v.aaaa.ovvv.transpose((0, 2, 1, 3))
+    tmp78 = np.copy(v.aaaa.ooov) * -1
+    tmp78 += np.transpose(v.aaaa.ovoo, (0, 2, 3, 1))
+    tmp70 = np.copy(tmp1) * -1
+    tmp70 += np.transpose(tmp1, (0, 2, 1, 3))
+    tmp68 = np.copy(v.aaaa.ovvv) * -1
+    tmp68 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3))
     tmp113 = einsum(tmp22, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 3, 4))
-    t2new.abab = tmp113.copy() * -1
+    t2new.abab = np.copy(tmp113) * -1
     tmp112 = einsum(t1.bb, (0, 1), v.aabb.ovvv, (2, 3, 4, 1), (2, 0, 3, 4))
     t2new.abab += tmp112
     tmp166 = einsum(tmp165, (0, 1, 2, 3), t1.bb, (4, 1), (4, 0, 2, 3))
@@ -153,10 +153,10 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp167
     tmp150 = einsum(v.bbbb.ooov, (0, 1, 2, 3), t1.bb, (4, 3), (4, 0, 1, 2))
     tmp159 = einsum(v.bbbb.ovvv, (0, 1, 2, 3), t1.bb, (4, 3), (4, 0, 1, 2))
-    t2new.bbbb = tmp159.transpose((1, 0, 3, 2)).copy() * -1
-    t2new.bbbb += tmp159.transpose((0, 1, 3, 2))
+    t2new.bbbb = np.copy(np.transpose(tmp159, (1, 0, 3, 2))) * -1
+    t2new.bbbb += np.transpose(tmp159, (0, 1, 3, 2))
     t2new.bbbb += tmp159 * -1
-    t2new.bbbb += tmp159.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp159, (1, 0, 2, 3))
     tmp25 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.bbbb, (4, 2, 3, 1), (4, 0)) * -1
     tmp24 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (0, 2, 4, 3), (1, 4))
     tmp29 = einsum(t1.aa, (0, 1), v.aabb.ovoo, (0, 1, 2, 3), (2, 3))
@@ -166,9 +166,9 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp174
     tmp127 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.bbbb, (4, 2, 5, 3), (4, 0, 5, 1))
     t2new.bbbb += tmp127 * 2
-    t2new.bbbb += tmp127.transpose((0, 1, 3, 2)) * -2
-    t2new.bbbb += tmp127.transpose((1, 0, 2, 3)) * -2
-    t2new.bbbb += tmp127.transpose((1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp127, (0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp127, (1, 0, 2, 3)) * -2
+    t2new.bbbb += np.transpose(tmp127, (1, 0, 3, 2)) * 2
     tmp180 = einsum(t1.bb, (0, 1), tmp21, (2, 3, 4, 1), (2, 0, 4, 3))
     tmp107 = einsum(t1.bb, (0, 1), tmp16, (0, 2), (1, 2))
     tmp104 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.bbbb, (0, 2, 4, 1), (4, 3)) * -1
@@ -179,7 +179,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new.abab += tmp116 * -1
     tmp100 = einsum(t2.abab, (0, 1, 2, 3), v.aaaa.ovov, (4, 5, 0, 2), (4, 1, 5, 3))
     t2new.abab += tmp100
-    tmp156 = f.bb.ov.copy()
+    tmp156 = np.copy(f.bb.ov)
     tmp156 += tmp13
     del tmp13
     tmp156 += tmp155 * -1
@@ -195,7 +195,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp41 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (0, 3, 1, 4), (2, 4)) * -1
     tmp44 = einsum(t1.aa, (0, 1), tmp43, (0, 1, 2, 3), (2, 3))
     del tmp43
-    tmp56 = f.aa.ov.copy()
+    tmp56 = np.copy(f.aa.ov)
     tmp56 += tmp0
     del tmp0
     tmp56 += tmp55 * -1
@@ -205,10 +205,10 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new.abab += tmp65 * -1
     tmp48 = einsum(v.aaaa.ooov, (0, 1, 2, 3), t1.aa, (4, 3), (4, 0, 1, 2))
     tmp39 = einsum(v.aaaa.ovov, (0, 1, 2, 3), t2.aaaa, (4, 2, 5, 3), (4, 0, 5, 1))
-    t2new.aaaa = tmp39.copy() * 2
-    t2new.aaaa += tmp39.transpose((0, 1, 3, 2)) * -2
-    t2new.aaaa += tmp39.transpose((1, 0, 2, 3)) * -2
-    t2new.aaaa += tmp39.transpose((1, 0, 3, 2)) * 2
+    t2new.aaaa = np.copy(tmp39) * 2
+    t2new.aaaa += np.transpose(tmp39, (0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp39, (1, 0, 2, 3)) * -2
+    t2new.aaaa += np.transpose(tmp39, (1, 0, 3, 2)) * 2
     tmp79 = einsum(t1.aa, (0, 1), tmp78, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp78
     tmp71 = einsum(t1.aa, (0, 1), tmp70, (2, 3, 0, 4), (2, 3, 1, 4))
@@ -221,17 +221,17 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp82 = einsum(t1.aa, (0, 1), v.aabb.ooov, (2, 0, 3, 4), (2, 3, 1, 4))
     t2new.abab += tmp82 * -1
     tmp60 = einsum(t1.aa, (0, 1), v.aaaa.ovvv, (2, 3, 4, 1), (0, 2, 3, 4))
-    t2new.aaaa += tmp60.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp60.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp60, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp60, (0, 1, 3, 2))
     t2new.aaaa += tmp60 * -1
-    t2new.aaaa += tmp60.transpose((1, 0, 2, 3))
-    tmp138 = tmp112.copy()
+    t2new.aaaa += np.transpose(tmp60, (1, 0, 2, 3))
+    tmp138 = np.copy(tmp112)
     tmp138 += tmp113 * -1
     t2new.abab += einsum(t2.aaaa, (0, 1, 2, 3), tmp138, (1, 4, 3, 5), (0, 4, 2, 5)) * 2
     tmp144 = einsum(t1.bb, (0, 1), v.bbbb.oooo, (2, 3, 4, 0), (2, 3, 4, 1))
     tmp101 = einsum(t2.bbbb, (0, 1, 2, 3), v.aabb.ovov, (4, 5, 1, 3), (4, 0, 5, 2))
     t2new.abab += tmp101 * 2
-    tmp169 = tmp166.transpose((0, 1, 3, 2)).copy() * -1
+    tmp169 = np.copy(np.transpose(tmp166, (0, 1, 3, 2))) * -1
     del tmp166
     tmp169 += tmp168 * -1
     del tmp168
@@ -239,114 +239,114 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp148 = einsum(t1.bb, (0, 1), v.bbbb.oovv, (2, 3, 4, 1), (0, 2, 3, 4))
     tmp184 = einsum(t1.bb, (0, 1), tmp159, (2, 3, 1, 4), (0, 2, 3, 4))
     del tmp159
-    tmp98 = f.bb.oo.copy()
-    tmp98 += tmp29.transpose((1, 0))
-    tmp98 += tmp24.transpose((1, 0)) * 0.5
-    tmp98 += tmp25.transpose((1, 0))
-    tmp98 += tmp31.transpose((1, 0)) * -1
+    tmp98 = np.copy(f.bb.oo)
+    tmp98 += np.transpose(tmp29, (1, 0))
+    tmp98 += np.transpose(tmp24, (1, 0)) * 0.5
+    tmp98 += np.transpose(tmp25, (1, 0))
+    tmp98 += np.transpose(tmp31, (1, 0)) * -1
     t2new.abab += einsum(tmp98, (0, 1), t2.abab, (2, 0, 3, 4), (2, 1, 3, 4)) * -1
-    tmp176 = v.bbbb.oovv.copy() * -1
+    tmp176 = np.copy(v.bbbb.oovv) * -1
     tmp176 += tmp127
-    tmp176 += tmp175.transpose((1, 0, 2, 3)) * -1
+    tmp176 += np.transpose(tmp175, (1, 0, 2, 3)) * -1
     del tmp175
     tmp186 = einsum(t1.bb, (0, 1), v.bbbb.vvvv, (2, 3, 4, 1), (0, 2, 3, 4))
-    tmp188 = v.bbbb.ovvv.copy()
+    tmp188 = np.copy(v.bbbb.ovvv)
     tmp188 += einsum(t1.bb, (0, 1), v.bbbb.ovov, (2, 3, 0, 4), (2, 4, 1, 3))
-    tmp163 = tmp112.copy() * -1
+    tmp163 = np.copy(tmp112) * -1
     tmp163 += tmp113
     del tmp113
     tmp182 = einsum(t1.bb, (0, 1), tmp180, (2, 3, 0, 4), (3, 2, 4, 1))
-    tmp108 = f.bb.vv.copy() * -1
-    tmp108 += tmp102.transpose((1, 0)) * -1
+    tmp108 = np.copy(f.bb.vv) * -1
+    tmp108 += np.transpose(tmp102, (1, 0)) * -1
     del tmp102
-    tmp108 += tmp103.transpose((1, 0)) * 0.5
+    tmp108 += np.transpose(tmp103, (1, 0)) * 0.5
     del tmp103
-    tmp108 += tmp104.transpose((1, 0))
+    tmp108 += np.transpose(tmp104, (1, 0))
     del tmp104
     tmp108 += tmp106 * -1
     del tmp106
-    tmp108 += tmp107.transpose((1, 0))
+    tmp108 += np.transpose(tmp107, (1, 0))
     del tmp107
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp108, (3, 4), (0, 1, 2, 4)) * -1
-    tmp178 = tmp116.copy() * 2
+    tmp178 = np.copy(tmp116) * 2
     tmp178 += tmp100 * -1
-    tmp161 = tmp21.copy() * -1
-    tmp161 += tmp21.transpose((0, 2, 1, 3))
+    tmp161 = np.copy(tmp21) * -1
+    tmp161 += np.transpose(tmp21, (0, 2, 1, 3))
     tmp157 = einsum(tmp156, (0, 1), t1.bb, (2, 1), (2, 0))
     del tmp156
-    tmp135 = v.bbbb.ovvv.copy()
-    tmp135 += v.bbbb.ovvv.transpose((0, 2, 3, 1)) * -1
-    tmp136 = tmp21.copy()
-    tmp136 += tmp21.transpose((0, 2, 1, 3)) * -1
-    tmp122 = v.aaaa.ooov.copy()
-    tmp122 += v.aaaa.ooov.transpose((0, 2, 1, 3)) * -1
+    tmp135 = np.copy(v.bbbb.ovvv)
+    tmp135 += np.transpose(v.bbbb.ovvv, (0, 2, 3, 1)) * -1
+    tmp136 = np.copy(tmp21)
+    tmp136 += np.transpose(tmp21, (0, 2, 1, 3)) * -1
+    tmp122 = np.copy(v.aaaa.ooov)
+    tmp122 += np.transpose(v.aaaa.ooov, (0, 2, 1, 3)) * -1
     tmp38 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (4, 5, 1, 3), (0, 4, 2, 5))
     t2new.aaaa += tmp38
-    t2new.aaaa += tmp38.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp38.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp38.transpose((1, 0, 3, 2))
-    tmp131 = v.aabb.vvov.transpose((2, 0, 1, 3)).copy()
+    t2new.aaaa += np.transpose(tmp38, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp38, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp38, (1, 0, 3, 2))
+    tmp131 = np.copy(np.transpose(v.aabb.vvov, (2, 0, 1, 3)))
     tmp131 += einsum(t1.aa, (0, 1), v.aabb.ovov, (0, 2, 3, 4), (3, 1, 2, 4)) * -1
     tmp124 = einsum(t2.aaaa, (0, 1, 2, 3), v.aabb.ovov, (1, 3, 4, 5), (0, 4, 2, 5))
     t2new.abab += tmp124 * 2
     tmp126 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (0, 4, 1, 5), (4, 2, 5, 3))
     t2new.bbbb += tmp126
-    t2new.bbbb += tmp126.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp126.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp126.transpose((1, 0, 3, 2))
-    tmp128 = v.bbbb.ooov.copy()
-    tmp128 += v.bbbb.ooov.transpose((0, 2, 1, 3)) * -1
+    t2new.bbbb += np.transpose(tmp126, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp126, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp126, (1, 0, 3, 2))
+    tmp128 = np.copy(v.bbbb.ooov)
+    tmp128 += np.transpose(v.bbbb.ooov, (0, 2, 1, 3)) * -1
     tmp114 = einsum(v.aabb.vvov, (0, 1, 2, 3), t1.bb, (4, 3), (4, 2, 0, 1))
-    tmp133 = v.aaaa.ovvv.copy()
-    tmp133 += v.aaaa.ovvv.transpose((0, 2, 3, 1)) * -1
+    tmp133 = np.copy(v.aaaa.ovvv)
+    tmp133 += np.transpose(v.aaaa.ovvv, (0, 2, 3, 1)) * -1
     tmp91 = einsum(t1.aa, (0, 1), v.aaaa.vvvv, (2, 3, 4, 1), (0, 2, 3, 4))
-    tmp36 = f.aa.oo.copy()
-    tmp36 += tmp17.transpose((1, 0))
-    tmp36 += tmp5.transpose((1, 0))
-    tmp36 += tmp6.transpose((1, 0)) * 0.5
-    tmp36 += tmp19.transpose((1, 0)) * -1
+    tmp36 = np.copy(f.aa.oo)
+    tmp36 += np.transpose(tmp17, (1, 0))
+    tmp36 += np.transpose(tmp5, (1, 0))
+    tmp36 += np.transpose(tmp6, (1, 0)) * 0.5
+    tmp36 += np.transpose(tmp19, (1, 0)) * -1
     t2new.abab += einsum(tmp36, (0, 1), t2.abab, (0, 2, 3, 4), (1, 2, 3, 4)) * -1
-    tmp46 = f.aa.vv.copy() * -1
-    tmp46 += tmp40.transpose((1, 0)) * -1
+    tmp46 = np.copy(f.aa.vv) * -1
+    tmp46 += np.transpose(tmp40, (1, 0)) * -1
     del tmp40
-    tmp46 += tmp41.transpose((1, 0))
+    tmp46 += np.transpose(tmp41, (1, 0))
     del tmp41
-    tmp46 += tmp42.transpose((1, 0)) * 0.5
+    tmp46 += np.transpose(tmp42, (1, 0)) * 0.5
     del tmp42
-    tmp46 += tmp44.transpose((1, 0)) * -1
+    tmp46 += np.transpose(tmp44, (1, 0)) * -1
     del tmp44
-    tmp46 += tmp45.transpose((1, 0))
+    tmp46 += np.transpose(tmp45, (1, 0))
     del tmp45
     t2new.abab += einsum(tmp46, (0, 1), t2.abab, (2, 3, 0, 4), (2, 3, 1, 4)) * -1
     tmp57 = einsum(t1.aa, (0, 1), tmp56, (2, 1), (0, 2))
     del tmp56
     t2new.abab += einsum(tmp57, (0, 1), t2.abab, (1, 2, 3, 4), (0, 2, 3, 4)) * -1
-    tmp74 = tmp64.copy()
+    tmp74 = np.copy(tmp64)
     tmp74 += tmp65 * -1
     t2new.abab += einsum(t2.bbbb, (0, 1, 2, 3), tmp74, (4, 1, 5, 3), (4, 0, 5, 2)) * 2
     tmp50 = einsum(v.aaaa.oovv, (0, 1, 2, 3), t1.aa, (4, 3), (4, 0, 1, 2))
-    tmp95 = v.aaaa.ovvv.copy()
+    tmp95 = np.copy(v.aaaa.ovvv)
     tmp95 += einsum(t1.aa, (0, 1), v.aaaa.ovov, (2, 3, 0, 4), (2, 4, 3, 1))
     tmp52 = einsum(t1.aa, (0, 1), tmp48, (2, 3, 4, 0), (2, 4, 3, 1))
-    tmp66 = tmp64.copy() * -1
+    tmp66 = np.copy(tmp64) * -1
     del tmp64
     tmp66 += tmp65
     del tmp65
-    tmp80 = v.aaaa.oovv.copy() * -1
+    tmp80 = np.copy(v.aaaa.oovv) * -1
     tmp80 += tmp39
-    tmp80 += tmp79.transpose((1, 0, 2, 3)) * -1
+    tmp80 += np.transpose(tmp79, (1, 0, 2, 3)) * -1
     del tmp79
-    tmp72 = tmp69.transpose((0, 1, 3, 2)).copy() * -1
+    tmp72 = np.copy(np.transpose(tmp69, (0, 1, 3, 2))) * -1
     del tmp69
     tmp72 += tmp71 * -1
     tmp34 = einsum(v.aaaa.oooo, (0, 1, 2, 3), t1.aa, (3, 4), (0, 1, 2, 4))
     tmp89 = einsum(t1.aa, (0, 1), tmp87, (2, 3, 0, 4), (3, 2, 4, 1))
-    tmp85 = tmp82.copy() * 2
+    tmp85 = np.copy(tmp82) * 2
     tmp85 += tmp83 * -1
-    tmp61 = v.aaaa.ovvv.copy() * -1
-    tmp61 += v.aaaa.ovvv.transpose((0, 2, 1, 3))
-    tmp62 = tmp1.copy() * -1
-    tmp62 += tmp1.transpose((0, 2, 1, 3))
+    tmp61 = np.copy(v.aaaa.ovvv) * -1
+    tmp61 += np.transpose(v.aaaa.ovvv, (0, 2, 1, 3))
+    tmp62 = np.copy(tmp1) * -1
+    tmp62 += np.transpose(tmp1, (0, 2, 1, 3))
     tmp93 = einsum(t1.aa, (0, 1), tmp60, (2, 3, 1, 4), (0, 2, 3, 4))
     del tmp60
     tmp26 = einsum(tmp16, (0, 1), t1.bb, (2, 1), (2, 0))
@@ -357,99 +357,99 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp9
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp10, (4, 1), (0, 4, 2, 3)) * -1
     tmp143 = einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.oooo, (4, 1, 5, 0), (4, 5, 2, 3)) * -1
-    t2new.bbbb += tmp143.transpose((1, 0, 3, 2)) * 0.5
-    t2new.bbbb += tmp143.transpose((1, 0, 3, 2)) * 0.5
-    t2new.bbbb += tmp143.transpose((1, 0, 3, 2)) * 0.5
-    t2new.bbbb += tmp143.transpose((1, 0, 3, 2)) * 0.5
+    t2new.bbbb += np.transpose(tmp143, (1, 0, 3, 2)) * 0.5
+    t2new.bbbb += np.transpose(tmp143, (1, 0, 3, 2)) * 0.5
+    t2new.bbbb += np.transpose(tmp143, (1, 0, 3, 2)) * 0.5
+    t2new.bbbb += np.transpose(tmp143, (1, 0, 3, 2)) * 0.5
     del tmp143
     tmp171 = einsum(tmp138, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (4, 1, 5, 3))
     del tmp138
-    t2new.bbbb += tmp171.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp171.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp171, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp171, (1, 0, 3, 2))
     del tmp171
     tmp160 = einsum(tmp21, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 4, 3))
     del tmp21
     t2new.bbbb += tmp160 * -1
-    t2new.bbbb += tmp160.transpose((1, 0, 2, 3))
-    t2new.bbbb += tmp160.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp160.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp160, (1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp160, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp160, (1, 0, 3, 2)) * -1
     del tmp160
     tmp145 = einsum(t1.bb, (0, 1), tmp144, (2, 0, 3, 4), (3, 2, 4, 1))
     del tmp144
-    t2new.bbbb += tmp145.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp145, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp145
     del tmp145
     tmp172 = einsum(v.bbbb.ooov, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 4, 3))
-    t2new.bbbb += tmp172.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp172, (1, 0, 2, 3))
     t2new.bbbb += tmp172 * -1
-    t2new.bbbb += tmp172.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp172.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp172, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp172, (0, 1, 3, 2))
     del tmp172
     tmp181 = einsum(t2.bbbb, (0, 1, 2, 3), tmp180, (4, 5, 1, 0), (5, 4, 2, 3))
     del tmp180
-    t2new.bbbb += tmp181.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp181.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp181, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp181, (0, 1, 3, 2)) * -1
     del tmp181
     tmp173 = einsum(tmp101, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (4, 1, 5, 3))
-    t2new.bbbb += tmp173.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp173, (1, 0, 3, 2))
     t2new.bbbb += tmp173
-    t2new.bbbb += tmp173.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp173.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp173.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp173.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp173.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp173, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp173, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp173, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp173, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp173, (1, 0, 3, 2))
     t2new.bbbb += tmp173
     del tmp173
     tmp170 = einsum(tmp169, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp169
-    t2new.bbbb += tmp170.transpose((1, 0, 2, 3)) * 2
+    t2new.bbbb += np.transpose(tmp170, (1, 0, 2, 3)) * 2
     t2new.bbbb += tmp170 * -2
-    t2new.bbbb += tmp170.transpose((1, 0, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp170, (1, 0, 3, 2)) * -2
     del tmp170
     tmp153 = einsum(tmp152, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 4, 3))
     del tmp152
-    t2new.bbbb += tmp153.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp153, (0, 1, 3, 2))
     t2new.bbbb += tmp153 * -1
-    t2new.bbbb += tmp153.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp153.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp153, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp153, (1, 0, 2, 3))
     del tmp153
     tmp149 = einsum(t1.bb, (0, 1), tmp148, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp148
     t2new.bbbb += tmp149
-    t2new.bbbb += tmp149.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp149.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp149.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp149, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp149, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp149, (1, 0, 3, 2))
     del tmp149
     tmp185 = einsum(tmp184, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 4, 3))
     del tmp184
-    t2new.bbbb += tmp185.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp185, (1, 0, 2, 3))
     t2new.bbbb += tmp185 * -1
-    t2new.bbbb += tmp185.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp185.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp185, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp185, (0, 1, 3, 2))
     del tmp185
     tmp146 = einsum(t2.bbbb, (0, 1, 2, 3), tmp98, (1, 4), (0, 4, 2, 3)) * -1
     del tmp98
-    t2new.bbbb += tmp146.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp146.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp146.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp146.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp146, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp146, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp146, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp146, (0, 1, 3, 2)) * -1
     del tmp146
     tmp177 = einsum(tmp176, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (4, 0, 5, 2)) * 2
     del tmp176
     t2new.bbbb += tmp177
-    t2new.bbbb += tmp177.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp177.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp177.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp177, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp177, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp177, (1, 0, 3, 2))
     del tmp177
     tmp190 = einsum(v.bbbb.ovvv, (0, 1, 2, 3), t2.bbbb, (4, 5, 1, 3), (4, 5, 0, 2))
     t2new.bbbb += einsum(tmp190, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 4, 3)) * -2
     del tmp190
     tmp187 = einsum(tmp186, (0, 1, 2, 3), t1.bb, (4, 2), (4, 0, 1, 3))
     del tmp186
-    t2new.bbbb += tmp187.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp187, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp187
     del tmp187
-    tmp189 = v.bbbb.vvvv.copy()
+    tmp189 = np.copy(v.bbbb.vvvv)
     tmp189 += einsum(tmp188, (0, 1, 2, 3), t1.bb, (0, 4), (3, 4, 2, 1))
     del tmp188
     t2new.bbbb += einsum(tmp189, (0, 1, 2, 3), t2.bbbb, (4, 5, 0, 3), (4, 5, 2, 1)) * -2
@@ -457,24 +457,24 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp164 = einsum(t2.abab, (0, 1, 2, 3), tmp163, (0, 4, 2, 5), (1, 4, 3, 5))
     del tmp163
     t2new.bbbb += tmp164 * -1
-    t2new.bbbb += tmp164.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp164, (0, 1, 3, 2))
     del tmp164
     tmp183 = einsum(tmp182, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 4, 3))
     del tmp182
-    t2new.bbbb += tmp183.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp183, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp183
     del tmp183
     tmp147 = einsum(t2.bbbb, (0, 1, 2, 3), tmp108, (3, 4), (0, 1, 2, 4)) * -2
     del tmp108
-    t2new.bbbb += tmp147.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp147.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp147, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp147, (1, 0, 3, 2))
     del tmp147
     tmp179 = einsum(tmp178, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (4, 1, 5, 3)) * 0.5
     del tmp178
     t2new.bbbb += tmp179 * -1
-    t2new.bbbb += tmp179.transpose((1, 0, 2, 3))
-    t2new.bbbb += tmp179.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp179.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp179, (1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp179, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp179, (1, 0, 3, 2)) * -1
     del tmp179
     tmp162 = einsum(tmp105, (0, 1, 2, 3), t1.bb, (4, 1), (4, 0, 3, 2)) * -1
     del tmp105
@@ -484,16 +484,16 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp162
     tmp158 = einsum(t2.bbbb, (0, 1, 2, 3), tmp157, (4, 1), (0, 4, 2, 3)) * -1
     del tmp157
-    t2new.bbbb += tmp158.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp158.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp158.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp158, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp158, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp158, (0, 1, 3, 2)) * -1
     del tmp158
     tmp151 = einsum(tmp150, (0, 1, 2, 3), t2.bbbb, (2, 3, 4, 5), (0, 1, 4, 5))
     del tmp150
-    t2new.bbbb += tmp151.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp151.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp151.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp151.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp151, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp151, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp151, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp151, (1, 0, 3, 2)) * -1
     del tmp151
     tmp139 = einsum(t1.aa, (0, 1), v.aabb.ovvv, (2, 1, 3, 4), (0, 2, 3, 4))
     tmp139 += einsum(t1.bb, (0, 1), tmp2, (2, 3, 0, 4), (2, 3, 4, 1)) * -1
@@ -507,26 +507,26 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp137, (4, 1, 3, 5), (0, 4, 2, 5))
     del tmp137
     tmp111 = einsum(v.aabb.ovoo, (0, 1, 2, 3), t1.aa, (4, 1), (4, 0, 2, 3))
-    tmp123 = v.aaaa.oovv.copy() * -2
-    tmp123 += tmp39.transpose((1, 0, 3, 2)) * 2
+    tmp123 = np.copy(v.aaaa.oovv) * -2
+    tmp123 += np.transpose(tmp39, (1, 0, 3, 2)) * 2
     del tmp39
-    tmp123 += tmp38.transpose((1, 0, 3, 2))
+    tmp123 += np.transpose(tmp38, (1, 0, 3, 2))
     tmp123 += einsum(t1.aa, (0, 1), tmp122, (2, 3, 0, 4), (3, 2, 4, 1)) * 2
     del tmp122
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp123, (0, 4, 2, 5), (4, 1, 5, 3)) * 0.5
     del tmp123
-    tmp132 = v.aabb.vvvv.copy()
+    tmp132 = np.copy(v.aabb.vvvv)
     tmp132 += einsum(t1.bb, (0, 1), tmp131, (0, 2, 3, 4), (3, 2, 4, 1)) * -1
     del tmp131
     t2new.abab += einsum(tmp132, (0, 1, 2, 3), t2.abab, (4, 5, 0, 2), (4, 5, 1, 3))
     del tmp132
-    tmp125 = tmp82.copy() * -2
+    tmp125 = np.copy(tmp82) * -2
     tmp125 += tmp124 * 2
     del tmp124
     tmp125 += tmp83
     t2new.abab += einsum(t2.bbbb, (0, 1, 2, 3), tmp125, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp125
-    tmp120 = v.aabb.vvov.transpose((2, 0, 1, 3)).copy()
+    tmp120 = np.copy(np.transpose(v.aabb.vvov, (2, 0, 1, 3)))
     tmp120 += einsum(v.aabb.vvvv, (0, 1, 2, 3), t1.bb, (4, 3), (4, 0, 1, 2))
     t2new.abab += einsum(tmp120, (0, 1, 2, 3), t1.aa, (4, 1), (4, 0, 2, 3))
     del tmp120
@@ -543,7 +543,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp110 = einsum(t1.aa, (0, 1), v.aabb.vvoo, (2, 1, 3, 4), (0, 3, 4, 2))
     t2new.abab += einsum(tmp110, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 3, 4)) * -1
     del tmp110
-    tmp3 = t2.abab.copy()
+    tmp3 = np.copy(t2.abab)
     tmp3 += einsum(t1.aa, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3))
     t2new.abab += einsum(tmp3, (0, 1, 2, 3), tmp111, (4, 0, 1, 5), (4, 5, 2, 3))
     del tmp111
@@ -555,20 +555,20 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp109 = einsum(v.aabb.ooov, (0, 1, 2, 3), t1.bb, (4, 3), (0, 1, 4, 2))
     t2new.abab += einsum(tmp109, (0, 1, 2, 3), tmp3, (0, 3, 4, 5), (1, 2, 4, 5))
     del tmp3, tmp109
-    tmp129 = v.bbbb.oovv.copy() * -1
-    tmp129 += tmp126.transpose((1, 0, 3, 2)) * 0.5
+    tmp129 = np.copy(v.bbbb.oovv) * -1
+    tmp129 += np.transpose(tmp126, (1, 0, 3, 2)) * 0.5
     del tmp126
-    tmp129 += tmp127.transpose((1, 0, 3, 2))
+    tmp129 += np.transpose(tmp127, (1, 0, 3, 2))
     del tmp127
     tmp129 += einsum(t1.bb, (0, 1), tmp128, (2, 3, 0, 4), (3, 2, 4, 1))
     del tmp128
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp129, (1, 4, 3, 5), (0, 4, 2, 5))
     del tmp129
-    tmp99 = t2.abab.copy()
+    tmp99 = np.copy(t2.abab)
     tmp99 += einsum(t1.aa, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3)) * 2
     t2new.abab += einsum(tmp99, (0, 1, 2, 3), v.aabb.oooo, (4, 0, 5, 1), (4, 5, 2, 3)) * 0.5
     del tmp99
-    tmp130 = tmp116.copy() * -1
+    tmp130 = np.copy(tmp116) * -1
     del tmp116
     tmp130 += tmp100 * 0.5
     del tmp100
@@ -576,16 +576,16 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp101
     t2new.abab += einsum(tmp130, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 2), (4, 1, 5, 3)) * 2
     del tmp130
-    tmp115 = tmp114.transpose((0, 1, 3, 2)).copy()
+    tmp115 = np.copy(np.transpose(tmp114, (0, 1, 3, 2)))
     tmp115 += einsum(tmp22, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 3, 4)) * -1
     del tmp22
     t2new.abab += einsum(tmp115, (0, 1, 2, 3), t2.abab, (4, 1, 2, 5), (4, 0, 3, 5)) * -1
     del tmp115
-    tmp117 = v.aabb.vvoo.transpose((2, 3, 0, 1)).copy()
+    tmp117 = np.copy(np.transpose(v.aabb.vvoo, (2, 3, 0, 1)))
     tmp117 += einsum(v.aabb.ovoo, (0, 1, 2, 3), t1.aa, (0, 4), (2, 3, 1, 4)) * -1
     t2new.abab += einsum(tmp117, (0, 1, 2, 3), t2.abab, (4, 0, 2, 5), (4, 1, 3, 5)) * -1
     del tmp117
-    tmp118 = v.aabb.oovv.copy()
+    tmp118 = np.copy(v.aabb.oovv)
     tmp118 += einsum(v.aabb.ooov, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 3, 4)) * -1
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp118, (0, 4, 3, 5), (4, 1, 2, 5)) * -1
     del tmp118
@@ -595,119 +595,119 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp119
     tmp134 = einsum(t1.aa, (0, 1), tmp133, (2, 1, 3, 4), (0, 2, 4, 3)) * -1
     del tmp133
-    tmp134 += tmp71.transpose((0, 1, 3, 2))
+    tmp134 += np.transpose(tmp71, (0, 1, 3, 2))
     del tmp71
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp134, (4, 0, 2, 5), (4, 1, 5, 3))
     del tmp134
     tmp92 = einsum(t1.aa, (0, 1), tmp91, (2, 3, 1, 4), (0, 2, 3, 4))
     del tmp91
-    t2new.aaaa += tmp92.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp92, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp92
     del tmp92
     tmp37 = einsum(t2.aaaa, (0, 1, 2, 3), tmp36, (1, 4), (0, 4, 2, 3)) * -1
     del tmp36
-    t2new.aaaa += tmp37.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp37.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp37.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp37.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp37, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp37, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp37, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp37, (0, 1, 3, 2)) * -1
     del tmp37
     tmp77 = einsum(t2.aaaa, (0, 1, 2, 3), tmp38, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp38
-    t2new.aaaa += tmp77.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp77, (1, 0, 3, 2))
     t2new.aaaa += tmp77
-    t2new.aaaa += tmp77.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp77.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp77.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp77.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp77.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp77, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp77, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp77, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp77, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp77, (1, 0, 3, 2))
     t2new.aaaa += tmp77
     del tmp77
     tmp47 = einsum(t2.aaaa, (0, 1, 2, 3), tmp46, (3, 4), (0, 1, 2, 4)) * -2
     del tmp46
-    t2new.aaaa += tmp47.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp47.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp47, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp47, (1, 0, 3, 2))
     del tmp47
     tmp58 = einsum(t2.aaaa, (0, 1, 2, 3), tmp57, (4, 1), (0, 4, 2, 3)) * -1
     del tmp57
-    t2new.aaaa += tmp58.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp58.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp58.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp58, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp58, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp58, (0, 1, 3, 2)) * -1
     del tmp58
     tmp75 = einsum(tmp74, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp74
-    t2new.aaaa += tmp75.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp75.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp75, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp75, (1, 0, 3, 2))
     del tmp75
     tmp76 = einsum(v.aaaa.ooov, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3))
-    t2new.aaaa += tmp76.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp76, (1, 0, 2, 3))
     t2new.aaaa += tmp76 * -1
-    t2new.aaaa += tmp76.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp76.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp76, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp76, (0, 1, 3, 2))
     del tmp76
     tmp88 = einsum(t2.aaaa, (0, 1, 2, 3), tmp87, (4, 5, 1, 0), (5, 4, 2, 3))
     del tmp87
-    t2new.aaaa += tmp88.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp88.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp88, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp88, (0, 1, 3, 2)) * -1
     del tmp88
     tmp51 = einsum(t1.aa, (0, 1), tmp50, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp50
     t2new.aaaa += tmp51
-    t2new.aaaa += tmp51.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp51.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp51.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp51, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp51, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp51, (1, 0, 3, 2))
     del tmp51
-    tmp96 = v.aaaa.vvvv.copy() * -1
+    tmp96 = np.copy(v.aaaa.vvvv) * -1
     tmp96 += einsum(tmp95, (0, 1, 2, 3), t1.aa, (0, 4), (1, 4, 3, 2))
     del tmp95
     t2new.aaaa += einsum(tmp96, (0, 1, 2, 3), t2.aaaa, (4, 5, 0, 3), (4, 5, 2, 1)) * 2
     del tmp96
     tmp53 = einsum(t1.aa, (0, 1), tmp52, (2, 0, 3, 4), (2, 3, 1, 4))
     del tmp52
-    t2new.aaaa += tmp53.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp53, (0, 1, 3, 2))
     t2new.aaaa += tmp53 * -1
-    t2new.aaaa += tmp53.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp53.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp53, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp53, (1, 0, 2, 3))
     del tmp53
     tmp67 = einsum(t2.abab, (0, 1, 2, 3), tmp66, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp66
     t2new.aaaa += tmp67 * -1
-    t2new.aaaa += tmp67.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp67, (0, 1, 3, 2))
     del tmp67
     tmp49 = einsum(t2.aaaa, (0, 1, 2, 3), tmp48, (4, 5, 0, 1), (4, 5, 2, 3))
     del tmp48
-    t2new.aaaa += tmp49.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp49.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp49.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp49.transpose((1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp49, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp49, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp49, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp49, (1, 0, 3, 2)) * -1
     del tmp49
     tmp81 = einsum(t2.aaaa, (0, 1, 2, 3), tmp80, (4, 1, 5, 3), (0, 4, 2, 5)) * 2
     del tmp80
     t2new.aaaa += tmp81
-    t2new.aaaa += tmp81.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp81.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp81.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp81, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp81, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp81, (1, 0, 3, 2))
     del tmp81
     tmp73 = einsum(t2.aaaa, (0, 1, 2, 3), tmp72, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp72
-    t2new.aaaa += tmp73.transpose((1, 0, 2, 3)) * 2
+    t2new.aaaa += np.transpose(tmp73, (1, 0, 2, 3)) * 2
     t2new.aaaa += tmp73 * -2
-    t2new.aaaa += tmp73.transpose((1, 0, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp73, (1, 0, 3, 2)) * -2
     del tmp73
     tmp35 = einsum(tmp34, (0, 1, 2, 3), t1.aa, (1, 4), (2, 0, 3, 4))
     del tmp34
-    t2new.aaaa += tmp35.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp35, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp35
     del tmp35
     tmp33 = einsum(v.aaaa.oooo, (0, 1, 2, 3), t2.aaaa, (3, 1, 4, 5), (0, 2, 4, 5)) * -1
-    t2new.aaaa += tmp33.transpose((1, 0, 3, 2)) * 0.5
-    t2new.aaaa += tmp33.transpose((1, 0, 3, 2)) * 0.5
-    t2new.aaaa += tmp33.transpose((1, 0, 3, 2)) * 0.5
-    t2new.aaaa += tmp33.transpose((1, 0, 3, 2)) * 0.5
+    t2new.aaaa += np.transpose(tmp33, (1, 0, 3, 2)) * 0.5
+    t2new.aaaa += np.transpose(tmp33, (1, 0, 3, 2)) * 0.5
+    t2new.aaaa += np.transpose(tmp33, (1, 0, 3, 2)) * 0.5
+    t2new.aaaa += np.transpose(tmp33, (1, 0, 3, 2)) * 0.5
     del tmp33
     tmp97 = einsum(v.aaaa.ovvv, (0, 1, 2, 3), t2.aaaa, (4, 5, 3, 1), (4, 5, 0, 2)) * -1
     t2new.aaaa += einsum(t1.aa, (0, 1), tmp97, (2, 3, 0, 4), (2, 3, 1, 4)) * -2
     del tmp97
-    tmp84 = tmp82.copy()
+    tmp84 = np.copy(tmp82)
     del tmp82
     tmp84 += tmp83 * -0.5
     del tmp83
@@ -715,21 +715,21 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp84
     tmp90 = einsum(tmp89, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
     del tmp89
-    t2new.aaaa += tmp90.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp90, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp90
     del tmp90
     tmp86 = einsum(tmp85, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 5, 2)) * 0.5
     del tmp85
     t2new.aaaa += tmp86 * -1
-    t2new.aaaa += tmp86.transpose((1, 0, 2, 3))
-    t2new.aaaa += tmp86.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp86, (1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp86, (0, 1, 3, 2))
     del tmp86
     tmp59 = einsum(tmp1, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
     del tmp1
     t2new.aaaa += tmp59 * -1
-    t2new.aaaa += tmp59.transpose((1, 0, 2, 3))
-    t2new.aaaa += tmp59.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp59.transpose((1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp59, (1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp59, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp59, (1, 0, 3, 2)) * -1
     del tmp59
     tmp63 = einsum(t1.aa, (0, 1), tmp61, (2, 1, 3, 4), (0, 2, 4, 3)) * -1
     del tmp61
@@ -739,54 +739,54 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp63
     tmp94 = einsum(t1.aa, (0, 1), tmp93, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp93
-    t2new.aaaa += tmp94.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp94, (1, 0, 2, 3))
     t2new.aaaa += tmp94 * -1
-    t2new.aaaa += tmp94.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp94.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp94, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp94, (0, 1, 3, 2))
     del tmp94
-    tmp23 = t2.bbbb.copy() * 2
+    tmp23 = np.copy(t2.bbbb) * 2
     tmp23 += einsum(t1.bb, (0, 1), t1.bb, (2, 3), (2, 0, 3, 1))
     t1new.bb += einsum(tmp23, (0, 1, 2, 3), v.bbbb.ovvv, (0, 2, 4, 3), (1, 4))
     del tmp23
-    tmp27 = tmp24.transpose((1, 0)).copy()
+    tmp27 = np.copy(np.transpose(tmp24, (1, 0)))
     del tmp24
-    tmp27 += tmp25.transpose((1, 0)) * 2
+    tmp27 += np.transpose(tmp25, (1, 0)) * 2
     del tmp25
-    tmp27 += tmp26.transpose((1, 0))
+    tmp27 += np.transpose(tmp26, (1, 0))
     del tmp26
     t1new.bb += einsum(t1.bb, (0, 1), tmp27, (0, 2), (2, 1)) * -1
     del tmp27
-    tmp32 = f.bb.oo.copy()
-    tmp32 += tmp29.transpose((1, 0))
+    tmp32 = np.copy(f.bb.oo)
+    tmp32 += np.transpose(tmp29, (1, 0))
     del tmp29
-    tmp32 += tmp31.transpose((1, 0)) * -1
+    tmp32 += np.transpose(tmp31, (1, 0)) * -1
     del tmp31
     t1new.bb += einsum(tmp32, (0, 1), t1.bb, (0, 2), (1, 2)) * -1
     del tmp32
-    tmp28 = f.bb.vv.copy()
+    tmp28 = np.copy(f.bb.vv)
     tmp28 += einsum(v.bbbb.ovvv, (0, 1, 2, 3), t1.bb, (0, 3), (1, 2)) * -1
     t1new.bb += einsum(tmp28, (0, 1), t1.bb, (2, 0), (2, 1))
     del tmp28
-    tmp12 = f.aa.vv.copy()
+    tmp12 = np.copy(f.aa.vv)
     tmp12 += einsum(t1.aa, (0, 1), v.aaaa.ovvv, (0, 1, 2, 3), (2, 3))
     t1new.aa += einsum(tmp12, (0, 1), t1.aa, (2, 0), (2, 1))
     del tmp12
-    tmp20 = f.aa.oo.copy()
-    tmp20 += tmp17.transpose((1, 0))
+    tmp20 = np.copy(f.aa.oo)
+    tmp20 += np.transpose(tmp17, (1, 0))
     del tmp17
-    tmp20 += tmp19.transpose((1, 0)) * -1
+    tmp20 += np.transpose(tmp19, (1, 0)) * -1
     del tmp19
     t1new.aa += einsum(t1.aa, (0, 1), tmp20, (0, 2), (2, 1)) * -1
     del tmp20
-    tmp4 = t2.aaaa.copy() * 2
+    tmp4 = np.copy(t2.aaaa) * 2
     tmp4 += einsum(t1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
     t1new.aa += einsum(v.aaaa.ovvv, (0, 1, 2, 3), tmp4, (0, 4, 3, 1), (4, 2)) * -1
     del tmp4
-    tmp11 = tmp5.transpose((1, 0)).copy() * 2
+    tmp11 = np.copy(np.transpose(tmp5, (1, 0))) * 2
     del tmp5
-    tmp11 += tmp6.transpose((1, 0))
+    tmp11 += np.transpose(tmp6, (1, 0))
     del tmp6
-    tmp11 += tmp10.transpose((1, 0))
+    tmp11 += np.transpose(tmp10, (1, 0))
     del tmp10
     t1new.aa += einsum(tmp11, (0, 1), t1.aa, (0, 2), (1, 2)) * -1
     del tmp11
@@ -800,12 +800,12 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t1new.bb += einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.ooov, (4, 1, 0, 3), (4, 2)) * 2
     t1new.bb += einsum(t1.bb, (0, 1), v.bbbb.oovv, (2, 0, 3, 1), (2, 3)) * -1
     t1new.bb += einsum(v.aabb.ovoo, (0, 1, 2, 3), t2.abab, (0, 3, 1, 4), (2, 4)) * -1
-    t2new.aaaa += v.aaaa.ovov.transpose((0, 2, 1, 3))
-    t2new.aaaa += v.aaaa.ovov.transpose((0, 2, 3, 1)) * -1
+    t2new.aaaa += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
+    t2new.aaaa += np.transpose(v.aaaa.ovov, (0, 2, 3, 1)) * -1
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), v.aabb.oooo, (4, 0, 5, 1), (4, 5, 2, 3)) * 0.5
-    t2new.abab += v.aabb.ovov.transpose((0, 2, 1, 3))
-    t2new.bbbb += v.bbbb.ovov.transpose((0, 2, 1, 3))
-    t2new.bbbb += v.bbbb.ovov.transpose((0, 2, 3, 1)) * -1
+    t2new.abab += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
+    t2new.bbbb += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
+    t2new.bbbb += np.transpose(v.bbbb.ovov, (0, 2, 3, 1)) * -1
 
     return {f"t1new": t1new, f"t2new": t2new}
 

--- a/ebcc/codegen/UDFCC2.py
+++ b/ebcc/codegen/UDFCC2.py
@@ -2018,9 +2018,9 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.abab = pack_2e(rdm2.abab.oooo, rdm2.abab.ooov, rdm2.abab.oovo, rdm2.abab.ovoo, rdm2.abab.vooo, rdm2.abab.oovv, rdm2.abab.ovov, rdm2.abab.ovvo, rdm2.abab.voov, rdm2.abab.vovo, rdm2.abab.vvoo, rdm2.abab.ovvv, rdm2.abab.vovv, rdm2.abab.vvov, rdm2.abab.vvvo, rdm2.abab.vvvv)
     rdm2.bbbb = pack_2e(rdm2.bbbb.oooo, rdm2.bbbb.ooov, rdm2.bbbb.oovo, rdm2.bbbb.ovoo, rdm2.bbbb.vooo, rdm2.bbbb.oovv, rdm2.bbbb.ovov, rdm2.bbbb.ovvo, rdm2.bbbb.voov, rdm2.bbbb.vovo, rdm2.bbbb.vvoo, rdm2.bbbb.ovvv, rdm2.bbbb.vovv, rdm2.bbbb.vvov, rdm2.bbbb.vvvo, rdm2.bbbb.vvvv)
     rdm2 = Namespace(
-        aaaa=rdm2.aaaa.swapaxes(1, 2),
-        aabb=rdm2.abab.swapaxes(1, 2),
-        bbbb=rdm2.bbbb.swapaxes(1, 2),
+        aaaa=rdm2.aaaa.transpose(0, 2, 1, 3),
+        aabb=rdm2.abab.transpose(0, 2, 1, 3),
+        bbbb=rdm2.bbbb.transpose(0, 2, 1, 3),
     )
 
     return rdm2

--- a/ebcc/codegen/UDFCC2.py
+++ b/ebcc/codegen/UDFCC2.py
@@ -42,7 +42,7 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp1 = einsum(v.baa.xov, (0, 1, 2), t1.aa, (1, 2), (0,)) * 0.5
     tmp1 += tmp0
     tmp5 = einsum(t1.bb, (0, 1), v.bbb.xov, (2, 3, 1), (2, 0, 3))
-    tmp4 = f.aa.ov.copy()
+    tmp4 = np.copy(f.aa.ov)
     tmp4 += einsum(v.baa.xov, (0, 1, 2), tmp3, (0, 1, 3), (3, 2)) * -0.5
     del tmp3
     tmp7 = einsum(v.bbb.xov, (0, 1, 2), t2.bbbb, (3, 1, 4, 2), (0, 3, 4))
@@ -52,7 +52,7 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp2 += einsum(v.bbb.xov, (0, 1, 2), t2.abab, (3, 1, 4, 2), (0, 3, 4))
     tmp2 += einsum(tmp1, (0,), t1.aa, (1, 2), (0, 1, 2))
     del tmp1
-    tmp6 = f.bb.ov.copy()
+    tmp6 = np.copy(f.bb.ov)
     tmp6 += einsum(tmp5, (0, 1, 2), v.bbb.xov, (0, 1, 3), (2, 3)) * -0.5
     del tmp5
     e_cc = einsum(v.baa.xov, (0, 1, 2), tmp2, (0, 1, 2), ())
@@ -107,7 +107,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp56 = einsum(tmp0, (0, 1, 2), tmp0, (0, 3, 4), (3, 1, 4, 2))
     tmp18 = einsum(v.bbb.xov, (0, 1, 2), tmp17, (0, 1, 3), (3, 2))
     tmp26 = einsum(v.baa.xov, (0, 1, 2), t2.abab, (1, 3, 2, 4), (0, 3, 4))
-    tmp7 = tmp5.copy()
+    tmp7 = np.copy(tmp5)
     tmp7 += tmp6
     tmp11 = einsum(v.baa.xov, (0, 1, 2), tmp0, (0, 1, 3), (3, 2))
     tmp3 = einsum(v.bbb.xov, (0, 1, 2), t2.abab, (3, 1, 4, 2), (0, 3, 4))
@@ -123,12 +123,12 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp92 = einsum(tmp32, (0, 1, 2), tmp17, (0, 3, 4), (3, 1, 4, 2))
     tmp33 = einsum(v.bbb.xov, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (3, 4, 1, 2))
     tmp66 = einsum(f.bb.ov, (0, 1), t1.bb, (2, 1), (0, 2))
-    tmp72 = v.bbb.xov.copy()
+    tmp72 = np.copy(v.bbb.xov)
     tmp72 += tmp32
     tmp72 += tmp71 * -1
     tmp73 = einsum(tmp17, (0, 1, 2), tmp0, (0, 3, 4), (3, 4, 1, 2))
     tmp40 = einsum(t1.aa, (0, 1), f.aa.ov, (0, 2), (2, 1))
-    tmp69 = tmp15.copy()
+    tmp69 = np.copy(tmp15)
     tmp69 += tmp50 * -1
     tmp62 = einsum(v.bbb.xoo, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 4, 1, 2))
     tmp67 = einsum(tmp17, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 4, 1, 2))
@@ -139,7 +139,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp59 = einsum(tmp0, (0, 1, 2), tmp15, (0, 3, 4), (1, 3, 2, 4))
     tmp38 = einsum(t1.aa, (0, 1), tmp37, (2, 3, 4, 0), (3, 4, 2, 1))
     del tmp37
-    tmp51 = v.baa.xov.copy()
+    tmp51 = np.copy(v.baa.xov)
     tmp51 += tmp15
     tmp51 += tmp50 * -1
     del tmp50
@@ -147,18 +147,18 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp47
     tmp57 = einsum(t1.aa, (0, 1), tmp56, (2, 3, 0, 4), (3, 2, 4, 1))
     del tmp56
-    tmp30 = f.bb.ov.copy()
+    tmp30 = np.copy(f.bb.ov)
     tmp30 += tmp18 * -1
-    tmp29 = tmp26.copy()
+    tmp29 = np.copy(tmp26)
     tmp29 += einsum(v.bbb.xov, (0, 1, 2), t2.bbbb, (3, 1, 4, 2), (0, 3, 4)) * 2
     tmp29 += einsum(tmp7, (0,), t1.bb, (1, 2), (0, 1, 2))
     tmp19 = einsum(v.bbb.xov, (0, 1, 2), tmp7, (0,), (1, 2))
     tmp21 = einsum(v.baa.xov, (0, 1, 2), tmp7, (0,), (1, 2))
-    tmp27 = t2.bbbb.copy()
+    tmp27 = np.copy(t2.bbbb)
     tmp27 += einsum(t1.bb, (0, 1), t1.bb, (2, 3), (0, 2, 3, 1)) * -0.5
-    tmp4 = t2.aaaa.copy()
+    tmp4 = np.copy(t2.aaaa)
     tmp4 += einsum(t1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 1, 3)) * -0.5
-    tmp12 = f.aa.ov.copy()
+    tmp12 = np.copy(f.aa.ov)
     tmp12 += tmp11 * -1
     tmp10 = einsum(t2.aaaa, (0, 1, 2, 3), v.baa.xov, (4, 1, 3), (4, 0, 2))
     tmp10 += tmp3 * 0.5
@@ -167,7 +167,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp87
     tmp96 = einsum(tmp95, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 4, 3))
     del tmp95
-    tmp82 = f.bb.vv.copy()
+    tmp82 = np.copy(f.bb.vv)
     tmp82 += tmp64 * -1
     tmp97 = einsum(tmp32, (0, 1, 2), tmp32, (0, 3, 4), (1, 3, 2, 4))
     tmp80 = einsum(tmp79, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 4, 3))
@@ -180,7 +180,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp92
     tmp91 = einsum(v.bbb.xov, (0, 1, 2), tmp32, (0, 3, 4), (3, 1, 2, 4))
     tmp90 = einsum(tmp33, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 4, 3))
-    tmp65 = f.bb.vv.copy()
+    tmp65 = np.copy(f.bb.vv)
     tmp65 += tmp64 * -1
     del tmp64
     tmp83 = einsum(tmp66, (0, 1), t2.bbbb, (2, 0, 3, 4), (1, 2, 3, 4))
@@ -191,9 +191,9 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp77 = einsum(tmp32, (0, 1, 2), tmp0, (0, 3, 4), (3, 4, 1, 2))
     tmp34 = einsum(v.baa.xov, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (1, 3, 4, 2))
     tmp76 = einsum(tmp32, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 4, 1, 2))
-    tmp41 = f.aa.vv.copy()
+    tmp41 = np.copy(f.aa.vv)
     tmp41 += tmp40 * -1
-    tmp75 = v.bbb.xov.copy()
+    tmp75 = np.copy(v.bbb.xov)
     tmp75 += tmp32
     tmp75 += tmp71 * -1
     del tmp71
@@ -222,10 +222,10 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp58 = einsum(tmp57, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
     del tmp57
     tmp36 = einsum(t2.aaaa, (0, 1, 2, 3), f.aa.oo, (4, 1), (4, 0, 2, 3))
-    tmp42 = f.aa.vv.copy()
+    tmp42 = np.copy(f.aa.vv)
     tmp42 += tmp40 * -1
     del tmp40
-    tmp9 = tmp5.copy()
+    tmp9 = np.copy(tmp5)
     del tmp5
     tmp9 += tmp6
     del tmp6
@@ -233,32 +233,32 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp29
     tmp31 += einsum(tmp30, (0, 1), t1.bb, (2, 1), (0, 2))
     del tmp30
-    tmp20 = f.bb.ov.copy()
+    tmp20 = np.copy(f.bb.ov)
     tmp20 += tmp18 * -1
     del tmp18
     tmp20 += tmp19
     del tmp19
-    tmp22 = f.aa.ov.copy()
+    tmp22 = np.copy(f.aa.ov)
     tmp22 += tmp11 * -1
     del tmp11
     tmp22 += tmp21
     del tmp21
     tmp25 = einsum(v.baa.xov, (0, 1, 2), tmp17, (0, 3, 4), (1, 3, 4, 2))
-    tmp35 = f.bb.oo.copy()
+    tmp35 = np.copy(f.bb.oo)
     tmp35 += einsum(tmp17, (0, 1, 2), v.bbb.xoo, (0, 3, 1), (2, 3)) * -1
     del tmp17
     tmp35 += einsum(tmp7, (0,), v.bbb.xoo, (0, 1, 2), (1, 2))
-    tmp28 = tmp26.copy()
+    tmp28 = np.copy(tmp26)
     del tmp26
     tmp28 += einsum(v.bbb.xov, (0, 1, 2), tmp27, (1, 3, 2, 4), (0, 3, 4)) * 2
     del tmp27
     tmp28 += einsum(tmp7, (0,), t1.bb, (1, 2), (0, 1, 2))
-    tmp8 = tmp3.copy()
+    tmp8 = np.copy(tmp3)
     del tmp3
     tmp8 += einsum(v.baa.xov, (0, 1, 2), tmp4, (1, 3, 2, 4), (0, 3, 4)) * 2
     del tmp4
     tmp8 += einsum(tmp7, (0,), t1.aa, (1, 2), (0, 1, 2))
-    tmp23 = f.aa.oo.copy()
+    tmp23 = np.copy(f.aa.oo)
     tmp23 += einsum(tmp0, (0, 1, 2), v.baa.xoo, (0, 3, 1), (2, 3)) * -1
     del tmp0
     tmp23 += einsum(tmp7, (0,), v.baa.xoo, (0, 1, 2), (1, 2))
@@ -267,52 +267,52 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp10
     tmp13 += einsum(tmp12, (0, 1), t1.aa, (2, 1), (0, 2))
     del tmp12
-    t2new.bbbb = tmp80.copy()
-    t2new.bbbb += tmp81.transpose((1, 0, 3, 2)) * 2
-    t2new.bbbb += tmp80.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb = np.copy(tmp80)
+    t2new.bbbb += np.transpose(tmp81, (1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp80, (0, 1, 3, 2)) * -1
     del tmp80
-    t2new.bbbb += tmp81.transpose((0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp81, (0, 1, 3, 2)) * -2
     del tmp81
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), tmp82, (3, 4), (0, 1, 4, 2)) * -2
     del tmp82
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), tmp65, (3, 4), (0, 1, 2, 4)) * 2
-    t2new.bbbb += tmp83.transpose((1, 0, 3, 2)) * 2
-    t2new.bbbb += tmp85.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp88.transpose((1, 0, 2, 3))
-    t2new.bbbb += tmp88.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp85.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp83.transpose((0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp83, (1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp85, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp88, (1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp88, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp85, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp83, (0, 1, 3, 2)) * -2
     del tmp83
-    t2new.bbbb += tmp85.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp85, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp88 * -1
-    t2new.bbbb += tmp88.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp88, (0, 1, 3, 2))
     del tmp88
     t2new.bbbb += tmp85
     del tmp85
     t2new.bbbb += tmp89
-    t2new.bbbb += tmp89.transpose((1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp89, (1, 0, 2, 3)) * -1
     del tmp89
-    t2new.bbbb += tmp90.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp90.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp90, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp90, (1, 0, 3, 2)) * -1
     t2new.bbbb += tmp90 * -1
-    t2new.bbbb += tmp90.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp90, (1, 0, 2, 3))
     del tmp90
-    t2new.bbbb += tmp91.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp93.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp93.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp91, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp93, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp93, (1, 0, 3, 2)) * -1
     t2new.bbbb += tmp96
-    t2new.bbbb += tmp96.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp96, (0, 1, 3, 2)) * -1
     del tmp96
     t2new.bbbb += tmp97
-    t2new.bbbb += tmp97.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp97, (0, 1, 3, 2)) * -1
     del tmp97
-    t2new.bbbb += tmp91.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp91, (1, 0, 3, 2)) * -1
     del tmp91
     t2new.bbbb += tmp98 * -1
-    t2new.bbbb += tmp98.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp98, (1, 0, 2, 3))
     del tmp98
     t2new.bbbb += tmp93 * -1
-    t2new.bbbb += tmp93.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp93, (1, 0, 2, 3))
     del tmp93
     t2new.abab = einsum(t2.abab, (0, 1, 2, 3), f.bb.oo, (4, 1), (0, 4, 2, 3)) * -1
     t2new.abab += einsum(tmp63, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3))
@@ -342,55 +342,55 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp76
     t2new.abab += einsum(tmp77, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3)) * -1
     del tmp77
-    t2new.aaaa = tmp36.transpose((1, 0, 3, 2)).copy() * 2
+    t2new.aaaa = np.copy(np.transpose(tmp36, (1, 0, 3, 2))) * 2
     t2new.aaaa += tmp39
-    t2new.aaaa += tmp36.transpose((0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp36, (0, 1, 3, 2)) * -2
     del tmp36
-    t2new.aaaa += tmp39.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp39, (0, 1, 3, 2)) * -1
     del tmp39
     t2new.aaaa += einsum(tmp41, (0, 1), t2.aaaa, (2, 3, 4, 0), (2, 3, 1, 4)) * -2
     del tmp41
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp42, (3, 4), (0, 1, 2, 4)) * 2
     del tmp42
-    t2new.aaaa += tmp44.transpose((1, 0, 3, 2)) * 2
-    t2new.aaaa += tmp46.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp49.transpose((1, 0, 2, 3))
-    t2new.aaaa += tmp49.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp46.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp44.transpose((0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp44, (1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp46, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp49, (1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp49, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp46, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp44, (0, 1, 3, 2)) * -2
     del tmp44
-    t2new.aaaa += tmp46.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp46, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp49 * -1
-    t2new.aaaa += tmp49.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp49, (0, 1, 3, 2))
     del tmp49
     t2new.aaaa += tmp46
     del tmp46
     t2new.aaaa += tmp52
-    t2new.aaaa += tmp52.transpose((1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp52, (1, 0, 2, 3)) * -1
     del tmp52
-    t2new.aaaa += tmp53.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp53.transpose((1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp53, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp53, (1, 0, 3, 2)) * -1
     t2new.aaaa += tmp53 * -1
-    t2new.aaaa += tmp53.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp53, (1, 0, 2, 3))
     del tmp53
-    t2new.aaaa += tmp54.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp54, (0, 1, 3, 2))
     t2new.aaaa += tmp55
-    t2new.aaaa += tmp55.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp55, (0, 1, 3, 2)) * -1
     del tmp55
     t2new.aaaa += tmp58
-    t2new.aaaa += tmp58.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp58, (0, 1, 3, 2)) * -1
     del tmp58
-    t2new.aaaa += tmp60.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp60.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp54.transpose((1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp60, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp60, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp54, (1, 0, 3, 2)) * -1
     del tmp54
     t2new.aaaa += tmp61 * -1
-    t2new.aaaa += tmp61.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp61, (1, 0, 2, 3))
     del tmp61
     t2new.aaaa += tmp60 * -1
-    t2new.aaaa += tmp60.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp60, (1, 0, 2, 3))
     del tmp60
-    t1new.bb = f.bb.ov.copy()
+    t1new.bb = np.copy(f.bb.ov)
     t1new.bb += einsum(t1.bb, (0, 1), f.bb.vv, (2, 1), (0, 2))
     t1new.bb += einsum(tmp24, (0, 1, 2, 3), t2.bbbb, (2, 1, 4, 3), (0, 4)) * -2
     del tmp24
@@ -478,26 +478,26 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp27 = einsum(v.baa.xvv, (0, 1, 2), t1.aa, (3, 2), (0, 3, 1))
     tmp7 = einsum(t1.bb, (0, 1), v.bbb.xvv, (2, 3, 1), (2, 0, 3))
     tmp4 = einsum(t1.bb, (0, 1), v.bbb.xov, (2, 3, 1), (2, 0, 3))
-    tmp14 = tmp12.copy()
+    tmp14 = np.copy(tmp12)
     tmp14 += tmp13
-    tmp101 = tmp12.copy()
+    tmp101 = np.copy(tmp12)
     del tmp12
     tmp101 += tmp13
     del tmp13
     tmp1 = einsum(v.baa.xov, (0, 1, 2), t1.aa, (3, 2), (0, 3, 1))
     tmp48 = einsum(l2.aaaa, (0, 1, 2, 3), t1.aa, (4, 1), (2, 3, 4, 0))
-    tmp55 = tmp52.copy() * 0.5
+    tmp55 = np.copy(tmp52) * 0.5
     tmp55 += tmp53
     tmp55 += tmp54 * 0.5
     tmp50 = einsum(l2.abab, (0, 1, 2, 3), t1.aa, (4, 0), (2, 4, 3, 1))
     tmp63 = einsum(l2.bbbb, (0, 1, 2, 3), t1.bb, (4, 1), (2, 3, 4, 0))
     tmp61 = einsum(l2.abab, (0, 1, 2, 3), t1.bb, (4, 1), (2, 3, 4, 0))
-    tmp68 = tmp65.copy()
+    tmp68 = np.copy(tmp65)
     tmp68 += tmp66
     tmp68 += tmp67 * 2
-    tmp156 = v.baa.xov.copy()
+    tmp156 = np.copy(v.baa.xov)
     tmp156 += tmp27
-    tmp158 = v.bbb.xov.copy()
+    tmp158 = np.copy(v.bbb.xov)
     tmp158 += tmp7
     tmp107 = einsum(v.bbb.xov, (0, 1, 2), tmp4, (0, 1, 3), (3, 2))
     tmp108 = einsum(v.bbb.xov, (0, 1, 2), tmp14, (0,), (1, 2))
@@ -529,21 +529,21 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp129 = einsum(tmp63, (0, 1, 2, 3), v.bbb.xoo, (4, 2, 0), (4, 1, 3)) * -1
     tmp187 = einsum(v.bbb.xvv, (0, 1, 2), l1.bb, (2, 3), (0, 3, 1))
     tmp193 = einsum(v.bbb.xov, (0, 1, 2), tmp101, (0,), (1, 2))
-    tmp191 = v.bbb.xoo.copy()
-    tmp191 += tmp4.transpose((0, 2, 1))
-    tmp109 = f.bb.ov.copy()
+    tmp191 = np.copy(v.bbb.xoo)
+    tmp191 += np.transpose(tmp4, (0, 2, 1))
+    tmp109 = np.copy(f.bb.ov)
     tmp109 += tmp107 * -1
     tmp109 += tmp108
     tmp200 = einsum(v.bbb.xov, (0, 1, 2), tmp7, (0, 1, 3), (2, 3))
     tmp142 = einsum(v.bbb.xvv, (0, 1, 2), tmp101, (0,), (1, 2))
-    tmp164 = f.aa.ov.copy()
+    tmp164 = np.copy(f.aa.ov)
     tmp164 += tmp11 * -1
     tmp164 += tmp163
-    tmp144 = v.baa.xoo.copy()
-    tmp144 += tmp1.transpose((0, 2, 1))
+    tmp144 = np.copy(v.baa.xoo)
+    tmp144 += np.transpose(tmp1, (0, 2, 1))
     tmp102 = einsum(tmp101, (0,), v.baa.xvv, (0, 1, 2), (1, 2))
     tmp172 = einsum(v.baa.xov, (0, 1, 2), tmp27, (0, 1, 3), (2, 3))
-    tmp16 = f.aa.ov.copy()
+    tmp16 = np.copy(f.aa.ov)
     tmp16 += tmp11 * -1
     tmp16 += tmp15
     tmp157 = einsum(l2.aaaa, (0, 1, 2, 3), tmp156, (4, 3, 1), (4, 2, 0))
@@ -559,51 +559,51 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp9 = einsum(v.bbb.xov, (0, 1, 2), t2.bbbb, (3, 1, 4, 2), (0, 3, 4))
     tmp25 = einsum(v.bbb.xov, (0, 1, 2), t2.abab, (3, 1, 4, 2), (0, 3, 4))
     tmp24 = einsum(v.baa.xov, (0, 1, 2), t2.aaaa, (3, 1, 4, 2), (0, 3, 4))
-    tmp93 = v.bbb.xoo.copy()
-    tmp93 += tmp4.transpose((0, 2, 1))
+    tmp93 = np.copy(v.bbb.xoo)
+    tmp93 += np.transpose(tmp4, (0, 2, 1))
     tmp117 = einsum(tmp4, (0, 1, 2), tmp4, (0, 3, 4), (1, 3, 2, 4))
     tmp118 = einsum(v.bbb.xoo, (0, 1, 2), tmp4, (0, 3, 4), (3, 1, 2, 4))
     tmp115 = einsum(v.bbb.xoo, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (1, 3, 4, 2))
     tmp116 = einsum(v.bbb.xov, (0, 1, 2), v.bbb.xov, (0, 3, 4), (1, 3, 2, 4))
     tmp18 = einsum(tmp17, (0, 1, 2, 3), t2.abab, (4, 5, 2, 3), (4, 0, 5, 1))
-    tmp2 = v.baa.xoo.copy()
+    tmp2 = np.copy(v.baa.xoo)
     tmp2 += tmp1
-    tmp5 = v.bbb.xoo.copy()
+    tmp5 = np.copy(v.bbb.xoo)
     tmp5 += tmp4
     tmp137 = einsum(t2.bbbb, (0, 1, 2, 3), l2.bbbb, (2, 3, 4, 5), (4, 5, 0, 1))
     tmp138 = einsum(tmp63, (0, 1, 2, 3), t1.bb, (4, 3), (0, 1, 4, 2))
-    tmp44 = tmp41.copy()
+    tmp44 = np.copy(tmp41)
     del tmp41
     tmp44 += tmp42
     tmp44 += tmp43 * 2
-    tmp74 = tmp65.copy()
+    tmp74 = np.copy(tmp65)
     tmp74 += tmp66
     del tmp66
-    tmp74 += tmp67.transpose((1, 0)) * 2
+    tmp74 += np.transpose(tmp67, (1, 0)) * 2
     del tmp67
-    tmp72 = tmp52.copy() * 0.5
+    tmp72 = np.copy(tmp52) * 0.5
     tmp72 += tmp53
-    tmp72 += tmp54.transpose((1, 0)) * 0.5
-    tmp57 = l1.aa.transpose((1, 0)).copy() * -0.5
+    tmp72 += np.transpose(tmp54, (1, 0)) * 0.5
+    tmp57 = np.copy(np.transpose(l1.aa, (1, 0))) * -0.5
     tmp57 += t1.aa * -0.5
     tmp57 += tmp46 * -1
     tmp57 += tmp47 * -0.5
     tmp57 += tmp49
     tmp57 += tmp51 * 0.5
     tmp57 += tmp56
-    tmp39 = tmp38.copy() * 0.5
+    tmp39 = np.copy(tmp38) * 0.5
     del tmp38
     tmp39 += tmp34
-    tmp39 += tmp35.transpose((1, 0)) * 0.5
-    tmp70 = l1.bb.transpose((1, 0)).copy() * -1
+    tmp39 += np.transpose(tmp35, (1, 0)) * 0.5
+    tmp70 = np.copy(np.transpose(l1.bb, (1, 0))) * -1
     tmp70 += t1.bb * -1
     tmp70 += tmp59 * -1
     tmp70 += tmp60 * -2
     tmp70 += tmp62
     tmp70 += tmp64 * 2
     tmp70 += tmp69
-    tmp19 = v.baa.xoo.copy()
-    tmp19 += tmp1.transpose((0, 2, 1))
+    tmp19 = np.copy(v.baa.xoo)
+    tmp19 += np.transpose(tmp1, (0, 2, 1))
     tmp30 = einsum(tmp1, (0, 1, 2), tmp1, (0, 3, 4), (3, 1, 4, 2))
     tmp29 = einsum(v.baa.xov, (0, 1, 2), v.baa.xov, (0, 3, 4), (1, 3, 2, 4))
     tmp28 = einsum(v.baa.xoo, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 1, 2, 4))
@@ -611,11 +611,11 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp96 = einsum(tmp48, (0, 1, 2, 3), t1.aa, (4, 3), (0, 1, 4, 2))
     tmp95 = einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (4, 5, 0, 1), (2, 3, 4, 5))
     tmp112 = einsum(v.bbb.xvv, (0, 1, 2), v.bbb.xov, (0, 3, 4), (3, 1, 2, 4))
-    tmp149 = v.baa.xov.copy()
+    tmp149 = np.copy(v.baa.xov)
     tmp149 += tmp27
-    tmp150 = v.bbb.xov.copy()
+    tmp150 = np.copy(v.bbb.xov)
     tmp150 += tmp7
-    tmp190 = tmp187.copy()
+    tmp190 = np.copy(tmp187)
     tmp190 += tmp128 * -1
     tmp190 += tmp129 * -2
     tmp190 += tmp130 * -1
@@ -625,7 +625,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp190 += tmp189 * 2
     del tmp189
     tmp123 = einsum(tmp4, (0, 1, 2), v.bbb.xoo, (0, 3, 1), (3, 2))
-    tmp202 = f.bb.ov.copy()
+    tmp202 = np.copy(f.bb.ov)
     tmp202 += tmp107 * -1
     tmp202 += tmp193
     tmp192 = einsum(tmp191, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 2, 3, 4))
@@ -637,9 +637,9 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp65
     tmp208 = einsum(v.bbb.xov, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (3, 4, 1, 2))
     tmp207 = einsum(tmp4, (0, 1, 2), v.bbb.xov, (0, 3, 4), (1, 3, 2, 4))
-    tmp201 = f.bb.vv.copy()
-    tmp201 += tmp200.transpose((1, 0)) * -1
-    tmp201 += tmp142.transpose((1, 0))
+    tmp201 = np.copy(f.bb.vv)
+    tmp201 += np.transpose(tmp200, (1, 0)) * -1
+    tmp201 += np.transpose(tmp142, (1, 0))
     tmp198 = einsum(v.bbb.xvv, (0, 1, 2), v.baa.xvv, (0, 3, 4), (3, 4, 1, 2))
     tmp88 = einsum(tmp61, (0, 1, 2, 3), t1.aa, (4, 3), (0, 4, 1, 2))
     tmp77 = einsum(tmp1, (0, 1, 2), v.baa.xoo, (0, 3, 1), (3, 2))
@@ -650,13 +650,13 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp184 = einsum(v.baa.xov, (0, 1, 2), tmp1, (0, 3, 4), (3, 1, 4, 2))
     tmp145 = einsum(v.baa.xov, (0, 1, 2), tmp144, (0, 3, 4), (3, 4, 1, 2))
     tmp180 = einsum(v.baa.xov, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 4, 1, 2))
-    tmp176 = f.aa.vv.copy()
-    tmp176 += tmp172.transpose((1, 0)) * -1
-    tmp176 += tmp102.transpose((1, 0))
+    tmp176 = np.copy(f.aa.vv)
+    tmp176 += np.transpose(tmp172, (1, 0)) * -1
+    tmp176 += np.transpose(tmp102, (1, 0))
     tmp80 = einsum(tmp16, (0, 1), t1.aa, (2, 1), (2, 0))
     tmp79 = einsum(v.baa.xoo, (0, 1, 2), tmp14, (0,), (1, 2))
     tmp22 = einsum(v.baa.xov, (0, 1, 2), v.baa.xvv, (0, 3, 4), (1, 3, 4, 2))
-    tmp160 = tmp148.copy()
+    tmp160 = np.copy(tmp148)
     tmp160 += tmp82 * -2
     tmp160 += tmp83 * -1
     tmp160 += tmp84 * -2
@@ -667,29 +667,29 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp159
     tmp154 = einsum(tmp144, (0, 1, 2), v.baa.xvv, (0, 3, 4), (1, 2, 3, 4))
     tmp169 = einsum(v.baa.xvv, (0, 1, 2), v.baa.xvv, (0, 3, 4), (1, 3, 4, 2))
-    tmp10 = v.bbb.xov.copy()
+    tmp10 = np.copy(v.bbb.xov)
     tmp10 += tmp7
     tmp10 += tmp8
     tmp10 += tmp9 * 2
-    tmp86 = v.baa.xov.copy()
+    tmp86 = np.copy(v.baa.xov)
     tmp86 += tmp27
     tmp86 += tmp24 * 2
     tmp86 += tmp25
-    tmp124 = tmp8.copy() * 0.5
+    tmp124 = np.copy(tmp8) * 0.5
     tmp124 += tmp9
     tmp113 = einsum(v.bbb.xov, (0, 1, 2), tmp93, (0, 3, 4), (1, 3, 4, 2))
-    tmp119 = tmp115.transpose((3, 2, 1, 0)).copy()
+    tmp119 = np.copy(np.transpose(tmp115, (3, 2, 1, 0)))
     tmp119 += einsum(tmp116, (0, 1, 2, 3), t2.bbbb, (4, 5, 2, 3), (1, 0, 4, 5))
-    tmp119 += tmp117.transpose((2, 3, 1, 0))
-    tmp119 += tmp118.transpose((1, 3, 0, 2))
-    tmp119 += tmp118.transpose((3, 2, 0, 1)) * -1
-    tmp114 = v.bbb.xov.copy()
+    tmp119 += np.transpose(tmp117, (2, 3, 1, 0))
+    tmp119 += np.transpose(tmp118, (1, 3, 0, 2))
+    tmp119 += np.transpose(tmp118, (3, 2, 0, 1)) * -1
+    tmp114 = np.copy(v.bbb.xov)
     tmp114 += tmp8
     del tmp8
     tmp114 += tmp9 * 2
     del tmp9
     tmp104 = einsum(v.bbb.xov, (0, 1, 2), v.baa.xvv, (0, 3, 4), (1, 3, 4, 2))
-    tmp110 = tmp18.transpose((1, 0, 2, 3)).copy()
+    tmp110 = np.copy(np.transpose(tmp18, (1, 0, 2, 3)))
     tmp110 += einsum(tmp2, (0, 1, 2), tmp93, (0, 3, 4), (2, 1, 4, 3))
     tmp105 = einsum(v.bbb.xov, (0, 1, 2), tmp2, (0, 3, 4), (4, 3, 1, 2))
     tmp106 = einsum(tmp5, (0, 1, 2), v.bbb.xov, (0, 3, 4), (2, 1, 3, 4))
@@ -697,7 +697,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp94 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 5, 0, 1), (2, 4, 3, 5))
     tmp136 = einsum(l1.bb, (0, 1), t2.abab, (2, 3, 4, 0), (2, 1, 3, 4))
     tmp136 += einsum(t2.abab, (0, 1, 2, 3), tmp50, (0, 4, 5, 3), (4, 5, 1, 2)) * -1
-    tmp140 = t1.bb.copy() * -1
+    tmp140 = np.copy(t1.bb) * -1
     tmp140 += tmp59 * -1
     del tmp59
     tmp140 += tmp60 * -2
@@ -713,9 +713,9 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp135 += einsum(t2.bbbb, (0, 1, 2, 3), tmp63, (4, 1, 5, 3), (4, 5, 0, 2)) * -2
     tmp134 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 4, 0, 5), (3, 4, 1, 5))
     tmp134 += einsum(l2.bbbb, (0, 1, 2, 3), t2.bbbb, (4, 3, 5, 1), (2, 4, 5, 0)) * 4
-    tmp139 = tmp137.transpose((1, 0, 3, 2)).copy()
+    tmp139 = np.copy(np.transpose(tmp137, (1, 0, 3, 2)))
     del tmp137
-    tmp139 += tmp138.transpose((0, 1, 3, 2)) * -1
+    tmp139 += np.transpose(tmp138, (0, 1, 3, 2)) * -1
     tmp45 = einsum(v.bbb.xvv, (0, 1, 2), tmp44, (2, 1), (0,))
     del tmp44
     tmp75 = einsum(v.bbb.xoo, (0, 1, 2), tmp74, (2, 1), (0,))
@@ -728,34 +728,34 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp39
     tmp71 = einsum(tmp70, (0, 1), v.bbb.xov, (2, 0, 1), (2,))
     del tmp70
-    tmp121 = tmp42.copy()
+    tmp121 = np.copy(tmp42)
     del tmp42
     tmp121 += tmp43 * 2
     del tmp43
-    tmp26 = v.baa.xov.copy()
+    tmp26 = np.copy(v.baa.xov)
     tmp26 += tmp24 * 2
     tmp26 += tmp25
     tmp23 = einsum(v.baa.xov, (0, 1, 2), tmp19, (0, 3, 4), (1, 3, 4, 2))
-    tmp32 = tmp28.transpose((3, 2, 1, 0)).copy()
+    tmp32 = np.copy(np.transpose(tmp28, (3, 2, 1, 0)))
     tmp32 += einsum(t2.aaaa, (0, 1, 2, 3), tmp29, (4, 5, 2, 3), (5, 4, 0, 1))
-    tmp32 += tmp30.transpose((2, 3, 1, 0))
-    tmp32 += tmp31.transpose((1, 3, 0, 2))
-    tmp32 += tmp31.transpose((3, 2, 0, 1)) * -1
-    tmp20 = tmp18.transpose((0, 1, 3, 2)).copy()
+    tmp32 += np.transpose(tmp30, (2, 3, 1, 0))
+    tmp32 += np.transpose(tmp31, (1, 3, 0, 2))
+    tmp32 += np.transpose(tmp31, (3, 2, 0, 1)) * -1
+    tmp20 = np.copy(np.transpose(tmp18, (0, 1, 3, 2)))
     del tmp18
     tmp20 += einsum(tmp5, (0, 1, 2), tmp19, (0, 3, 4), (4, 3, 2, 1))
     tmp0 = einsum(v.baa.xov, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 2, 3, 4))
     tmp3 = einsum(v.baa.xov, (0, 1, 2), tmp2, (0, 3, 4), (4, 3, 1, 2))
     tmp6 = einsum(tmp5, (0, 1, 2), v.baa.xov, (0, 3, 4), (3, 2, 1, 4))
-    tmp36 = tmp34.copy()
+    tmp36 = np.copy(tmp34)
     del tmp34
     tmp36 += tmp35 * 0.5
     del tmp35
-    tmp78 = tmp24.copy() * 2
+    tmp78 = np.copy(tmp24) * 2
     del tmp24
     tmp78 += tmp25
     del tmp25
-    tmp98 = t1.aa.copy() * -0.5
+    tmp98 = np.copy(t1.aa) * -0.5
     tmp98 += tmp46 * -1
     del tmp46
     tmp98 += tmp47 * -0.5
@@ -769,9 +769,9 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp91 = einsum(l1.aa, (0, 1), t2.aaaa, (2, 3, 4, 0), (1, 2, 3, 4)) * -1
     tmp91 += einsum(tmp48, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (0, 2, 4, 5)) * -2
     tmp91 += einsum(tmp50, (0, 1, 2, 3), t2.abab, (4, 2, 5, 3), (0, 1, 4, 5)) * 0.5
-    tmp97 = tmp95.transpose((1, 0, 3, 2)).copy()
+    tmp97 = np.copy(np.transpose(tmp95, (1, 0, 3, 2)))
     del tmp95
-    tmp97 += tmp96.transpose((0, 1, 3, 2)) * -1
+    tmp97 += np.transpose(tmp96, (0, 1, 3, 2)) * -1
     tmp89 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 3, 0, 5), (2, 4, 1, 5))
     tmp92 = einsum(t2.abab, (0, 1, 2, 3), l1.aa, (2, 4), (4, 0, 1, 3))
     tmp92 += einsum(t2.abab, (0, 1, 2, 3), tmp61, (4, 1, 5, 2), (4, 0, 5, 3)) * -1
@@ -780,7 +780,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp217 = einsum(tmp63, (0, 1, 2, 3), tmp112, (2, 4, 3, 5), (1, 0, 5, 4))
     tmp224 = einsum(l2.bbbb, (0, 1, 2, 3), tmp118, (2, 3, 4, 5), (4, 5, 0, 1))
     del tmp118
-    tmp212 = tmp187.copy() * 0.5
+    tmp212 = np.copy(tmp187) * 0.5
     del tmp187
     tmp212 += tmp128 * -0.5
     tmp212 += tmp129 * -1
@@ -790,18 +790,18 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp212 += einsum(l2.bbbb, (0, 1, 2, 3), tmp150, (4, 3, 1), (4, 2, 0))
     tmp211 = einsum(v.bbb.xvv, (0, 1, 2), tmp93, (0, 3, 4), (4, 3, 1, 2))
     tmp215 = einsum(v.bbb.xov, (0, 1, 2), tmp190, (0, 3, 4), (3, 1, 4, 2))
-    tmp216 = f.bb.oo.copy()
+    tmp216 = np.copy(f.bb.oo)
     tmp216 += tmp123 * -1
     tmp216 += einsum(v.bbb.xoo, (0, 1, 2), tmp101, (0,), (1, 2))
     del tmp101
     tmp216 += einsum(t1.bb, (0, 1), tmp202, (2, 1), (0, 2))
     tmp214 = einsum(l2.bbbb, (0, 1, 2, 3), tmp192, (4, 3, 1, 5), (4, 2, 5, 0))
     tmp222 = einsum(tmp202, (0, 1), tmp63, (2, 3, 0, 4), (2, 3, 1, 4))
-    tmp196 = f.bb.oo.copy()
+    tmp196 = np.copy(f.bb.oo)
     tmp196 += tmp123 * -1
-    tmp196 += tmp125.transpose((1, 0))
-    tmp196 += tmp126.transpose((1, 0))
-    tmp194 = f.bb.ov.copy()
+    tmp196 += np.transpose(tmp125, (1, 0))
+    tmp196 += np.transpose(tmp126, (1, 0))
+    tmp194 = np.copy(f.bb.ov)
     tmp194 += tmp193
     del tmp193
     tmp210 = einsum(tmp209, (0, 1, 2, 3), l1.bb, (4, 1), (2, 0, 3, 4))
@@ -811,17 +811,17 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp228 = einsum(tmp208, (0, 1, 2, 3), tmp63, (1, 4, 2, 5), (4, 0, 5, 3)) * -1
     tmp218 = einsum(tmp138, (0, 1, 2, 3), tmp116, (2, 3, 4, 5), (0, 1, 4, 5))
     del tmp138
-    tmp225 = tmp115.transpose((3, 2, 1, 0)).copy()
+    tmp225 = np.copy(np.transpose(tmp115, (3, 2, 1, 0)))
     del tmp115
-    tmp225 += tmp117.transpose((0, 3, 1, 2))
+    tmp225 += np.transpose(tmp117, (0, 3, 1, 2))
     del tmp117
     tmp226 = einsum(tmp207, (0, 1, 2, 3), tmp63, (4, 0, 1, 5), (4, 2, 5, 3))
     tmp223 = einsum(tmp201, (0, 1), l2.bbbb, (2, 0, 3, 4), (3, 4, 1, 2)) * -1
-    tmp213 = f.bb.ov.copy()
+    tmp213 = np.copy(f.bb.ov)
     tmp213 += tmp108
     del tmp108
-    tmp221 = f.bb.vv.copy()
-    tmp221 += tmp200.transpose((1, 0)) * -1
+    tmp221 = np.copy(f.bb.vv)
+    tmp221 += np.transpose(tmp200, (1, 0)) * -1
     del tmp200
     tmp221 += einsum(v.bbb.xvv, (0, 1, 2), tmp14, (0,), (1, 2))
     del tmp14
@@ -833,23 +833,23 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp195 = einsum(tmp191, (0, 1, 2), v.baa.xvv, (0, 3, 4), (2, 1, 3, 4))
     del tmp191
     tmp197 = einsum(tmp88, (0, 1, 2, 3), tmp17, (1, 3, 4, 5), (0, 2, 4, 5))
-    tmp166 = f.aa.oo.copy()
+    tmp166 = np.copy(f.aa.oo)
     tmp166 += tmp77 * -1
-    tmp166 += tmp162.transpose((1, 0))
+    tmp166 += np.transpose(tmp162, (1, 0))
     del tmp162
-    tmp166 += tmp165.transpose((1, 0))
+    tmp166 += np.transpose(tmp165, (1, 0))
     del tmp165
     tmp186 = einsum(v.baa.xov, (0, 1, 2), tmp93, (0, 3, 4), (1, 3, 4, 2))
     tmp204 = einsum(tmp19, (0, 1, 2), tmp93, (0, 3, 4), (2, 1, 4, 3))
-    tmp174 = f.aa.vv.copy()
-    tmp174 += tmp172.transpose((1, 0)) * -1
+    tmp174 = np.copy(f.aa.vv)
+    tmp174 += np.transpose(tmp172, (1, 0)) * -1
     del tmp172
-    tmp174 += tmp173.transpose((1, 0))
+    tmp174 += np.transpose(tmp173, (1, 0))
     del tmp173
-    tmp167 = f.aa.ov.copy()
+    tmp167 = np.copy(f.aa.ov)
     tmp167 += tmp163
     del tmp163
-    tmp151 = tmp148.copy() * 0.5
+    tmp151 = np.copy(tmp148) * 0.5
     del tmp148
     tmp151 += tmp82 * -1
     tmp151 += tmp83 * -0.5
@@ -866,20 +866,20 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp146 = einsum(l1.aa, (0, 1), tmp145, (2, 1, 3, 4), (3, 2, 4, 0))
     tmp178 = einsum(l2.aaaa, (0, 1, 2, 3), tmp31, (2, 3, 4, 5), (4, 5, 0, 1))
     del tmp31
-    tmp153 = f.aa.ov.copy()
+    tmp153 = np.copy(f.aa.ov)
     tmp153 += tmp15
     del tmp15
     tmp181 = einsum(tmp180, (0, 1, 2, 3), tmp48, (1, 4, 2, 5), (4, 0, 5, 3)) * -1
     tmp177 = einsum(tmp176, (0, 1), l2.aaaa, (2, 0, 3, 4), (3, 4, 1, 2)) * -1
     del tmp176
-    tmp152 = f.aa.oo.copy()
+    tmp152 = np.copy(f.aa.oo)
     tmp152 += tmp77 * -1
-    tmp152 += tmp79.transpose((1, 0))
+    tmp152 += np.transpose(tmp79, (1, 0))
     tmp152 += tmp80
     tmp168 = einsum(tmp22, (0, 1, 2, 3), tmp48, (4, 5, 0, 2), (5, 4, 3, 1))
-    tmp179 = tmp28.transpose((3, 2, 1, 0)).copy()
+    tmp179 = np.copy(np.transpose(tmp28, (3, 2, 1, 0)))
     del tmp28
-    tmp179 += tmp30.transpose((0, 3, 1, 2))
+    tmp179 += np.transpose(tmp30, (0, 3, 1, 2))
     del tmp30
     tmp161 = einsum(v.baa.xov, (0, 1, 2), tmp160, (0, 3, 4), (3, 1, 4, 2))
     tmp155 = einsum(l2.aaaa, (0, 1, 2, 3), tmp154, (4, 3, 1, 5), (4, 2, 5, 0))
@@ -887,7 +887,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp147 = einsum(v.baa.xvv, (0, 1, 2), tmp19, (0, 3, 4), (4, 3, 1, 2))
     tmp170 = einsum(l2.aaaa, (0, 1, 2, 3), tmp169, (4, 5, 1, 0), (2, 3, 4, 5))
     del tmp169
-    tmp132 = tmp128.copy() * -1
+    tmp132 = np.copy(tmp128) * -1
     del tmp128
     tmp132 += tmp129 * -2
     del tmp129
@@ -897,17 +897,17 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp131
     tmp132 += einsum(l2.abab, (0, 1, 2, 3), tmp86, (4, 2, 0), (4, 3, 1))
     tmp132 += einsum(tmp10, (0, 1, 2), l2.bbbb, (3, 2, 4, 1), (0, 4, 3)) * 2
-    tmp143 = f.bb.vv.copy()
-    tmp143 += tmp142.transpose((1, 0))
+    tmp143 = np.copy(f.bb.vv)
+    tmp143 += np.transpose(tmp142, (1, 0))
     del tmp142
-    tmp127 = f.bb.oo.copy()
+    tmp127 = np.copy(f.bb.oo)
     tmp127 += tmp123 * -1
     del tmp123
     tmp127 += einsum(tmp124, (0, 1, 2), v.bbb.xov, (0, 3, 2), (1, 3)) * 2
     del tmp124
-    tmp127 += tmp125.transpose((1, 0))
+    tmp127 += np.transpose(tmp125, (1, 0))
     del tmp125
-    tmp127 += tmp126.transpose((1, 0))
+    tmp127 += np.transpose(tmp126, (1, 0))
     del tmp126
     tmp120 = einsum(tmp112, (0, 1, 2, 3), t2.bbbb, (4, 5, 1, 3), (0, 4, 5, 2)) * 0.5
     del tmp112
@@ -950,7 +950,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp141 += einsum(v.bbb.xov, (0, 1, 2), tmp140, (3, 2), (0, 3, 1)) * -0.5
     del tmp140
     tmp141 += einsum(tmp68, (0, 1), v.bbb.xoo, (2, 3, 0), (2, 1, 3)) * -0.5
-    tmp76 = tmp40.copy()
+    tmp76 = np.copy(tmp40)
     del tmp40
     tmp76 += tmp45
     del tmp45
@@ -975,7 +975,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp33 += einsum(tmp2, (0, 1, 2), tmp27, (0, 3, 4), (2, 1, 3, 4)) * -1
     tmp33 += einsum(t1.aa, (0, 1), tmp32, (0, 2, 3, 4), (2, 4, 3, 1)) * -1
     del tmp32
-    tmp87 = tmp82.copy() * -1
+    tmp87 = np.copy(tmp82) * -1
     del tmp82
     tmp87 += tmp83 * -0.5
     del tmp83
@@ -985,8 +985,8 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp85
     tmp87 += einsum(l2.aaaa, (0, 1, 2, 3), tmp86, (4, 3, 1), (4, 2, 0))
     tmp87 += einsum(l2.abab, (0, 1, 2, 3), tmp10, (4, 3, 1), (4, 2, 0)) * 0.5
-    tmp103 = f.aa.vv.copy()
-    tmp103 += tmp102.transpose((1, 0))
+    tmp103 = np.copy(f.aa.vv)
+    tmp103 += np.transpose(tmp102, (1, 0))
     del tmp102
     tmp21 = einsum(t2.abab, (0, 1, 2, 3), tmp0, (4, 2, 3, 5), (4, 0, 1, 5)) * 0.5
     tmp21 += einsum(tmp3, (0, 1, 2, 3), t2.abab, (0, 4, 3, 5), (2, 1, 4, 5)) * -0.5
@@ -1001,16 +1001,16 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp36
     tmp37 += einsum(tmp2, (0, 1, 2), l1.aa, (3, 1), (0, 2, 3))
     del tmp2
-    tmp81 = f.aa.oo.copy()
+    tmp81 = np.copy(f.aa.oo)
     tmp81 += tmp77 * -1
     del tmp77
     tmp81 += einsum(v.baa.xov, (0, 1, 2), tmp78, (0, 3, 2), (3, 1))
     del tmp78
-    tmp81 += tmp79.transpose((1, 0))
+    tmp81 += np.transpose(tmp79, (1, 0))
     del tmp79
     tmp81 += tmp80
     del tmp80
-    tmp100 = tmp52.copy()
+    tmp100 = np.copy(tmp52)
     del tmp52
     tmp100 += tmp53 * 2
     del tmp53
@@ -1043,12 +1043,12 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp98
     tmp99 += einsum(v.baa.xoo, (0, 1, 2), tmp55, (2, 3), (0, 3, 1)) * -2
     del tmp55
-    l2new.bbbb = tmp116.transpose((3, 2, 1, 0)).copy()
+    l2new.bbbb = np.copy(np.transpose(tmp116, (3, 2, 1, 0)))
     l2new.bbbb += einsum(tmp113, (0, 1, 2, 3), l1.bb, (4, 2), (3, 4, 0, 1)) * -1
     del tmp113
-    l2new.bbbb += tmp116.transpose((2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp116, (2, 3, 1, 0)) * -1
     del tmp116
-    l2new.bbbb += tmp210.transpose((3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp210, (3, 2, 0, 1))
     l2new.bbbb += einsum(tmp211, (0, 1, 2, 3), l2.bbbb, (4, 3, 5, 0), (2, 4, 5, 1)) * 2
     del tmp211
     l2new.bbbb += einsum(v.bbb.xov, (0, 1, 2), tmp212, (0, 3, 4), (2, 4, 3, 1)) * -2
@@ -1056,63 +1056,63 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.bbbb += einsum(l2.bbbb, (0, 1, 2, 3), tmp196, (3, 4), (0, 1, 2, 4)) * -2
     l2new.bbbb += einsum(l1.bb, (0, 1), tmp213, (2, 3), (3, 0, 1, 2)) * -1
     del tmp213
-    l2new.bbbb += tmp214.transpose((2, 3, 0, 1)) * -2
-    l2new.bbbb += tmp215.transpose((3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp214, (2, 3, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp215, (3, 2, 1, 0))
     l2new.bbbb += einsum(tmp216, (0, 1), l2.bbbb, (2, 3, 4, 0), (2, 3, 1, 4)) * 2
     del tmp216
     l2new.bbbb += einsum(l1.bb, (0, 1), tmp194, (2, 3), (3, 0, 2, 1))
-    l2new.bbbb += tmp214.transpose((3, 2, 1, 0)) * -2
-    l2new.bbbb += tmp215.transpose((2, 3, 0, 1))
+    l2new.bbbb += np.transpose(tmp214, (3, 2, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp215, (2, 3, 0, 1))
     l2new.bbbb += einsum(l1.bb, (0, 1), tmp194, (2, 3), (0, 3, 1, 2))
-    l2new.bbbb += tmp214.transpose((3, 2, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp214, (3, 2, 0, 1)) * 2
     del tmp214
-    l2new.bbbb += tmp215.transpose((2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp215, (2, 3, 1, 0)) * -1
     del tmp215
     l2new.bbbb += einsum(l1.bb, (0, 1), tmp194, (2, 3), (0, 3, 2, 1)) * -1
-    l2new.bbbb += tmp217.transpose((2, 3, 1, 0)) * 2
-    l2new.bbbb += tmp218.transpose((3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp217, (2, 3, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp218, (3, 2, 1, 0)) * 2
     del tmp218
-    l2new.bbbb += tmp220.transpose((2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp220, (2, 3, 1, 0)) * -2
     del tmp220
     l2new.bbbb += einsum(tmp221, (0, 1), l2.bbbb, (2, 0, 3, 4), (1, 2, 3, 4)) * -1
     del tmp221
-    l2new.bbbb += tmp222.transpose((2, 3, 1, 0)) * -2
-    l2new.bbbb += tmp223.transpose((2, 3, 1, 0)) * -1
-    l2new.bbbb += tmp217.transpose((3, 2, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp222, (2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp223, (2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp217, (3, 2, 1, 0)) * -2
     del tmp217
-    l2new.bbbb += tmp223.transpose((3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp223, (3, 2, 1, 0)) * 2
     del tmp223
-    l2new.bbbb += tmp222.transpose((3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp222, (3, 2, 1, 0)) * 2
     del tmp222
-    l2new.bbbb += tmp224.transpose((2, 3, 0, 1)) * -2
-    l2new.bbbb += tmp224.transpose((2, 3, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp224, (2, 3, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp224, (2, 3, 1, 0)) * 2
     del tmp224
     l2new.bbbb += einsum(tmp225, (0, 1, 2, 3), l2.bbbb, (4, 5, 0, 2), (4, 5, 1, 3)) * -2
     del tmp225
     l2new.bbbb += einsum(tmp209, (0, 1, 2, 3), l1.bb, (4, 1), (3, 4, 0, 2))
     del tmp209
-    l2new.bbbb += tmp210.transpose((3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp210, (3, 2, 1, 0)) * -1
     del tmp210
-    l2new.bbbb += tmp226.transpose((3, 2, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp226, (3, 2, 0, 1)) * -2
     l2new.bbbb += einsum(tmp107, (0, 1), l1.bb, (2, 3), (1, 2, 3, 0))
-    l2new.bbbb += tmp227.transpose((3, 2, 0, 1)) * -1
-    l2new.bbbb += tmp228.transpose((3, 2, 0, 1)) * -2
-    l2new.bbbb += tmp226.transpose((2, 3, 0, 1)) * 2
-    l2new.bbbb += tmp227.transpose((2, 3, 0, 1))
+    l2new.bbbb += np.transpose(tmp227, (3, 2, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp228, (3, 2, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp226, (2, 3, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp227, (2, 3, 0, 1))
     l2new.bbbb += einsum(tmp107, (0, 1), l1.bb, (2, 3), (2, 1, 3, 0)) * -1
-    l2new.bbbb += tmp228.transpose((2, 3, 0, 1)) * 2
-    l2new.bbbb += tmp226.transpose((3, 2, 1, 0)) * 2
-    l2new.bbbb += tmp227.transpose((3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp228, (2, 3, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp226, (3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp227, (3, 2, 1, 0))
     l2new.bbbb += einsum(l1.bb, (0, 1), tmp107, (2, 3), (3, 0, 2, 1)) * -1
-    l2new.bbbb += tmp228.transpose((3, 2, 1, 0)) * 2
-    l2new.bbbb += tmp226.transpose((2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp228, (3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp226, (2, 3, 1, 0)) * -2
     del tmp226
     l2new.bbbb += einsum(l1.bb, (0, 1), tmp107, (2, 3), (0, 3, 2, 1))
-    l2new.bbbb += tmp227.transpose((2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp227, (2, 3, 1, 0)) * -1
     del tmp227
-    l2new.bbbb += tmp228.transpose((2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp228, (2, 3, 1, 0)) * -2
     del tmp228
-    l2new.abab = tmp17.transpose((2, 3, 0, 1)).copy()
+    l2new.abab = np.copy(np.transpose(tmp17, (2, 3, 0, 1)))
     del tmp17
     l2new.abab += einsum(tmp186, (0, 1, 2, 3), l1.bb, (4, 2), (3, 4, 0, 1)) * -1
     l2new.abab += einsum(tmp154, (0, 1, 2, 3), l2.abab, (3, 4, 1, 5), (2, 4, 0, 5)) * -1
@@ -1133,9 +1133,9 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp196
     l2new.abab += einsum(tmp0, (0, 1, 2, 3), tmp50, (4, 0, 5, 2), (1, 3, 4, 5)) * -1
     del tmp0
-    l2new.abab += tmp197.transpose((2, 3, 0, 1))
+    l2new.abab += np.transpose(tmp197, (2, 3, 0, 1))
     del tmp197
-    l2new.abab += tmp199.transpose((2, 3, 0, 1))
+    l2new.abab += np.transpose(tmp199, (2, 3, 0, 1))
     del tmp199
     l2new.abab += einsum(l2.abab, (0, 1, 2, 3), tmp174, (0, 4), (4, 1, 2, 3))
     l2new.abab += einsum(tmp164, (0, 1), tmp50, (2, 0, 3, 4), (1, 4, 2, 3)) * -1
@@ -1170,12 +1170,12 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp207
     l2new.abab += einsum(tmp61, (0, 1, 2, 3), tmp208, (4, 1, 2, 5), (3, 5, 0, 4))
     del tmp61, tmp208
-    l2new.aaaa = tmp29.transpose((3, 2, 1, 0)).copy()
+    l2new.aaaa = np.copy(np.transpose(tmp29, (3, 2, 1, 0)))
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp23, (2, 3, 1, 4), (4, 0, 2, 3)) * -1
     del tmp23
-    l2new.aaaa += tmp29.transpose((2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp29, (2, 3, 1, 0)) * -1
     del tmp29
-    l2new.aaaa += tmp146.transpose((3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp146, (3, 2, 0, 1))
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp147, (3, 4, 5, 1), (5, 0, 2, 4)) * 2
     del tmp147
     l2new.aaaa += einsum(tmp151, (0, 1, 2), v.baa.xov, (0, 3, 4), (4, 2, 1, 3)) * -2
@@ -1184,65 +1184,65 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp152
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp153, (2, 3), (3, 0, 1, 2)) * -1
     del tmp153
-    l2new.aaaa += tmp155.transpose((2, 3, 0, 1)) * -2
-    l2new.aaaa += tmp161.transpose((3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp155, (2, 3, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp161, (3, 2, 1, 0))
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp166, (3, 4), (0, 1, 4, 2)) * 2
     del tmp166
     l2new.aaaa += einsum(tmp167, (0, 1), l1.aa, (2, 3), (1, 2, 0, 3))
-    l2new.aaaa += tmp155.transpose((3, 2, 1, 0)) * -2
-    l2new.aaaa += tmp161.transpose((2, 3, 0, 1))
+    l2new.aaaa += np.transpose(tmp155, (3, 2, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp161, (2, 3, 0, 1))
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp167, (2, 3), (0, 3, 1, 2))
-    l2new.aaaa += tmp155.transpose((3, 2, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp155, (3, 2, 0, 1)) * 2
     del tmp155
-    l2new.aaaa += tmp161.transpose((2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp161, (2, 3, 1, 0)) * -1
     del tmp161
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp167, (2, 3), (0, 3, 2, 1)) * -1
     del tmp167
-    l2new.aaaa += tmp168.transpose((2, 3, 1, 0)) * 2
-    l2new.aaaa += tmp170.transpose((2, 3, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp168, (2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp170, (2, 3, 1, 0)) * -2
     del tmp170
-    l2new.aaaa += tmp171.transpose((3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp171, (3, 2, 1, 0)) * 2
     del tmp171
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp174, (1, 4), (4, 0, 2, 3)) * -1
     del tmp174
-    l2new.aaaa += tmp175.transpose((2, 3, 1, 0)) * -2
-    l2new.aaaa += tmp177.transpose((2, 3, 1, 0)) * -1
-    l2new.aaaa += tmp168.transpose((3, 2, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp175, (2, 3, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp177, (2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp168, (3, 2, 1, 0)) * -2
     del tmp168
-    l2new.aaaa += tmp177.transpose((3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp177, (3, 2, 1, 0)) * 2
     del tmp177
-    l2new.aaaa += tmp175.transpose((3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp175, (3, 2, 1, 0)) * 2
     del tmp175
-    l2new.aaaa += tmp178.transpose((2, 3, 0, 1)) * -2
-    l2new.aaaa += tmp178.transpose((2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp178, (2, 3, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp178, (2, 3, 1, 0)) * 2
     del tmp178
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp179, (2, 4, 3, 5), (0, 1, 4, 5)) * -2
     del tmp179
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp145, (2, 1, 3, 4), (4, 0, 2, 3))
     del tmp145
-    l2new.aaaa += tmp146.transpose((3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp146, (3, 2, 1, 0)) * -1
     del tmp146
-    l2new.aaaa += tmp181.transpose((3, 2, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp181, (3, 2, 0, 1)) * -2
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp11, (2, 3), (3, 0, 1, 2))
-    l2new.aaaa += tmp183.transpose((3, 2, 0, 1)) * -1
-    l2new.aaaa += tmp185.transpose((3, 2, 0, 1)) * -2
-    l2new.aaaa += tmp181.transpose((2, 3, 0, 1)) * 2
-    l2new.aaaa += tmp183.transpose((2, 3, 0, 1))
+    l2new.aaaa += np.transpose(tmp183, (3, 2, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp185, (3, 2, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp181, (2, 3, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp183, (2, 3, 0, 1))
     l2new.aaaa += einsum(tmp11, (0, 1), l1.aa, (2, 3), (2, 1, 3, 0)) * -1
-    l2new.aaaa += tmp185.transpose((2, 3, 0, 1)) * 2
-    l2new.aaaa += tmp181.transpose((3, 2, 1, 0)) * 2
-    l2new.aaaa += tmp183.transpose((3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp185, (2, 3, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp181, (3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp183, (3, 2, 1, 0))
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp11, (2, 3), (3, 0, 2, 1)) * -1
-    l2new.aaaa += tmp185.transpose((3, 2, 1, 0)) * 2
-    l2new.aaaa += tmp181.transpose((2, 3, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp185, (3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp181, (2, 3, 1, 0)) * -2
     del tmp181
     l2new.aaaa += einsum(tmp11, (0, 1), l1.aa, (2, 3), (2, 1, 0, 3))
     del tmp11
-    l2new.aaaa += tmp183.transpose((2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp183, (2, 3, 1, 0)) * -1
     del tmp183
-    l2new.aaaa += tmp185.transpose((2, 3, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp185, (2, 3, 1, 0)) * -2
     del tmp185
-    l1new.bb = f.bb.ov.transpose((1, 0)).copy()
+    l1new.bb = np.copy(np.transpose(f.bb.ov, (1, 0)))
     l1new.bb += einsum(tmp111, (0, 1, 2, 3), l2.abab, (3, 4, 0, 2), (4, 1)) * -1
     del tmp111
     l1new.bb += einsum(l2.bbbb, (0, 1, 2, 3), tmp120, (4, 2, 3, 1), (0, 4)) * 4
@@ -1260,7 +1260,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp68, tmp109
     l1new.bb += einsum(tmp143, (0, 1), l1.bb, (0, 2), (1, 2))
     del tmp143
-    l1new.aa = f.aa.ov.transpose((1, 0)).copy()
+    l1new.aa = np.copy(np.transpose(f.aa.ov, (1, 0)))
     l1new.aa += einsum(l2.abab, (0, 1, 2, 3), tmp21, (4, 2, 3, 1), (0, 4)) * -2
     del tmp21
     l1new.aa += einsum(tmp33, (0, 1, 2, 3), l2.aaaa, (4, 3, 1, 2), (4, 0)) * 2
@@ -1318,10 +1318,10 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp1 = einsum(t1.aa, (0, 1), l1.aa, (1, 2), (2, 0))
     tmp10 = einsum(l2.bbbb, (0, 1, 2, 3), t1.bb, (4, 1), (2, 3, 4, 0))
     tmp9 = einsum(l2.abab, (0, 1, 2, 3), t1.bb, (4, 1), (2, 3, 4, 0))
-    tmp11 = tmp5.copy()
+    tmp11 = np.copy(tmp5)
     tmp11 += tmp4
     tmp11 += tmp3 * 2
-    tmp8 = tmp1.copy()
+    tmp8 = np.copy(tmp1)
     tmp8 += tmp0 * 2
     tmp8 += tmp2
     tmp7 = einsum(l2.abab, (0, 1, 2, 3), t1.aa, (4, 0), (2, 4, 3, 1))
@@ -1332,9 +1332,9 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm1.aa.vv = einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (2, 3, 4, 1), (0, 4)) * 2
     rdm1.aa.vv += einsum(t2.abab, (0, 1, 2, 3), l2.abab, (4, 3, 0, 1), (4, 2))
     rdm1.aa.vv += einsum(l1.aa, (0, 1), t1.aa, (1, 2), (0, 2))
-    rdm1.bb.vo = l1.bb.copy()
-    rdm1.aa.vo = l1.aa.copy()
-    rdm1.bb.ov = t1.bb.copy()
+    rdm1.bb.vo = np.copy(l1.bb)
+    rdm1.aa.vo = np.copy(l1.aa)
+    rdm1.bb.ov = np.copy(t1.bb)
     rdm1.bb.ov += einsum(t2.bbbb, (0, 1, 2, 3), l1.bb, (3, 1), (0, 2)) * 2
     rdm1.bb.ov += einsum(l1.aa, (0, 1), t2.abab, (1, 2, 0, 3), (2, 3))
     rdm1.bb.ov += einsum(tmp9, (0, 1, 2, 3), t2.abab, (0, 1, 3, 4), (2, 4)) * -1
@@ -1352,20 +1352,20 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp7
     rdm1.aa.ov += einsum(t1.aa, (0, 1), tmp8, (0, 2), (2, 1)) * -1
     del tmp8
-    rdm1.bb.oo = tmp3.transpose((1, 0)).copy() * -2
+    rdm1.bb.oo = np.copy(np.transpose(tmp3, (1, 0))) * -2
     del tmp3
-    rdm1.bb.oo += tmp4.transpose((1, 0)) * -1
+    rdm1.bb.oo += np.transpose(tmp4, (1, 0)) * -1
     del tmp4
     rdm1.bb.oo += delta.bb.oo
-    rdm1.bb.oo += tmp5.transpose((1, 0)) * -1
+    rdm1.bb.oo += np.transpose(tmp5, (1, 0)) * -1
     del tmp5
-    rdm1.aa.oo = tmp0.transpose((1, 0)).copy() * -2
+    rdm1.aa.oo = np.copy(np.transpose(tmp0, (1, 0))) * -2
     del tmp0
     rdm1.aa.oo += delta.aa.oo
     del delta
-    rdm1.aa.oo += tmp1.transpose((1, 0)) * -1
+    rdm1.aa.oo += np.transpose(tmp1, (1, 0)) * -1
     del tmp1
-    rdm1.aa.oo += tmp2.transpose((1, 0)) * -1
+    rdm1.aa.oo += np.transpose(tmp2, (1, 0)) * -1
     del tmp2
     rdm1.aa = np.block([[rdm1.aa.oo, rdm1.aa.ov], [rdm1.aa.vo, rdm1.aa.vv]])
     rdm1.bb = np.block([[rdm1.bb.oo, rdm1.bb.ov], [rdm1.bb.vo, rdm1.bb.vv]])
@@ -1419,12 +1419,12 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp51 = einsum(t2.abab, (0, 1, 2, 3), tmp14, (0, 4, 5, 2), (4, 5, 1, 3))
     tmp18 = einsum(t2.bbbb, (0, 1, 2, 3), l2.bbbb, (2, 3, 4, 5), (4, 5, 0, 1))
     tmp20 = einsum(tmp19, (0, 1, 2, 3), t1.bb, (4, 3), (0, 1, 4, 2))
-    tmp17 = tmp8.copy()
+    tmp17 = np.copy(tmp8)
     tmp17 += tmp9
     tmp17 += tmp10 * 2
     tmp13 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 5, 0, 1), (2, 4, 3, 5))
     tmp15 = einsum(tmp14, (0, 1, 2, 3), t1.aa, (4, 3), (0, 4, 1, 2))
-    tmp12 = tmp0.copy() * 0.5
+    tmp12 = np.copy(tmp0) * 0.5
     tmp12 += tmp1
     tmp12 += tmp2 * 0.5
     tmp7 = einsum(t1.aa, (0, 1), tmp6, (2, 3, 4, 1), (2, 3, 0, 4))
@@ -1435,29 +1435,29 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp80 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 3, 0, 4), (1, 4))
     tmp108 = einsum(t1.bb, (0, 1), l1.bb, (2, 0), (2, 1))
     tmp112 = einsum(tmp19, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 3, 4))
-    tmp85 = tmp83.copy()
+    tmp85 = np.copy(tmp83)
     tmp85 += tmp84 * 4
     tmp86 = einsum(l2.aaaa, (0, 1, 2, 3), t2.abab, (3, 4, 1, 5), (2, 4, 0, 5))
     tmp87 = einsum(t2.bbbb, (0, 1, 2, 3), l2.abab, (4, 3, 5, 1), (5, 0, 4, 2))
     tmp64 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (4, 3, 0, 1), (4, 2))
     tmp63 = einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (2, 3, 4, 1), (0, 4))
     tmp104 = einsum(l1.aa, (0, 1), t1.aa, (1, 2), (0, 2))
-    tmp118 = tmp66.copy() * 4
+    tmp118 = np.copy(tmp66) * 4
     tmp118 += tmp106
     tmp107 = einsum(tmp6, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 3, 4))
     tmp70 = einsum(t2.aaaa, (0, 1, 2, 3), l2.abab, (3, 4, 1, 5), (0, 5, 2, 4))
     tmp68 = einsum(t2.abab, (0, 1, 2, 3), l2.bbbb, (4, 3, 5, 1), (0, 5, 2, 4))
     tmp36 = einsum(t2.bbbb, (0, 1, 2, 3), l1.bb, (3, 1), (0, 2))
     tmp35 = einsum(l1.aa, (0, 1), t2.abab, (1, 2, 0, 3), (2, 3))
-    tmp102 = tmp51.copy()
+    tmp102 = np.copy(tmp51)
     tmp102 += tmp50 * 4
     tmp49 = einsum(l1.bb, (0, 1), t2.bbbb, (2, 3, 4, 0), (1, 2, 3, 4))
-    tmp52 = tmp18.transpose((1, 0, 3, 2)).copy()
-    tmp52 += tmp20.transpose((0, 1, 3, 2)) * -1
+    tmp52 = np.copy(np.transpose(tmp18, (1, 0, 3, 2)))
+    tmp52 += np.transpose(tmp20, (0, 1, 3, 2)) * -1
     tmp61 = einsum(tmp17, (0, 1), t1.bb, (0, 2), (1, 2)) * 0.5
     tmp39 = einsum(t2.abab, (0, 1, 2, 3), tmp14, (0, 1, 4, 2), (4, 3))
     tmp40 = einsum(tmp19, (0, 1, 2, 3), t2.bbbb, (1, 0, 4, 3), (2, 4))
-    tmp58 = tmp8.copy() * 0.5
+    tmp58 = np.copy(tmp8) * 0.5
     tmp58 += tmp9 * 0.5
     tmp58 += tmp10
     tmp41 = einsum(tmp17, (0, 1), t1.bb, (0, 2), (1, 2))
@@ -1465,7 +1465,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp57 = einsum(t2.aaaa, (0, 1, 2, 3), tmp14, (1, 4, 5, 3), (0, 4, 5, 2))
     tmp22 = einsum(l1.bb, (0, 1), t2.abab, (2, 1, 3, 0), (2, 3))
     tmp21 = einsum(l1.aa, (0, 1), t2.aaaa, (2, 1, 3, 0), (2, 3))
-    tmp45 = tmp13.copy()
+    tmp45 = np.copy(tmp13)
     tmp45 += tmp15
     tmp26 = einsum(tmp6, (0, 1, 2, 3), t2.aaaa, (1, 0, 4, 3), (2, 4))
     tmp28 = einsum(t2.abab, (0, 1, 2, 3), tmp27, (0, 4, 1, 3), (4, 2))
@@ -1473,30 +1473,30 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp44 = einsum(tmp6, (0, 1, 2, 3), t2.abab, (1, 4, 3, 5), (0, 2, 4, 5)) * -1
     tmp43 = einsum(t2.bbbb, (0, 1, 2, 3), tmp27, (4, 5, 1, 3), (4, 5, 0, 2))
     tmp25 = einsum(t2.aaaa, (0, 1, 2, 3), l1.aa, (3, 4), (4, 0, 1, 2))
-    tmp33 = tmp5.transpose((1, 0, 3, 2)).copy()
-    tmp33 += tmp7.transpose((0, 1, 3, 2)) * -1
-    tmp78 = tmp32.copy() * 4
+    tmp33 = np.copy(np.transpose(tmp5, (1, 0, 3, 2)))
+    tmp33 += np.transpose(tmp7, (0, 1, 3, 2)) * -1
+    tmp78 = np.copy(tmp32) * 4
     tmp78 += tmp31
     tmp130 = einsum(l2.bbbb, (0, 1, 2, 3), t1.bb, (3, 4), (2, 0, 1, 4))
     tmp132 = einsum(t2.bbbb, (0, 1, 2, 3), l2.bbbb, (4, 5, 0, 1), (4, 5, 2, 3))
     tmp129 = einsum(l2.abab, (0, 1, 2, 3), t1.bb, (3, 4), (2, 0, 1, 4))
     tmp128 = einsum(t1.aa, (0, 1), l2.aaaa, (2, 3, 4, 0), (4, 2, 3, 1))
     tmp131 = einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (2, 3, 4, 5), (0, 1, 4, 5))
-    tmp109 = tmp108.copy()
+    tmp109 = np.copy(tmp108)
     tmp109 += tmp80
     tmp109 += tmp81 * 2
     tmp127 = einsum(t1.bb, (0, 1), tmp112, (0, 2, 3, 4), (2, 3, 4, 1)) * -1
     tmp125 = einsum(tmp85, (0, 1, 2, 3), t1.bb, (0, 4), (1, 4, 2, 3))
     tmp123 = einsum(l1.bb, (0, 1), t2.bbbb, (2, 1, 3, 4), (2, 0, 3, 4))
     tmp126 = einsum(tmp19, (0, 1, 2, 3), t2.bbbb, (1, 0, 4, 5), (2, 3, 4, 5)) * -1
-    tmp88 = tmp86.copy()
+    tmp88 = np.copy(tmp86)
     tmp88 += tmp87
     tmp89 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 4, 5, 1), (3, 4, 0, 5))
     tmp115 = einsum(tmp14, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 3, 4))
-    tmp105 = tmp104.copy() * 0.5
+    tmp105 = np.copy(tmp104) * 0.5
     tmp105 += tmp63
     tmp105 += tmp64 * 0.5
-    tmp113 = tmp104.copy()
+    tmp113 = np.copy(tmp104)
     del tmp104
     tmp113 += tmp63 * 2
     tmp113 += tmp64
@@ -1505,83 +1505,83 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp120 = einsum(t2.aaaa, (0, 1, 2, 3), tmp6, (1, 0, 4, 5), (4, 5, 2, 3)) * -1
     tmp121 = einsum(t1.aa, (0, 1), tmp107, (0, 2, 3, 4), (2, 3, 4, 1)) * -1
     tmp116 = einsum(t2.aaaa, (0, 1, 2, 3), l1.aa, (4, 1), (0, 4, 2, 3))
-    tmp124 = tmp83.copy() * 0.25
+    tmp124 = np.copy(tmp83) * 0.25
     tmp124 += tmp84
-    tmp111 = tmp108.copy() * 0.5
+    tmp111 = np.copy(tmp108) * 0.5
     del tmp108
     tmp111 += tmp80 * 0.5
     tmp111 += tmp81
     tmp114 = einsum(t1.aa, (0, 1), tmp27, (0, 2, 3, 4), (2, 3, 1, 4))
     tmp110 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 3, 0, 5), (2, 4, 1, 5))
-    tmp122 = tmp70.copy()
+    tmp122 = np.copy(tmp70)
     tmp122 += tmp68
-    tmp117 = tmp66.copy()
+    tmp117 = np.copy(tmp66)
     tmp117 += tmp106 * 0.25
-    tmp96 = tmp35.copy()
+    tmp96 = np.copy(tmp35)
     tmp96 += tmp36 * 2
     tmp94 = einsum(tmp84, (0, 1, 2, 3), t2.bbbb, (4, 0, 5, 2), (4, 1, 5, 3))
-    tmp82 = tmp80.copy() * 0.5
+    tmp82 = np.copy(tmp80) * 0.5
     tmp82 += tmp81
     tmp103 = einsum(tmp102, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 4, 3))
     del tmp102
     tmp97 = einsum(tmp49, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 4, 3))
     tmp101 = einsum(tmp52, (0, 1, 2, 3), t1.bb, (0, 4), (1, 3, 2, 4))
     tmp98 = einsum(t2.bbbb, (0, 1, 2, 3), tmp17, (1, 4), (0, 4, 2, 3)) * -1
-    tmp62 = tmp39.copy() * 0.5
+    tmp62 = np.copy(tmp39) * 0.5
     tmp62 += tmp40
     tmp62 += tmp61
     del tmp61
-    tmp37 = t1.bb.copy()
+    tmp37 = np.copy(t1.bb)
     tmp37 += tmp35
     tmp37 += tmp36 * 2
     tmp100 = einsum(t2.bbbb, (0, 1, 2, 3), tmp52, (0, 1, 4, 5), (4, 5, 2, 3))
-    tmp92 = tmp80.copy()
+    tmp92 = np.copy(tmp80)
     del tmp80
     tmp92 += tmp81 * 2
     del tmp81
     tmp93 = einsum(tmp86, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5))
-    tmp48 = t1.bb.copy()
+    tmp48 = np.copy(t1.bb)
     tmp48 += tmp35
     tmp48 += tmp36 * 2
     tmp99 = einsum(t2.bbbb, (0, 1, 2, 3), tmp58, (1, 4), (0, 4, 2, 3)) * -2
-    tmp42 = tmp39.copy()
+    tmp42 = np.copy(tmp39)
     del tmp39
     tmp42 += tmp40 * 2
     del tmp40
     tmp42 += tmp41
     del tmp41
     tmp95 = einsum(tmp83, (0, 1, 2, 3), t2.bbbb, (4, 0, 5, 2), (1, 4, 3, 5))
-    tmp91 = tmp57.copy()
+    tmp91 = np.copy(tmp57)
     tmp91 += tmp56
-    tmp72 = tmp21.copy() * 2
+    tmp72 = np.copy(tmp21) * 2
     tmp72 += tmp22
-    tmp74 = tmp63.copy() * 2
+    tmp74 = np.copy(tmp63) * 2
     tmp74 += tmp64
     tmp55 = einsum(l1.bb, (0, 1), t2.abab, (2, 3, 4, 0), (2, 1, 3, 4))
     tmp47 = einsum(t2.abab, (0, 1, 2, 3), tmp14, (4, 1, 5, 2), (4, 0, 5, 3))
     tmp46 = einsum(tmp45, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 3, 4))
-    tmp30 = tmp26.copy() * 2
+    tmp30 = np.copy(tmp26) * 2
     del tmp26
     tmp30 += tmp28
     del tmp28
     tmp30 += tmp29
     del tmp29
-    tmp90 = tmp44.copy()
+    tmp90 = np.copy(tmp44)
     tmp90 += tmp43
     tmp59 = einsum(t2.abab, (0, 1, 2, 3), tmp27, (0, 4, 5, 3), (4, 5, 1, 2))
     tmp38 = einsum(t2.abab, (0, 1, 2, 3), l1.aa, (2, 4), (4, 0, 1, 3))
-    tmp54 = t1.aa.copy()
+    tmp54 = np.copy(t1.aa)
     tmp54 += tmp21 * 2
     tmp54 += tmp22
     tmp75 = einsum(t2.aaaa, (0, 1, 2, 3), tmp12, (1, 4), (4, 0, 2, 3)) * -2
-    tmp24 = t1.aa.copy()
+    tmp24 = np.copy(t1.aa)
     tmp24 += tmp21 * 2
     tmp24 += tmp22
     tmp73 = einsum(tmp25, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3))
     tmp71 = einsum(t2.abab, (0, 1, 2, 3), tmp70, (4, 1, 5, 3), (4, 0, 5, 2))
     tmp77 = einsum(t1.aa, (0, 1), tmp33, (0, 2, 3, 4), (2, 4, 3, 1))
     tmp76 = einsum(t2.aaaa, (0, 1, 2, 3), tmp33, (0, 1, 4, 5), (4, 5, 2, 3))
-    tmp65 = tmp63.copy()
+    tmp65 = np.copy(tmp63)
     del tmp63
     tmp65 += tmp64 * 0.5
     del tmp64
@@ -1589,89 +1589,89 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp78
     tmp69 = einsum(tmp68, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 5, 2))
     tmp67 = einsum(t2.aaaa, (0, 1, 2, 3), tmp66, (1, 4, 3, 5), (4, 0, 5, 2))
-    tmp60 = t1.bb.copy() * 0.5
+    tmp60 = np.copy(t1.bb) * 0.5
     tmp60 += tmp35 * 0.5
     del tmp35
     tmp60 += tmp36
     del tmp36
     tmp53 = einsum(tmp52, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 3, 4)) * 2
     del tmp52
-    tmp23 = t1.aa.copy() * 0.5
+    tmp23 = np.copy(t1.aa) * 0.5
     tmp23 += tmp21
     del tmp21
     tmp23 += tmp22 * 0.5
     del tmp22
-    tmp4 = tmp0.copy()
+    tmp4 = np.copy(tmp0)
     tmp4 += tmp1 * 2
     tmp4 += tmp2
     tmp34 = einsum(t1.aa, (0, 1), tmp33, (0, 2, 3, 4), (2, 3, 4, 1)) * 2
     del tmp33
-    tmp16 = delta.bb.oo.copy() * -1
+    tmp16 = np.copy(delta.bb.oo) * -1
     tmp16 += tmp8
     tmp16 += tmp9
     tmp16 += tmp10 * 2
-    tmp11 = delta.bb.oo.copy() * -0.5
+    tmp11 = np.copy(delta.bb.oo) * -0.5
     tmp11 += tmp8 * 0.5
     del tmp8
     tmp11 += tmp9 * 0.5
     del tmp9
     tmp11 += tmp10
     del tmp10
-    tmp3 = delta.aa.oo.copy() * -1
+    tmp3 = np.copy(delta.aa.oo) * -1
     tmp3 += tmp0
     del tmp0
     tmp3 += tmp1 * 2
     del tmp1
     tmp3 += tmp2
     del tmp2
-    rdm2.bbbb.vvvv = tmp132.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.bbbb.vvvv = np.copy(np.transpose(tmp132, (1, 0, 3, 2))) * 2
     del tmp132
     rdm2.bbbb.vvvv += einsum(t1.bb, (0, 1), tmp130, (0, 2, 3, 4), (2, 3, 1, 4)) * 2
     rdm2.abab.vvvv = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 3, 4, 5), (0, 1, 4, 5))
     rdm2.abab.vvvv += einsum(tmp129, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3))
-    rdm2.aaaa.vvvv = tmp131.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.aaaa.vvvv = np.copy(np.transpose(tmp131, (1, 0, 3, 2))) * 2
     del tmp131
     rdm2.aaaa.vvvv += einsum(tmp128, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3)) * 2
-    rdm2.bbbb.vvvo = tmp130.transpose((2, 1, 3, 0)).copy() * 2
+    rdm2.bbbb.vvvo = np.copy(np.transpose(tmp130, (2, 1, 3, 0))) * 2
     rdm2.abab.vvvo = einsum(l2.abab, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
-    rdm2.aaaa.vvvo = tmp128.transpose((2, 1, 3, 0)).copy() * 2
-    rdm2.bbbb.vvov = tmp130.transpose((2, 1, 0, 3)).copy() * -2
+    rdm2.aaaa.vvvo = np.copy(np.transpose(tmp128, (2, 1, 3, 0))) * 2
+    rdm2.bbbb.vvov = np.copy(np.transpose(tmp130, (2, 1, 0, 3))) * -2
     del tmp130
-    rdm2.abab.vvov = tmp129.transpose((1, 2, 0, 3)).copy()
+    rdm2.abab.vvov = np.copy(np.transpose(tmp129, (1, 2, 0, 3)))
     del tmp129
-    rdm2.aaaa.vvov = tmp128.transpose((2, 1, 0, 3)).copy() * -2
+    rdm2.aaaa.vvov = np.copy(np.transpose(tmp128, (2, 1, 0, 3))) * -2
     del tmp128
-    rdm2.bbbb.vovv = tmp123.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.bbbb.vovv = np.copy(np.transpose(tmp123, (1, 0, 3, 2))) * 2
     rdm2.bbbb.vovv += einsum(t1.bb, (0, 1), tmp109, (2, 3), (2, 0, 1, 3)) * -1
     rdm2.bbbb.vovv += einsum(t1.bb, (0, 1), tmp109, (2, 3), (2, 0, 3, 1))
-    rdm2.bbbb.vovv += tmp125.transpose((2, 0, 1, 3))
-    rdm2.bbbb.vovv += tmp125.transpose((2, 0, 3, 1)) * -1
-    rdm2.bbbb.vovv += tmp126.transpose((1, 0, 3, 2)) * 2
-    rdm2.bbbb.vovv += tmp127.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.vovv += np.transpose(tmp125, (2, 0, 1, 3))
+    rdm2.bbbb.vovv += np.transpose(tmp125, (2, 0, 3, 1)) * -1
+    rdm2.bbbb.vovv += np.transpose(tmp126, (1, 0, 3, 2)) * 2
+    rdm2.bbbb.vovv += np.transpose(tmp127, (1, 0, 3, 2)) * 2
     rdm2.abab.vovv = einsum(t2.abab, (0, 1, 2, 3), l1.aa, (4, 0), (4, 1, 2, 3))
     rdm2.abab.vovv += einsum(t1.bb, (0, 1), tmp105, (2, 3), (2, 0, 3, 1)) * 2
     rdm2.abab.vovv += einsum(tmp88, (0, 1, 2, 3), t1.aa, (0, 4), (2, 1, 4, 3)) * 2
     rdm2.abab.vovv += einsum(tmp89, (0, 1, 2, 3), t1.bb, (0, 4), (2, 1, 3, 4)) * -1
     rdm2.abab.vovv += einsum(t2.abab, (0, 1, 2, 3), tmp14, (0, 1, 4, 5), (5, 4, 2, 3)) * -1
     rdm2.abab.vovv += einsum(tmp115, (0, 1, 2, 3), t1.aa, (0, 4), (2, 1, 4, 3)) * -1
-    rdm2.aaaa.vovv = tmp116.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.aaaa.vovv = np.copy(np.transpose(tmp116, (1, 0, 3, 2))) * 2
     rdm2.aaaa.vovv += einsum(tmp113, (0, 1), t1.aa, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.aaaa.vovv += einsum(tmp105, (0, 1), t1.aa, (2, 3), (0, 2, 1, 3)) * 2
-    rdm2.aaaa.vovv += tmp119.transpose((2, 0, 1, 3))
-    rdm2.aaaa.vovv += tmp119.transpose((2, 0, 3, 1)) * -1
-    rdm2.aaaa.vovv += tmp120.transpose((1, 0, 3, 2)) * 2
-    rdm2.aaaa.vovv += tmp121.transpose((1, 0, 3, 2)) * 2
-    rdm2.bbbb.ovvv = tmp123.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.aaaa.vovv += np.transpose(tmp119, (2, 0, 1, 3))
+    rdm2.aaaa.vovv += np.transpose(tmp119, (2, 0, 3, 1)) * -1
+    rdm2.aaaa.vovv += np.transpose(tmp120, (1, 0, 3, 2)) * 2
+    rdm2.aaaa.vovv += np.transpose(tmp121, (1, 0, 3, 2)) * 2
+    rdm2.bbbb.ovvv = np.copy(np.transpose(tmp123, (0, 1, 3, 2))) * -2
     del tmp123
     rdm2.bbbb.ovvv += einsum(t1.bb, (0, 1), tmp109, (2, 3), (0, 2, 1, 3))
     rdm2.bbbb.ovvv += einsum(t1.bb, (0, 1), tmp111, (2, 3), (0, 2, 3, 1)) * -2
     rdm2.bbbb.ovvv += einsum(tmp124, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 4, 3)) * -4
     del tmp124
-    rdm2.bbbb.ovvv += tmp125.transpose((0, 2, 3, 1))
+    rdm2.bbbb.ovvv += np.transpose(tmp125, (0, 2, 3, 1))
     del tmp125
-    rdm2.bbbb.ovvv += tmp126.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.ovvv += np.transpose(tmp126, (0, 1, 3, 2)) * -2
     del tmp126
-    rdm2.bbbb.ovvv += tmp127.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.ovvv += np.transpose(tmp127, (0, 1, 3, 2)) * -2
     del tmp127
     rdm2.abab.ovvv = einsum(l1.bb, (0, 1), t2.abab, (2, 1, 3, 4), (2, 0, 3, 4))
     rdm2.abab.ovvv += einsum(tmp111, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1)) * 2
@@ -1680,106 +1680,106 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp122
     rdm2.abab.ovvv += einsum(t2.abab, (0, 1, 2, 3), tmp27, (0, 4, 1, 5), (4, 5, 2, 3)) * -1
     rdm2.abab.ovvv += einsum(t1.bb, (0, 1), tmp114, (2, 0, 3, 4), (2, 4, 3, 1)) * -1
-    rdm2.aaaa.ovvv = tmp116.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.aaaa.ovvv = np.copy(np.transpose(tmp116, (0, 1, 3, 2))) * -2
     del tmp116
     rdm2.aaaa.ovvv += einsum(tmp113, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
     rdm2.aaaa.ovvv += einsum(tmp105, (0, 1), t1.aa, (2, 3), (2, 0, 1, 3)) * -2
     rdm2.aaaa.ovvv += einsum(t1.aa, (0, 1), tmp117, (0, 2, 3, 4), (2, 3, 1, 4)) * -4
     del tmp117
-    rdm2.aaaa.ovvv += tmp119.transpose((0, 2, 3, 1))
+    rdm2.aaaa.ovvv += np.transpose(tmp119, (0, 2, 3, 1))
     del tmp119
-    rdm2.aaaa.ovvv += tmp120.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.ovvv += np.transpose(tmp120, (0, 1, 3, 2)) * -2
     del tmp120
-    rdm2.aaaa.ovvv += tmp121.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.ovvv += np.transpose(tmp121, (0, 1, 3, 2)) * -2
     del tmp121
-    rdm2.bbbb.vvoo = l2.bbbb.copy() * 2
-    rdm2.abab.vvoo = l2.abab.copy()
-    rdm2.aaaa.vvoo = l2.aaaa.copy() * 2
+    rdm2.bbbb.vvoo = np.copy(l2.bbbb) * 2
+    rdm2.abab.vvoo = np.copy(l2.abab)
+    rdm2.aaaa.vvoo = np.copy(l2.aaaa) * 2
     rdm2.bbbb.vovo = einsum(delta.bb.oo, (0, 1), tmp109, (2, 3), (2, 0, 3, 1))
-    rdm2.bbbb.vovo += tmp84.transpose((2, 1, 3, 0)) * -4
+    rdm2.bbbb.vovo += np.transpose(tmp84, (2, 1, 3, 0)) * -4
     rdm2.bbbb.vovo += einsum(t1.bb, (0, 1), l1.bb, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.bbbb.vovo += tmp83.transpose((2, 1, 3, 0)) * -1
-    rdm2.bbbb.vovo += tmp112.transpose((2, 1, 3, 0)) * 2
+    rdm2.bbbb.vovo += np.transpose(tmp83, (2, 1, 3, 0)) * -1
+    rdm2.bbbb.vovo += np.transpose(tmp112, (2, 1, 3, 0)) * 2
     rdm2.abab.vovo = einsum(delta.bb.oo, (0, 1), tmp105, (2, 3), (2, 0, 3, 1)) * 2
-    rdm2.abab.vovo += tmp89.transpose((2, 1, 3, 0)) * -1
+    rdm2.abab.vovo += np.transpose(tmp89, (2, 1, 3, 0)) * -1
     rdm2.abab.vovo += einsum(tmp14, (0, 1, 2, 3), t1.aa, (0, 4), (3, 2, 4, 1)) * -1
     rdm2.aaaa.vovo = einsum(delta.aa.oo, (0, 1), tmp113, (2, 3), (2, 0, 3, 1))
-    rdm2.aaaa.vovo += tmp66.transpose((2, 1, 3, 0)) * -4
+    rdm2.aaaa.vovo += np.transpose(tmp66, (2, 1, 3, 0)) * -4
     rdm2.aaaa.vovo += einsum(l1.aa, (0, 1), t1.aa, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.aaaa.vovo += tmp106.transpose((2, 1, 3, 0)) * -1
-    rdm2.aaaa.vovo += tmp107.transpose((2, 1, 3, 0)) * 2
+    rdm2.aaaa.vovo += np.transpose(tmp106, (2, 1, 3, 0)) * -1
+    rdm2.aaaa.vovo += np.transpose(tmp107, (2, 1, 3, 0)) * 2
     rdm2.bbbb.voov = einsum(delta.bb.oo, (0, 1), tmp111, (2, 3), (2, 0, 1, 3)) * -2
-    rdm2.bbbb.voov += tmp84.transpose((2, 1, 0, 3)) * 4
+    rdm2.bbbb.voov += np.transpose(tmp84, (2, 1, 0, 3)) * 4
     rdm2.bbbb.voov += einsum(t1.bb, (0, 1), l1.bb, (2, 3), (2, 0, 3, 1))
-    rdm2.bbbb.voov += tmp83.transpose((2, 1, 0, 3))
-    rdm2.bbbb.voov += tmp112.transpose((2, 1, 0, 3)) * -2
-    rdm2.abab.voov = tmp86.transpose((2, 1, 0, 3)).copy() * 2
+    rdm2.bbbb.voov += np.transpose(tmp83, (2, 1, 0, 3))
+    rdm2.bbbb.voov += np.transpose(tmp112, (2, 1, 0, 3)) * -2
+    rdm2.abab.voov = np.copy(np.transpose(tmp86, (2, 1, 0, 3))) * 2
     del tmp86
-    rdm2.abab.voov += tmp87.transpose((2, 1, 0, 3)) * 2
+    rdm2.abab.voov += np.transpose(tmp87, (2, 1, 0, 3)) * 2
     del tmp87
     rdm2.abab.voov += einsum(t1.bb, (0, 1), l1.aa, (2, 3), (2, 0, 3, 1))
-    rdm2.abab.voov += tmp115.transpose((2, 1, 0, 3)) * -1
+    rdm2.abab.voov += np.transpose(tmp115, (2, 1, 0, 3)) * -1
     del tmp115
     rdm2.aaaa.voov = einsum(delta.aa.oo, (0, 1), tmp105, (2, 3), (2, 0, 1, 3)) * -2
-    rdm2.aaaa.voov += tmp66.transpose((2, 1, 0, 3)) * 4
+    rdm2.aaaa.voov += np.transpose(tmp66, (2, 1, 0, 3)) * 4
     rdm2.aaaa.voov += einsum(l1.aa, (0, 1), t1.aa, (2, 3), (0, 2, 1, 3))
-    rdm2.aaaa.voov += tmp106.transpose((2, 1, 0, 3))
-    rdm2.aaaa.voov += tmp107.transpose((2, 1, 0, 3)) * -2
+    rdm2.aaaa.voov += np.transpose(tmp106, (2, 1, 0, 3))
+    rdm2.aaaa.voov += np.transpose(tmp107, (2, 1, 0, 3)) * -2
     rdm2.bbbb.ovvo = einsum(delta.bb.oo, (0, 1), tmp109, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.bbbb.ovvo += tmp84.transpose((1, 2, 3, 0)) * 4
+    rdm2.bbbb.ovvo += np.transpose(tmp84, (1, 2, 3, 0)) * 4
     rdm2.bbbb.ovvo += einsum(t1.bb, (0, 1), l1.bb, (2, 3), (0, 2, 1, 3))
-    rdm2.bbbb.ovvo += tmp83.transpose((1, 2, 3, 0))
-    rdm2.bbbb.ovvo += tmp112.transpose((1, 2, 3, 0)) * -2
-    rdm2.abab.ovvo = tmp70.transpose((0, 3, 2, 1)).copy() * 2
+    rdm2.bbbb.ovvo += np.transpose(tmp83, (1, 2, 3, 0))
+    rdm2.bbbb.ovvo += np.transpose(tmp112, (1, 2, 3, 0)) * -2
+    rdm2.abab.ovvo = np.copy(np.transpose(tmp70, (0, 3, 2, 1))) * 2
     del tmp70
     rdm2.abab.ovvo += einsum(l1.bb, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
-    rdm2.abab.ovvo += tmp68.transpose((0, 3, 2, 1)) * 2
+    rdm2.abab.ovvo += np.transpose(tmp68, (0, 3, 2, 1)) * 2
     del tmp68
-    rdm2.abab.ovvo += tmp114.transpose((0, 3, 2, 1)) * -1
+    rdm2.abab.ovvo += np.transpose(tmp114, (0, 3, 2, 1)) * -1
     del tmp114
     rdm2.aaaa.ovvo = einsum(delta.aa.oo, (0, 1), tmp113, (2, 3), (0, 2, 3, 1)) * -1
     del tmp113
-    rdm2.aaaa.ovvo += tmp66.transpose((1, 2, 3, 0)) * 4
+    rdm2.aaaa.ovvo += np.transpose(tmp66, (1, 2, 3, 0)) * 4
     rdm2.aaaa.ovvo += einsum(l1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
-    rdm2.aaaa.ovvo += tmp106.transpose((1, 2, 3, 0))
-    rdm2.aaaa.ovvo += tmp107.transpose((1, 2, 3, 0)) * -2
+    rdm2.aaaa.ovvo += np.transpose(tmp106, (1, 2, 3, 0))
+    rdm2.aaaa.ovvo += np.transpose(tmp107, (1, 2, 3, 0)) * -2
     rdm2.bbbb.ovov = einsum(delta.bb.oo, (0, 1), tmp111, (2, 3), (0, 2, 1, 3)) * 2
     del tmp111
-    rdm2.bbbb.ovov += tmp84.transpose((1, 2, 0, 3)) * -4
+    rdm2.bbbb.ovov += np.transpose(tmp84, (1, 2, 0, 3)) * -4
     del tmp84
     rdm2.bbbb.ovov += einsum(t1.bb, (0, 1), l1.bb, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.bbbb.ovov += tmp83.transpose((1, 2, 0, 3)) * -1
+    rdm2.bbbb.ovov += np.transpose(tmp83, (1, 2, 0, 3)) * -1
     del tmp83
-    rdm2.bbbb.ovov += tmp112.transpose((1, 2, 0, 3)) * 2
+    rdm2.bbbb.ovov += np.transpose(tmp112, (1, 2, 0, 3)) * 2
     del tmp112
     rdm2.abab.ovov = einsum(delta.aa.oo, (0, 1), tmp109, (2, 3), (0, 2, 1, 3))
     del tmp109
-    rdm2.abab.ovov += tmp110.transpose((1, 2, 0, 3)) * -1
+    rdm2.abab.ovov += np.transpose(tmp110, (1, 2, 0, 3)) * -1
     del tmp110
     rdm2.abab.ovov += einsum(t1.bb, (0, 1), tmp27, (2, 3, 0, 4), (3, 4, 2, 1)) * -1
     rdm2.aaaa.ovov = einsum(delta.aa.oo, (0, 1), tmp105, (2, 3), (0, 2, 1, 3)) * 2
     del tmp105
-    rdm2.aaaa.ovov += tmp66.transpose((1, 2, 0, 3)) * -4
+    rdm2.aaaa.ovov += np.transpose(tmp66, (1, 2, 0, 3)) * -4
     del tmp66
     rdm2.aaaa.ovov += einsum(l1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.aaaa.ovov += tmp106.transpose((1, 2, 0, 3)) * -1
+    rdm2.aaaa.ovov += np.transpose(tmp106, (1, 2, 0, 3)) * -1
     del tmp106
-    rdm2.aaaa.ovov += tmp107.transpose((1, 2, 0, 3)) * 2
+    rdm2.aaaa.ovov += np.transpose(tmp107, (1, 2, 0, 3)) * 2
     del tmp107
-    rdm2.bbbb.oovv = t2.bbbb.copy() * 2
+    rdm2.bbbb.oovv = np.copy(t2.bbbb) * 2
     rdm2.bbbb.oovv += einsum(tmp92, (0, 1), t2.bbbb, (2, 3, 4, 0), (2, 3, 4, 1)) * -2
     del tmp92
-    rdm2.bbbb.oovv += tmp93.transpose((0, 1, 3, 2)) * -2
-    rdm2.bbbb.oovv += tmp94.transpose((0, 1, 3, 2)) * -8
-    rdm2.bbbb.oovv += tmp95.transpose((0, 1, 3, 2)) * -2
-    rdm2.bbbb.oovv += tmp95.transpose((1, 0, 2, 3)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp93, (0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp94, (0, 1, 3, 2)) * -8
+    rdm2.bbbb.oovv += np.transpose(tmp95, (0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp95, (1, 0, 2, 3)) * -2
     rdm2.bbbb.oovv += einsum(tmp48, (0, 1), t1.bb, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.bbbb.oovv += tmp93.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp93, (1, 0, 3, 2)) * 2
     del tmp93
     rdm2.bbbb.oovv += tmp94 * 8
     del tmp94
     rdm2.bbbb.oovv += tmp95 * 2
-    rdm2.bbbb.oovv += tmp95.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp95, (1, 0, 3, 2)) * 2
     del tmp95
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp37, (2, 3), (0, 2, 1, 3))
     rdm2.bbbb.oovv += einsum(tmp96, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3))
@@ -1787,28 +1787,28 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp96
     rdm2.bbbb.oovv += tmp97 * 2
     rdm2.bbbb.oovv += einsum(t2.bbbb, (0, 1, 2, 3), tmp82, (3, 4), (0, 1, 4, 2)) * 4
-    rdm2.bbbb.oovv += tmp97.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp97, (0, 1, 3, 2)) * -2
     del tmp97
-    rdm2.bbbb.oovv += tmp98.transpose((0, 1, 3, 2)) * -1
+    rdm2.bbbb.oovv += np.transpose(tmp98, (0, 1, 3, 2)) * -1
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp42, (2, 3), (0, 2, 1, 3)) * -1
-    rdm2.bbbb.oovv += tmp99.transpose((0, 1, 3, 2)) * -1
+    rdm2.bbbb.oovv += np.transpose(tmp99, (0, 1, 3, 2)) * -1
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp42, (2, 3), (0, 2, 3, 1))
-    rdm2.bbbb.oovv += tmp99.transpose((1, 0, 3, 2))
+    rdm2.bbbb.oovv += np.transpose(tmp99, (1, 0, 3, 2))
     del tmp99
     rdm2.bbbb.oovv += einsum(tmp42, (0, 1), t1.bb, (2, 3), (0, 2, 3, 1))
-    rdm2.bbbb.oovv += tmp98.transpose((1, 0, 3, 2))
+    rdm2.bbbb.oovv += np.transpose(tmp98, (1, 0, 3, 2))
     del tmp98
     rdm2.bbbb.oovv += einsum(tmp62, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3)) * -2
-    rdm2.bbbb.oovv += tmp100.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp100, (1, 0, 3, 2)) * 2
     del tmp100
     rdm2.bbbb.oovv += einsum(tmp101, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 4, 3)) * 2
     del tmp101
-    rdm2.bbbb.oovv += tmp103.transpose((1, 0, 2, 3))
+    rdm2.bbbb.oovv += np.transpose(tmp103, (1, 0, 2, 3))
     rdm2.bbbb.oovv += tmp103 * -1
-    rdm2.bbbb.oovv += tmp103.transpose((1, 0, 3, 2)) * -1
-    rdm2.bbbb.oovv += tmp103.transpose((0, 1, 3, 2))
+    rdm2.bbbb.oovv += np.transpose(tmp103, (1, 0, 3, 2)) * -1
+    rdm2.bbbb.oovv += np.transpose(tmp103, (0, 1, 3, 2))
     del tmp103
-    rdm2.abab.oovv = t2.abab.copy()
+    rdm2.abab.oovv = np.copy(t2.abab)
     rdm2.abab.oovv += einsum(tmp82, (0, 1), t2.abab, (2, 3, 4, 0), (2, 3, 4, 1)) * -2
     del tmp82
     rdm2.abab.oovv += einsum(tmp85, (0, 1, 2, 3), t2.abab, (4, 0, 5, 2), (4, 1, 5, 3))
@@ -1834,20 +1834,20 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.abab.oovv += einsum(tmp91, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 3, 4)) * -2
     del tmp91
     rdm2.abab.oovv += einsum(tmp59, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 3, 4))
-    rdm2.aaaa.oovv = t2.aaaa.copy() * 2
+    rdm2.aaaa.oovv = np.copy(t2.aaaa) * 2
     rdm2.aaaa.oovv += einsum(tmp65, (0, 1), t2.aaaa, (2, 3, 4, 0), (2, 3, 4, 1)) * -4
     del tmp65
-    rdm2.aaaa.oovv += tmp67.transpose((0, 1, 3, 2)) * -8
-    rdm2.aaaa.oovv += tmp69.transpose((0, 1, 3, 2)) * -2
-    rdm2.aaaa.oovv += tmp71.transpose((0, 1, 3, 2)) * -2
-    rdm2.aaaa.oovv += tmp71.transpose((1, 0, 2, 3)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp67, (0, 1, 3, 2)) * -8
+    rdm2.aaaa.oovv += np.transpose(tmp69, (0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp71, (0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp71, (1, 0, 2, 3)) * -2
     rdm2.aaaa.oovv += einsum(t1.aa, (0, 1), tmp54, (2, 3), (2, 0, 1, 3)) * -1
     rdm2.aaaa.oovv += tmp67 * 8
     del tmp67
     rdm2.aaaa.oovv += tmp69 * 2
     del tmp69
     rdm2.aaaa.oovv += tmp71 * 2
-    rdm2.aaaa.oovv += tmp71.transpose((1, 0, 3, 2)) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp71, (1, 0, 3, 2)) * 2
     del tmp71
     rdm2.aaaa.oovv += einsum(tmp24, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
     rdm2.aaaa.oovv += einsum(t1.aa, (0, 1), tmp72, (2, 3), (2, 0, 3, 1))
@@ -1856,135 +1856,135 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.aaaa.oovv += tmp73 * 2
     rdm2.aaaa.oovv += einsum(t2.aaaa, (0, 1, 2, 3), tmp74, (3, 4), (0, 1, 4, 2)) * 2
     del tmp74
-    rdm2.aaaa.oovv += tmp73.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp73, (0, 1, 3, 2)) * -2
     del tmp73
-    rdm2.aaaa.oovv += tmp75.transpose((1, 0, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp75, (1, 0, 3, 2)) * -2
     rdm2.aaaa.oovv += einsum(tmp30, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1)) * -1
     rdm2.aaaa.oovv += einsum(tmp30, (0, 1), t1.aa, (2, 3), (2, 0, 1, 3))
-    rdm2.aaaa.oovv += tmp75.transpose((0, 1, 3, 2)) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp75, (0, 1, 3, 2)) * 2
     del tmp75
     rdm2.aaaa.oovv += einsum(t1.aa, (0, 1), tmp30, (2, 3), (2, 0, 1, 3))
     rdm2.aaaa.oovv += einsum(t1.aa, (0, 1), tmp30, (2, 3), (2, 0, 3, 1)) * -1
-    rdm2.aaaa.oovv += tmp76.transpose((1, 0, 3, 2)) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp76, (1, 0, 3, 2)) * 2
     del tmp76
     rdm2.aaaa.oovv += einsum(tmp77, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3)) * 2
     del tmp77
-    rdm2.aaaa.oovv += tmp79.transpose((1, 0, 2, 3))
+    rdm2.aaaa.oovv += np.transpose(tmp79, (1, 0, 2, 3))
     rdm2.aaaa.oovv += tmp79 * -1
-    rdm2.aaaa.oovv += tmp79.transpose((1, 0, 3, 2)) * -1
-    rdm2.aaaa.oovv += tmp79.transpose((0, 1, 3, 2))
+    rdm2.aaaa.oovv += np.transpose(tmp79, (1, 0, 3, 2)) * -1
+    rdm2.aaaa.oovv += np.transpose(tmp79, (0, 1, 3, 2))
     del tmp79
     rdm2.bbbb.vooo = einsum(l1.bb, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3))
     rdm2.bbbb.vooo += einsum(delta.bb.oo, (0, 1), l1.bb, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.bbbb.vooo += tmp19.transpose((3, 2, 1, 0)) * 2
+    rdm2.bbbb.vooo += np.transpose(tmp19, (3, 2, 1, 0)) * 2
     rdm2.abab.vooo = einsum(delta.bb.oo, (0, 1), l1.aa, (2, 3), (2, 0, 3, 1))
-    rdm2.abab.vooo += tmp14.transpose((3, 2, 0, 1)) * -1
+    rdm2.abab.vooo += np.transpose(tmp14, (3, 2, 0, 1)) * -1
     del tmp14
     rdm2.aaaa.vooo = einsum(delta.aa.oo, (0, 1), l1.aa, (2, 3), (2, 0, 3, 1))
     rdm2.aaaa.vooo += einsum(delta.aa.oo, (0, 1), l1.aa, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.aaaa.vooo += tmp6.transpose((3, 2, 1, 0)) * 2
+    rdm2.aaaa.vooo += np.transpose(tmp6, (3, 2, 1, 0)) * 2
     rdm2.bbbb.ovoo = einsum(l1.bb, (0, 1), delta.bb.oo, (2, 3), (2, 0, 1, 3)) * -1
     rdm2.bbbb.ovoo += einsum(delta.bb.oo, (0, 1), l1.bb, (2, 3), (0, 2, 1, 3))
-    rdm2.bbbb.ovoo += tmp19.transpose((2, 3, 1, 0)) * -2
+    rdm2.bbbb.ovoo += np.transpose(tmp19, (2, 3, 1, 0)) * -2
     del tmp19
     rdm2.abab.ovoo = einsum(delta.aa.oo, (0, 1), l1.bb, (2, 3), (0, 2, 1, 3))
-    rdm2.abab.ovoo += tmp27.transpose((1, 3, 0, 2)) * -1
+    rdm2.abab.ovoo += np.transpose(tmp27, (1, 3, 0, 2)) * -1
     del tmp27
     rdm2.aaaa.ovoo = einsum(delta.aa.oo, (0, 1), l1.aa, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.aaaa.ovoo += einsum(delta.aa.oo, (0, 1), l1.aa, (2, 3), (0, 2, 1, 3))
-    rdm2.aaaa.ovoo += tmp6.transpose((2, 3, 1, 0)) * -2
+    rdm2.aaaa.ovoo += np.transpose(tmp6, (2, 3, 1, 0)) * -2
     del tmp6
     rdm2.bbbb.oovo = einsum(tmp60, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3)) * 2
     del tmp60
     rdm2.bbbb.oovo += einsum(tmp37, (0, 1), delta.bb.oo, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.bbbb.oovo += tmp49.transpose((2, 1, 3, 0)) * 2
+    rdm2.bbbb.oovo += np.transpose(tmp49, (2, 1, 3, 0)) * 2
     rdm2.bbbb.oovo += einsum(tmp62, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3)) * -2
     rdm2.bbbb.oovo += einsum(tmp62, (0, 1), delta.bb.oo, (2, 3), (2, 0, 1, 3)) * 2
     del tmp62
-    rdm2.bbbb.oovo += tmp50.transpose((1, 2, 3, 0)) * 4
-    rdm2.bbbb.oovo += tmp51.transpose((1, 2, 3, 0))
+    rdm2.bbbb.oovo += np.transpose(tmp50, (1, 2, 3, 0)) * 4
+    rdm2.bbbb.oovo += np.transpose(tmp51, (1, 2, 3, 0))
     rdm2.bbbb.oovo += einsum(tmp58, (0, 1), t1.bb, (2, 3), (1, 2, 3, 0)) * 2
-    rdm2.bbbb.oovo += tmp50.transpose((2, 1, 3, 0)) * -4
-    rdm2.bbbb.oovo += tmp51.transpose((2, 1, 3, 0)) * -1
+    rdm2.bbbb.oovo += np.transpose(tmp50, (2, 1, 3, 0)) * -4
+    rdm2.bbbb.oovo += np.transpose(tmp51, (2, 1, 3, 0)) * -1
     rdm2.bbbb.oovo += einsum(tmp58, (0, 1), t1.bb, (2, 3), (2, 1, 3, 0)) * -2
-    rdm2.bbbb.oovo += tmp53.transpose((2, 1, 3, 0)) * -1
+    rdm2.bbbb.oovo += np.transpose(tmp53, (2, 1, 3, 0)) * -1
     rdm2.abab.oovo = einsum(delta.bb.oo, (0, 1), tmp23, (2, 3), (2, 0, 3, 1)) * 2
-    rdm2.abab.oovo += tmp55.transpose((0, 2, 3, 1)) * -1
+    rdm2.abab.oovo += np.transpose(tmp55, (0, 2, 3, 1)) * -1
     del tmp55
     rdm2.abab.oovo += einsum(delta.bb.oo, (0, 1), tmp30, (2, 3), (2, 0, 3, 1)) * -1
-    rdm2.abab.oovo += tmp56.transpose((0, 2, 3, 1)) * -2
+    rdm2.abab.oovo += np.transpose(tmp56, (0, 2, 3, 1)) * -2
     del tmp56
-    rdm2.abab.oovo += tmp57.transpose((0, 2, 3, 1)) * -2
+    rdm2.abab.oovo += np.transpose(tmp57, (0, 2, 3, 1)) * -2
     del tmp57
     rdm2.abab.oovo += einsum(tmp58, (0, 1), t1.aa, (2, 3), (2, 1, 3, 0)) * -2
     del tmp58
     rdm2.abab.oovo += einsum(tmp45, (0, 1, 2, 3), t1.aa, (0, 4), (1, 3, 4, 2))
     del tmp45
-    rdm2.abab.oovo += tmp59.transpose((0, 2, 3, 1))
+    rdm2.abab.oovo += np.transpose(tmp59, (0, 2, 3, 1))
     del tmp59
     rdm2.aaaa.oovo = einsum(delta.aa.oo, (0, 1), tmp54, (2, 3), (2, 0, 3, 1))
     del tmp54
     rdm2.aaaa.oovo += einsum(delta.aa.oo, (0, 1), tmp24, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.aaaa.oovo += tmp25.transpose((2, 1, 3, 0)) * 2
+    rdm2.aaaa.oovo += np.transpose(tmp25, (2, 1, 3, 0)) * 2
     rdm2.aaaa.oovo += einsum(delta.aa.oo, (0, 1), tmp30, (2, 3), (2, 0, 3, 1)) * -1
     rdm2.aaaa.oovo += einsum(delta.aa.oo, (0, 1), tmp30, (2, 3), (0, 2, 3, 1))
-    rdm2.aaaa.oovo += tmp31.transpose((1, 2, 3, 0))
-    rdm2.aaaa.oovo += tmp32.transpose((1, 2, 3, 0)) * 4
+    rdm2.aaaa.oovo += np.transpose(tmp31, (1, 2, 3, 0))
+    rdm2.aaaa.oovo += np.transpose(tmp32, (1, 2, 3, 0)) * 4
     rdm2.aaaa.oovo += einsum(t1.aa, (0, 1), tmp4, (2, 3), (3, 0, 1, 2))
-    rdm2.aaaa.oovo += tmp31.transpose((2, 1, 3, 0)) * -1
-    rdm2.aaaa.oovo += tmp32.transpose((2, 1, 3, 0)) * -4
+    rdm2.aaaa.oovo += np.transpose(tmp31, (2, 1, 3, 0)) * -1
+    rdm2.aaaa.oovo += np.transpose(tmp32, (2, 1, 3, 0)) * -4
     rdm2.aaaa.oovo += einsum(tmp4, (0, 1), t1.aa, (2, 3), (2, 1, 3, 0)) * -1
-    rdm2.aaaa.oovo += tmp34.transpose((2, 1, 3, 0)) * -1
+    rdm2.aaaa.oovo += np.transpose(tmp34, (2, 1, 3, 0)) * -1
     rdm2.bbbb.ooov = einsum(tmp48, (0, 1), delta.bb.oo, (2, 3), (0, 2, 3, 1)) * -1
     del tmp48
     rdm2.bbbb.ooov += einsum(tmp37, (0, 1), delta.bb.oo, (2, 3), (2, 0, 3, 1))
-    rdm2.bbbb.ooov += tmp49.transpose((2, 1, 0, 3)) * -2
+    rdm2.bbbb.ooov += np.transpose(tmp49, (2, 1, 0, 3)) * -2
     del tmp49
     rdm2.bbbb.ooov += einsum(tmp42, (0, 1), delta.bb.oo, (2, 3), (0, 2, 3, 1))
     rdm2.bbbb.ooov += einsum(tmp42, (0, 1), delta.bb.oo, (2, 3), (2, 0, 3, 1)) * -1
-    rdm2.bbbb.ooov += tmp50.transpose((1, 2, 0, 3)) * -4
-    rdm2.bbbb.ooov += tmp51.transpose((1, 2, 0, 3)) * -1
+    rdm2.bbbb.ooov += np.transpose(tmp50, (1, 2, 0, 3)) * -4
+    rdm2.bbbb.ooov += np.transpose(tmp51, (1, 2, 0, 3)) * -1
     rdm2.bbbb.ooov += einsum(tmp17, (0, 1), t1.bb, (2, 3), (1, 2, 0, 3)) * -1
-    rdm2.bbbb.ooov += tmp50.transpose((2, 1, 0, 3)) * 4
+    rdm2.bbbb.ooov += np.transpose(tmp50, (2, 1, 0, 3)) * 4
     del tmp50
-    rdm2.bbbb.ooov += tmp51.transpose((2, 1, 0, 3))
+    rdm2.bbbb.ooov += np.transpose(tmp51, (2, 1, 0, 3))
     del tmp51
     rdm2.bbbb.ooov += einsum(t1.bb, (0, 1), tmp17, (2, 3), (0, 3, 2, 1))
-    rdm2.bbbb.ooov += tmp53.transpose((2, 1, 0, 3))
+    rdm2.bbbb.ooov += np.transpose(tmp53, (2, 1, 0, 3))
     del tmp53
     rdm2.abab.ooov = einsum(delta.aa.oo, (0, 1), tmp37, (2, 3), (0, 2, 1, 3))
     del tmp37
-    rdm2.abab.ooov += tmp38.transpose((1, 2, 0, 3)) * -1
+    rdm2.abab.ooov += np.transpose(tmp38, (1, 2, 0, 3)) * -1
     del tmp38
     rdm2.abab.ooov += einsum(delta.aa.oo, (0, 1), tmp42, (2, 3), (0, 2, 1, 3)) * -1
     del tmp42
-    rdm2.abab.ooov += tmp43.transpose((1, 2, 0, 3)) * -2
+    rdm2.abab.ooov += np.transpose(tmp43, (1, 2, 0, 3)) * -2
     del tmp43
-    rdm2.abab.ooov += tmp44.transpose((1, 2, 0, 3)) * -2
+    rdm2.abab.ooov += np.transpose(tmp44, (1, 2, 0, 3)) * -2
     del tmp44
     rdm2.abab.ooov += einsum(t1.bb, (0, 1), tmp4, (2, 3), (3, 0, 2, 1)) * -1
-    rdm2.abab.ooov += tmp46.transpose((1, 2, 0, 3))
+    rdm2.abab.ooov += np.transpose(tmp46, (1, 2, 0, 3))
     del tmp46
-    rdm2.abab.ooov += tmp47.transpose((1, 2, 0, 3))
+    rdm2.abab.ooov += np.transpose(tmp47, (1, 2, 0, 3))
     del tmp47
     rdm2.aaaa.ooov = einsum(delta.aa.oo, (0, 1), tmp23, (2, 3), (2, 0, 1, 3)) * -2
     del tmp23
     rdm2.aaaa.ooov += einsum(delta.aa.oo, (0, 1), tmp24, (2, 3), (0, 2, 1, 3))
     del tmp24
-    rdm2.aaaa.ooov += tmp25.transpose((2, 1, 0, 3)) * -2
+    rdm2.aaaa.ooov += np.transpose(tmp25, (2, 1, 0, 3)) * -2
     del tmp25
     rdm2.aaaa.ooov += einsum(delta.aa.oo, (0, 1), tmp30, (2, 3), (2, 0, 1, 3))
     rdm2.aaaa.ooov += einsum(delta.aa.oo, (0, 1), tmp30, (2, 3), (0, 2, 1, 3)) * -1
     del tmp30
-    rdm2.aaaa.ooov += tmp31.transpose((1, 2, 0, 3)) * -1
-    rdm2.aaaa.ooov += tmp32.transpose((1, 2, 0, 3)) * -4
+    rdm2.aaaa.ooov += np.transpose(tmp31, (1, 2, 0, 3)) * -1
+    rdm2.aaaa.ooov += np.transpose(tmp32, (1, 2, 0, 3)) * -4
     rdm2.aaaa.ooov += einsum(t1.aa, (0, 1), tmp4, (2, 3), (3, 0, 2, 1)) * -1
-    rdm2.aaaa.ooov += tmp31.transpose((2, 1, 0, 3))
+    rdm2.aaaa.ooov += np.transpose(tmp31, (2, 1, 0, 3))
     del tmp31
-    rdm2.aaaa.ooov += tmp32.transpose((2, 1, 0, 3)) * 4
+    rdm2.aaaa.ooov += np.transpose(tmp32, (2, 1, 0, 3)) * 4
     del tmp32
     rdm2.aaaa.ooov += einsum(tmp4, (0, 1), t1.aa, (2, 3), (2, 1, 0, 3))
-    rdm2.aaaa.ooov += tmp34.transpose((2, 1, 0, 3))
+    rdm2.aaaa.ooov += np.transpose(tmp34, (2, 1, 0, 3))
     del tmp34
     rdm2.bbbb.oooo = einsum(delta.bb.oo, (0, 1), tmp16, (2, 3), (0, 3, 1, 2)) * -1
     rdm2.bbbb.oooo += einsum(tmp16, (0, 1), delta.bb.oo, (2, 3), (1, 2, 3, 0))
@@ -1992,17 +1992,17 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.bbbb.oooo += einsum(delta.bb.oo, (0, 1), tmp17, (2, 3), (3, 0, 2, 1)) * -1
     rdm2.bbbb.oooo += einsum(delta.bb.oo, (0, 1), tmp17, (2, 3), (0, 3, 2, 1))
     del tmp17
-    rdm2.bbbb.oooo += tmp18.transpose((3, 2, 1, 0)) * 2
+    rdm2.bbbb.oooo += np.transpose(tmp18, (3, 2, 1, 0)) * 2
     del tmp18
-    rdm2.bbbb.oooo += tmp20.transpose((2, 3, 1, 0)) * -2
+    rdm2.bbbb.oooo += np.transpose(tmp20, (2, 3, 1, 0)) * -2
     del tmp20
     rdm2.abab.oooo = einsum(delta.aa.oo, (0, 1), tmp11, (2, 3), (0, 3, 1, 2)) * -2
     del tmp11
     rdm2.abab.oooo += einsum(delta.bb.oo, (0, 1), tmp12, (2, 3), (3, 0, 2, 1)) * -2
     del tmp12
-    rdm2.abab.oooo += tmp13.transpose((1, 3, 0, 2))
+    rdm2.abab.oooo += np.transpose(tmp13, (1, 3, 0, 2))
     del tmp13
-    rdm2.abab.oooo += tmp15.transpose((1, 3, 0, 2))
+    rdm2.abab.oooo += np.transpose(tmp15, (1, 3, 0, 2))
     del tmp15
     rdm2.aaaa.oooo = einsum(delta.aa.oo, (0, 1), tmp3, (2, 3), (0, 3, 1, 2)) * -1
     rdm2.aaaa.oooo += einsum(delta.aa.oo, (0, 1), tmp3, (2, 3), (3, 0, 1, 2))
@@ -2010,17 +2010,17 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.aaaa.oooo += einsum(delta.aa.oo, (0, 1), tmp4, (2, 3), (3, 0, 2, 1)) * -1
     rdm2.aaaa.oooo += einsum(delta.aa.oo, (0, 1), tmp4, (2, 3), (0, 3, 2, 1))
     del delta, tmp4
-    rdm2.aaaa.oooo += tmp5.transpose((3, 2, 1, 0)) * 2
+    rdm2.aaaa.oooo += np.transpose(tmp5, (3, 2, 1, 0)) * 2
     del tmp5
-    rdm2.aaaa.oooo += tmp7.transpose((2, 3, 1, 0)) * -2
+    rdm2.aaaa.oooo += np.transpose(tmp7, (2, 3, 1, 0)) * -2
     del tmp7
     rdm2.aaaa = pack_2e(rdm2.aaaa.oooo, rdm2.aaaa.ooov, rdm2.aaaa.oovo, rdm2.aaaa.ovoo, rdm2.aaaa.vooo, rdm2.aaaa.oovv, rdm2.aaaa.ovov, rdm2.aaaa.ovvo, rdm2.aaaa.voov, rdm2.aaaa.vovo, rdm2.aaaa.vvoo, rdm2.aaaa.ovvv, rdm2.aaaa.vovv, rdm2.aaaa.vvov, rdm2.aaaa.vvvo, rdm2.aaaa.vvvv)
     rdm2.abab = pack_2e(rdm2.abab.oooo, rdm2.abab.ooov, rdm2.abab.oovo, rdm2.abab.ovoo, rdm2.abab.vooo, rdm2.abab.oovv, rdm2.abab.ovov, rdm2.abab.ovvo, rdm2.abab.voov, rdm2.abab.vovo, rdm2.abab.vvoo, rdm2.abab.ovvv, rdm2.abab.vovv, rdm2.abab.vvov, rdm2.abab.vvvo, rdm2.abab.vvvv)
     rdm2.bbbb = pack_2e(rdm2.bbbb.oooo, rdm2.bbbb.ooov, rdm2.bbbb.oovo, rdm2.bbbb.ovoo, rdm2.bbbb.vooo, rdm2.bbbb.oovv, rdm2.bbbb.ovov, rdm2.bbbb.ovvo, rdm2.bbbb.voov, rdm2.bbbb.vovo, rdm2.bbbb.vvoo, rdm2.bbbb.ovvv, rdm2.bbbb.vovv, rdm2.bbbb.vvov, rdm2.bbbb.vvvo, rdm2.bbbb.vvvv)
     rdm2 = Namespace(
-        aaaa=rdm2.aaaa.transpose(0, 2, 1, 3),
-        aabb=rdm2.abab.transpose(0, 2, 1, 3),
-        bbbb=rdm2.bbbb.transpose(0, 2, 1, 3),
+        aaaa=np.transpose(rdm2.aaaa, (0, 2, 1, 3)),
+        aabb=np.transpose(rdm2.abab, (0, 2, 1, 3)),
+        bbbb=np.transpose(rdm2.bbbb, (0, 2, 1, 3)),
     )
 
     return rdm2
@@ -2293,45 +2293,45 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r2new = Namespace()
     tmp8 = einsum(v.baa.xov, (0, 1, 2), r2.aaa, (3, 1, 2), (0, 3))
     tmp9 = einsum(v.bbb.xov, (0, 1, 2), r2.bab, (1, 3, 2), (0, 3)) * -1
-    tmp74 = ints.tmp206.copy()
+    tmp74 = np.copy(ints.tmp206)
     del ints.tmp206
-    tmp74 += ints.tmp37.transpose((0, 2, 1, 3)) * 0.5
-    tmp72 = ints.tmp52.copy() * 2
+    tmp74 += np.transpose(ints.tmp37, (0, 2, 1, 3)) * 0.5
+    tmp72 = np.copy(ints.tmp52) * 2
     tmp72 += ints.tmp55
-    tmp70 = ints.tmp51.copy()
+    tmp70 = np.copy(ints.tmp51)
     tmp70 += ints.tmp54 * 0.5
     tmp40 = einsum(r2.bbb, (0, 1, 2), v.bbb.xov, (3, 1, 2), (3, 0))
     tmp39 = einsum(r2.aba, (0, 1, 2), v.baa.xov, (3, 0, 2), (3, 1))
-    tmp49 = ints.tmp186.copy()
+    tmp49 = np.copy(ints.tmp186)
     del ints.tmp186
     tmp49 += ints.tmp166 * 2
     del ints.tmp166
-    tmp63 = f.bb.oo.copy()
+    tmp63 = np.copy(f.bb.oo)
     tmp63 += ints.tmp36
-    tmp61 = ints.tmp54.copy()
+    tmp61 = np.copy(ints.tmp54)
     tmp61 += ints.tmp51 * 2
-    tmp65 = ints.tmp210.copy()
+    tmp65 = np.copy(ints.tmp210)
     del ints.tmp210
     tmp65 += ints.tmp208 * 2
     del ints.tmp208
-    tmp10 = tmp8.copy() * 2
+    tmp10 = np.copy(tmp8) * 2
     tmp10 += tmp9
-    tmp11 = ints.tmp26.copy()
+    tmp11 = np.copy(ints.tmp26)
     tmp11 += ints.tmp29 * 0.5
-    tmp15 = ints.tmp2.copy()
-    tmp15 += ints.tmp84.transpose((0, 2, 1, 3)) * 2
+    tmp15 = np.copy(ints.tmp2)
+    tmp15 += np.transpose(ints.tmp84, (0, 2, 1, 3)) * 2
     del ints.tmp84
-    tmp13 = ints.tmp27.copy() * 2
+    tmp13 = np.copy(ints.tmp27) * 2
     tmp13 += ints.tmp30
-    tmp19 = ints.tmp113.copy()
+    tmp19 = np.copy(ints.tmp113)
     tmp19 += ints.tmp94 * 2
-    tmp25 = ints.tmp88.copy()
+    tmp25 = np.copy(ints.tmp88)
     del ints.tmp88
     tmp25 += ints.tmp86 * 2
     del ints.tmp86
-    tmp23 = f.aa.oo.copy()
+    tmp23 = np.copy(f.aa.oo)
     tmp23 += ints.tmp1
-    tmp21 = tmp8.copy() * 2
+    tmp21 = np.copy(tmp8) * 2
     tmp21 += tmp9
     tmp44 = einsum(r2.bbb, (0, 1, 2), ints.tmp97, (0, 1, 2, 3), (3,))
     del ints.tmp97
@@ -2373,22 +2373,22 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp18 = einsum(r2.bab, (0, 1, 2), ints.tmp98, (3, 0, 4, 2), (3, 1, 4)) * -1
     tmp22 = einsum(v.baa.xov, (0, 1, 2), tmp21, (0, 3), (1, 3, 2))
     del tmp21
-    tmp45 = tmp43.copy()
+    tmp45 = np.copy(tmp43)
     del tmp43
     tmp45 += tmp44 * 2
     del tmp44
-    tmp78 = ints.tmp197.copy()
+    tmp78 = np.copy(ints.tmp197)
     del ints.tmp197
-    tmp78 += ints.tmp220.transpose((1, 2, 0, 3)) * -1
+    tmp78 += np.transpose(ints.tmp220, (1, 2, 0, 3)) * -1
     del ints.tmp220
-    tmp55 = ints.tmp176.transpose((1, 0)).copy() * 2
+    tmp55 = np.copy(np.transpose(ints.tmp176, (1, 0))) * 2
     del ints.tmp176
-    tmp55 += ints.tmp178.transpose((1, 0))
+    tmp55 += np.transpose(ints.tmp178, (1, 0))
     del ints.tmp178
     tmp55 += f.bb.vv * -1
     tmp55 += tmp54
     del tmp54
-    tmp58 = ints.tmp170.copy()
+    tmp58 = np.copy(ints.tmp170)
     del ints.tmp170
     tmp58 += ints.tmp173 * 2
     del ints.tmp173
@@ -2407,76 +2407,76 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp183
     tmp58 += ints.tmp185 * -1
     del ints.tmp185
-    tmp77 = ints.tmp199.copy()
+    tmp77 = np.copy(ints.tmp199)
     del ints.tmp199
-    tmp77 += ints.tmp204.transpose((0, 2, 1, 3)) * -1
+    tmp77 += np.transpose(ints.tmp204, (0, 2, 1, 3)) * -1
     del ints.tmp204
-    tmp76 = tmp68.copy()
+    tmp76 = np.copy(tmp68)
     del tmp68
     tmp76 += tmp69
     del tmp69
-    tmp76 += tmp71.transpose((1, 0, 2))
+    tmp76 += np.transpose(tmp71, (1, 0, 2))
     del tmp71
-    tmp76 += tmp73.transpose((1, 0, 2))
+    tmp76 += np.transpose(tmp73, (1, 0, 2))
     del tmp73
     tmp76 += tmp75
     del tmp75
-    tmp67 = tmp59.copy() * 2
+    tmp67 = np.copy(tmp59) * 2
     del tmp59
-    tmp67 += tmp60.transpose((1, 0, 2)) * -2
+    tmp67 += np.transpose(tmp60, (1, 0, 2)) * -2
     del tmp60
-    tmp67 += tmp62.transpose((1, 0, 2))
+    tmp67 += np.transpose(tmp62, (1, 0, 2))
     del tmp62
-    tmp67 += tmp64.transpose((1, 0, 2)) * -2
+    tmp67 += np.transpose(tmp64, (1, 0, 2)) * -2
     del tmp64
     tmp67 += tmp66
     del tmp66
-    tmp53 = ints.tmp51.copy() * 2
+    tmp53 = np.copy(ints.tmp51) * 2
     del ints.tmp51
     tmp53 += ints.tmp54
     del ints.tmp54
     tmp53 += v.bbb.xov
-    tmp57 = ints.tmp153.copy()
+    tmp57 = np.copy(ints.tmp153)
     del ints.tmp153
-    tmp57 += ints.tmp160.transpose((1, 0, 2, 3))
+    tmp57 += np.transpose(ints.tmp160, (1, 0, 2, 3))
     del ints.tmp160
-    tmp57 += ints.tmp161.transpose((1, 0, 2, 3)) * 2
+    tmp57 += np.transpose(ints.tmp161, (1, 0, 2, 3)) * 2
     del ints.tmp161
-    tmp57 += ints.tmp172.transpose((1, 0, 2, 3))
+    tmp57 += np.transpose(ints.tmp172, (1, 0, 2, 3))
     del ints.tmp172
     tmp57 += ints.tmp4
     tmp57 += ints.tmp159 * -1
     del ints.tmp159
     tmp57 += ints.tmp175 * -1
     del ints.tmp175
-    tmp52 = tmp8.copy()
+    tmp52 = np.copy(tmp8)
     del tmp8
     tmp52 += tmp9 * 0.5
     del tmp9
-    tmp48 = f.bb.oo.copy()
+    tmp48 = np.copy(f.bb.oo)
     tmp48 += ints.tmp36
-    tmp48 += ints.tmp52.transpose((1, 0)) * 2
-    tmp48 += ints.tmp55.transpose((1, 0))
-    tmp47 = f.aa.oo.copy()
+    tmp48 += np.transpose(ints.tmp52, (1, 0)) * 2
+    tmp48 += np.transpose(ints.tmp55, (1, 0))
+    tmp47 = np.copy(f.aa.oo)
     tmp47 += ints.tmp1
-    tmp47 += ints.tmp27.transpose((1, 0)) * 2
-    tmp47 += ints.tmp30.transpose((1, 0))
-    tmp50 = ints.tmp180.copy()
+    tmp47 += np.transpose(ints.tmp27, (1, 0)) * 2
+    tmp47 += np.transpose(ints.tmp30, (1, 0))
+    tmp50 = np.copy(ints.tmp180)
     del ints.tmp180
     tmp50 += ints.tmp190 * -1
     del ints.tmp190
-    tmp56 = tmp31.copy() * 2
+    tmp56 = np.copy(tmp31) * 2
     tmp56 += tmp32 * -1
-    tmp51 = ints.tmp123.copy()
+    tmp51 = np.copy(ints.tmp123)
     tmp51 += ints.tmp125
-    tmp30 = ints.tmp90.transpose((1, 0)).copy() * 2
+    tmp30 = np.copy(np.transpose(ints.tmp90, (1, 0))) * 2
     del ints.tmp90
-    tmp30 += ints.tmp92.transpose((1, 0))
+    tmp30 += np.transpose(ints.tmp92, (1, 0))
     del ints.tmp92
     tmp30 += f.aa.vv * -1
     tmp30 += tmp29
     del tmp29
-    tmp35 = ints.tmp111.copy()
+    tmp35 = np.copy(ints.tmp111)
     del ints.tmp111
     tmp35 += ints.tmp66 * 2
     del ints.tmp66
@@ -2495,141 +2495,141 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp78
     tmp35 += ints.tmp79 * -1
     del ints.tmp79
-    tmp46 = ints.tmp121.copy()
+    tmp46 = np.copy(ints.tmp121)
     del ints.tmp121
-    tmp46 += ints.tmp128.transpose((0, 2, 1, 3))
+    tmp46 += np.transpose(ints.tmp128, (0, 2, 1, 3))
     del ints.tmp128
-    tmp46 += ints.tmp129.transpose((0, 2, 1, 3)) * 2
+    tmp46 += np.transpose(ints.tmp129, (0, 2, 1, 3)) * 2
     del ints.tmp129
-    tmp46 += ints.tmp137.transpose((0, 2, 1, 3))
+    tmp46 += np.transpose(ints.tmp137, (0, 2, 1, 3))
     del ints.tmp137
     tmp46 += ints.tmp39
     tmp46 += ints.tmp127 * -1
     del ints.tmp127
     tmp46 += ints.tmp138 * -1
     del ints.tmp138
-    tmp37 = ints.tmp113.copy()
+    tmp37 = np.copy(ints.tmp113)
     del ints.tmp113
     tmp37 += ints.tmp94 * 2
     del ints.tmp94
-    tmp36 = ints.tmp141.copy()
+    tmp36 = np.copy(ints.tmp141)
     del ints.tmp141
     tmp36 += ints.tmp148 * -1
     del ints.tmp148
-    tmp41 = tmp39.copy() * -1
+    tmp41 = np.copy(tmp39) * -1
     del tmp39
     tmp41 += tmp40 * 2
     del tmp40
-    tmp42 = ints.tmp29.copy()
+    tmp42 = np.copy(ints.tmp29)
     del ints.tmp29
     tmp42 += v.baa.xov
     tmp42 += ints.tmp26 * 2
     del ints.tmp26
-    tmp38 = ints.tmp123.copy()
+    tmp38 = np.copy(ints.tmp123)
     del ints.tmp123
     tmp38 += ints.tmp125
     del ints.tmp125
-    tmp33 = tmp31.copy()
+    tmp33 = np.copy(tmp31)
     del tmp31
     tmp33 += tmp32 * -0.5
     del tmp32
-    tmp17 = tmp12.transpose((1, 0, 2)).copy()
+    tmp17 = np.copy(np.transpose(tmp12, (1, 0, 2)))
     del tmp12
-    tmp17 += tmp14.transpose((1, 0, 2))
+    tmp17 += np.transpose(tmp14, (1, 0, 2))
     del tmp14
     tmp17 += tmp16
     del tmp16
-    tmp27 = tmp18.copy()
+    tmp27 = np.copy(tmp18)
     del tmp18
-    tmp27 += tmp20.transpose((1, 0, 2)) * -2
+    tmp27 += np.transpose(tmp20, (1, 0, 2)) * -2
     del tmp20
-    tmp27 += tmp22.transpose((1, 0, 2))
+    tmp27 += np.transpose(tmp22, (1, 0, 2))
     del tmp22
-    tmp27 += tmp24.transpose((1, 0, 2)) * -2
+    tmp27 += np.transpose(tmp24, (1, 0, 2)) * -2
     del tmp24
     tmp27 += tmp26
     del tmp26
-    tmp34 = ints.tmp103.copy()
+    tmp34 = np.copy(ints.tmp103)
     del ints.tmp103
-    tmp34 += ints.tmp69.transpose((2, 0, 1, 3)) * -1
+    tmp34 += np.transpose(ints.tmp69, (2, 0, 1, 3)) * -1
     del ints.tmp69
-    tmp28 = ints.tmp72.copy()
+    tmp28 = np.copy(ints.tmp72)
     del ints.tmp72
-    tmp28 += ints.tmp80.transpose((0, 2, 1, 3)) * -1
+    tmp28 += np.transpose(ints.tmp80, (0, 2, 1, 3)) * -1
     del ints.tmp80
-    tmp7 = f.bb.oo.copy()
+    tmp7 = np.copy(f.bb.oo)
     tmp7 += ints.tmp36
     del ints.tmp36
-    tmp7 += ints.tmp42.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp42, (1, 0))
     del ints.tmp42
-    tmp7 += ints.tmp43.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp43, (1, 0))
     del ints.tmp43
-    tmp7 += ints.tmp52.transpose((1, 0)) * 2
+    tmp7 += np.transpose(ints.tmp52, (1, 0)) * 2
     del ints.tmp52
-    tmp7 += ints.tmp55.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp55, (1, 0))
     del ints.tmp55
-    tmp7 += ints.tmp58.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp58, (1, 0))
     del ints.tmp58
-    tmp7 += ints.tmp59.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp59, (1, 0))
     del ints.tmp59
-    tmp7 += ints.tmp41.transpose((1, 0)) * -1
+    tmp7 += np.transpose(ints.tmp41, (1, 0)) * -1
     del ints.tmp41
-    tmp7 += ints.tmp57.transpose((1, 0)) * -1
+    tmp7 += np.transpose(ints.tmp57, (1, 0)) * -1
     del ints.tmp57
-    tmp3 = f.aa.ov.copy()
+    tmp3 = np.copy(f.aa.ov)
     tmp3 += ints.tmp14
     del ints.tmp14
     tmp3 += ints.tmp19
     del ints.tmp19
     tmp3 += ints.tmp12 * -1
     del ints.tmp12
-    tmp5 = ints.tmp37.copy()
+    tmp5 = np.copy(ints.tmp37)
     del ints.tmp37
     tmp5 += ints.tmp47 * -1
     del ints.tmp47
-    tmp2 = f.bb.ov.copy()
+    tmp2 = np.copy(f.bb.ov)
     tmp2 += ints.tmp18
     del ints.tmp18
     tmp2 += ints.tmp21
     del ints.tmp21
     tmp2 += ints.tmp17 * -1
     del ints.tmp17
-    tmp6 = ints.tmp39.copy()
+    tmp6 = np.copy(ints.tmp39)
     del ints.tmp39
     tmp6 += ints.tmp49
     del ints.tmp49
-    tmp4 = f.aa.oo.copy()
-    tmp4 += ints.tmp11.transpose((1, 0))
+    tmp4 = np.copy(f.aa.oo)
+    tmp4 += np.transpose(ints.tmp11, (1, 0))
     del ints.tmp11
     tmp4 += ints.tmp1
     del ints.tmp1
-    tmp4 += ints.tmp27.transpose((1, 0)) * 2
+    tmp4 += np.transpose(ints.tmp27, (1, 0)) * 2
     del ints.tmp27
-    tmp4 += ints.tmp30.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp30, (1, 0))
     del ints.tmp30
-    tmp4 += ints.tmp33.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp33, (1, 0))
     del ints.tmp33
-    tmp4 += ints.tmp34.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp34, (1, 0))
     del ints.tmp34
-    tmp4 += ints.tmp9.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp9, (1, 0))
     del ints.tmp9
-    tmp4 += ints.tmp32.transpose((1, 0)) * -1
+    tmp4 += np.transpose(ints.tmp32, (1, 0)) * -1
     del ints.tmp32
-    tmp4 += ints.tmp7.transpose((1, 0)) * -1
+    tmp4 += np.transpose(ints.tmp7, (1, 0)) * -1
     del ints.tmp7
-    tmp0 = ints.tmp24.copy()
+    tmp0 = np.copy(ints.tmp24)
     del ints.tmp24
     tmp0 += ints.tmp4
     del ints.tmp4
-    tmp1 = ints.tmp22.copy()
+    tmp1 = np.copy(ints.tmp22)
     del ints.tmp22
     tmp1 += ints.tmp2 * -1
     del ints.tmp2
-    r2new.bbb = tmp67.copy()
-    r2new.bbb += tmp67.transpose((1, 0, 2)) * -1
+    r2new.bbb = np.copy(tmp67)
+    r2new.bbb += np.transpose(tmp67, (1, 0, 2)) * -1
     del tmp67
     r2new.bbb += tmp76 * -1
-    r2new.bbb += tmp76.transpose((1, 0, 2))
+    r2new.bbb += np.transpose(tmp76, (1, 0, 2))
     del tmp76
     r2new.bbb += einsum(tmp77, (0, 1, 2, 3), r2.bbb, (3, 2, 4), (0, 1, 4)) * -2
     del tmp77
@@ -2679,11 +2679,11 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r2new.aba += einsum(r2.aba, (0, 1, 2), tmp48, (1, 3), (0, 3, 2)) * -1
     del tmp48
     r2new.aba += einsum(tmp35, (0, 1), r1.b, (2,), (0, 2, 1))
-    r2new.aaa = tmp17.copy() * -1
-    r2new.aaa += tmp17.transpose((1, 0, 2))
+    r2new.aaa = np.copy(tmp17) * -1
+    r2new.aaa += np.transpose(tmp17, (1, 0, 2))
     del tmp17
     r2new.aaa += tmp27
-    r2new.aaa += tmp27.transpose((1, 0, 2)) * -1
+    r2new.aaa += np.transpose(tmp27, (1, 0, 2)) * -1
     del tmp27
     r2new.aaa += einsum(tmp28, (0, 1, 2, 3), r2.aaa, (3, 2, 4), (0, 1, 4)) * -2
     del tmp28
@@ -2955,45 +2955,45 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r2new = Namespace()
     tmp13 = einsum(v.baa.xov, (0, 1, 2), r2.aaa, (3, 2, 1), (0, 3))
     tmp14 = einsum(v.bbb.xov, (0, 1, 2), r2.bab, (2, 3, 1), (0, 3)) * -1
-    tmp71 = ints.tmp59.copy()
+    tmp71 = np.copy(ints.tmp59)
     tmp71 += ints.tmp56 * 2
     tmp38 = einsum(r2.aba, (0, 1, 2), v.baa.xov, (3, 2, 0), (3, 1))
-    tmp73 = ints.tmp40.copy()
+    tmp73 = np.copy(ints.tmp40)
     tmp73 += ints.tmp201 * 2
     del ints.tmp201
-    tmp51 = ints.tmp155.copy()
+    tmp51 = np.copy(ints.tmp155)
     del ints.tmp155
     tmp51 += ints.tmp190 * 2
     del ints.tmp190
     tmp39 = einsum(v.bbb.xov, (0, 1, 2), r2.bbb, (3, 2, 1), (0, 3))
     tmp59 = einsum(f.bb.ov, (0, 1), r2.bbb, (2, 1, 3), (0, 3, 2))
-    tmp62 = ints.tmp56.copy() * 2
+    tmp62 = np.copy(ints.tmp56) * 2
     tmp62 += ints.tmp59
-    tmp64 = ints.tmp57.transpose((1, 0)).copy()
-    tmp64 += ints.tmp60.transpose((1, 0)) * 0.5
+    tmp64 = np.copy(np.transpose(ints.tmp57, (1, 0)))
+    tmp64 += np.transpose(ints.tmp60, (1, 0)) * 0.5
     tmp64 += f.bb.vv * -0.5
-    tmp66 = ints.tmp199.copy()
+    tmp66 = np.copy(ints.tmp199)
     del ints.tmp199
     tmp66 += ints.tmp203 * 0.5
     del ints.tmp203
-    tmp24 = ints.tmp93.copy()
+    tmp24 = np.copy(ints.tmp93)
     tmp24 += ints.tmp82 * 2
-    tmp26 = tmp13.copy() * 2
+    tmp26 = np.copy(tmp13) * 2
     tmp26 += tmp14
-    tmp28 = ints.tmp2.copy()
+    tmp28 = np.copy(ints.tmp2)
     tmp28 += ints.tmp76 * 2
     del ints.tmp76
-    tmp18 = ints.tmp30.transpose((1, 0)).copy()
-    tmp18 += ints.tmp33.transpose((1, 0)) * 0.5
+    tmp18 = np.copy(np.transpose(ints.tmp30, (1, 0)))
+    tmp18 += np.transpose(ints.tmp33, (1, 0)) * 0.5
     tmp18 += f.aa.vv * -0.5
     tmp11 = einsum(f.aa.ov, (0, 1), r2.aaa, (2, 1, 3), (0, 3, 2))
-    tmp16 = ints.tmp29.copy() * 2
+    tmp16 = np.copy(ints.tmp29) * 2
     tmp16 += ints.tmp32
-    tmp15 = tmp13.copy()
+    tmp15 = np.copy(tmp13)
     del tmp13
     tmp15 += tmp14 * 0.5
     del tmp14
-    tmp20 = ints.tmp74.copy()
+    tmp20 = np.copy(ints.tmp74)
     del ints.tmp74
     tmp20 += ints.tmp78 * 0.5
     del ints.tmp78
@@ -3036,53 +3036,53 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp16
     tmp21 = einsum(tmp20, (0, 1, 2, 3), r1.a, (2,), (0, 1, 3)) * 2
     del tmp20
-    tmp1 = f.bb.ov.copy()
+    tmp1 = np.copy(f.bb.ov)
     tmp1 += ints.tmp19
     del ints.tmp19
     tmp1 += ints.tmp22
     del ints.tmp22
     tmp1 += ints.tmp18 * -1
     del ints.tmp18
-    tmp0 = f.aa.ov.copy()
+    tmp0 = np.copy(f.aa.ov)
     tmp0 += ints.tmp15
     del ints.tmp15
     tmp0 += ints.tmp20
     del ints.tmp20
     tmp0 += ints.tmp13 * -1
     del ints.tmp13
-    tmp54 = f.bb.oo.copy()
+    tmp54 = np.copy(f.bb.oo)
     tmp54 += ints.tmp164
     del ints.tmp164
-    tmp54 += ints.tmp168.transpose((1, 0)) * 2
+    tmp54 += np.transpose(ints.tmp168, (1, 0)) * 2
     del ints.tmp168
-    tmp54 += ints.tmp170.transpose((1, 0))
+    tmp54 += np.transpose(ints.tmp170, (1, 0))
     del ints.tmp170
-    tmp75 = tmp69.copy() * 2
+    tmp75 = np.copy(tmp69) * 2
     del tmp69
-    tmp75 += tmp70.transpose((0, 2, 1)) * -2
+    tmp75 += np.transpose(tmp70, (0, 2, 1)) * -2
     del tmp70
-    tmp75 += tmp72.transpose((0, 2, 1))
+    tmp75 += np.transpose(tmp72, (0, 2, 1))
     del tmp72
     tmp75 += tmp74
     del tmp74
     tmp57 = einsum(ints.tmp51, (0, 1, 2, 3), r2.bbb, (3, 2, 4), (0, 1, 4)) * -1
     del ints.tmp51
-    tmp68 = tmp58.copy()
+    tmp68 = np.copy(tmp58)
     del tmp58
     tmp68 += tmp60 * 2
     del tmp60
     tmp68 += tmp61
     del tmp61
-    tmp68 += tmp63.transpose((0, 2, 1))
+    tmp68 += np.transpose(tmp63, (0, 2, 1))
     del tmp63
-    tmp68 += tmp65.transpose((0, 2, 1))
+    tmp68 += np.transpose(tmp65, (0, 2, 1))
     del tmp65
     tmp68 += tmp67
     del tmp67
-    tmp76 = tmp47.copy() * -1
+    tmp76 = np.copy(tmp47) * -1
     tmp76 += tmp7
     tmp76 += tmp8 * 2
-    tmp56 = ints.tmp166.copy() * 2
+    tmp56 = np.copy(ints.tmp166) * 2
     del ints.tmp166
     tmp56 += ints.tmp172
     del ints.tmp172
@@ -3101,43 +3101,43 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp179
     tmp56 += ints.tmp180 * -2
     del ints.tmp180
-    tmp44 = ints.tmp57.transpose((1, 0)).copy() * 2
-    tmp44 += ints.tmp60.transpose((1, 0))
+    tmp44 = np.copy(np.transpose(ints.tmp57, (1, 0))) * 2
+    tmp44 += np.transpose(ints.tmp60, (1, 0))
     tmp44 += f.bb.vv * -1
     tmp44 += tmp43
     del tmp43
-    tmp55 = tmp32.copy() * 0.5
+    tmp55 = np.copy(tmp32) * 0.5
     tmp55 += tmp3 * -1
     tmp55 += tmp4 * 0.5
-    tmp53 = ints.tmp157.copy()
+    tmp53 = np.copy(ints.tmp157)
     del ints.tmp157
-    tmp53 += ints.tmp181.transpose((0, 2, 1, 3))
+    tmp53 += np.transpose(ints.tmp181, (0, 2, 1, 3))
     del ints.tmp181
-    tmp53 += ints.tmp183.transpose((0, 2, 1, 3)) * 2
+    tmp53 += np.transpose(ints.tmp183, (0, 2, 1, 3)) * 2
     del ints.tmp183
     tmp53 += ints.tmp4
     tmp53 += ints.tmp151 * -1
     del ints.tmp151
-    tmp53 += ints.tmp182.transpose((0, 2, 1, 3)) * -1
+    tmp53 += np.transpose(ints.tmp182, (0, 2, 1, 3)) * -1
     del ints.tmp182
-    tmp46 = ints.tmp30.transpose((1, 0)).copy() * 2
-    tmp46 += ints.tmp33.transpose((1, 0))
+    tmp46 = np.copy(np.transpose(ints.tmp30, (1, 0))) * 2
+    tmp46 += np.transpose(ints.tmp33, (1, 0))
     tmp46 += f.aa.vv * -1
     tmp46 += tmp45
     del tmp45
-    tmp52 = ints.tmp56.copy() * 2
+    tmp52 = np.copy(ints.tmp56) * 2
     del ints.tmp56
     tmp52 += ints.tmp59
     del ints.tmp59
     tmp52 += v.bbb.xov
     tmp49 = einsum(r2.bab, (0, 1, 2), ints.tmp26, (3, 4, 1, 0), (3, 4, 2)) * -1
-    tmp50 = ints.tmp154.copy()
+    tmp50 = np.copy(ints.tmp154)
     del ints.tmp154
     tmp50 += ints.tmp174 * -1
     del ints.tmp174
     tmp35 = einsum(ints.tmp26, (0, 1, 2, 3), r2.aba, (2, 3, 4), (0, 4, 1))
     del ints.tmp26
-    tmp34 = ints.tmp109.copy()
+    tmp34 = np.copy(ints.tmp109)
     del ints.tmp109
     tmp34 += ints.tmp112 * 2
     del ints.tmp112
@@ -3156,98 +3156,98 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp67
     tmp34 += ints.tmp68 * -1
     del ints.tmp68
-    tmp37 = ints.tmp82.copy() * 2
+    tmp37 = np.copy(ints.tmp82) * 2
     del ints.tmp82
     tmp37 += ints.tmp93
     del ints.tmp93
-    tmp40 = tmp38.copy() * -1
+    tmp40 = np.copy(tmp38) * -1
     del tmp38
     tmp40 += tmp39 * 2
     del tmp39
-    tmp48 = tmp47.copy() * -0.5
+    tmp48 = np.copy(tmp47) * -0.5
     del tmp47
     tmp48 += tmp7 * 0.5
     tmp48 += tmp8
-    tmp36 = ints.tmp125.copy()
+    tmp36 = np.copy(ints.tmp125)
     del ints.tmp125
     tmp36 += ints.tmp136 * -1
     del ints.tmp136
-    tmp31 = f.aa.oo.copy()
+    tmp31 = np.copy(f.aa.oo)
     tmp31 += ints.tmp107
     del ints.tmp107
-    tmp31 += ints.tmp114.transpose((1, 0)) * 2
+    tmp31 += np.transpose(ints.tmp114, (1, 0)) * 2
     del ints.tmp114
-    tmp31 += ints.tmp116.transpose((1, 0))
+    tmp31 += np.transpose(ints.tmp116, (1, 0))
     del ints.tmp116
-    tmp41 = ints.tmp32.copy()
+    tmp41 = np.copy(ints.tmp32)
     del ints.tmp32
     tmp41 += v.baa.xov
     tmp41 += ints.tmp29 * 2
     del ints.tmp29
-    tmp42 = ints.tmp126.copy()
+    tmp42 = np.copy(ints.tmp126)
     del ints.tmp126
-    tmp42 += ints.tmp138.transpose((0, 1, 3, 2))
+    tmp42 += np.transpose(ints.tmp138, (0, 1, 3, 2))
     del ints.tmp138
-    tmp42 += ints.tmp140.transpose((0, 1, 3, 2)) * 2
+    tmp42 += np.transpose(ints.tmp140, (0, 1, 3, 2)) * 2
     del ints.tmp140
     tmp42 += ints.tmp42
     tmp42 += ints.tmp122 * -1
     del ints.tmp122
-    tmp42 += ints.tmp139.transpose((0, 1, 3, 2)) * -1
+    tmp42 += np.transpose(ints.tmp139, (0, 1, 3, 2)) * -1
     del ints.tmp139
-    tmp33 = tmp32.copy()
+    tmp33 = np.copy(tmp32)
     del tmp32
     tmp33 += tmp3 * -2
     tmp33 += tmp4
-    tmp30 = tmp23.copy()
+    tmp30 = np.copy(tmp23)
     del tmp23
-    tmp30 += tmp25.transpose((0, 2, 1)) * -2
+    tmp30 += np.transpose(tmp25, (0, 2, 1)) * -2
     del tmp25
-    tmp30 += tmp27.transpose((0, 2, 1))
+    tmp30 += np.transpose(tmp27, (0, 2, 1))
     del tmp27
     tmp30 += tmp29
     del tmp29
     tmp10 = einsum(r2.aaa, (0, 1, 2), ints.tmp23, (3, 4, 0, 1), (3, 4, 2))
     del ints.tmp23
-    tmp22 = tmp12.copy() * 2
+    tmp22 = np.copy(tmp12) * 2
     del tmp12
     tmp22 += tmp17
     del tmp17
-    tmp22 += tmp19.transpose((0, 2, 1))
+    tmp22 += np.transpose(tmp19, (0, 2, 1))
     del tmp19
     tmp22 += tmp21
     del tmp21
-    tmp9 = tmp7.copy()
+    tmp9 = np.copy(tmp7)
     del tmp7
     tmp9 += tmp8 * 2
     del tmp8
     tmp9 += einsum(r1.b, (0,), tmp1, (1, 0), (1,)) * -1
-    tmp6 = ints.tmp46.copy()
+    tmp6 = np.copy(ints.tmp46)
     del ints.tmp46
-    tmp6 += ints.tmp57.transpose((1, 0)) * 2
+    tmp6 += np.transpose(ints.tmp57, (1, 0)) * 2
     del ints.tmp57
-    tmp6 += ints.tmp60.transpose((1, 0))
+    tmp6 += np.transpose(ints.tmp60, (1, 0))
     del ints.tmp60
     tmp6 += f.bb.vv * -1
-    tmp6 += ints.tmp44.transpose((1, 0)) * -1
+    tmp6 += np.transpose(ints.tmp44, (1, 0)) * -1
     del ints.tmp44
-    tmp6 += ints.tmp47.transpose((1, 0)) * -1
+    tmp6 += np.transpose(ints.tmp47, (1, 0)) * -1
     del ints.tmp47
-    tmp5 = tmp3.copy() * -2
+    tmp5 = np.copy(tmp3) * -2
     del tmp3
     tmp5 += tmp4
     del tmp4
     tmp5 += einsum(r1.a, (0,), tmp0, (1, 0), (1,))
-    tmp2 = ints.tmp30.transpose((1, 0)).copy() * 2
+    tmp2 = np.copy(np.transpose(ints.tmp30, (1, 0))) * 2
     del ints.tmp30
-    tmp2 += ints.tmp33.transpose((1, 0))
+    tmp2 += np.transpose(ints.tmp33, (1, 0))
     del ints.tmp33
     tmp2 += ints.tmp9
     del ints.tmp9
     tmp2 += f.aa.vv * -1
-    tmp2 += ints.tmp11.transpose((1, 0)) * -1
+    tmp2 += np.transpose(ints.tmp11, (1, 0)) * -1
     del ints.tmp11
-    tmp2 += ints.tmp7.transpose((1, 0)) * -1
+    tmp2 += np.transpose(ints.tmp7, (1, 0)) * -1
     del ints.tmp7
     r2new.bbb = einsum(r1.b, (0,), ints.tmp216, (1, 2, 3, 0), (3, 2, 1)) * 2
     del ints.tmp216
@@ -3255,11 +3255,11 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp57
     r2new.bbb += einsum(ints.tmp224, (0, 1, 2, 3), r2.bbb, (3, 1, 4), (0, 2, 4)) * 2
     del ints.tmp224
-    r2new.bbb += tmp68.transpose((1, 2, 0)) * -1
-    r2new.bbb += tmp68.transpose((2, 1, 0))
+    r2new.bbb += np.transpose(tmp68, (1, 2, 0)) * -1
+    r2new.bbb += np.transpose(tmp68, (2, 1, 0))
     del tmp68
-    r2new.bbb += tmp75.transpose((1, 2, 0))
-    r2new.bbb += tmp75.transpose((2, 1, 0)) * -1
+    r2new.bbb += np.transpose(tmp75, (1, 2, 0))
+    r2new.bbb += np.transpose(tmp75, (2, 1, 0)) * -1
     del tmp75
     r2new.bbb += einsum(r2.bbb, (0, 1, 2), tmp54, (2, 3), (0, 1, 3)) * -2
     r2new.bbb += einsum(tmp76, (0,), t2.bbbb, (1, 0, 2, 3), (2, 3, 1)) * -2
@@ -3315,11 +3315,11 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp99
     r2new.aaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp10, (0, 1, 4), (2, 3, 4)) * 2
     del tmp10
-    r2new.aaa += tmp22.transpose((1, 2, 0)) * -1
-    r2new.aaa += tmp22.transpose((2, 1, 0))
+    r2new.aaa += np.transpose(tmp22, (1, 2, 0)) * -1
+    r2new.aaa += np.transpose(tmp22, (2, 1, 0))
     del tmp22
-    r2new.aaa += tmp30.transpose((1, 2, 0))
-    r2new.aaa += tmp30.transpose((2, 1, 0)) * -1
+    r2new.aaa += np.transpose(tmp30, (1, 2, 0))
+    r2new.aaa += np.transpose(tmp30, (2, 1, 0)) * -1
     del tmp30
     r2new.aaa += einsum(r2.aaa, (0, 1, 2), tmp31, (2, 3), (0, 1, 3)) * -2
     del tmp31
@@ -3833,15 +3833,15 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     ints = kwargs["ints"]
     r1new = Namespace()
     r2new = Namespace()
-    tmp15 = ints.tmp77.copy()
+    tmp15 = np.copy(ints.tmp77)
     tmp15 += v.bbb.xov
     tmp15 += ints.tmp82 * 2
-    tmp13 = ints.tmp59.copy()
+    tmp13 = np.copy(ints.tmp59)
     tmp13 += v.baa.xov
     tmp13 += ints.tmp56 * 2
     tmp39 = einsum(r2.bbb, (0, 1, 2), t2.bbbb, (0, 1, 3, 2), (3,))
     tmp38 = einsum(r2.aba, (0, 1, 2), t2.abab, (0, 1, 2, 3), (3,))
-    tmp34 = ints.tmp56.copy() * 2
+    tmp34 = np.copy(ints.tmp56) * 2
     del ints.tmp56
     tmp34 += ints.tmp59
     del ints.tmp59
@@ -3849,29 +3849,29 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp16 = einsum(tmp15, (0, 1, 2), r2.bab, (1, 3, 2), (0, 3)) * -1
     tmp14 = einsum(tmp13, (0, 1, 2), r2.aaa, (3, 1, 2), (0, 3)) * -1
     del tmp13
-    tmp53 = f.bb.oo.copy()
-    tmp53 += ints.tmp21.transpose((1, 0))
-    tmp43 = ints.tmp419.copy()
+    tmp53 = np.copy(f.bb.oo)
+    tmp53 += np.transpose(ints.tmp21, (1, 0))
+    tmp43 = np.copy(ints.tmp419)
     del ints.tmp419
     tmp43 += ints.tmp423 * 2
     del ints.tmp423
     tmp51 = einsum(r2.bbb, (0, 1, 2), tmp15, (3, 1, 2), (3, 0)) * -1
     del tmp15
-    tmp59 = tmp38.copy() * -0.5
+    tmp59 = np.copy(tmp38) * -0.5
     tmp59 += tmp39
-    tmp61 = ints.tmp158.copy() * 2
+    tmp61 = np.copy(ints.tmp158) * 2
     tmp61 += ints.tmp161
     tmp35 = einsum(r2.aba, (0, 1, 2), tmp34, (3, 0, 2), (3, 1))
-    tmp25 = ints.tmp57.copy() * 2
+    tmp25 = np.copy(ints.tmp57) * 2
     tmp25 += ints.tmp60
     tmp23 = einsum(t2.aaaa, (0, 1, 2, 3), r2.aaa, (0, 1, 3), (2,))
-    tmp19 = f.aa.oo.copy()
-    tmp19 += ints.tmp1.transpose((1, 0))
-    tmp17 = tmp14.copy() * -2
+    tmp19 = np.copy(f.aa.oo)
+    tmp19 += np.transpose(ints.tmp1, (1, 0))
+    tmp17 = np.copy(tmp14) * -2
     del tmp14
     tmp17 += tmp16
     del tmp16
-    tmp11 = ints.tmp358.copy()
+    tmp11 = np.copy(ints.tmp358)
     tmp11 += ints.tmp362 * 2
     tmp9 = einsum(r2.bab, (0, 1, 2), t2.abab, (1, 0, 3, 2), (3,)) * -1
     tmp54 = einsum(r2.bbb, (0, 1, 2), tmp53, (1, 3), (0, 3, 2)) * -1
@@ -3887,7 +3887,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp57 = einsum(r2.aba, (0, 1, 2), ints.tmp421, (0, 3, 2, 4), (3, 1, 4))
     tmp56 = einsum(ints.tmp64, (0, 1, 2, 3), r1.b, (1,), (0, 2, 3))
     tmp47 = einsum(t1.bb, (0, 1), f.bb.ov, (0, 2), (2, 1))
-    tmp36 = ints.tmp77.copy() * 0.5
+    tmp36 = np.copy(ints.tmp77) * 0.5
     del ints.tmp77
     tmp36 += ints.tmp82
     del ints.tmp82
@@ -3906,113 +3906,113 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp10 = einsum(ints.tmp166, (0, 1, 2, 3), tmp9, (3,), (0, 1, 2))
     del ints.tmp166
     tmp8 = einsum(ints.tmp364, (0, 1, 2, 3), r2.bab, (1, 4, 3), (0, 4, 2)) * -1
-    tmp64 = ints.tmp246.copy()
+    tmp64 = np.copy(ints.tmp246)
     del ints.tmp246
-    tmp64 += ints.tmp326.transpose((2, 3, 0, 1)) * -1
+    tmp64 += np.transpose(ints.tmp326, (2, 3, 0, 1)) * -1
     del ints.tmp326
-    tmp55 = tmp50.transpose((1, 0, 2)).copy() * -1
+    tmp55 = np.copy(np.transpose(tmp50, (1, 0, 2))) * -1
     del tmp50
-    tmp55 += tmp52.transpose((1, 0, 2))
+    tmp55 += np.transpose(tmp52, (1, 0, 2))
     del tmp52
-    tmp55 += tmp54.transpose((1, 0, 2)) * -1
+    tmp55 += np.transpose(tmp54, (1, 0, 2)) * -1
     del tmp54
     tmp63 = einsum(r1.b, (0,), f.bb.ov, (1, 2), (1, 0, 2))
     tmp63 += tmp56
     del tmp56
     tmp63 += tmp57
     del tmp57
-    tmp63 += tmp58.transpose((1, 0, 2))
+    tmp63 += np.transpose(tmp58, (1, 0, 2))
     del tmp58
     tmp63 += tmp60 * -1
     del tmp60
-    tmp63 += tmp62.transpose((1, 0, 2))
+    tmp63 += np.transpose(tmp62, (1, 0, 2))
     del tmp62
-    tmp48 = ints.tmp437.copy() * 2
+    tmp48 = np.copy(ints.tmp437) * 2
     del ints.tmp437
     tmp48 += ints.tmp439
     del ints.tmp439
     tmp48 += f.bb.vv * -1
-    tmp48 += tmp47.transpose((1, 0))
+    tmp48 += np.transpose(tmp47, (1, 0))
     del tmp47
-    tmp44 = ints.tmp441.copy()
+    tmp44 = np.copy(ints.tmp441)
     del ints.tmp441
-    tmp44 += ints.tmp442.transpose((1, 0, 2, 3)) * -1
+    tmp44 += np.transpose(ints.tmp442, (1, 0, 2, 3)) * -1
     del ints.tmp442
     tmp46 = einsum(tmp34, (0, 1, 2), r2.aaa, (3, 1, 2), (0, 3))
     del tmp34
     tmp46 += einsum(tmp36, (0, 1, 2), r2.bab, (1, 3, 2), (0, 3)) * -1
-    tmp45 = ints.tmp171.copy()
-    tmp45 += ints.tmp36.transpose((1, 0, 2, 3))
-    tmp49 = tmp23.copy() * 2
+    tmp45 = np.copy(ints.tmp171)
+    tmp45 += np.transpose(ints.tmp36, (1, 0, 2, 3))
+    tmp49 = np.copy(tmp23) * 2
     del tmp23
     tmp49 += tmp9
     del tmp9
-    tmp42 = f.bb.oo.copy()
+    tmp42 = np.copy(f.bb.oo)
     tmp42 += ints.tmp158 * 2
     tmp42 += ints.tmp161
-    tmp42 += ints.tmp21.transpose((1, 0))
-    tmp41 = f.aa.oo.copy()
-    tmp41 += ints.tmp1.transpose((1, 0))
+    tmp42 += np.transpose(ints.tmp21, (1, 0))
+    tmp41 = np.copy(f.aa.oo)
+    tmp41 += np.transpose(ints.tmp1, (1, 0))
     tmp41 += ints.tmp57 * 2
     tmp41 += ints.tmp60
-    tmp30 = ints.tmp388.copy() * 2
+    tmp30 = np.copy(ints.tmp388) * 2
     del ints.tmp388
     tmp30 += ints.tmp390
     del ints.tmp390
     tmp30 += f.aa.vv * -1
-    tmp30 += tmp29.transpose((1, 0))
+    tmp30 += np.transpose(tmp29, (1, 0))
     del tmp29
-    tmp37 = tmp35.copy() * -1
+    tmp37 = np.copy(tmp35) * -1
     del tmp35
     tmp37 += einsum(r2.bbb, (0, 1, 2), tmp36, (3, 1, 2), (3, 0)) * 4
     del tmp36
-    tmp32 = ints.tmp358.copy()
+    tmp32 = np.copy(ints.tmp358)
     del ints.tmp358
     tmp32 += ints.tmp362 * 2
     del ints.tmp362
-    tmp40 = tmp38.copy() * -1
+    tmp40 = np.copy(tmp38) * -1
     del tmp38
     tmp40 += tmp39 * 2
     del tmp39
-    tmp33 = ints.tmp171.copy()
+    tmp33 = np.copy(ints.tmp171)
     del ints.tmp171
-    tmp33 += ints.tmp36.transpose((0, 1, 3, 2))
+    tmp33 += np.transpose(ints.tmp36, (0, 1, 3, 2))
     del ints.tmp36
-    tmp31 = ints.tmp417.copy()
+    tmp31 = np.copy(ints.tmp417)
     del ints.tmp417
-    tmp31 += ints.tmp418.transpose((1, 0, 2, 3)) * -1
+    tmp31 += np.transpose(ints.tmp418, (1, 0, 2, 3)) * -1
     del ints.tmp418
     tmp27 = einsum(r1.a, (0,), f.aa.ov, (1, 2), (1, 0, 2)) * -1
     tmp27 += tmp22 * -1
     del tmp22
     tmp27 += tmp24 * 2
     del tmp24
-    tmp27 += tmp26.transpose((1, 0, 2)) * -1
+    tmp27 += np.transpose(tmp26, (1, 0, 2)) * -1
     del tmp26
-    tmp21 = tmp8.copy()
+    tmp21 = np.copy(tmp8)
     del tmp8
     tmp21 += tmp10
     del tmp10
-    tmp21 += tmp12.transpose((1, 0, 2)) * -2
+    tmp21 += np.transpose(tmp12, (1, 0, 2)) * -2
     del tmp12
-    tmp21 += tmp18.transpose((1, 0, 2))
+    tmp21 += np.transpose(tmp18, (1, 0, 2))
     del tmp18
-    tmp21 += tmp20.transpose((1, 0, 2)) * -2
+    tmp21 += np.transpose(tmp20, (1, 0, 2)) * -2
     del tmp20
-    tmp28 = ints.tmp167.copy()
+    tmp28 = np.copy(ints.tmp167)
     del ints.tmp167
-    tmp28 += ints.tmp33.transpose((2, 3, 0, 1)) * -1
+    tmp28 += np.transpose(ints.tmp33, (2, 3, 0, 1)) * -1
     del ints.tmp33
-    tmp7 = f.bb.oo.copy()
+    tmp7 = np.copy(f.bb.oo)
     tmp7 += ints.tmp158 * 2
     del ints.tmp158
     tmp7 += ints.tmp161
     del ints.tmp161
-    tmp7 += ints.tmp183.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp183, (1, 0))
     del ints.tmp183
-    tmp7 += ints.tmp187.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp187, (1, 0))
     del ints.tmp187
-    tmp7 += ints.tmp21.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp21, (1, 0))
     del ints.tmp21
     tmp7 += ints.tmp221
     del ints.tmp221
@@ -4022,7 +4022,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp181
     tmp7 += ints.tmp219 * -1
     del ints.tmp219
-    tmp3 = ints.tmp100.copy()
+    tmp3 = np.copy(ints.tmp100)
     del ints.tmp100
     tmp3 += ints.tmp108 * 0.5
     del ints.tmp108
@@ -4085,11 +4085,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp8
     tmp3 += ints.tmp91 * -0.5
     del ints.tmp91
-    tmp5 = ints.tmp142.copy()
+    tmp5 = np.copy(ints.tmp142)
     del ints.tmp142
-    tmp5 += ints.tmp239.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp239, (0, 2, 1, 3))
     del ints.tmp239
-    tmp5 += ints.tmp257.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp257, (0, 2, 1, 3))
     del ints.tmp257
     tmp5 += ints.tmp267
     del ints.tmp267
@@ -4107,8 +4107,8 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp316
     tmp5 += ints.tmp346
     del ints.tmp346
-    tmp5 += ints.tmp67.transpose((0, 2, 1, 3))
-    tmp5 += ints.tmp249.transpose((0, 2, 1, 3)) * -1
+    tmp5 += np.transpose(ints.tmp67, (0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp249, (0, 2, 1, 3)) * -1
     del ints.tmp249
     tmp5 += ints.tmp264 * -1
     del ints.tmp264
@@ -4124,11 +4124,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp329
     tmp5 += ints.tmp339 * -1
     del ints.tmp339
-    tmp5 += ints.tmp340.transpose((0, 2, 1, 3)) * -1
+    tmp5 += np.transpose(ints.tmp340, (0, 2, 1, 3)) * -1
     del ints.tmp340
     tmp5 += ints.tmp354 * -1
     del ints.tmp354
-    tmp2 = ints.tmp102.copy() * 0.5
+    tmp2 = np.copy(ints.tmp102) * 0.5
     del ints.tmp102
     tmp2 += ints.tmp110
     del ints.tmp110
@@ -4191,11 +4191,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp7
     tmp2 += ints.tmp89 * -0.5
     del ints.tmp89
-    tmp6 = ints.tmp241.transpose((1, 2, 0, 3)).copy()
+    tmp6 = np.copy(np.transpose(ints.tmp241, (1, 2, 0, 3)))
     del ints.tmp241
-    tmp6 += ints.tmp247.transpose((0, 2, 1, 3))
+    tmp6 += np.transpose(ints.tmp247, (0, 2, 1, 3))
     del ints.tmp247
-    tmp6 += ints.tmp255.transpose((0, 2, 1, 3))
+    tmp6 += np.transpose(ints.tmp255, (0, 2, 1, 3))
     del ints.tmp255
     tmp6 += ints.tmp268 * 2
     del ints.tmp268
@@ -4225,22 +4225,22 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp311
     tmp6 += ints.tmp318 * -1
     del ints.tmp318
-    tmp6 += ints.tmp337.transpose((0, 2, 1, 3)) * -1
+    tmp6 += np.transpose(ints.tmp337, (0, 2, 1, 3)) * -1
     del ints.tmp337
     tmp6 += ints.tmp344 * -1
     del ints.tmp344
-    tmp6 += ints.tmp64.transpose((1, 2, 0, 3)) * -1
+    tmp6 += np.transpose(ints.tmp64, (1, 2, 0, 3)) * -1
     del ints.tmp64
-    tmp4 = f.aa.oo.copy()
+    tmp4 = np.copy(f.aa.oo)
     tmp4 += ints.tmp175
     del ints.tmp175
     tmp4 += ints.tmp176
     del ints.tmp176
-    tmp4 += ints.tmp1.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp1, (1, 0))
     del ints.tmp1
-    tmp4 += ints.tmp30.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp30, (1, 0))
     del ints.tmp30
-    tmp4 += ints.tmp32.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp32, (1, 0))
     del ints.tmp32
     tmp4 += ints.tmp57 * 2
     del ints.tmp57
@@ -4250,7 +4250,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp174
     tmp4 += ints.tmp28 * -1
     del ints.tmp28
-    tmp0 = ints.tmp129.copy()
+    tmp0 = np.copy(ints.tmp129)
     del ints.tmp129
     tmp0 += ints.tmp133
     del ints.tmp133
@@ -4258,14 +4258,14 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp147
     tmp0 += ints.tmp153 * 2
     del ints.tmp153
-    tmp0 += ints.tmp17.transpose((1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp17, (1, 0, 2, 3))
     del ints.tmp17
     tmp0 += ints.tmp213
     del ints.tmp213
-    tmp0 += ints.tmp25.transpose((1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp25, (1, 0, 2, 3))
     tmp0 += ints.tmp54
     del ints.tmp54
-    tmp0 += ints.tmp55.transpose((1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp55, (1, 0, 2, 3))
     del ints.tmp55
     tmp0 += ints.tmp78
     del ints.tmp78
@@ -4283,7 +4283,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp172
     tmp0 += ints.tmp195 * -1
     del ints.tmp195
-    tmp0 += ints.tmp197.transpose((1, 0, 2, 3)) * -1
+    tmp0 += np.transpose(ints.tmp197, (1, 0, 2, 3)) * -1
     del ints.tmp197
     tmp0 += ints.tmp231 * -1
     del ints.tmp231
@@ -4293,13 +4293,13 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp74
     tmp0 += ints.tmp79 * -1
     del ints.tmp79
-    tmp1 = ints.tmp127.copy()
+    tmp1 = np.copy(ints.tmp127)
     del ints.tmp127
     tmp1 += ints.tmp131
     del ints.tmp131
     tmp1 += ints.tmp148 * 2
     del ints.tmp148
-    tmp1 += ints.tmp15.transpose((1, 2, 0, 3))
+    tmp1 += np.transpose(ints.tmp15, (1, 2, 0, 3))
     del ints.tmp15
     tmp1 += ints.tmp168
     del ints.tmp168
@@ -4307,9 +4307,9 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp190
     tmp1 += ints.tmp228
     del ints.tmp228
-    tmp1 += ints.tmp34.transpose((0, 2, 1, 3))
+    tmp1 += np.transpose(ints.tmp34, (0, 2, 1, 3))
     del ints.tmp34
-    tmp1 += ints.tmp52.transpose((0, 2, 1, 3))
+    tmp1 += np.transpose(ints.tmp52, (0, 2, 1, 3))
     del ints.tmp52
     tmp1 += ints.tmp75 * 2
     del ints.tmp75
@@ -4321,11 +4321,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp145
     tmp1 += ints.tmp151 * -1
     del ints.tmp151
-    tmp1 += ints.tmp192.transpose((0, 2, 1, 3)) * -1
+    tmp1 += np.transpose(ints.tmp192, (0, 2, 1, 3)) * -1
     del ints.tmp192
     tmp1 += ints.tmp211 * -1
     del ints.tmp211
-    tmp1 += ints.tmp23.transpose((1, 2, 0, 3)) * -1
+    tmp1 += np.transpose(ints.tmp23, (1, 2, 0, 3)) * -1
     del ints.tmp23
     tmp1 += ints.tmp50 * -1
     del ints.tmp50
@@ -4333,11 +4333,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp72
     tmp1 += ints.tmp94 * -1
     del ints.tmp94
-    r2new.bbb = tmp55.copy() * 2
-    r2new.bbb += tmp55.transpose((1, 0, 2)) * -2
+    r2new.bbb = np.copy(tmp55) * 2
+    r2new.bbb += np.transpose(tmp55, (1, 0, 2)) * -2
     del tmp55
     r2new.bbb += tmp63 * -1
-    r2new.bbb += tmp63.transpose((1, 0, 2))
+    r2new.bbb += np.transpose(tmp63, (1, 0, 2))
     del tmp63
     r2new.bbb += einsum(tmp64, (0, 1, 2, 3), r2.bbb, (3, 2, 4), (0, 1, 4)) * 2
     del tmp64
@@ -4381,11 +4381,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp41
     r2new.aba += einsum(r2.aba, (0, 1, 2), tmp42, (1, 3), (0, 3, 2)) * -1
     del tmp42
-    r2new.aaa = tmp21.copy()
-    r2new.aaa += tmp21.transpose((1, 0, 2)) * -1
+    r2new.aaa = np.copy(tmp21)
+    r2new.aaa += np.transpose(tmp21, (1, 0, 2)) * -1
     del tmp21
     r2new.aaa += tmp27
-    r2new.aaa += tmp27.transpose((1, 0, 2)) * -1
+    r2new.aaa += np.transpose(tmp27, (1, 0, 2)) * -1
     del tmp27
     r2new.aaa += einsum(tmp28, (0, 1, 2, 3), r2.aaa, (1, 0, 4), (2, 3, 4)) * -2
     del tmp28
@@ -4808,13 +4808,13 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     ints = kwargs["ints"]
     r1new = Namespace()
     r2new = Namespace()
-    tmp43 = ints.tmp60.copy()
+    tmp43 = np.copy(ints.tmp60)
     tmp43 += v.baa.xov
     tmp43 += ints.tmp57 * 2
-    tmp45 = ints.tmp84.copy()
+    tmp45 = np.copy(ints.tmp84)
     tmp45 += v.bbb.xov
     tmp45 += ints.tmp81 * 2
-    tmp59 = ints.tmp57.copy() * 2
+    tmp59 = np.copy(ints.tmp57) * 2
     del ints.tmp57
     tmp59 += ints.tmp60
     del ints.tmp60
@@ -4825,27 +4825,27 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp43
     tmp46 = einsum(r2.bab, (0, 1, 2), tmp45, (3, 2, 0), (3, 1)) * -1
     tmp21 = einsum(r2.bbb, (0, 1, 2), t1.bb, (3, 1), (2, 3, 0))
-    tmp70 = ints.tmp246.copy()
+    tmp70 = np.copy(ints.tmp246)
     tmp70 += ints.tmp313 * 2
     tmp33 = einsum(r2.aba, (0, 1, 2), t2.abab, (2, 3, 0, 1), (3,))
     tmp78 = einsum(r2.bbb, (0, 1, 2), tmp45, (3, 2, 1), (3, 0)) * -1
     del tmp45
-    tmp84 = ints.tmp255.copy()
+    tmp84 = np.copy(ints.tmp255)
     tmp84 += ints.tmp257 * 0.5
     tmp84 += f.bb.vv * -0.5
     tmp34 = einsum(r2.bbb, (0, 1, 2), t2.bbbb, (3, 2, 0, 1), (3,))
     tmp60 = einsum(r2.aba, (0, 1, 2), tmp59, (3, 2, 0), (3, 1))
-    tmp52 = tmp15.copy() * 2
+    tmp52 = np.copy(tmp15) * 2
     tmp52 += tmp16
-    tmp50 = ints.tmp58.copy()
+    tmp50 = np.copy(ints.tmp58)
     tmp50 += ints.tmp61 * 0.5
     tmp50 += f.aa.vv * -0.5
     tmp2 = einsum(t1.aa, (0, 1), r2.aaa, (2, 1, 3), (3, 0, 2))
-    tmp47 = tmp44.copy() * -2
+    tmp47 = np.copy(tmp44) * -2
     del tmp44
     tmp47 += tmp46
     del tmp46
-    tmp41 = ints.tmp47.copy()
+    tmp41 = np.copy(ints.tmp47)
     tmp41 += ints.tmp163 * 2
     tmp74 = einsum(r1.b, (0,), ints.tmp236, (1, 2, 0, 3), (1, 2, 3))
     tmp75 = einsum(f.bb.ov, (0, 1), tmp21, (2, 0, 3), (2, 1, 3))
@@ -4860,7 +4860,7 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp83 = einsum(v.bbb.xov, (0, 1, 2), tmp60, (0, 3), (1, 2, 3))
     tmp63 = einsum(t1.bb, (0, 1), f.bb.ov, (0, 2), (2, 1))
     tmp65 = einsum(t1.aa, (0, 1), f.aa.ov, (0, 2), (2, 1))
-    tmp61 = ints.tmp81.copy() * 2
+    tmp61 = np.copy(ints.tmp81) * 2
     del ints.tmp81
     tmp61 += ints.tmp84
     del ints.tmp84
@@ -4877,22 +4877,22 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp38 = einsum(ints.tmp24, (0, 1, 2, 3), r1.a, (2,), (0, 1, 3))
     tmp25 = einsum(r2.aba, (0, 1, 2), t1.aa, (3, 0), (2, 3, 1))
     tmp6 = einsum(r2.bab, (0, 1, 2), t1.bb, (3, 0), (2, 3, 1)) * -1
-    tmp72 = f.bb.oo.copy()
+    tmp72 = np.copy(f.bb.oo)
     tmp72 += ints.tmp151 * 2
     del ints.tmp151
     tmp72 += ints.tmp154
     del ints.tmp154
-    tmp72 += ints.tmp22.transpose((1, 0))
+    tmp72 += np.transpose(ints.tmp22, (1, 0))
     del ints.tmp22
-    tmp80 = tmp74.copy()
+    tmp80 = np.copy(tmp74)
     del tmp74
     tmp80 += tmp75 * 2
     del tmp75
     tmp80 += tmp76
     del tmp76
-    tmp80 += tmp77.transpose((0, 2, 1)) * -2
+    tmp80 += np.transpose(tmp77, (0, 2, 1)) * -2
     del tmp77
-    tmp80 += tmp79.transpose((0, 2, 1)) * 2
+    tmp80 += np.transpose(tmp79, (0, 2, 1)) * 2
     del tmp79
     tmp73 = einsum(r2.bbb, (0, 1, 2), t2.bbbb, (3, 4, 0, 1), (2, 3, 4))
     tmp86 = einsum(f.bb.ov, (0, 1), r1.b, (2,), (0, 1, 2))
@@ -4900,61 +4900,61 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp81
     tmp86 += tmp82 * 2
     del tmp82
-    tmp86 += tmp83.transpose((0, 2, 1))
+    tmp86 += np.transpose(tmp83, (0, 2, 1))
     del tmp83
-    tmp86 += tmp85.transpose((0, 2, 1))
+    tmp86 += np.transpose(tmp85, (0, 2, 1))
     del tmp85
-    tmp64 = ints.tmp255.copy() * 2
+    tmp64 = np.copy(ints.tmp255) * 2
     tmp64 += ints.tmp257
     tmp64 += f.bb.vv * -1
-    tmp64 += tmp63.transpose((1, 0))
+    tmp64 += np.transpose(tmp63, (1, 0))
     del tmp63
-    tmp66 = ints.tmp58.copy() * 2
+    tmp66 = np.copy(ints.tmp58) * 2
     tmp66 += ints.tmp61
     tmp66 += f.aa.vv * -1
-    tmp66 += tmp65.transpose((1, 0))
+    tmp66 += np.transpose(tmp65, (1, 0))
     del tmp65
     tmp68 = einsum(r2.bab, (0, 1, 2), t2.abab, (3, 4, 1, 0), (3, 2, 4)) * -1
     tmp71 = einsum(tmp59, (0, 1, 2), r2.aaa, (3, 2, 1), (0, 3))
     del tmp59
     tmp71 += einsum(tmp61, (0, 1, 2), r2.bab, (2, 3, 1), (0, 3)) * -0.5
-    tmp69 = ints.tmp170.copy()
-    tmp69 += ints.tmp52.transpose((0, 1, 3, 2)) * -1
-    tmp57 = ints.tmp250.copy()
-    tmp57 += ints.tmp319.transpose((0, 1, 3, 2)) * -1
-    tmp55 = f.aa.oo.copy()
+    tmp69 = np.copy(ints.tmp170)
+    tmp69 += np.transpose(ints.tmp52, (0, 1, 3, 2)) * -1
+    tmp57 = np.copy(ints.tmp250)
+    tmp57 += np.transpose(ints.tmp319, (0, 1, 3, 2)) * -1
+    tmp55 = np.copy(f.aa.oo)
     tmp55 += ints.tmp148 * 2
     del ints.tmp148
     tmp55 += ints.tmp157
     del ints.tmp157
-    tmp55 += ints.tmp19.transpose((1, 0))
+    tmp55 += np.transpose(ints.tmp19, (1, 0))
     del ints.tmp19
-    tmp62 = tmp60.copy() * -1
+    tmp62 = np.copy(tmp60) * -1
     del tmp60
     tmp62 += einsum(tmp61, (0, 1, 2), r2.bbb, (3, 2, 1), (0, 3)) * 2
     del tmp61
-    tmp58 = ints.tmp163.copy() * 2
+    tmp58 = np.copy(ints.tmp163) * 2
     tmp58 += ints.tmp47
     tmp56 = einsum(r2.aba, (0, 1, 2), t2.abab, (3, 4, 0, 1), (2, 3, 4))
-    tmp67 = tmp33.copy() * -1
+    tmp67 = np.copy(tmp33) * -1
     tmp67 += tmp34 * 2
     tmp54 = einsum(r1.a, (0,), f.aa.ov, (1, 2), (1, 2, 0))
-    tmp54 += tmp51.transpose((0, 2, 1))
+    tmp54 += np.transpose(tmp51, (0, 2, 1))
     del tmp51
     tmp54 += tmp53
     del tmp53
-    tmp49 = tmp38.copy()
+    tmp49 = np.copy(tmp38)
     del tmp38
     tmp49 += tmp39 * 2
     del tmp39
     tmp49 += tmp40
     del tmp40
-    tmp49 += tmp42.transpose((0, 2, 1)) * -2
+    tmp49 += np.transpose(tmp42, (0, 2, 1)) * -2
     del tmp42
-    tmp49 += tmp48.transpose((0, 2, 1))
+    tmp49 += np.transpose(tmp48, (0, 2, 1))
     del tmp48
     tmp37 = einsum(t2.aaaa, (0, 1, 2, 3), r2.aaa, (2, 3, 4), (4, 0, 1))
-    tmp9 = ints.tmp103.copy()
+    tmp9 = np.copy(ints.tmp103)
     del ints.tmp103
     tmp9 += ints.tmp111 * 0.5
     del ints.tmp111
@@ -5015,7 +5015,7 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp87
     tmp9 += ints.tmp8 * -1
     del ints.tmp8
-    tmp27 = ints.tmp105.copy() * 0.5
+    tmp27 = np.copy(ints.tmp105) * 0.5
     tmp27 += ints.tmp113
     tmp27 += ints.tmp136
     tmp27 += ints.tmp142 * 0.5
@@ -5047,32 +5047,32 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp27 += ints.tmp41 * -0.5
     tmp27 += ints.tmp7 * -0.5
     tmp27 += ints.tmp85 * -0.5
-    tmp31 = ints.tmp138.copy()
+    tmp31 = np.copy(ints.tmp138)
     del ints.tmp138
     tmp31 += ints.tmp72
     del ints.tmp72
     tmp23 = einsum(r2.aba, (0, 1, 2), t1.bb, (3, 1), (2, 3, 0))
-    tmp20 = ints.tmp236.copy() * 0.5
+    tmp20 = np.copy(ints.tmp236) * 0.5
     del ints.tmp236
     tmp20 += ints.tmp251 * 0.5
     del ints.tmp251
-    tmp20 += ints.tmp275.transpose((0, 2, 1, 3))
+    tmp20 += np.transpose(ints.tmp275, (0, 2, 1, 3))
     del ints.tmp275
-    tmp20 += ints.tmp301.transpose((0, 3, 1, 2)) * 0.5
+    tmp20 += np.transpose(ints.tmp301, (0, 3, 1, 2)) * 0.5
     del ints.tmp301
-    tmp20 += ints.tmp263.transpose((0, 3, 1, 2)) * -0.5
+    tmp20 += np.transpose(ints.tmp263, (0, 3, 1, 2)) * -0.5
     del ints.tmp263
-    tmp20 += ints.tmp272.transpose((0, 3, 1, 2)) * -1
+    tmp20 += np.transpose(ints.tmp272, (0, 3, 1, 2)) * -1
     del ints.tmp272
-    tmp20 += ints.tmp279.transpose((0, 3, 1, 2)) * -0.5
+    tmp20 += np.transpose(ints.tmp279, (0, 3, 1, 2)) * -0.5
     del ints.tmp279
-    tmp26 = ints.tmp250.copy()
+    tmp26 = np.copy(ints.tmp250)
     del ints.tmp250
     tmp26 += ints.tmp334
     del ints.tmp334
-    tmp26 += ints.tmp319.transpose((0, 1, 3, 2)) * -1
+    tmp26 += np.transpose(ints.tmp319, (0, 1, 3, 2)) * -1
     del ints.tmp319
-    tmp24 = ints.tmp309.copy()
+    tmp24 = np.copy(ints.tmp309)
     del ints.tmp309
     tmp24 += ints.tmp315 * 2
     del ints.tmp315
@@ -5080,46 +5080,46 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp335
     tmp24 += ints.tmp49
     tmp24 += ints.tmp312 * -1
-    tmp19 = ints.tmp253.copy()
+    tmp19 = np.copy(ints.tmp253)
     del ints.tmp253
-    tmp19 += ints.tmp265.transpose((0, 1, 3, 2))
+    tmp19 += np.transpose(ints.tmp265, (0, 1, 3, 2))
     del ints.tmp265
-    tmp19 += ints.tmp271.transpose((0, 1, 3, 2))
+    tmp19 += np.transpose(ints.tmp271, (0, 1, 3, 2))
     del ints.tmp271
-    tmp19 += ints.tmp277.transpose((0, 1, 3, 2)) * 2
+    tmp19 += np.transpose(ints.tmp277, (0, 1, 3, 2)) * 2
     del ints.tmp277
-    tmp19 += ints.tmp303.transpose((0, 1, 3, 2))
+    tmp19 += np.transpose(ints.tmp303, (0, 1, 3, 2))
     del ints.tmp303
     tmp19 += ints.tmp99
     tmp19 += ints.tmp274 * -1
     del ints.tmp274
-    tmp19 += ints.tmp281.transpose((0, 1, 3, 2)) * -1
+    tmp19 += np.transpose(ints.tmp281, (0, 1, 3, 2)) * -1
     del ints.tmp281
-    tmp22 = ints.tmp243.copy()
+    tmp22 = np.copy(ints.tmp243)
     tmp22 += ints.tmp310 * 2
     del ints.tmp310
     tmp22 += ints.tmp317
     del ints.tmp317
-    tmp22 += ints.tmp332.transpose((0, 1, 3, 2))
+    tmp22 += np.transpose(ints.tmp332, (0, 1, 3, 2))
     del ints.tmp332
-    tmp22 += ints.tmp246.transpose((0, 1, 3, 2)) * -1
+    tmp22 += np.transpose(ints.tmp246, (0, 1, 3, 2)) * -1
     del ints.tmp246
     tmp22 += ints.tmp313 * -2
     del ints.tmp313
-    tmp22 += ints.tmp330.transpose((0, 1, 3, 2)) * -1
+    tmp22 += np.transpose(ints.tmp330, (0, 1, 3, 2)) * -1
     del ints.tmp330
-    tmp32 = ints.tmp239.transpose((1, 0)).copy()
+    tmp32 = np.copy(np.transpose(ints.tmp239, (1, 0)))
     del ints.tmp239
     tmp32 += ints.tmp255 * 2
     del ints.tmp255
     tmp32 += ints.tmp257
     del ints.tmp257
     tmp32 += f.bb.vv * -1
-    tmp32 += ints.tmp194.transpose((1, 0)) * -1
+    tmp32 += np.transpose(ints.tmp194, (1, 0)) * -1
     del ints.tmp194
-    tmp32 += ints.tmp197.transpose((1, 0)) * -1
+    tmp32 += np.transpose(ints.tmp197, (1, 0)) * -1
     del ints.tmp197
-    tmp36 = f.bb.ov.copy()
+    tmp36 = np.copy(f.bb.ov)
     tmp36 += ints.tmp38
     tmp36 += ints.tmp41
     tmp36 += ints.tmp110 * -1
@@ -5130,19 +5130,19 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp33
     tmp35 += tmp34 * 2
     del tmp34
-    tmp29 = ints.tmp135.copy()
+    tmp29 = np.copy(ints.tmp135)
     del ints.tmp135
     tmp29 += ints.tmp66 * -1
     del ints.tmp66
     tmp28 = einsum(tmp21, (0, 1, 2), t1.bb, (3, 2), (0, 1, 3)) * -1
-    tmp18 = f.aa.ov.copy()
+    tmp18 = np.copy(f.aa.ov)
     tmp18 += ints.tmp34
     del ints.tmp34
     tmp18 += ints.tmp42
     del ints.tmp42
     tmp18 += ints.tmp102 * -1
     del ints.tmp102
-    tmp8 = ints.tmp105.copy()
+    tmp8 = np.copy(ints.tmp105)
     del ints.tmp105
     tmp8 += ints.tmp113 * 2
     del ints.tmp113
@@ -5205,26 +5205,26 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp7
     tmp8 += ints.tmp85 * -1
     del ints.tmp85
-    tmp3 = ints.tmp160.copy() * 2
+    tmp3 = np.copy(ints.tmp160) * 2
     del ints.tmp160
     tmp3 += ints.tmp166
     del ints.tmp166
-    tmp3 += ints.tmp203.transpose((0, 1, 3, 2))
+    tmp3 += np.transpose(ints.tmp203, (0, 1, 3, 2))
     del ints.tmp203
     tmp3 += ints.tmp44
     tmp3 += ints.tmp163 * -2
     del ints.tmp163
-    tmp3 += ints.tmp201.transpose((0, 1, 3, 2)) * -1
+    tmp3 += np.transpose(ints.tmp201, (0, 1, 3, 2)) * -1
     del ints.tmp201
-    tmp3 += ints.tmp47.transpose((0, 1, 3, 2)) * -1
+    tmp3 += np.transpose(ints.tmp47, (0, 1, 3, 2)) * -1
     del ints.tmp47
-    tmp1 = ints.tmp144.copy() * 0.5
+    tmp1 = np.copy(ints.tmp144) * 0.5
     del ints.tmp144
-    tmp1 += ints.tmp24.transpose((0, 2, 3, 1)) * 0.5
+    tmp1 += np.transpose(ints.tmp24, (0, 2, 3, 1)) * 0.5
     del ints.tmp24
-    tmp1 += ints.tmp53.transpose((0, 2, 3, 1)) * 0.5
+    tmp1 += np.transpose(ints.tmp53, (0, 2, 3, 1)) * 0.5
     del ints.tmp53
-    tmp1 += ints.tmp92.transpose((0, 1, 3, 2))
+    tmp1 += np.transpose(ints.tmp92, (0, 1, 3, 2))
     del ints.tmp92
     tmp1 += ints.tmp75 * -0.5
     del ints.tmp75
@@ -5232,29 +5232,29 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp89
     tmp1 += ints.tmp95 * -0.5
     del ints.tmp95
-    tmp11 = ints.tmp141.copy()
+    tmp11 = np.copy(ints.tmp141)
     del ints.tmp141
     tmp11 += ints.tmp69
     del ints.tmp69
     tmp12 = einsum(tmp2, (0, 1, 2), t1.aa, (3, 2), (0, 1, 3)) * -1
-    tmp14 = ints.tmp31.transpose((1, 0)).copy()
+    tmp14 = np.copy(np.transpose(ints.tmp31, (1, 0)))
     del ints.tmp31
     tmp14 += ints.tmp58 * 2
     del ints.tmp58
     tmp14 += ints.tmp61
     del ints.tmp61
     tmp14 += f.aa.vv * -1
-    tmp14 += ints.tmp29.transpose((1, 0)) * -1
+    tmp14 += np.transpose(ints.tmp29, (1, 0)) * -1
     del ints.tmp29
-    tmp14 += ints.tmp33.transpose((1, 0)) * -1
+    tmp14 += np.transpose(ints.tmp33, (1, 0)) * -1
     del ints.tmp33
-    tmp13 = ints.tmp132.copy()
+    tmp13 = np.copy(ints.tmp132)
     del ints.tmp132
     tmp13 += ints.tmp63 * -1
     del ints.tmp63
-    tmp7 = ints.tmp205.transpose((0, 1, 3, 2)).copy()
+    tmp7 = np.copy(np.transpose(ints.tmp205, (0, 1, 3, 2)))
     del ints.tmp205
-    tmp7 += ints.tmp52.transpose((0, 1, 3, 2))
+    tmp7 += np.transpose(ints.tmp52, (0, 1, 3, 2))
     del ints.tmp52
     tmp7 += ints.tmp170 * -1
     del ints.tmp170
@@ -5263,7 +5263,7 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp15
     tmp17 += tmp16
     del tmp16
-    tmp5 = ints.tmp162.copy()
+    tmp5 = np.copy(ints.tmp162)
     del ints.tmp162
     tmp5 += ints.tmp168 * 2
     del ints.tmp168
@@ -5273,10 +5273,10 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp5 += ints.tmp165 * -1
     tmp4 = einsum(r2.bab, (0, 1, 2), t1.aa, (3, 1), (3, 2, 0)) * -1
     tmp10 = einsum(tmp6, (0, 1, 2), t1.aa, (3, 2), (3, 0, 1))
-    tmp0 = ints.tmp146.copy()
+    tmp0 = np.copy(ints.tmp146)
     del ints.tmp146
-    tmp0 += ints.tmp26.transpose((0, 2, 1, 3))
-    tmp0 += ints.tmp55.transpose((0, 2, 1, 3))
+    tmp0 += np.transpose(ints.tmp26, (0, 2, 1, 3))
+    tmp0 += np.transpose(ints.tmp55, (0, 2, 1, 3))
     del ints.tmp55
     tmp0 += ints.tmp77
     del ints.tmp77
@@ -5286,17 +5286,17 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp97
     tmp0 += ints.tmp100 * -1
     del ints.tmp100
-    tmp0 += ints.tmp94.transpose((0, 2, 1, 3)) * -1
+    tmp0 += np.transpose(ints.tmp94, (0, 2, 1, 3)) * -1
     del ints.tmp94
     r2new.bbb = einsum(tmp73, (0, 1, 2), ints.tmp243, (1, 2, 3, 4), (4, 3, 0)) * -2
     del ints.tmp243, tmp73
     r2new.bbb += einsum(ints.tmp430, (0, 1, 2, 3), r2.bbb, (3, 2, 4), (1, 0, 4)) * -2
     del ints.tmp430
-    r2new.bbb += tmp80.transpose((1, 2, 0))
-    r2new.bbb += tmp80.transpose((2, 1, 0)) * -1
+    r2new.bbb += np.transpose(tmp80, (1, 2, 0))
+    r2new.bbb += np.transpose(tmp80, (2, 1, 0)) * -1
     del tmp80
-    r2new.bbb += tmp86.transpose((1, 2, 0)) * -1
-    r2new.bbb += tmp86.transpose((2, 1, 0))
+    r2new.bbb += np.transpose(tmp86, (1, 2, 0)) * -1
+    r2new.bbb += np.transpose(tmp86, (2, 1, 0))
     del tmp86
     r2new.bbb += einsum(tmp72, (0, 1), r2.bbb, (2, 3, 0), (2, 3, 1)) * -2
     r2new.bab = einsum(ints.tmp312, (0, 1, 2, 3), r2.aaa, (4, 2, 0), (3, 4, 1)) * 2
@@ -5345,11 +5345,11 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp365
     r2new.aaa += einsum(tmp37, (0, 1, 2), ints.tmp44, (2, 1, 3, 4), (4, 3, 0)) * 2
     del ints.tmp44, tmp37
-    r2new.aaa += tmp49.transpose((1, 2, 0))
-    r2new.aaa += tmp49.transpose((2, 1, 0)) * -1
+    r2new.aaa += np.transpose(tmp49, (1, 2, 0))
+    r2new.aaa += np.transpose(tmp49, (2, 1, 0)) * -1
     del tmp49
-    r2new.aaa += tmp54.transpose((1, 2, 0)) * -1
-    r2new.aaa += tmp54.transpose((2, 1, 0))
+    r2new.aaa += np.transpose(tmp54, (1, 2, 0)) * -1
+    r2new.aaa += np.transpose(tmp54, (2, 1, 0))
     del tmp54
     r2new.aaa += einsum(r2.aaa, (0, 1, 2), tmp55, (2, 3), (0, 1, 3)) * -2
     del tmp55

--- a/ebcc/codegen/UDFCCD.py
+++ b/ebcc/codegen/UDFCCD.py
@@ -66,35 +66,35 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     t2new = Namespace()
     tmp17 = einsum(v.bbb.xov, (0, 1, 2), v.bbb.xov, (0, 3, 4), (3, 1, 4, 2))
     tmp10 = einsum(v.baa.xov, (0, 1, 2), v.baa.xov, (0, 3, 4), (1, 3, 2, 4))
-    tmp18 = tmp17.transpose((1, 0, 2, 3)).copy() * -1
-    tmp18 += tmp17.transpose((1, 0, 3, 2))
+    tmp18 = np.copy(np.transpose(tmp17, (1, 0, 2, 3))) * -1
+    tmp18 += np.transpose(tmp17, (1, 0, 3, 2))
     tmp30 = einsum(v.bbb.xov, (0, 1, 2), t2.bbbb, (3, 1, 4, 2), (0, 3, 4))
     tmp29 = einsum(t2.abab, (0, 1, 2, 3), v.baa.xov, (4, 0, 2), (4, 1, 3))
     tmp3 = einsum(t2.aaaa, (0, 1, 2, 3), v.baa.xov, (4, 1, 3), (4, 0, 2))
     tmp4 = einsum(t2.abab, (0, 1, 2, 3), v.bbb.xov, (4, 1, 3), (4, 0, 2))
-    tmp13 = tmp10.transpose((1, 0, 2, 3)).copy()
-    tmp13 += tmp10.transpose((1, 0, 3, 2)) * -1
+    tmp13 = np.copy(np.transpose(tmp10, (1, 0, 2, 3)))
+    tmp13 += np.transpose(tmp10, (1, 0, 3, 2)) * -1
     tmp52 = einsum(tmp18, (0, 1, 2, 3), t2.bbbb, (4, 0, 5, 2), (1, 4, 3, 5))
     tmp41 = einsum(v.bbb.xoo, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 2, 3, 4))
-    tmp31 = tmp29.copy() * 0.5
+    tmp31 = np.copy(tmp29) * 0.5
     tmp31 += tmp30
-    tmp7 = tmp3.copy() * 2
+    tmp7 = np.copy(tmp3) * 2
     tmp7 += tmp4
-    tmp5 = tmp3.copy() * 2
+    tmp5 = np.copy(tmp3) * 2
     tmp5 += tmp4
     tmp14 = einsum(t2.aaaa, (0, 1, 2, 3), tmp13, (1, 4, 5, 3), (4, 0, 5, 2))
     tmp12 = einsum(v.baa.xoo, (0, 1, 2), v.baa.xvv, (0, 3, 4), (1, 2, 3, 4))
     tmp47 = einsum(v.bbb.xoo, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (3, 1, 2, 4))
     tmp59 = einsum(t2.bbbb, (0, 1, 2, 3), tmp17, (4, 5, 3, 2), (0, 1, 5, 4))
-    tmp53 = tmp41.transpose((1, 0, 3, 2)).copy()
-    tmp53 += tmp52.transpose((1, 0, 3, 2)) * -2
+    tmp53 = np.copy(np.transpose(tmp41, (1, 0, 3, 2)))
+    tmp53 += np.transpose(tmp52, (1, 0, 3, 2)) * -2
     del tmp52
     tmp45 = einsum(tmp31, (0, 1, 2), v.bbb.xov, (0, 3, 2), (1, 3))
-    tmp33 = tmp29.copy()
+    tmp33 = np.copy(tmp29)
     tmp33 += tmp30 * 2
     tmp55 = einsum(tmp13, (0, 1, 2, 3), t2.abab, (0, 4, 3, 5), (1, 4, 2, 5))
     del tmp13
-    tmp34 = tmp3.copy()
+    tmp34 = np.copy(tmp3)
     tmp34 += tmp4 * 0.5
     tmp27 = einsum(v.baa.xoo, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (1, 2, 3, 4))
     tmp8 = einsum(v.baa.xov, (0, 1, 2), tmp7, (0, 3, 4), (1, 3, 2, 4))
@@ -104,15 +104,15 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp19 = einsum(t2.abab, (0, 1, 2, 3), tmp18, (1, 4, 5, 3), (0, 4, 2, 5))
     del tmp18
     tmp25 = einsum(v.baa.xov, (0, 1, 2), tmp5, (0, 3, 2), (1, 3))
-    tmp15 = tmp12.transpose((1, 0, 3, 2)).copy()
-    tmp15 += tmp14.transpose((1, 0, 3, 2)) * -2
+    tmp15 = np.copy(np.transpose(tmp12, (1, 0, 3, 2)))
+    tmp15 += np.transpose(tmp14, (1, 0, 3, 2)) * -2
     del tmp14
     tmp6 = einsum(v.baa.xov, (0, 1, 2), tmp5, (0, 1, 3), (2, 3)) * 0.5
     del tmp5
     tmp23 = einsum(tmp10, (0, 1, 2, 3), t2.aaaa, (4, 5, 3, 2), (4, 5, 1, 0))
     tmp0 = einsum(v.baa.xoo, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 1, 2, 4))
     tmp57 = einsum(t2.bbbb, (0, 1, 2, 3), tmp41, (4, 1, 5, 3), (0, 4, 2, 5))
-    tmp50 = f.bb.vv.copy() * -0.5
+    tmp50 = np.copy(f.bb.vv) * -0.5
     tmp50 += einsum(tmp31, (0, 1, 2), v.bbb.xov, (0, 1, 3), (2, 3))
     tmp48 = einsum(tmp47, (0, 1, 2, 3), t2.bbbb, (1, 3, 4, 5), (2, 0, 4, 5))
     del tmp47
@@ -130,12 +130,12 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp58 = einsum(v.bbb.xvv, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (3, 1, 2, 4))
     tmp56 = einsum(t2.abab, (0, 1, 2, 3), tmp55, (0, 4, 2, 5), (4, 1, 5, 3))
     del tmp55
-    tmp35 = f.aa.vv.copy() * -0.5
+    tmp35 = np.copy(f.aa.vv) * -0.5
     tmp35 += einsum(tmp34, (0, 1, 2), v.baa.xov, (0, 1, 3), (3, 2))
     del tmp34
     tmp28 = einsum(t2.abab, (0, 1, 2, 3), tmp27, (4, 0, 5, 1), (4, 5, 2, 3))
     del tmp27
-    tmp38 = tmp12.transpose((1, 0, 3, 2)).copy()
+    tmp38 = np.copy(np.transpose(tmp12, (1, 0, 3, 2)))
     tmp38 += einsum(tmp10, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 2), (0, 4, 3, 5)) * 2
     tmp38 += tmp8 * -1
     tmp37 = einsum(v.baa.xvv, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (3, 4, 1, 2))
@@ -154,51 +154,51 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp22 = einsum(v.baa.xvv, (0, 1, 2), v.baa.xvv, (0, 3, 4), (3, 1, 2, 4))
     tmp16 = einsum(t2.aaaa, (0, 1, 2, 3), tmp15, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp15
-    tmp9 = f.aa.vv.copy() * -0.5
-    tmp9 += tmp6.transpose((1, 0))
+    tmp9 = np.copy(f.aa.vv) * -0.5
+    tmp9 += np.transpose(tmp6, (1, 0))
     tmp24 = einsum(t2.aaaa, (0, 1, 2, 3), tmp23, (4, 5, 0, 1), (5, 4, 2, 3)) * -1
     del tmp23
     tmp21 = einsum(tmp12, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp12
     tmp1 = einsum(t2.aaaa, (0, 1, 2, 3), tmp0, (4, 0, 5, 1), (5, 4, 2, 3))
     del tmp0
-    t2new.bbbb = tmp46.transpose((1, 0, 3, 2)).copy() * 2
-    t2new.bbbb += tmp48.transpose((0, 1, 3, 2)) * -2
+    t2new.bbbb = np.copy(np.transpose(tmp46, (1, 0, 3, 2))) * 2
+    t2new.bbbb += np.transpose(tmp48, (0, 1, 3, 2)) * -2
     del tmp48
-    t2new.bbbb += tmp46.transpose((0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp46, (0, 1, 3, 2)) * -2
     del tmp46
     t2new.bbbb += einsum(tmp32, (0, 1), t2.bbbb, (2, 3, 4, 1), (2, 3, 4, 0)) * -2
-    t2new.bbbb += tmp49.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp49, (1, 0, 3, 2))
     t2new.bbbb += einsum(tmp50, (0, 1), t2.bbbb, (2, 3, 4, 1), (2, 3, 0, 4)) * 4
     del tmp50
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), f.bb.vv, (4, 3), (0, 1, 2, 4)) * 2
-    t2new.bbbb += tmp49.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp17.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp17.transpose((1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp49, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp17, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp17, (1, 0, 2, 3)) * -1
     del tmp17
-    t2new.bbbb += tmp49.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp51.transpose((0, 1, 3, 2)) * -2
-    t2new.bbbb += tmp51.transpose((1, 0, 2, 3)) * -2
-    t2new.bbbb += tmp54.transpose((0, 1, 3, 2)) * 2
-    t2new.bbbb += tmp56.transpose((1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp49, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp51, (0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp51, (1, 0, 2, 3)) * -2
+    t2new.bbbb += np.transpose(tmp54, (0, 1, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp56, (1, 0, 2, 3)) * -1
     t2new.bbbb += tmp51 * 2
-    t2new.bbbb += tmp51.transpose((1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp51, (1, 0, 3, 2)) * 2
     del tmp51
-    t2new.bbbb += tmp54.transpose((1, 0, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp54, (1, 0, 3, 2)) * -2
     del tmp54
     t2new.bbbb += tmp56
     del tmp56
     t2new.bbbb += tmp49
     del tmp49
     t2new.bbbb += tmp57 * -2
-    t2new.bbbb += tmp57.transpose((1, 0, 2, 3)) * 2
+    t2new.bbbb += np.transpose(tmp57, (1, 0, 2, 3)) * 2
     del tmp57
     t2new.bbbb += einsum(tmp58, (0, 1, 2, 3), t2.bbbb, (4, 5, 1, 3), (4, 5, 0, 2)) * -2
     del tmp58
     t2new.bbbb += tmp60 * 2
     del tmp60
-    t2new.bbbb += tmp61.transpose((0, 1, 3, 2)) * -2
-    t2new.bbbb += tmp61.transpose((1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp61, (0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp61, (1, 0, 3, 2)) * 2
     del tmp61
     t2new.abab = einsum(t2.abab, (0, 1, 2, 3), f.bb.oo, (4, 1), (0, 4, 2, 3)) * -1
     t2new.abab += tmp28
@@ -233,10 +233,10 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     del tmp45
     t2new.abab += einsum(tmp25, (0, 1), t2.abab, (0, 2, 3, 4), (1, 2, 3, 4)) * -1
     del tmp25
-    t2new.aaaa = tmp1.transpose((0, 1, 3, 2)).copy() * -2
+    t2new.aaaa = np.copy(np.transpose(tmp1, (0, 1, 3, 2))) * -2
     del tmp1
-    t2new.aaaa += tmp2.transpose((1, 0, 3, 2)) * 2
-    t2new.aaaa += tmp2.transpose((0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp2, (1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp2, (0, 1, 3, 2)) * -2
     del tmp2
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp6, (3, 4), (0, 1, 2, 4)) * -4
     del tmp6
@@ -244,33 +244,33 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     t2new.aaaa += einsum(tmp9, (0, 1), t2.aaaa, (2, 3, 4, 1), (2, 3, 0, 4)) * 4
     del tmp9
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), f.aa.vv, (4, 3), (0, 1, 2, 4)) * 2
-    t2new.aaaa += tmp8.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp10.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp10.transpose((1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp8, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp10, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp10, (1, 0, 2, 3)) * -1
     del tmp10
-    t2new.aaaa += tmp8.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp11.transpose((0, 1, 3, 2)) * -2
-    t2new.aaaa += tmp11.transpose((1, 0, 2, 3)) * -2
-    t2new.aaaa += tmp16.transpose((1, 0, 2, 3)) * 2
-    t2new.aaaa += tmp20.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp8, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp11, (0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp11, (1, 0, 2, 3)) * -2
+    t2new.aaaa += np.transpose(tmp16, (1, 0, 2, 3)) * 2
+    t2new.aaaa += np.transpose(tmp20, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp11 * 2
-    t2new.aaaa += tmp11.transpose((1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp11, (1, 0, 3, 2)) * 2
     del tmp11
     t2new.aaaa += tmp16 * -2
     del tmp16
     t2new.aaaa += tmp20
     del tmp20
-    t2new.aaaa += tmp8.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp8, (1, 0, 3, 2))
     del tmp8
     t2new.aaaa += tmp21 * -2
-    t2new.aaaa += tmp21.transpose((1, 0, 2, 3)) * 2
+    t2new.aaaa += np.transpose(tmp21, (1, 0, 2, 3)) * 2
     del tmp21
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp22, (4, 2, 5, 3), (0, 1, 4, 5)) * -2
     del tmp22
     t2new.aaaa += tmp24 * 2
     del tmp24
-    t2new.aaaa += tmp26.transpose((1, 0, 3, 2)) * -2
-    t2new.aaaa += tmp26.transpose((0, 1, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp26, (1, 0, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp26, (0, 1, 3, 2)) * 2
     del tmp26
 
     return {f"t2new": t2new}
@@ -308,27 +308,27 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp1 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 3, 4, 1), (0, 4))
     tmp74 = einsum(t2.bbbb, (0, 1, 2, 3), l2.bbbb, (2, 3, 4, 1), (4, 0))
     tmp73 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 3, 0, 4), (4, 1))
-    tmp54 = tmp11.copy() * 0.5
+    tmp54 = np.copy(tmp11) * 0.5
     tmp54 += tmp12
-    tmp50 = tmp48.copy()
+    tmp50 = np.copy(tmp48)
     del tmp48
     tmp50 += tmp49 * 2
     del tmp49
-    tmp33 = v.bbb.xov.copy()
+    tmp33 = np.copy(v.bbb.xov)
     tmp33 += tmp11
     tmp33 += tmp12 * 2
-    tmp31 = v.baa.xov.copy()
+    tmp31 = np.copy(v.baa.xov)
     tmp31 += tmp8 * 2
     tmp31 += tmp9
     tmp42 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 3, 0, 1), (2, 4))
     tmp41 = einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (4, 3, 0, 1), (2, 4))
-    tmp2 = tmp0.copy()
+    tmp2 = np.copy(tmp0)
     del tmp0
     tmp2 += tmp1 * 0.5
     del tmp1
-    tmp15 = tmp8.copy() * 2
+    tmp15 = np.copy(tmp8) * 2
     tmp15 += tmp9
-    tmp75 = tmp73.copy() * 0.5
+    tmp75 = np.copy(tmp73) * 0.5
     del tmp73
     tmp75 += tmp74
     del tmp74
@@ -337,12 +337,12 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     del tmp54
     tmp96 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 4, 0, 5), (5, 1, 4, 3))
     tmp97 = einsum(t2.bbbb, (0, 1, 2, 3), l2.bbbb, (4, 3, 5, 1), (5, 0, 4, 2))
-    tmp10 = v.baa.xov.copy() * 0.5
+    tmp10 = np.copy(v.baa.xov) * 0.5
     tmp10 += tmp8
     del tmp8
     tmp10 += tmp9 * 0.5
     del tmp9
-    tmp13 = v.bbb.xov.copy()
+    tmp13 = np.copy(v.bbb.xov)
     tmp13 += tmp11
     del tmp11
     tmp13 += tmp12 * 2
@@ -350,7 +350,7 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp51 = einsum(tmp50, (0, 1), v.bbb.xov, (2, 3, 1), (2, 3, 0))
     tmp93 = einsum(l2.bbbb, (0, 1, 2, 3), tmp33, (4, 3, 1), (4, 2, 0))
     tmp92 = einsum(l2.abab, (0, 1, 2, 3), tmp31, (4, 2, 0), (4, 3, 1))
-    tmp43 = tmp41.copy() * 2
+    tmp43 = np.copy(tmp41) * 2
     del tmp41
     tmp43 += tmp42
     del tmp42
@@ -365,15 +365,15 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp100 = einsum(v.bbb.xov, (0, 1, 2), tmp75, (3, 1), (0, 3, 2))
     tmp86 = einsum(t2.bbbb, (0, 1, 2, 3), l2.bbbb, (2, 3, 4, 5), (4, 5, 0, 1))
     tmp79 = einsum(v.bbb.xov, (0, 1, 2), v.bbb.xov, (0, 3, 4), (3, 1, 4, 2))
-    tmp56 = f.bb.oo.copy()
-    tmp56 += tmp55.transpose((1, 0))
+    tmp56 = np.copy(f.bb.oo)
+    tmp56 += np.transpose(tmp55, (1, 0))
     del tmp55
     tmp90 = einsum(tmp50, (0, 1), v.bbb.xov, (2, 3, 1), (2, 3, 0)) * 0.5
     del tmp50
-    tmp67 = f.bb.vv.copy() * -1
-    tmp67 += tmp66.transpose((1, 0))
+    tmp67 = np.copy(f.bb.vv) * -1
+    tmp67 += np.transpose(tmp66, (1, 0))
     del tmp66
-    tmp98 = tmp96.copy()
+    tmp98 = np.copy(tmp96)
     del tmp96
     tmp98 += tmp97 * 4
     del tmp97
@@ -381,10 +381,10 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp57 = einsum(tmp10, (0, 1, 2), l2.abab, (2, 3, 1, 4), (0, 4, 3))
     tmp58 = einsum(l2.bbbb, (0, 1, 2, 3), tmp13, (4, 3, 1), (4, 2, 0))
     tmp69 = einsum(v.bbb.xoo, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 2, 3, 4))
-    tmp52 = v.bbb.xov.copy()
+    tmp52 = np.copy(v.bbb.xov)
     tmp52 += tmp51 * -1
     del tmp51
-    tmp94 = tmp92.copy()
+    tmp94 = np.copy(tmp92)
     del tmp92
     tmp94 += tmp93 * 2
     del tmp93
@@ -400,21 +400,21 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp6 = einsum(v.baa.xoo, (0, 1, 2), v.baa.xvv, (0, 3, 4), (1, 2, 3, 4))
     tmp20 = einsum(v.baa.xov, (0, 1, 2), v.baa.xov, (0, 3, 4), (1, 3, 2, 4))
     tmp21 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (2, 3, 4, 5), (4, 5, 0, 1))
-    tmp4 = v.baa.xov.copy() * 0.5
+    tmp4 = np.copy(v.baa.xov) * 0.5
     tmp4 += tmp3 * -1
     del tmp3
     tmp46 = einsum(tmp43, (0, 1), v.baa.xov, (2, 1, 3), (2, 0, 3)) * 0.5
     del tmp43
-    tmp35 = tmp32.copy() * 2
+    tmp35 = np.copy(tmp32) * 2
     del tmp32
     tmp35 += tmp34
     del tmp34
-    tmp39 = tmp37.copy() * 4
+    tmp39 = np.copy(tmp37) * 4
     del tmp37
     tmp39 += tmp38
     del tmp38
     tmp23 = einsum(v.baa.xvv, (0, 1, 2), v.baa.xvv, (0, 3, 4), (3, 1, 2, 4))
-    tmp26 = f.aa.vv.copy() * -0.5
+    tmp26 = np.copy(f.aa.vv) * -0.5
     tmp26 += tmp25
     del tmp25
     tmp101 = einsum(tmp100, (0, 1, 2), v.bbb.xov, (0, 3, 4), (3, 1, 4, 2)) * -2
@@ -433,7 +433,7 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     del tmp98
     tmp85 = einsum(l2.bbbb, (0, 1, 2, 3), tmp84, (4, 0, 5, 1), (2, 3, 5, 4))
     del tmp84
-    tmp59 = tmp57.copy()
+    tmp59 = np.copy(tmp57)
     del tmp57
     tmp59 += tmp58
     del tmp58
@@ -444,7 +444,7 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp102 = einsum(tmp76, (0, 1, 2), v.bbb.xov, (0, 3, 4), (3, 1, 4, 2)) * -1
     tmp53 = einsum(v.bbb.xoo, (0, 1, 2), v.baa.xvv, (0, 3, 4), (1, 2, 3, 4))
     tmp70 = einsum(v.baa.xoo, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 2, 3, 4))
-    tmp17 = f.aa.oo.copy() * 0.5
+    tmp17 = np.copy(f.aa.oo) * 0.5
     tmp17 += tmp16
     del tmp16
     tmp77 = einsum(t2.aaaa, (0, 1, 2, 3), l2.abab, (3, 4, 1, 5), (0, 5, 2, 4))
@@ -452,7 +452,7 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp72 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 4, 5, 1), (3, 4, 0, 5))
     tmp62 = einsum(tmp61, (0, 1, 2, 3), tmp60, (1, 3, 4, 5), (0, 2, 4, 5))
     del tmp61
-    tmp65 = f.aa.vv.copy() * -1
+    tmp65 = np.copy(f.aa.vv) * -1
     tmp65 += einsum(tmp15, (0, 1, 2), v.baa.xov, (0, 1, 3), (2, 3))
     tmp71 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 3, 0, 5), (2, 4, 1, 5))
     tmp68 = einsum(v.bbb.xoo, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 4, 1, 2))
@@ -466,7 +466,7 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     tmp18 = einsum(l2.aaaa, (0, 1, 2, 3), tmp10, (4, 3, 1), (4, 2, 0)) * 4
     tmp18 += einsum(l2.abab, (0, 1, 2, 3), tmp13, (4, 3, 1), (4, 2, 0))
     tmp7 = einsum(tmp6, (0, 1, 2, 3), l2.aaaa, (4, 3, 5, 1), (5, 0, 4, 2))
-    tmp19 = f.aa.oo.copy()
+    tmp19 = np.copy(f.aa.oo)
     tmp19 += einsum(v.baa.xov, (0, 1, 2), tmp15, (0, 3, 2), (3, 1))
     del tmp15
     tmp22 = einsum(tmp21, (0, 1, 2, 3), tmp20, (2, 3, 4, 5), (0, 1, 4, 5))
@@ -488,45 +488,45 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     del tmp13
     tmp27 = einsum(l2.aaaa, (0, 1, 2, 3), tmp26, (1, 4), (2, 3, 4, 0)) * -2
     del tmp26
-    l2new.bbbb = tmp80.transpose((2, 3, 0, 1)).copy()
-    l2new.bbbb += tmp80.transpose((3, 2, 0, 1)) * -1
+    l2new.bbbb = np.copy(np.transpose(tmp80, (2, 3, 0, 1)))
+    l2new.bbbb += np.transpose(tmp80, (3, 2, 0, 1)) * -1
     del tmp80
-    l2new.bbbb += tmp81.transpose((3, 2, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp81, (3, 2, 0, 1)) * 2
     l2new.bbbb += einsum(v.bbb.xov, (0, 1, 2), tmp82, (0, 3, 4), (2, 4, 3, 1)) * -1
     del tmp82
-    l2new.bbbb += tmp83.transpose((3, 2, 0, 1)) * -1
-    l2new.bbbb += tmp81.transpose((3, 2, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp83, (3, 2, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp81, (3, 2, 1, 0)) * -2
     l2new.bbbb += einsum(tmp59, (0, 1, 2), v.bbb.xov, (0, 3, 4), (4, 2, 3, 1)) * 2
-    l2new.bbbb += tmp83.transpose((3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp83, (3, 2, 1, 0))
     del tmp83
-    l2new.bbbb += tmp85.transpose((2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp85, (2, 3, 1, 0)) * -2
     del tmp85
-    l2new.bbbb += tmp87.transpose((3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp87, (3, 2, 1, 0)) * 2
     del tmp87
-    l2new.bbbb += tmp88.transpose((3, 2, 1, 0)) * 2
-    l2new.bbbb += tmp88.transpose((2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp88, (3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp88, (2, 3, 1, 0)) * -2
     del tmp88
     l2new.bbbb += einsum(l2.bbbb, (0, 1, 2, 3), tmp89, (2, 3, 4, 5), (0, 1, 5, 4)) * 2
     del tmp89
-    l2new.bbbb += tmp91.transpose((2, 3, 1, 0)) * -1
-    l2new.bbbb += tmp81.transpose((2, 3, 0, 1)) * -2
-    l2new.bbbb += tmp95.transpose((3, 2, 1, 0))
-    l2new.bbbb += tmp81.transpose((2, 3, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp91, (2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp81, (2, 3, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp95, (3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp81, (2, 3, 1, 0)) * 2
     del tmp81
-    l2new.bbbb += tmp95.transpose((3, 2, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp95, (3, 2, 0, 1)) * -1
     del tmp95
-    l2new.bbbb += tmp99.transpose((3, 2, 0, 1))
-    l2new.bbbb += tmp101.transpose((3, 2, 1, 0))
-    l2new.bbbb += tmp99.transpose((2, 3, 0, 1)) * -1
-    l2new.bbbb += tmp101.transpose((2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp99, (3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp101, (3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp99, (2, 3, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp101, (2, 3, 1, 0)) * -1
     del tmp101
-    l2new.bbbb += tmp99.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += tmp102.transpose((3, 2, 0, 1)) * -1
-    l2new.bbbb += tmp99.transpose((2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp99, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp102, (3, 2, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp99, (2, 3, 1, 0))
     del tmp99
-    l2new.bbbb += tmp102.transpose((2, 3, 0, 1))
+    l2new.bbbb += np.transpose(tmp102, (2, 3, 0, 1))
     del tmp102
-    l2new.bbbb += tmp91.transpose((3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp91, (3, 2, 1, 0))
     del tmp91
     l2new.abab = einsum(tmp52, (0, 1, 2), v.baa.xov, (0, 3, 4), (4, 2, 3, 1))
     del tmp52
@@ -539,9 +539,9 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     l2new.abab += einsum(tmp59, (0, 1, 2), v.baa.xov, (0, 3, 4), (4, 2, 3, 1)) * 2
     del tmp59
     l2new.abab += einsum(tmp17, (0, 1), l2.abab, (2, 3, 0, 4), (2, 3, 1, 4)) * -2
-    l2new.abab += tmp62.transpose((2, 3, 0, 1))
+    l2new.abab += np.transpose(tmp62, (2, 3, 0, 1))
     del tmp62
-    l2new.abab += tmp64.transpose((2, 3, 0, 1))
+    l2new.abab += np.transpose(tmp64, (2, 3, 0, 1))
     del tmp64
     l2new.abab += einsum(tmp65, (0, 1), l2.abab, (0, 2, 3, 4), (1, 2, 3, 4)) * -1
     del tmp65
@@ -569,47 +569,47 @@ def update_lams(f=None, l2=None, t2=None, v=None, **kwargs):
     del tmp20, tmp77
     l2new.abab += einsum(tmp78, (0, 1, 2, 3), tmp79, (1, 4, 5, 3), (2, 5, 0, 4)) * -2
     del tmp79, tmp78
-    l2new.aaaa = tmp5.transpose((3, 2, 1, 0)).copy()
-    l2new.aaaa += tmp5.transpose((2, 3, 1, 0)) * -1
+    l2new.aaaa = np.copy(np.transpose(tmp5, (3, 2, 1, 0)))
+    l2new.aaaa += np.transpose(tmp5, (2, 3, 1, 0)) * -1
     del tmp5
-    l2new.aaaa += tmp7.transpose((3, 2, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp7, (3, 2, 0, 1)) * 2
     l2new.aaaa += einsum(v.baa.xov, (0, 1, 2), tmp14, (0, 3, 4), (2, 4, 3, 1)) * -2
     del tmp14
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp17, (3, 4), (0, 1, 2, 4)) * -4
     del tmp17
-    l2new.aaaa += tmp7.transpose((3, 2, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp7, (3, 2, 1, 0)) * -2
     l2new.aaaa += einsum(tmp18, (0, 1, 2), v.baa.xov, (0, 3, 4), (4, 2, 3, 1))
     del tmp18
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp19, (3, 4), (0, 1, 4, 2)) * 2
     del tmp19
-    l2new.aaaa += tmp22.transpose((3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp22, (3, 2, 1, 0)) * 2
     del tmp22
-    l2new.aaaa += tmp24.transpose((2, 3, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp24, (2, 3, 1, 0)) * -2
     del tmp24
-    l2new.aaaa += tmp27.transpose((2, 3, 1, 0)) * 2
-    l2new.aaaa += tmp27.transpose((3, 2, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp27, (2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp27, (3, 2, 1, 0)) * -2
     del tmp27
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp28, (2, 3, 4, 5), (0, 1, 5, 4)) * 2
     del tmp28
-    l2new.aaaa += tmp30.transpose((3, 2, 0, 1)) * -1
-    l2new.aaaa += tmp7.transpose((2, 3, 0, 1)) * -2
-    l2new.aaaa += tmp36.transpose((2, 3, 0, 1))
-    l2new.aaaa += tmp7.transpose((2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp30, (3, 2, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp7, (2, 3, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp36, (2, 3, 0, 1))
+    l2new.aaaa += np.transpose(tmp7, (2, 3, 1, 0)) * 2
     del tmp7
-    l2new.aaaa += tmp36.transpose((2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp36, (2, 3, 1, 0)) * -1
     del tmp36
-    l2new.aaaa += tmp40.transpose((3, 2, 0, 1))
-    l2new.aaaa += tmp45.transpose((2, 3, 0, 1))
-    l2new.aaaa += tmp40.transpose((2, 3, 0, 1)) * -1
-    l2new.aaaa += tmp45.transpose((3, 2, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp40, (3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp45, (2, 3, 0, 1))
+    l2new.aaaa += np.transpose(tmp40, (2, 3, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp45, (3, 2, 0, 1)) * -1
     del tmp45
-    l2new.aaaa += tmp40.transpose((3, 2, 1, 0)) * -1
-    l2new.aaaa += tmp47.transpose((2, 3, 1, 0)) * -1
-    l2new.aaaa += tmp40.transpose((2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp40, (3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp47, (2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp40, (2, 3, 1, 0))
     del tmp40
-    l2new.aaaa += tmp47.transpose((3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp47, (3, 2, 1, 0))
     del tmp47
-    l2new.aaaa += tmp30.transpose((2, 3, 0, 1))
+    l2new.aaaa += np.transpose(tmp30, (2, 3, 0, 1))
     del tmp30
 
     return {f"l2new": l2new}
@@ -691,7 +691,7 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     tmp25 = einsum(l2.bbbb, (0, 1, 2, 3), t2.bbbb, (2, 3, 4, 1), (0, 4))
     tmp12 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (4, 3, 0, 1), (4, 2))
     tmp13 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 3, 4, 1), (0, 4))
-    tmp32 = tmp5.copy() * 0.5
+    tmp32 = np.copy(tmp5) * 0.5
     tmp32 += tmp6
     tmp35 = einsum(t2.abab, (0, 1, 2, 3), l2.aaaa, (4, 2, 5, 0), (5, 1, 4, 3))
     tmp39 = einsum(t2.bbbb, (0, 1, 2, 3), l2.abab, (4, 3, 5, 1), (5, 0, 4, 2))
@@ -701,22 +701,22 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     tmp29 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 3, 5, 1), (2, 4, 0, 5))
     tmp21 = einsum(t2.aaaa, (0, 1, 2, 3), l2.abab, (3, 4, 1, 5), (0, 5, 2, 4))
     tmp19 = einsum(t2.abab, (0, 1, 2, 3), l2.bbbb, (4, 3, 5, 1), (0, 5, 2, 4))
-    tmp8 = tmp0.copy()
+    tmp8 = np.copy(tmp0)
     tmp8 += tmp1 * 0.5
     tmp4 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (2, 3, 4, 5), (4, 5, 0, 1))
     tmp43 = einsum(l2.bbbb, (0, 1, 2, 3), t2.bbbb, (2, 3, 4, 5), (0, 1, 4, 5))
     tmp42 = einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (2, 3, 4, 5), (0, 1, 4, 5))
-    tmp31 = tmp24.copy()
+    tmp31 = np.copy(tmp24)
     tmp31 += tmp25 * 2
     tmp41 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 4, 0, 5), (5, 1, 4, 3))
-    tmp23 = tmp12.copy()
+    tmp23 = np.copy(tmp12)
     tmp23 += tmp13 * 0.5
     tmp27 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 4, 5, 1), (3, 4, 0, 5))
-    tmp14 = tmp12.copy() * 2
+    tmp14 = np.copy(tmp12) * 2
     del tmp12
     tmp14 += tmp13
     del tmp13
-    tmp26 = tmp24.copy() * 0.5
+    tmp26 = np.copy(tmp24) * 0.5
     del tmp24
     tmp26 += tmp25
     del tmp25
@@ -726,99 +726,99 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     tmp40 = einsum(t2.abab, (0, 1, 2, 3), tmp39, (0, 4, 2, 5), (1, 4, 3, 5))
     tmp38 = einsum(tmp37, (0, 1, 2, 3), t2.bbbb, (4, 0, 5, 2), (1, 4, 3, 5))
     tmp34 = einsum(tmp11, (0, 1, 2, 3), t2.bbbb, (1, 0, 4, 5), (3, 2, 4, 5))
-    tmp30 = tmp17.copy() * 4
+    tmp30 = np.copy(tmp17) * 4
     tmp30 += tmp29
-    tmp10 = tmp5.copy()
+    tmp10 = np.copy(tmp5)
     tmp10 += tmp6 * 2
-    tmp28 = tmp21.copy()
+    tmp28 = np.copy(tmp21)
     tmp28 += tmp19
     tmp9 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 3, 4, 5), (4, 0, 5, 1))
-    tmp3 = tmp0.copy() * 2
+    tmp3 = np.copy(tmp0) * 2
     tmp3 += tmp1
     tmp18 = einsum(t2.aaaa, (0, 1, 2, 3), tmp17, (1, 4, 3, 5), (0, 4, 2, 5))
     tmp15 = einsum(t2.aaaa, (0, 1, 2, 3), tmp8, (1, 4), (0, 4, 2, 3)) * -2
     tmp20 = einsum(t2.abab, (0, 1, 2, 3), tmp19, (4, 1, 5, 3), (4, 0, 5, 2))
     tmp22 = einsum(tmp21, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (0, 4, 2, 5))
     tmp16 = einsum(t2.aaaa, (0, 1, 2, 3), tmp4, (1, 0, 4, 5), (5, 4, 2, 3))
-    tmp7 = delta.bb.oo.copy() * -1
+    tmp7 = np.copy(delta.bb.oo) * -1
     tmp7 += tmp5
     del tmp5
     tmp7 += tmp6 * 2
     del tmp6
-    tmp2 = delta.aa.oo.copy() * -0.5
+    tmp2 = np.copy(delta.aa.oo) * -0.5
     tmp2 += tmp0
     del tmp0
     tmp2 += tmp1 * 0.5
     del tmp1
-    rdm2.bbbb.vvvv = tmp43.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.bbbb.vvvv = np.copy(np.transpose(tmp43, (1, 0, 3, 2))) * 2
     del tmp43
     rdm2.abab.vvvv = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 3, 4, 5), (0, 1, 4, 5))
-    rdm2.aaaa.vvvv = tmp42.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.aaaa.vvvv = np.copy(np.transpose(tmp42, (1, 0, 3, 2))) * 2
     del tmp42
-    rdm2.bbbb.vvoo = l2.bbbb.copy() * 2
-    rdm2.abab.vvoo = l2.abab.copy()
-    rdm2.aaaa.vvoo = l2.aaaa.copy() * 2
+    rdm2.bbbb.vvoo = np.copy(l2.bbbb) * 2
+    rdm2.abab.vvoo = np.copy(l2.abab)
+    rdm2.aaaa.vvoo = np.copy(l2.aaaa) * 2
     rdm2.bbbb.vovo = einsum(tmp31, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3))
-    rdm2.bbbb.vovo += tmp37.transpose((2, 1, 3, 0)) * -4
-    rdm2.bbbb.vovo += tmp41.transpose((2, 1, 3, 0)) * -1
+    rdm2.bbbb.vovo += np.transpose(tmp37, (2, 1, 3, 0)) * -4
+    rdm2.bbbb.vovo += np.transpose(tmp41, (2, 1, 3, 0)) * -1
     rdm2.abab.vovo = einsum(tmp23, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3)) * 2
-    rdm2.abab.vovo += tmp27.transpose((2, 1, 3, 0)) * -1
+    rdm2.abab.vovo += np.transpose(tmp27, (2, 1, 3, 0)) * -1
     rdm2.aaaa.vovo = einsum(delta.aa.oo, (0, 1), tmp14, (2, 3), (2, 0, 3, 1))
-    rdm2.aaaa.vovo += tmp17.transpose((2, 1, 3, 0)) * -4
-    rdm2.aaaa.vovo += tmp29.transpose((2, 1, 3, 0)) * -1
+    rdm2.aaaa.vovo += np.transpose(tmp17, (2, 1, 3, 0)) * -4
+    rdm2.aaaa.vovo += np.transpose(tmp29, (2, 1, 3, 0)) * -1
     rdm2.bbbb.voov = einsum(tmp26, (0, 1), delta.bb.oo, (2, 3), (0, 2, 3, 1)) * -2
-    rdm2.bbbb.voov += tmp41.transpose((2, 1, 0, 3))
-    rdm2.bbbb.voov += tmp37.transpose((2, 1, 0, 3)) * 4
-    rdm2.abab.voov = tmp39.transpose((2, 1, 0, 3)).copy() * 2
+    rdm2.bbbb.voov += np.transpose(tmp41, (2, 1, 0, 3))
+    rdm2.bbbb.voov += np.transpose(tmp37, (2, 1, 0, 3)) * 4
+    rdm2.abab.voov = np.copy(np.transpose(tmp39, (2, 1, 0, 3))) * 2
     del tmp39
-    rdm2.abab.voov += tmp35.transpose((2, 1, 0, 3)) * 2
+    rdm2.abab.voov += np.transpose(tmp35, (2, 1, 0, 3)) * 2
     del tmp35
     rdm2.aaaa.voov = einsum(tmp23, (0, 1), delta.aa.oo, (2, 3), (0, 2, 3, 1)) * -2
-    rdm2.aaaa.voov += tmp17.transpose((2, 1, 0, 3)) * 4
-    rdm2.aaaa.voov += tmp29.transpose((2, 1, 0, 3))
+    rdm2.aaaa.voov += np.transpose(tmp17, (2, 1, 0, 3)) * 4
+    rdm2.aaaa.voov += np.transpose(tmp29, (2, 1, 0, 3))
     rdm2.bbbb.ovvo = einsum(tmp31, (0, 1), delta.bb.oo, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.bbbb.ovvo += tmp41.transpose((1, 2, 3, 0))
-    rdm2.bbbb.ovvo += tmp37.transpose((1, 2, 3, 0)) * 4
-    rdm2.abab.ovvo = tmp19.transpose((0, 3, 2, 1)).copy() * 2
+    rdm2.bbbb.ovvo += np.transpose(tmp41, (1, 2, 3, 0))
+    rdm2.bbbb.ovvo += np.transpose(tmp37, (1, 2, 3, 0)) * 4
+    rdm2.abab.ovvo = np.copy(np.transpose(tmp19, (0, 3, 2, 1))) * 2
     del tmp19
-    rdm2.abab.ovvo += tmp21.transpose((0, 3, 2, 1)) * 2
+    rdm2.abab.ovvo += np.transpose(tmp21, (0, 3, 2, 1)) * 2
     del tmp21
     rdm2.aaaa.ovvo = einsum(delta.aa.oo, (0, 1), tmp14, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.aaaa.ovvo += tmp17.transpose((1, 2, 3, 0)) * 4
-    rdm2.aaaa.ovvo += tmp29.transpose((1, 2, 3, 0))
+    rdm2.aaaa.ovvo += np.transpose(tmp17, (1, 2, 3, 0)) * 4
+    rdm2.aaaa.ovvo += np.transpose(tmp29, (1, 2, 3, 0))
     rdm2.bbbb.ovov = einsum(tmp26, (0, 1), delta.bb.oo, (2, 3), (2, 0, 3, 1)) * 2
-    rdm2.bbbb.ovov += tmp37.transpose((1, 2, 0, 3)) * -4
+    rdm2.bbbb.ovov += np.transpose(tmp37, (1, 2, 0, 3)) * -4
     del tmp37
-    rdm2.bbbb.ovov += tmp41.transpose((1, 2, 0, 3)) * -1
+    rdm2.bbbb.ovov += np.transpose(tmp41, (1, 2, 0, 3)) * -1
     del tmp41
     rdm2.abab.ovov = einsum(delta.aa.oo, (0, 1), tmp26, (2, 3), (0, 2, 1, 3)) * 2
     rdm2.abab.ovov += einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 4, 5, 1), (0, 4, 5, 3)) * -1
     rdm2.aaaa.ovov = einsum(tmp23, (0, 1), delta.aa.oo, (2, 3), (2, 0, 3, 1)) * 2
-    rdm2.aaaa.ovov += tmp17.transpose((1, 2, 0, 3)) * -4
+    rdm2.aaaa.ovov += np.transpose(tmp17, (1, 2, 0, 3)) * -4
     del tmp17
-    rdm2.aaaa.ovov += tmp29.transpose((1, 2, 0, 3)) * -1
+    rdm2.aaaa.ovov += np.transpose(tmp29, (1, 2, 0, 3)) * -1
     del tmp29
-    rdm2.bbbb.oovv = t2.bbbb.copy() * 2
+    rdm2.bbbb.oovv = np.copy(t2.bbbb) * 2
     rdm2.bbbb.oovv += einsum(tmp31, (0, 1), t2.bbbb, (2, 3, 4, 0), (2, 3, 4, 1)) * -2
     del tmp31
-    rdm2.bbbb.oovv += tmp33.transpose((0, 1, 3, 2)) * 2
-    rdm2.bbbb.oovv += tmp33.transpose((1, 0, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp33, (0, 1, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp33, (1, 0, 3, 2)) * -2
     del tmp33
-    rdm2.bbbb.oovv += tmp34.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp34, (0, 1, 3, 2)) * -2
     del tmp34
-    rdm2.bbbb.oovv += tmp36.transpose((0, 1, 3, 2)) * -2
-    rdm2.bbbb.oovv += tmp38.transpose((0, 1, 3, 2)) * -8
-    rdm2.bbbb.oovv += tmp40.transpose((0, 1, 3, 2)) * -2
-    rdm2.bbbb.oovv += tmp40.transpose((1, 0, 2, 3)) * -2
-    rdm2.bbbb.oovv += tmp36.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp36, (0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp38, (0, 1, 3, 2)) * -8
+    rdm2.bbbb.oovv += np.transpose(tmp40, (0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp40, (1, 0, 2, 3)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp36, (1, 0, 3, 2)) * 2
     del tmp36
     rdm2.bbbb.oovv += tmp38 * 8
     del tmp38
     rdm2.bbbb.oovv += tmp40 * 2
-    rdm2.bbbb.oovv += tmp40.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp40, (1, 0, 3, 2)) * 2
     del tmp40
     rdm2.bbbb.oovv += einsum(tmp26, (0, 1), t2.bbbb, (2, 3, 4, 0), (2, 3, 1, 4)) * 4
-    rdm2.abab.oovv = t2.abab.copy()
+    rdm2.abab.oovv = np.copy(t2.abab)
     rdm2.abab.oovv += einsum(t2.abab, (0, 1, 2, 3), tmp26, (3, 4), (0, 1, 2, 4)) * -2
     del tmp26
     rdm2.abab.oovv += einsum(t2.abab, (0, 1, 2, 3), tmp3, (0, 4), (4, 1, 2, 3)) * -1
@@ -831,24 +831,24 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.abab.oovv += einsum(t2.abab, (0, 1, 2, 3), tmp30, (0, 4, 2, 5), (4, 1, 5, 3))
     del tmp30
     rdm2.abab.oovv += einsum(tmp14, (0, 1), t2.abab, (2, 3, 0, 4), (2, 3, 1, 4)) * -1
-    rdm2.aaaa.oovv = t2.aaaa.copy() * 2
+    rdm2.aaaa.oovv = np.copy(t2.aaaa) * 2
     rdm2.aaaa.oovv += einsum(t2.aaaa, (0, 1, 2, 3), tmp14, (3, 4), (0, 1, 2, 4)) * -2
     del tmp14
-    rdm2.aaaa.oovv += tmp15.transpose((1, 0, 3, 2)) * 2
-    rdm2.aaaa.oovv += tmp15.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp15, (1, 0, 3, 2)) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp15, (0, 1, 3, 2)) * -2
     del tmp15
-    rdm2.aaaa.oovv += tmp16.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp16, (0, 1, 3, 2)) * -2
     del tmp16
-    rdm2.aaaa.oovv += tmp18.transpose((0, 1, 3, 2)) * -8
-    rdm2.aaaa.oovv += tmp20.transpose((0, 1, 3, 2)) * -2
-    rdm2.aaaa.oovv += tmp22.transpose((0, 1, 3, 2)) * -2
-    rdm2.aaaa.oovv += tmp22.transpose((1, 0, 2, 3)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp18, (0, 1, 3, 2)) * -8
+    rdm2.aaaa.oovv += np.transpose(tmp20, (0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp22, (0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp22, (1, 0, 2, 3)) * -2
     rdm2.aaaa.oovv += tmp18 * 8
     del tmp18
     rdm2.aaaa.oovv += tmp20 * 2
     del tmp20
     rdm2.aaaa.oovv += tmp22 * 2
-    rdm2.aaaa.oovv += tmp22.transpose((1, 0, 3, 2)) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp22, (1, 0, 3, 2)) * 2
     del tmp22
     rdm2.aaaa.oovv += einsum(tmp23, (0, 1), t2.aaaa, (2, 3, 4, 0), (2, 3, 1, 4)) * 4
     del tmp23
@@ -857,13 +857,13 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.bbbb.oooo += einsum(tmp10, (0, 1), delta.bb.oo, (2, 3), (1, 2, 0, 3)) * -1
     rdm2.bbbb.oooo += einsum(delta.bb.oo, (0, 1), tmp10, (2, 3), (0, 3, 2, 1))
     del tmp10
-    rdm2.bbbb.oooo += tmp11.transpose((3, 2, 1, 0)) * 2
+    rdm2.bbbb.oooo += np.transpose(tmp11, (3, 2, 1, 0)) * 2
     del tmp11
     rdm2.abab.oooo = einsum(delta.aa.oo, (0, 1), tmp7, (2, 3), (0, 3, 1, 2)) * -1
     del tmp7
     rdm2.abab.oooo += einsum(delta.bb.oo, (0, 1), tmp8, (2, 3), (3, 0, 2, 1)) * -2
     del tmp8
-    rdm2.abab.oooo += tmp9.transpose((1, 3, 0, 2))
+    rdm2.abab.oooo += np.transpose(tmp9, (1, 3, 0, 2))
     del tmp9
     rdm2.aaaa.oooo = einsum(delta.aa.oo, (0, 1), tmp2, (2, 3), (0, 3, 1, 2)) * -2
     rdm2.aaaa.oooo += einsum(tmp2, (0, 1), delta.aa.oo, (2, 3), (1, 2, 3, 0)) * 2
@@ -871,7 +871,7 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.aaaa.oooo += einsum(tmp3, (0, 1), delta.aa.oo, (2, 3), (1, 2, 0, 3)) * -1
     rdm2.aaaa.oooo += einsum(tmp3, (0, 1), delta.aa.oo, (2, 3), (2, 1, 0, 3))
     del delta, tmp3
-    rdm2.aaaa.oooo += tmp4.transpose((3, 2, 1, 0)) * 2
+    rdm2.aaaa.oooo += np.transpose(tmp4, (3, 2, 1, 0)) * 2
     del tmp4
     rdm2.aaaa.ooov = np.zeros((t2.aaaa.shape[0], t2.aaaa.shape[0], t2.aaaa.shape[0], t2.aaaa.shape[-1]))
     rdm2.aaaa.oovo = np.zeros((t2.aaaa.shape[0], t2.aaaa.shape[0], t2.aaaa.shape[-1], t2.aaaa.shape[0]))
@@ -909,9 +909,9 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.abab = pack_2e(rdm2.abab.oooo, rdm2.abab.ooov, rdm2.abab.oovo, rdm2.abab.ovoo, rdm2.abab.vooo, rdm2.abab.oovv, rdm2.abab.ovov, rdm2.abab.ovvo, rdm2.abab.voov, rdm2.abab.vovo, rdm2.abab.vvoo, rdm2.abab.ovvv, rdm2.abab.vovv, rdm2.abab.vvov, rdm2.abab.vvvo, rdm2.abab.vvvv)
     rdm2.bbbb = pack_2e(rdm2.bbbb.oooo, rdm2.bbbb.ooov, rdm2.bbbb.oovo, rdm2.bbbb.ovoo, rdm2.bbbb.vooo, rdm2.bbbb.oovv, rdm2.bbbb.ovov, rdm2.bbbb.ovvo, rdm2.bbbb.voov, rdm2.bbbb.vovo, rdm2.bbbb.vvoo, rdm2.bbbb.ovvv, rdm2.bbbb.vovv, rdm2.bbbb.vvov, rdm2.bbbb.vvvo, rdm2.bbbb.vvvv)
     rdm2 = Namespace(
-        aaaa=rdm2.aaaa.transpose(0, 2, 1, 3),
-        aabb=rdm2.abab.transpose(0, 2, 1, 3),
-        bbbb=rdm2.bbbb.transpose(0, 2, 1, 3),
+        aaaa=np.transpose(rdm2.aaaa, (0, 2, 1, 3)),
+        aabb=np.transpose(rdm2.abab, (0, 2, 1, 3)),
+        bbbb=np.transpose(rdm2.bbbb, (0, 2, 1, 3)),
     )
 
     return rdm2
@@ -1113,40 +1113,40 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp7 = einsum(r2.bab, (0, 1, 2), v.bbb.xov, (3, 0, 2), (3, 1)) * -1
     tmp6 = einsum(r2.aaa, (0, 1, 2), v.baa.xov, (3, 1, 2), (3, 0))
     tmp31 = einsum(v.baa.xov, (0, 1, 2), r2.aba, (1, 3, 2), (0, 3))
-    tmp60 = ints.tmp19.copy()
+    tmp60 = np.copy(ints.tmp19)
     tmp60 += ints.tmp16 * 2
-    tmp39 = ints.tmp139.copy()
+    tmp39 = np.copy(ints.tmp139)
     del ints.tmp139
     tmp39 += ints.tmp121 * 2
     del ints.tmp121
-    tmp62 = ints.tmp159.copy()
+    tmp62 = np.copy(ints.tmp159)
     del ints.tmp159
     tmp62 += ints.tmp157 * 2
     del ints.tmp157
     tmp32 = einsum(v.bbb.xov, (0, 1, 2), r2.bbb, (3, 1, 2), (0, 3))
-    tmp54 = ints.tmp12.copy()
-    tmp54 += ints.tmp155.transpose((0, 2, 1, 3)) * 2
+    tmp54 = np.copy(ints.tmp12)
+    tmp54 += np.transpose(ints.tmp155, (0, 2, 1, 3)) * 2
     del ints.tmp155
-    tmp52 = ints.tmp17.copy() * 2
+    tmp52 = np.copy(ints.tmp17) * 2
     tmp52 += ints.tmp20
-    tmp50 = ints.tmp16.copy()
+    tmp50 = np.copy(ints.tmp16)
     tmp50 += ints.tmp19 * 0.5
-    tmp16 = ints.tmp6.copy() * 2
+    tmp16 = np.copy(ints.tmp6) * 2
     tmp16 += ints.tmp9
-    tmp14 = ints.tmp5.copy()
+    tmp14 = np.copy(ints.tmp5)
     tmp14 += ints.tmp8 * 0.5
-    tmp13 = tmp6.copy() * 2
+    tmp13 = np.copy(tmp6) * 2
     tmp13 += tmp7
-    tmp18 = ints.tmp1.copy()
-    tmp18 += ints.tmp42.transpose((0, 2, 1, 3)) * 2
+    tmp18 = np.copy(ints.tmp1)
+    tmp18 += np.transpose(ints.tmp42, (0, 2, 1, 3)) * 2
     del ints.tmp42
-    tmp10 = ints.tmp46.copy()
+    tmp10 = np.copy(ints.tmp46)
     del ints.tmp46
     tmp10 += ints.tmp44 * 2
     del ints.tmp44
-    tmp4 = ints.tmp69.copy()
+    tmp4 = np.copy(ints.tmp69)
     tmp4 += ints.tmp52 * 2
-    tmp8 = tmp6.copy() * 2
+    tmp8 = np.copy(tmp6) * 2
     tmp8 += tmp7
     tmp35 = einsum(ints.tmp65, (0, 1, 2, 3), r2.aba, (0, 1, 2), (3,))
     tmp36 = einsum(ints.tmp55, (0, 1, 2, 3), r2.bbb, (0, 1, 2), (3,))
@@ -1184,16 +1184,16 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp9 = einsum(tmp8, (0, 1), v.baa.xov, (0, 2, 3), (2, 1, 3))
     del tmp8
     tmp3 = einsum(r2.bab, (0, 1, 2), ints.tmp56, (3, 0, 4, 2), (3, 1, 4)) * -1
-    tmp44 = ints.tmp129.transpose((1, 0)).copy() * 2
+    tmp44 = np.copy(np.transpose(ints.tmp129, (1, 0))) * 2
     del ints.tmp129
-    tmp44 += ints.tmp131.transpose((1, 0))
+    tmp44 += np.transpose(ints.tmp131, (1, 0))
     del ints.tmp131
     tmp44 += f.bb.vv * -1
-    tmp66 = ints.tmp148.copy()
+    tmp66 = np.copy(ints.tmp148)
     del ints.tmp148
-    tmp66 += ints.tmp169.transpose((1, 2, 0, 3)) * -1
+    tmp66 += np.transpose(ints.tmp169, (1, 2, 0, 3)) * -1
     del ints.tmp169
-    tmp47 = f.bb.ov.copy()
+    tmp47 = np.copy(f.bb.ov)
     tmp47 += ints.tmp111
     del ints.tmp111
     tmp47 += ints.tmp112 * 2
@@ -1206,114 +1206,114 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp127
     tmp47 += ints.tmp142 * -2
     del ints.tmp142
-    tmp37 = tmp35.copy() * 0.5
+    tmp37 = np.copy(tmp35) * 0.5
     del tmp35
     tmp37 += tmp36
     del tmp36
-    tmp65 = ints.tmp150.copy()
+    tmp65 = np.copy(ints.tmp150)
     del ints.tmp150
-    tmp65 += ints.tmp153.transpose((0, 2, 1, 3)) * -1
+    tmp65 += np.transpose(ints.tmp153, (0, 2, 1, 3)) * -1
     del ints.tmp153
-    tmp64 = tmp57.copy() * 2
+    tmp64 = np.copy(tmp57) * 2
     del tmp57
     tmp64 += tmp58 * 2
     del tmp58
-    tmp64 += tmp59.transpose((1, 0, 2)) * -2
+    tmp64 += np.transpose(tmp59, (1, 0, 2)) * -2
     del tmp59
-    tmp64 += tmp61.transpose((1, 0, 2))
+    tmp64 += np.transpose(tmp61, (1, 0, 2))
     del tmp61
     tmp64 += tmp63
     del tmp63
-    tmp56 = tmp48.copy()
+    tmp56 = np.copy(tmp48)
     del tmp48
     tmp56 += tmp49
     del tmp49
-    tmp56 += tmp51.transpose((1, 0, 2))
+    tmp56 += np.transpose(tmp51, (1, 0, 2))
     del tmp51
-    tmp56 += tmp53.transpose((1, 0, 2))
+    tmp56 += np.transpose(tmp53, (1, 0, 2))
     del tmp53
     tmp56 += tmp55
     del tmp55
-    tmp46 = ints.tmp108.copy()
+    tmp46 = np.copy(ints.tmp108)
     del ints.tmp108
-    tmp46 += ints.tmp115.transpose((1, 0, 2, 3))
+    tmp46 += np.transpose(ints.tmp115, (1, 0, 2, 3))
     del ints.tmp115
-    tmp46 += ints.tmp116.transpose((1, 0, 2, 3)) * 2
+    tmp46 += np.transpose(ints.tmp116, (1, 0, 2, 3)) * 2
     del ints.tmp116
-    tmp46 += ints.tmp125.transpose((1, 0, 2, 3))
+    tmp46 += np.transpose(ints.tmp125, (1, 0, 2, 3))
     del ints.tmp125
     tmp46 += ints.tmp3
     tmp46 += ints.tmp114 * -1
     del ints.tmp114
     tmp46 += ints.tmp128 * -1
     del ints.tmp128
-    tmp42 = tmp6.copy()
+    tmp42 = np.copy(tmp6)
     del tmp6
     tmp42 += tmp7 * 0.5
     del tmp7
-    tmp40 = ints.tmp133.copy()
+    tmp40 = np.copy(ints.tmp133)
     del ints.tmp133
     tmp40 += ints.tmp136 * -1
     del ints.tmp136
-    tmp0 = f.aa.oo.copy()
-    tmp0 += ints.tmp6.transpose((1, 0)) * 2
+    tmp0 = np.copy(f.aa.oo)
+    tmp0 += np.transpose(ints.tmp6, (1, 0)) * 2
     del ints.tmp6
-    tmp0 += ints.tmp9.transpose((1, 0))
+    tmp0 += np.transpose(ints.tmp9, (1, 0))
     del ints.tmp9
-    tmp1 = f.bb.oo.copy()
-    tmp1 += ints.tmp17.transpose((1, 0)) * 2
+    tmp1 = np.copy(f.bb.oo)
+    tmp1 += np.transpose(ints.tmp17, (1, 0)) * 2
     del ints.tmp17
-    tmp1 += ints.tmp20.transpose((1, 0))
+    tmp1 += np.transpose(ints.tmp20, (1, 0))
     del ints.tmp20
-    tmp45 = tmp23.copy() * 2
+    tmp45 = np.copy(tmp23) * 2
     tmp45 += tmp24 * -1
-    tmp41 = ints.tmp79.copy()
+    tmp41 = np.copy(ints.tmp79)
     tmp41 += ints.tmp81
-    tmp43 = ints.tmp16.copy() * 2
+    tmp43 = np.copy(ints.tmp16) * 2
     del ints.tmp16
     tmp43 += ints.tmp19
     del ints.tmp19
     tmp43 += v.bbb.xov
-    tmp22 = ints.tmp48.transpose((1, 0)).copy() * 2
+    tmp22 = np.copy(np.transpose(ints.tmp48, (1, 0))) * 2
     del ints.tmp48
-    tmp22 += ints.tmp50.transpose((1, 0))
+    tmp22 += np.transpose(ints.tmp50, (1, 0))
     del ints.tmp50
     tmp22 += f.aa.vv * -1
-    tmp30 = ints.tmp79.copy()
+    tmp30 = np.copy(ints.tmp79)
     del ints.tmp79
     tmp30 += ints.tmp81
     del ints.tmp81
-    tmp29 = ints.tmp52.copy() * 2
+    tmp29 = np.copy(ints.tmp52) * 2
     del ints.tmp52
     tmp29 += ints.tmp69
     del ints.tmp69
-    tmp33 = tmp31.copy() * -0.5
+    tmp33 = np.copy(tmp31) * -0.5
     del tmp31
     tmp33 += tmp32
     del tmp32
-    tmp28 = ints.tmp101.copy()
+    tmp28 = np.copy(ints.tmp101)
     del ints.tmp101
     tmp28 += ints.tmp96 * -1
     del ints.tmp96
-    tmp38 = ints.tmp14.copy()
+    tmp38 = np.copy(ints.tmp14)
     tmp38 += ints.tmp77
     del ints.tmp77
-    tmp38 += ints.tmp84.transpose((0, 2, 1, 3))
+    tmp38 += np.transpose(ints.tmp84, (0, 2, 1, 3))
     del ints.tmp84
-    tmp38 += ints.tmp85.transpose((0, 2, 1, 3)) * 2
+    tmp38 += np.transpose(ints.tmp85, (0, 2, 1, 3)) * 2
     del ints.tmp85
-    tmp38 += ints.tmp92.transpose((0, 2, 1, 3))
+    tmp38 += np.transpose(ints.tmp92, (0, 2, 1, 3))
     del ints.tmp92
     tmp38 += ints.tmp83 * -1
     del ints.tmp83
     tmp38 += ints.tmp93 * -1
     del ints.tmp93
-    tmp34 = ints.tmp5.copy() * 2
+    tmp34 = np.copy(ints.tmp5) * 2
     del ints.tmp5
     tmp34 += ints.tmp8
     del ints.tmp8
     tmp34 += v.baa.xov
-    tmp27 = f.aa.ov.copy()
+    tmp27 = np.copy(f.aa.ov)
     tmp27 += ints.tmp28
     del ints.tmp28
     tmp27 += ints.tmp36 * 2
@@ -1326,39 +1326,39 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp40
     tmp27 += ints.tmp41 * -1
     del ints.tmp41
-    tmp26 = ints.tmp30.copy()
+    tmp26 = np.copy(ints.tmp30)
     del ints.tmp30
-    tmp26 += ints.tmp61.transpose((1, 2, 0, 3)) * -1
+    tmp26 += np.transpose(ints.tmp61, (1, 2, 0, 3)) * -1
     del ints.tmp61
-    tmp20 = tmp15.transpose((1, 0, 2)).copy()
+    tmp20 = np.copy(np.transpose(tmp15, (1, 0, 2)))
     del tmp15
-    tmp20 += tmp17.transpose((1, 0, 2))
+    tmp20 += np.transpose(tmp17, (1, 0, 2))
     del tmp17
     tmp20 += tmp19
     del tmp19
-    tmp12 = tmp2.copy() * 2
+    tmp12 = np.copy(tmp2) * 2
     del tmp2
     tmp12 += tmp3
     del tmp3
-    tmp12 += tmp5.transpose((1, 0, 2)) * -2
+    tmp12 += np.transpose(tmp5, (1, 0, 2)) * -2
     del tmp5
-    tmp12 += tmp9.transpose((1, 0, 2))
+    tmp12 += np.transpose(tmp9, (1, 0, 2))
     del tmp9
     tmp12 += tmp11
     del tmp11
-    tmp21 = ints.tmp33.copy()
+    tmp21 = np.copy(ints.tmp33)
     del ints.tmp33
-    tmp21 += ints.tmp38.transpose((0, 2, 1, 3)) * -1
+    tmp21 += np.transpose(ints.tmp38, (0, 2, 1, 3)) * -1
     del ints.tmp38
-    tmp25 = tmp23.copy()
+    tmp25 = np.copy(tmp23)
     del tmp23
     tmp25 += tmp24 * -0.5
     del tmp24
-    r2new.bbb = tmp56.copy() * -1
-    r2new.bbb += tmp56.transpose((1, 0, 2))
+    r2new.bbb = np.copy(tmp56) * -1
+    r2new.bbb += np.transpose(tmp56, (1, 0, 2))
     del tmp56
     r2new.bbb += tmp64
-    r2new.bbb += tmp64.transpose((1, 0, 2)) * -1
+    r2new.bbb += np.transpose(tmp64, (1, 0, 2)) * -1
     del tmp64
     r2new.bbb += einsum(r2.bbb, (0, 1, 2), tmp65, (3, 4, 1, 0), (3, 4, 2)) * -2
     del tmp65
@@ -1406,11 +1406,11 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     r2new.aba += einsum(r2.aba, (0, 1, 2), tmp1, (1, 3), (0, 3, 2)) * -1
     r2new.aba += einsum(tmp0, (0, 1), r2.aba, (0, 2, 3), (1, 2, 3)) * -1
     r2new.aba += einsum(tmp27, (0, 1), r1.b, (2,), (0, 2, 1)) * -1
-    r2new.aaa = tmp12.copy()
-    r2new.aaa += tmp12.transpose((1, 0, 2)) * -1
+    r2new.aaa = np.copy(tmp12)
+    r2new.aaa += np.transpose(tmp12, (1, 0, 2)) * -1
     del tmp12
     r2new.aaa += tmp20 * -1
-    r2new.aaa += tmp20.transpose((1, 0, 2))
+    r2new.aaa += np.transpose(tmp20, (1, 0, 2))
     del tmp20
     r2new.aaa += einsum(tmp21, (0, 1, 2, 3), r2.aaa, (2, 3, 4), (0, 1, 4)) * 2
     del tmp21
@@ -1625,43 +1625,43 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp7 = einsum(r2.bab, (0, 1, 2), v.bbb.xov, (3, 2, 0), (3, 1)) * -1
     tmp6 = einsum(r2.aaa, (0, 1, 2), v.baa.xov, (3, 2, 1), (3, 0))
     tmp30 = einsum(r2.aba, (0, 1, 2), v.baa.xov, (3, 2, 0), (3, 1))
-    tmp59 = ints.tmp19.copy()
+    tmp59 = np.copy(ints.tmp19)
     tmp59 += ints.tmp16 * 2
     tmp31 = einsum(r2.bbb, (0, 1, 2), v.bbb.xov, (3, 2, 1), (3, 0))
-    tmp40 = ints.tmp111.copy()
+    tmp40 = np.copy(ints.tmp111)
     del ints.tmp111
     tmp40 += ints.tmp137 * 2
     del ints.tmp137
-    tmp61 = ints.tmp12.copy()
+    tmp61 = np.copy(ints.tmp12)
     tmp61 += ints.tmp150 * 2
     del ints.tmp150
-    tmp54 = ints.tmp148.copy()
+    tmp54 = np.copy(ints.tmp148)
     del ints.tmp148
     tmp54 += ints.tmp152 * 0.5
     del ints.tmp152
-    tmp44 = ints.tmp17.transpose((1, 0)).copy()
-    tmp44 += ints.tmp20.transpose((1, 0)) * 0.5
+    tmp44 = np.copy(np.transpose(ints.tmp17, (1, 0)))
+    tmp44 += np.transpose(ints.tmp20, (1, 0)) * 0.5
     tmp44 += f.bb.vv * -0.5
-    tmp51 = ints.tmp16.copy() * 2
+    tmp51 = np.copy(ints.tmp16) * 2
     tmp51 += ints.tmp19
-    tmp16 = ints.tmp6.transpose((1, 0)).copy()
-    tmp16 += ints.tmp9.transpose((1, 0)) * 0.5
+    tmp16 = np.copy(np.transpose(ints.tmp6, (1, 0)))
+    tmp16 += np.transpose(ints.tmp9, (1, 0)) * 0.5
     tmp16 += f.aa.vv * -0.5
-    tmp14 = ints.tmp5.copy() * 2
+    tmp14 = np.copy(ints.tmp5) * 2
     tmp14 += ints.tmp8
-    tmp13 = tmp6.copy()
+    tmp13 = np.copy(tmp6)
     tmp13 += tmp7 * 0.5
-    tmp18 = ints.tmp29.copy()
+    tmp18 = np.copy(ints.tmp29)
     del ints.tmp29
     tmp18 += ints.tmp33 * 0.5
     del ints.tmp33
-    tmp4 = ints.tmp50.copy()
+    tmp4 = np.copy(ints.tmp50)
     tmp4 += ints.tmp38 * 2
-    tmp8 = tmp6.copy() * 2
+    tmp8 = np.copy(tmp6) * 2
     del tmp6
     tmp8 += tmp7
     del tmp7
-    tmp10 = ints.tmp1.copy()
+    tmp10 = np.copy(ints.tmp1)
     tmp10 += ints.tmp31 * 2
     del ints.tmp31
     tmp35 = einsum(r1.b, (0,), f.bb.ov, (1, 0), (1,))
@@ -1698,12 +1698,12 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp10
     tmp48 = einsum(ints.tmp41, (0, 1, 2, 3), r2.bbb, (2, 3, 4), (0, 1, 4))
     del ints.tmp41
-    tmp46 = f.bb.oo.copy()
-    tmp46 += ints.tmp122.transpose((1, 0)) * 2
+    tmp46 = np.copy(f.bb.oo)
+    tmp46 += np.transpose(ints.tmp122, (1, 0)) * 2
     del ints.tmp122
-    tmp46 += ints.tmp124.transpose((1, 0))
+    tmp46 += np.transpose(ints.tmp124, (1, 0))
     del ints.tmp124
-    tmp47 = f.bb.ov.copy()
+    tmp47 = np.copy(f.bb.ov)
     tmp47 += ints.tmp121
     del ints.tmp121
     tmp47 += ints.tmp126
@@ -1716,60 +1716,60 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp143
     tmp47 += ints.tmp144 * -1
     del ints.tmp144
-    tmp38 = tmp35.copy() * -1
+    tmp38 = np.copy(tmp35) * -1
     del tmp35
     tmp38 += tmp36
     del tmp36
     tmp38 += tmp37 * 2
     del tmp37
-    tmp63 = tmp57.copy() * 2
+    tmp63 = np.copy(tmp57) * 2
     del tmp57
-    tmp63 += tmp58.transpose((0, 2, 1)) * -2
+    tmp63 += np.transpose(tmp58, (0, 2, 1)) * -2
     del tmp58
-    tmp63 += tmp60.transpose((0, 2, 1))
+    tmp63 += np.transpose(tmp60, (0, 2, 1))
     del tmp60
     tmp63 += tmp62
     del tmp62
-    tmp56 = tmp49.copy()
+    tmp56 = np.copy(tmp49)
     del tmp49
     tmp56 += tmp50
     del tmp50
-    tmp56 += tmp52.transpose((0, 2, 1))
+    tmp56 += np.transpose(tmp52, (0, 2, 1))
     del tmp52
-    tmp56 += tmp53.transpose((0, 2, 1))
+    tmp56 += np.transpose(tmp53, (0, 2, 1))
     del tmp53
     tmp56 += tmp55
     del tmp55
-    tmp42 = ints.tmp16.copy() * 2
+    tmp42 = np.copy(ints.tmp16) * 2
     del ints.tmp16
     tmp42 += ints.tmp19
     del ints.tmp19
     tmp42 += v.bbb.xov
     tmp39 = einsum(r2.bab, (0, 1, 2), ints.tmp62, (3, 4, 1, 0), (3, 4, 2)) * -1
-    tmp0 = ints.tmp6.transpose((1, 0)).copy() * 2
+    tmp0 = np.copy(np.transpose(ints.tmp6, (1, 0))) * 2
     del ints.tmp6
-    tmp0 += ints.tmp9.transpose((1, 0))
+    tmp0 += np.transpose(ints.tmp9, (1, 0))
     del ints.tmp9
     tmp0 += f.aa.vv * -1
-    tmp45 = tmp21.copy() * 0.5
+    tmp45 = np.copy(tmp21) * 0.5
     tmp45 += tmp22 * -1
     tmp45 += tmp23 * 0.5
-    tmp41 = ints.tmp110.copy()
+    tmp41 = np.copy(ints.tmp110)
     del ints.tmp110
     tmp41 += ints.tmp141 * -1
     del ints.tmp141
-    tmp43 = ints.tmp113.copy()
+    tmp43 = np.copy(ints.tmp113)
     del ints.tmp113
-    tmp43 += ints.tmp128.transpose((0, 2, 1, 3))
+    tmp43 += np.transpose(ints.tmp128, (0, 2, 1, 3))
     del ints.tmp128
-    tmp43 += ints.tmp130.transpose((0, 2, 1, 3)) * 2
+    tmp43 += np.transpose(ints.tmp130, (0, 2, 1, 3)) * 2
     del ints.tmp130
     tmp43 += ints.tmp3
     tmp43 += ints.tmp107 * -1
     del ints.tmp107
-    tmp43 += ints.tmp129.transpose((0, 2, 1, 3)) * -1
+    tmp43 += np.transpose(ints.tmp129, (0, 2, 1, 3)) * -1
     del ints.tmp129
-    tmp26 = f.aa.ov.copy()
+    tmp26 = np.copy(f.aa.ov)
     tmp26 += ints.tmp22 * 2
     del ints.tmp22
     tmp26 += ints.tmp23
@@ -1782,63 +1782,63 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp55
     tmp26 += ints.tmp68 * -2
     del ints.tmp68
-    tmp29 = ints.tmp38.copy() * 2
+    tmp29 = np.copy(ints.tmp38) * 2
     del ints.tmp38
     tmp29 += ints.tmp50
     del ints.tmp50
-    tmp33 = ints.tmp8.copy()
+    tmp33 = np.copy(ints.tmp8)
     del ints.tmp8
     tmp33 += v.baa.xov
     tmp33 += ints.tmp5 * 2
     del ints.tmp5
-    tmp28 = ints.tmp105.copy()
+    tmp28 = np.copy(ints.tmp105)
     del ints.tmp105
     tmp28 += ints.tmp80 * -1
     del ints.tmp80
-    tmp32 = tmp30.copy() * -1
+    tmp32 = np.copy(tmp30) * -1
     del tmp30
     tmp32 += tmp31 * 2
     del tmp31
-    tmp34 = ints.tmp14.copy()
+    tmp34 = np.copy(ints.tmp14)
     tmp34 += ints.tmp82
     del ints.tmp82
-    tmp34 += ints.tmp94.transpose((0, 1, 3, 2))
+    tmp34 += np.transpose(ints.tmp94, (0, 1, 3, 2))
     del ints.tmp94
-    tmp34 += ints.tmp96.transpose((0, 1, 3, 2)) * 2
+    tmp34 += np.transpose(ints.tmp96, (0, 1, 3, 2)) * 2
     del ints.tmp96
     tmp34 += ints.tmp77 * -1
     del ints.tmp77
-    tmp34 += ints.tmp95.transpose((0, 1, 3, 2)) * -1
+    tmp34 += np.transpose(ints.tmp95, (0, 1, 3, 2)) * -1
     del ints.tmp95
-    tmp1 = ints.tmp17.transpose((1, 0)).copy() * 2
+    tmp1 = np.copy(np.transpose(ints.tmp17, (1, 0))) * 2
     del ints.tmp17
-    tmp1 += ints.tmp20.transpose((1, 0))
+    tmp1 += np.transpose(ints.tmp20, (1, 0))
     del ints.tmp20
     tmp1 += f.bb.vv * -1
-    tmp25 = f.aa.oo.copy()
-    tmp25 += ints.tmp70.transpose((1, 0)) * 2
+    tmp25 = np.copy(f.aa.oo)
+    tmp25 += np.transpose(ints.tmp70, (1, 0)) * 2
     del ints.tmp70
-    tmp25 += ints.tmp72.transpose((1, 0))
+    tmp25 += np.transpose(ints.tmp72, (1, 0))
     del ints.tmp72
     tmp27 = einsum(r2.aba, (0, 1, 2), ints.tmp62, (3, 4, 0, 1), (3, 2, 4))
     del ints.tmp62
-    tmp20 = tmp15.copy()
+    tmp20 = np.copy(tmp15)
     del tmp15
-    tmp20 += tmp17.transpose((0, 2, 1))
+    tmp20 += np.transpose(tmp17, (0, 2, 1))
     del tmp17
     tmp20 += tmp19
     del tmp19
     tmp2 = einsum(r2.aaa, (0, 1, 2), ints.tmp37, (3, 4, 1, 0), (3, 4, 2)) * -1
     del ints.tmp37
-    tmp12 = tmp3.copy()
+    tmp12 = np.copy(tmp3)
     del tmp3
-    tmp12 += tmp5.transpose((0, 2, 1)) * -2
+    tmp12 += np.transpose(tmp5, (0, 2, 1)) * -2
     del tmp5
-    tmp12 += tmp9.transpose((0, 2, 1))
+    tmp12 += np.transpose(tmp9, (0, 2, 1))
     del tmp9
     tmp12 += tmp11
     del tmp11
-    tmp24 = tmp21.copy()
+    tmp24 = np.copy(tmp21)
     del tmp21
     tmp24 += tmp22 * -2
     del tmp22
@@ -1850,11 +1850,11 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp165
     r2new.bbb += einsum(ints.tmp172, (0, 1, 2, 3), r2.bbb, (1, 3, 4), (0, 2, 4)) * -2
     del ints.tmp172
-    r2new.bbb += tmp56.transpose((1, 2, 0)) * -1
-    r2new.bbb += tmp56.transpose((2, 1, 0))
+    r2new.bbb += np.transpose(tmp56, (1, 2, 0)) * -1
+    r2new.bbb += np.transpose(tmp56, (2, 1, 0))
     del tmp56
-    r2new.bbb += tmp63.transpose((1, 2, 0))
-    r2new.bbb += tmp63.transpose((2, 1, 0)) * -1
+    r2new.bbb += np.transpose(tmp63, (1, 2, 0))
+    r2new.bbb += np.transpose(tmp63, (2, 1, 0)) * -1
     del tmp63
     r2new.bbb += einsum(t2.bbbb, (0, 1, 2, 3), tmp38, (1,), (2, 3, 0)) * -2
     r2new.bbb += einsum(tmp46, (0, 1), r2.bbb, (2, 3, 0), (2, 3, 1)) * -2
@@ -1908,11 +1908,11 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp56
     r2new.aaa += einsum(ints.tmp66, (0, 1, 2, 3), r2.aaa, (3, 1, 4), (0, 2, 4)) * 2
     del ints.tmp66
-    r2new.aaa += tmp12.transpose((1, 2, 0))
-    r2new.aaa += tmp12.transpose((2, 1, 0)) * -1
+    r2new.aaa += np.transpose(tmp12, (1, 2, 0))
+    r2new.aaa += np.transpose(tmp12, (2, 1, 0)) * -1
     del tmp12
-    r2new.aaa += tmp20.transpose((1, 2, 0)) * -1
-    r2new.aaa += tmp20.transpose((2, 1, 0))
+    r2new.aaa += np.transpose(tmp20, (1, 2, 0)) * -1
+    r2new.aaa += np.transpose(tmp20, (2, 1, 0))
     del tmp20
     r2new.aaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp24, (1,), (2, 3, 0)) * 2
     del tmp24
@@ -2134,15 +2134,15 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     ints = kwargs["ints"]
     r1new = Namespace()
     r2new = Namespace()
-    tmp16 = ints.tmp19.copy()
+    tmp16 = np.copy(ints.tmp19)
     tmp16 += v.baa.xov
     tmp16 += ints.tmp16 * 2
-    tmp18 = ints.tmp37.copy()
+    tmp18 = np.copy(ints.tmp37)
     tmp18 += v.bbb.xov
     tmp18 += ints.tmp42 * 2
     tmp38 = einsum(t2.bbbb, (0, 1, 2, 3), r2.bbb, (0, 1, 3), (2,))
     tmp37 = einsum(t2.abab, (0, 1, 2, 3), r2.aba, (0, 1, 2), (3,))
-    tmp34 = ints.tmp16.copy() * 2
+    tmp34 = np.copy(ints.tmp16) * 2
     del ints.tmp16
     tmp34 += ints.tmp19
     del ints.tmp19
@@ -2150,27 +2150,27 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp17 = einsum(tmp16, (0, 1, 2), r2.aaa, (3, 1, 2), (0, 3)) * -1
     del tmp16
     tmp19 = einsum(r2.bab, (0, 1, 2), tmp18, (3, 0, 2), (3, 1)) * -1
-    tmp39 = tmp37.copy() * -0.5
+    tmp39 = np.copy(tmp37) * -0.5
     del tmp37
     tmp39 += tmp38
     del tmp38
     tmp48 = einsum(r2.aba, (0, 1, 2), tmp34, (3, 0, 2), (3, 1))
-    tmp51 = ints.tmp69.copy() * 2
+    tmp51 = np.copy(ints.tmp69) * 2
     tmp51 += ints.tmp71
-    tmp40 = ints.tmp163.copy()
+    tmp40 = np.copy(ints.tmp163)
     del ints.tmp163
-    tmp40 += ints.tmp168.transpose((1, 0, 3, 2)) * 2
+    tmp40 += np.transpose(ints.tmp168, (1, 0, 3, 2)) * 2
     del ints.tmp168
     tmp56 = einsum(r2.bbb, (0, 1, 2), tmp18, (3, 1, 2), (3, 0)) * -1
     del tmp18
-    tmp14 = ints.tmp100.copy()
-    tmp14 += ints.tmp105.transpose((1, 0, 3, 2)) * 2
+    tmp14 = np.copy(ints.tmp100)
+    tmp14 += np.transpose(ints.tmp105, (1, 0, 3, 2)) * 2
     tmp12 = einsum(r2.bab, (0, 1, 2), t2.abab, (1, 0, 3, 2), (3,)) * -1
-    tmp20 = tmp17.copy() * -2
+    tmp20 = np.copy(tmp17) * -2
     del tmp17
     tmp20 += tmp19
     del tmp19
-    tmp26 = ints.tmp17.copy() * 2
+    tmp26 = np.copy(ints.tmp17) * 2
     tmp26 += ints.tmp20
     tmp24 = einsum(t2.aaaa, (0, 1, 2, 3), r2.aaa, (0, 1, 3), (2,))
     tmp50 = einsum(ints.tmp165, (0, 1, 2, 3), tmp39, (3,), (0, 1, 2)) * 2
@@ -2185,7 +2185,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp55 = einsum(r2.bbb, (0, 1, 2), tmp40, (3, 1, 4, 2), (0, 3, 4)) * -1
     tmp57 = einsum(tmp56, (0, 1), v.bbb.xov, (0, 2, 3), (2, 1, 3)) * -1
     del tmp56
-    tmp35 = ints.tmp37.copy() * 0.5
+    tmp35 = np.copy(ints.tmp37) * 0.5
     del ints.tmp37
     tmp35 += ints.tmp42
     del ints.tmp42
@@ -2202,7 +2202,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp26
     tmp25 = einsum(tmp24, (0,), ints.tmp104, (1, 2, 3, 0), (1, 2, 3))
     del ints.tmp104
-    tmp44 = ints.tmp181.copy() * 2
+    tmp44 = np.copy(ints.tmp181) * 2
     del ints.tmp181
     tmp44 += ints.tmp183
     del ints.tmp183
@@ -2212,126 +2212,126 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp46
     tmp53 += tmp47
     del tmp47
-    tmp53 += tmp49.transpose((1, 0, 2))
+    tmp53 += np.transpose(tmp49, (1, 0, 2))
     del tmp49
     tmp53 += tmp50 * -1
     del tmp50
-    tmp53 += tmp52.transpose((1, 0, 2))
+    tmp53 += np.transpose(tmp52, (1, 0, 2))
     del tmp52
-    tmp59 = ints.tmp202.copy()
+    tmp59 = np.copy(ints.tmp202)
     del ints.tmp202
-    tmp59 += ints.tmp204.transpose((2, 0, 3, 1)) * -1
+    tmp59 += np.transpose(ints.tmp204, (2, 0, 3, 1)) * -1
     del ints.tmp204
-    tmp58 = tmp54.copy()
+    tmp58 = np.copy(tmp54)
     del tmp54
-    tmp58 += tmp55.transpose((1, 0, 2)) * -1
+    tmp58 += np.transpose(tmp55, (1, 0, 2)) * -1
     del tmp55
-    tmp58 += tmp57.transpose((1, 0, 2))
+    tmp58 += np.transpose(tmp57, (1, 0, 2))
     del tmp57
-    tmp4 = f.aa.oo.copy()
+    tmp4 = np.copy(f.aa.oo)
     tmp4 += ints.tmp17 * 2
     del ints.tmp17
     tmp4 += ints.tmp20
     del ints.tmp20
-    tmp42 = ints.tmp153.copy()
-    tmp42 += ints.tmp157.transpose((1, 0, 3, 2))
-    tmp9 = f.bb.oo.copy()
+    tmp42 = np.copy(ints.tmp153)
+    tmp42 += np.transpose(ints.tmp157, (1, 0, 3, 2))
+    tmp9 = np.copy(f.bb.oo)
     tmp9 += ints.tmp69 * 2
     del ints.tmp69
     tmp9 += ints.tmp71
     del ints.tmp71
-    tmp45 = tmp24.copy() * 2
+    tmp45 = np.copy(tmp24) * 2
     del tmp24
     tmp45 += tmp12
     del tmp12
-    tmp41 = ints.tmp185.copy()
+    tmp41 = np.copy(ints.tmp185)
     del ints.tmp185
-    tmp41 += ints.tmp186.transpose((1, 0, 3, 2)) * -1
+    tmp41 += np.transpose(ints.tmp186, (1, 0, 3, 2)) * -1
     del ints.tmp186
     tmp43 = einsum(tmp34, (0, 1, 2), r2.aaa, (3, 1, 2), (0, 3))
     tmp43 += einsum(r2.bab, (0, 1, 2), tmp35, (3, 0, 2), (3, 1)) * -1
-    tmp30 = ints.tmp130.copy() * 2
+    tmp30 = np.copy(ints.tmp130) * 2
     del ints.tmp130
     tmp30 += ints.tmp132
     del ints.tmp132
     tmp30 += f.aa.vv * -1
-    tmp33 = ints.tmp153.copy()
+    tmp33 = np.copy(ints.tmp153)
     del ints.tmp153
-    tmp33 += ints.tmp157.transpose((1, 0, 3, 2))
+    tmp33 += np.transpose(ints.tmp157, (1, 0, 3, 2))
     del ints.tmp157
     tmp36 = einsum(r2.aba, (0, 1, 2), tmp34, (3, 0, 2), (3, 1)) * -0.5
     del tmp34
     tmp36 += einsum(r2.bbb, (0, 1, 2), tmp35, (3, 1, 2), (3, 0)) * 2
     del tmp35
-    tmp32 = ints.tmp100.copy()
+    tmp32 = np.copy(ints.tmp100)
     del ints.tmp100
-    tmp32 += ints.tmp105.transpose((1, 0, 3, 2)) * 2
+    tmp32 += np.transpose(ints.tmp105, (1, 0, 3, 2)) * 2
     del ints.tmp105
-    tmp31 = ints.tmp161.copy()
+    tmp31 = np.copy(ints.tmp161)
     del ints.tmp161
-    tmp31 += ints.tmp162.transpose((1, 0, 3, 2)) * -1
+    tmp31 += np.transpose(ints.tmp162, (1, 0, 3, 2)) * -1
     del ints.tmp162
-    tmp22 = tmp10.copy() * 2
+    tmp22 = np.copy(tmp10) * 2
     del tmp10
     tmp22 += tmp11
     del tmp11
     tmp22 += tmp13
     del tmp13
-    tmp22 += tmp15.transpose((1, 0, 2)) * -2
+    tmp22 += np.transpose(tmp15, (1, 0, 2)) * -2
     del tmp15
-    tmp22 += tmp21.transpose((1, 0, 2))
+    tmp22 += np.transpose(tmp21, (1, 0, 2))
     del tmp21
-    tmp29 = ints.tmp125.copy()
+    tmp29 = np.copy(ints.tmp125)
     del ints.tmp125
-    tmp29 += ints.tmp127.transpose((2, 0, 3, 1)) * -1
+    tmp29 += np.transpose(ints.tmp127, (2, 0, 3, 1)) * -1
     del ints.tmp127
     tmp28 = einsum(r1.a, (0,), f.aa.ov, (1, 2), (1, 0, 2)) * -1
     tmp28 += tmp23 * -1
     del tmp23
     tmp28 += tmp25 * 2
     del tmp25
-    tmp28 += tmp27.transpose((1, 0, 2)) * -1
+    tmp28 += np.transpose(tmp27, (1, 0, 2)) * -1
     del tmp27
-    tmp7 = f.aa.ov.copy() * 0.5
+    tmp7 = np.copy(f.aa.ov) * 0.5
     tmp7 += ints.tmp1
     tmp7 += ints.tmp4 * 0.5
     tmp7 += ints.tmp51 * 0.5
     tmp7 += ints.tmp22 * -1
     tmp7 += ints.tmp30 * -0.5
     tmp7 += ints.tmp45 * -1
-    tmp8 = f.bb.ov.copy()
+    tmp8 = np.copy(f.bb.ov)
     tmp8 += ints.tmp3
     tmp8 += ints.tmp49
     tmp8 += ints.tmp6 * 2
     tmp8 += ints.tmp25 * -2
     tmp8 += ints.tmp28 * -1
     tmp8 += ints.tmp47 * -2
-    tmp5 = ints.tmp27.copy()
+    tmp5 = np.copy(ints.tmp27)
     tmp5 += ints.tmp63
     del ints.tmp63
-    tmp5 += ints.tmp80.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp80, (0, 2, 1, 3))
     del ints.tmp80
-    tmp5 += ints.tmp84.transpose((0, 2, 1, 3)) * 2
+    tmp5 += np.transpose(ints.tmp84, (0, 2, 1, 3)) * 2
     del ints.tmp84
-    tmp5 += ints.tmp96.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp96, (0, 2, 1, 3))
     del ints.tmp96
-    tmp5 += ints.tmp77.transpose((0, 2, 1, 3)) * -1
+    tmp5 += np.transpose(ints.tmp77, (0, 2, 1, 3)) * -1
     del ints.tmp77
-    tmp5 += ints.tmp83.transpose((0, 2, 1, 3)) * -1
+    tmp5 += np.transpose(ints.tmp83, (0, 2, 1, 3)) * -1
     del ints.tmp83
-    tmp6 = ints.tmp24.copy()
+    tmp6 = np.copy(ints.tmp24)
     del ints.tmp24
-    tmp6 += ints.tmp78.transpose((2, 0, 1, 3)) * 2
+    tmp6 += np.transpose(ints.tmp78, (2, 0, 1, 3)) * 2
     del ints.tmp78
-    tmp6 += ints.tmp93.transpose((2, 0, 1, 3))
+    tmp6 += np.transpose(ints.tmp93, (2, 0, 1, 3))
     del ints.tmp93
     tmp6 += ints.tmp65 * -1
     del ints.tmp65
-    tmp6 += ints.tmp81.transpose((2, 0, 1, 3)) * -2
+    tmp6 += np.transpose(ints.tmp81, (2, 0, 1, 3)) * -2
     del ints.tmp81
-    tmp6 += ints.tmp86.transpose((2, 0, 1, 3)) * -1
+    tmp6 += np.transpose(ints.tmp86, (2, 0, 1, 3)) * -1
     del ints.tmp86
-    tmp2 = f.aa.ov.copy()
+    tmp2 = np.copy(f.aa.ov)
     tmp2 += ints.tmp1 * 2
     del ints.tmp1
     tmp2 += ints.tmp4
@@ -2344,7 +2344,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp30
     tmp2 += ints.tmp45 * -2
     del ints.tmp45
-    tmp3 = f.bb.ov.copy() * 0.5
+    tmp3 = np.copy(f.bb.ov) * 0.5
     tmp3 += ints.tmp3 * 0.5
     del ints.tmp3
     tmp3 += ints.tmp49 * 0.5
@@ -2357,36 +2357,36 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp28
     tmp3 += ints.tmp47 * -1
     del ints.tmp47
-    tmp0 = ints.tmp10.copy()
+    tmp0 = np.copy(ints.tmp10)
     del ints.tmp10
     tmp0 += ints.tmp14
-    tmp0 += ints.tmp38.transpose((1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp38, (1, 0, 2, 3))
     del ints.tmp38
-    tmp0 += ints.tmp43.transpose((1, 0, 2, 3)) * 2
+    tmp0 += np.transpose(ints.tmp43, (1, 0, 2, 3)) * 2
     del ints.tmp43
-    tmp0 += ints.tmp57.transpose((1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp57, (1, 0, 2, 3))
     del ints.tmp57
-    tmp0 += ints.tmp34.transpose((1, 0, 2, 3)) * -1
+    tmp0 += np.transpose(ints.tmp34, (1, 0, 2, 3)) * -1
     del ints.tmp34
-    tmp0 += ints.tmp39.transpose((1, 0, 2, 3)) * -1
+    tmp0 += np.transpose(ints.tmp39, (1, 0, 2, 3)) * -1
     del ints.tmp39
-    tmp1 = ints.tmp12.copy()
+    tmp1 = np.copy(ints.tmp12)
     del ints.tmp12
-    tmp1 += ints.tmp32.transpose((2, 0, 1, 3)) * 2
+    tmp1 += np.transpose(ints.tmp32, (2, 0, 1, 3)) * 2
     del ints.tmp32
-    tmp1 += ints.tmp54.transpose((2, 0, 1, 3))
+    tmp1 += np.transpose(ints.tmp54, (2, 0, 1, 3))
     del ints.tmp54
-    tmp1 += ints.tmp35.transpose((2, 0, 1, 3)) * -2
+    tmp1 += np.transpose(ints.tmp35, (2, 0, 1, 3)) * -2
     del ints.tmp35
-    tmp1 += ints.tmp40.transpose((2, 0, 1, 3)) * -1
+    tmp1 += np.transpose(ints.tmp40, (2, 0, 1, 3)) * -1
     del ints.tmp40
     tmp1 += ints.tmp8 * -1
     del ints.tmp8
-    r2new.bbb = tmp53.copy() * -1
-    r2new.bbb += tmp53.transpose((1, 0, 2))
+    r2new.bbb = np.copy(tmp53) * -1
+    r2new.bbb += np.transpose(tmp53, (1, 0, 2))
     del tmp53
     r2new.bbb += tmp58 * 2
-    r2new.bbb += tmp58.transpose((1, 0, 2)) * -2
+    r2new.bbb += np.transpose(tmp58, (1, 0, 2)) * -2
     del tmp58
     r2new.bbb += einsum(r2.bbb, (0, 1, 2), tmp59, (3, 1, 4, 0), (3, 4, 2)) * 2
     del tmp59
@@ -2428,11 +2428,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp39, ints.tmp146
     r2new.aba += einsum(tmp9, (0, 1), r2.aba, (2, 0, 3), (2, 1, 3)) * -1
     r2new.aba += einsum(tmp4, (0, 1), r2.aba, (0, 2, 3), (1, 2, 3)) * -1
-    r2new.aaa = tmp22.copy()
-    r2new.aaa += tmp22.transpose((1, 0, 2)) * -1
+    r2new.aaa = np.copy(tmp22)
+    r2new.aaa += np.transpose(tmp22, (1, 0, 2)) * -1
     del tmp22
     r2new.aaa += tmp28
-    r2new.aaa += tmp28.transpose((1, 0, 2)) * -1
+    r2new.aaa += np.transpose(tmp28, (1, 0, 2)) * -1
     del tmp28
     r2new.aaa += einsum(r2.aaa, (0, 1, 2), tmp29, (3, 0, 4, 1), (3, 4, 2)) * -2
     del tmp29
@@ -2641,13 +2641,13 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     ints = kwargs["ints"]
     r1new = Namespace()
     r2new = Namespace()
-    tmp23 = ints.tmp19.copy()
+    tmp23 = np.copy(ints.tmp19)
     tmp23 += v.baa.xov
     tmp23 += ints.tmp16 * 2
-    tmp25 = ints.tmp43.copy()
+    tmp25 = np.copy(ints.tmp43)
     tmp25 += v.bbb.xov
     tmp25 += ints.tmp40 * 2
-    tmp34 = ints.tmp16.copy() * 2
+    tmp34 = np.copy(ints.tmp16) * 2
     del ints.tmp16
     tmp34 += ints.tmp19
     del ints.tmp19
@@ -2659,26 +2659,26 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp26 = einsum(tmp25, (0, 1, 2), r2.bab, (2, 3, 1), (0, 3)) * -1
     tmp53 = einsum(r2.bbb, (0, 1, 2), tmp25, (3, 2, 1), (3, 0)) * -1
     del tmp25
-    tmp39 = ints.tmp159.copy()
+    tmp39 = np.copy(ints.tmp159)
     del ints.tmp159
-    tmp39 += ints.tmp168.transpose((1, 0, 3, 2)) * 2
+    tmp39 += np.transpose(ints.tmp168, (1, 0, 3, 2)) * 2
     del ints.tmp168
     tmp35 = einsum(r2.aba, (0, 1, 2), tmp34, (3, 2, 0), (3, 1))
-    tmp42 = ints.tmp71.copy()
+    tmp42 = np.copy(ints.tmp71)
     tmp42 += ints.tmp73 * 0.5
     tmp42 += f.bb.vv * -0.5
-    tmp48 = tmp11.copy() * -0.5
+    tmp48 = np.copy(tmp11) * -0.5
     tmp48 += tmp12
-    tmp4 = ints.tmp17.copy() * 2
+    tmp4 = np.copy(ints.tmp17) * 2
     del ints.tmp17
     tmp4 += ints.tmp20
     del ints.tmp20
     tmp4 += f.aa.vv * -1
     tmp5 = einsum(t2.aaaa, (0, 1, 2, 3), r2.aaa, (2, 3, 1), (0,))
-    tmp21 = ints.tmp102.copy()
-    tmp21 += ints.tmp111.transpose((1, 0, 3, 2)) * 2
+    tmp21 = np.copy(ints.tmp102)
+    tmp21 += np.transpose(ints.tmp111, (1, 0, 3, 2)) * 2
     tmp6 = einsum(t2.abab, (0, 1, 2, 3), r2.bab, (3, 2, 1), (0,)) * -1
-    tmp27 = tmp24.copy() * -2
+    tmp27 = np.copy(tmp24) * -2
     del tmp24
     tmp27 += tmp26
     del tmp26
@@ -2691,7 +2691,7 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp47 = einsum(tmp42, (0, 1), r2.bbb, (2, 0, 3), (3, 2, 1)) * -4
     tmp49 = einsum(ints.tmp165, (0, 1, 2, 3), tmp48, (1,), (0, 2, 3)) * 2
     del tmp48
-    tmp36 = ints.tmp40.copy() * 2
+    tmp36 = np.copy(ints.tmp40) * 2
     del ints.tmp40
     tmp36 += ints.tmp43
     del ints.tmp43
@@ -2705,83 +2705,83 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     tmp19 = einsum(ints.tmp113, (0, 1, 2, 3), r2.bab, (3, 4, 1), (0, 2, 4)) * -1
     tmp28 = einsum(v.baa.xov, (0, 1, 2), tmp27, (0, 3), (1, 2, 3))
     del tmp27
-    tmp55 = tmp51.copy()
+    tmp55 = np.copy(tmp51)
     del tmp51
-    tmp55 += tmp52.transpose((0, 2, 1)) * -2
+    tmp55 += np.transpose(tmp52, (0, 2, 1)) * -2
     del tmp52
-    tmp55 += tmp54.transpose((0, 2, 1)) * 2
+    tmp55 += np.transpose(tmp54, (0, 2, 1)) * 2
     del tmp54
     tmp44 = einsum(t2.bbbb, (0, 1, 2, 3), r2.bbb, (2, 3, 4), (4, 0, 1))
     tmp50 = einsum(f.bb.ov, (0, 1), r1.b, (2,), (0, 1, 2))
     tmp50 += tmp45
     del tmp45
-    tmp50 += tmp46.transpose((0, 2, 1))
+    tmp50 += np.transpose(tmp46, (0, 2, 1))
     del tmp46
-    tmp50 += tmp47.transpose((0, 2, 1))
+    tmp50 += np.transpose(tmp47, (0, 2, 1))
     del tmp47
     tmp50 += tmp49 * -1
     del tmp49
-    tmp43 = f.bb.oo.copy()
+    tmp43 = np.copy(f.bb.oo)
     tmp43 += ints.tmp161 * 2
     del ints.tmp161
     tmp43 += ints.tmp163
     del ints.tmp163
-    tmp7 = tmp5.copy()
+    tmp7 = np.copy(tmp5)
     del tmp5
     tmp7 += tmp6 * 0.5
     del tmp6
-    tmp40 = ints.tmp182.copy()
+    tmp40 = np.copy(ints.tmp182)
     del ints.tmp182
-    tmp40 += ints.tmp183.transpose((1, 0, 3, 2)) * -1
+    tmp40 += np.transpose(ints.tmp183, (1, 0, 3, 2)) * -1
     del ints.tmp183
     tmp38 = einsum(t2.abab, (0, 1, 2, 3), r2.bab, (3, 2, 4), (0, 4, 1)) * -1
     tmp41 = einsum(r2.aaa, (0, 1, 2), tmp34, (3, 2, 1), (3, 0))
     del tmp34
     tmp41 += einsum(tmp36, (0, 1, 2), r2.bab, (2, 3, 1), (0, 3)) * -0.5
-    tmp30 = f.aa.oo.copy()
+    tmp30 = np.copy(f.aa.oo)
     tmp30 += ints.tmp106 * 2
     del ints.tmp106
     tmp30 += ints.tmp108
     del ints.tmp108
-    tmp10 = ints.tmp71.copy() * 2
+    tmp10 = np.copy(ints.tmp71) * 2
     del ints.tmp71
     tmp10 += ints.tmp73
     del ints.tmp73
     tmp10 += f.bb.vv * -1
-    tmp33 = ints.tmp102.copy()
+    tmp33 = np.copy(ints.tmp102)
     del ints.tmp102
-    tmp33 += ints.tmp111.transpose((1, 0, 3, 2)) * 2
+    tmp33 += np.transpose(ints.tmp111, (1, 0, 3, 2)) * 2
     del ints.tmp111
-    tmp13 = tmp11.copy() * -1
+    tmp13 = np.copy(tmp11) * -1
     del tmp11
     tmp13 += tmp12 * 2
     del tmp12
-    tmp32 = ints.tmp157.copy()
+    tmp32 = np.copy(ints.tmp157)
     del ints.tmp157
-    tmp32 += ints.tmp158.transpose((1, 0, 3, 2)) * -1
+    tmp32 += np.transpose(ints.tmp158, (1, 0, 3, 2)) * -1
     del ints.tmp158
     tmp31 = einsum(r2.aba, (0, 1, 2), t2.abab, (3, 4, 0, 1), (2, 3, 4))
-    tmp37 = tmp35.copy() * -1
+    tmp37 = np.copy(tmp35) * -1
     del tmp35
     tmp37 += einsum(r2.bbb, (0, 1, 2), tmp36, (3, 2, 1), (3, 0)) * 2
     del tmp36
     tmp17 = einsum(r1.a, (0,), f.aa.ov, (1, 2), (1, 2, 0)) * -1
     tmp17 += tmp15 * 2
     del tmp15
-    tmp17 += tmp16.transpose((0, 2, 1)) * -1
+    tmp17 += np.transpose(tmp16, (0, 2, 1)) * -1
     del tmp16
-    tmp29 = tmp18.copy()
+    tmp29 = np.copy(tmp18)
     del tmp18
     tmp29 += tmp19
     del tmp19
     tmp29 += tmp20
     del tmp20
-    tmp29 += tmp22.transpose((0, 2, 1)) * -2
+    tmp29 += np.transpose(tmp22, (0, 2, 1)) * -2
     del tmp22
-    tmp29 += tmp28.transpose((0, 2, 1))
+    tmp29 += np.transpose(tmp28, (0, 2, 1))
     del tmp28
     tmp14 = einsum(r2.aaa, (0, 1, 2), t2.aaaa, (3, 4, 0, 1), (2, 3, 4))
-    tmp2 = f.bb.ov.copy() * 0.5
+    tmp2 = np.copy(f.bb.ov) * 0.5
     tmp2 += ints.tmp3 * 0.5
     del ints.tmp3
     tmp2 += ints.tmp44 * 0.5
@@ -2794,28 +2794,28 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp29
     tmp2 += ints.tmp41 * -1
     del ints.tmp41
-    tmp8 = ints.tmp58.copy()
-    tmp8 += ints.tmp81.transpose((0, 1, 3, 2))
+    tmp8 = np.copy(ints.tmp58)
+    tmp8 += np.transpose(ints.tmp81, (0, 1, 3, 2))
     del ints.tmp81
-    tmp8 += ints.tmp87.transpose((0, 1, 3, 2))
+    tmp8 += np.transpose(ints.tmp87, (0, 1, 3, 2))
     del ints.tmp87
-    tmp8 += ints.tmp93.transpose((0, 1, 3, 2)) * 2
+    tmp8 += np.transpose(ints.tmp93, (0, 1, 3, 2)) * 2
     del ints.tmp93
     tmp8 += ints.tmp90 * -1
     del ints.tmp90
-    tmp8 += ints.tmp97.transpose((0, 1, 3, 2)) * -1
+    tmp8 += np.transpose(ints.tmp97, (0, 1, 3, 2)) * -1
     del ints.tmp97
-    tmp9 = ints.tmp79.transpose((0, 3, 1, 2)).copy() * 0.5
+    tmp9 = np.copy(np.transpose(ints.tmp79, (0, 3, 1, 2))) * 0.5
     del ints.tmp79
-    tmp9 += ints.tmp88.transpose((0, 3, 1, 2))
+    tmp9 += np.transpose(ints.tmp88, (0, 3, 1, 2))
     del ints.tmp88
-    tmp9 += ints.tmp95.transpose((0, 3, 1, 2)) * 0.5
+    tmp9 += np.transpose(ints.tmp95, (0, 3, 1, 2)) * 0.5
     del ints.tmp95
     tmp9 += ints.tmp68 * -0.5
     del ints.tmp68
-    tmp9 += ints.tmp91.transpose((0, 2, 1, 3)) * -1
+    tmp9 += np.transpose(ints.tmp91, (0, 2, 1, 3)) * -1
     del ints.tmp91
-    tmp3 = f.aa.ov.copy() * 0.5
+    tmp3 = np.copy(f.aa.ov) * 0.5
     tmp3 += ints.tmp1
     del ints.tmp1
     tmp3 += ints.tmp46 * 0.5
@@ -2828,36 +2828,36 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp32
     tmp3 += ints.tmp38 * -1
     del ints.tmp38
-    tmp0 = ints.tmp14.copy()
-    tmp0 += ints.tmp36.transpose((0, 2, 1, 3))
+    tmp0 = np.copy(ints.tmp14)
+    tmp0 += np.transpose(ints.tmp36, (0, 2, 1, 3))
     del ints.tmp36
-    tmp0 += ints.tmp50.transpose((0, 2, 1, 3))
+    tmp0 += np.transpose(ints.tmp50, (0, 2, 1, 3))
     del ints.tmp50
-    tmp0 += ints.tmp56.transpose((0, 2, 1, 3)) * 2
+    tmp0 += np.transpose(ints.tmp56, (0, 2, 1, 3)) * 2
     del ints.tmp56
     tmp0 += ints.tmp53 * -1
     del ints.tmp53
-    tmp0 += ints.tmp59.transpose((0, 2, 1, 3)) * -1
+    tmp0 += np.transpose(ints.tmp59, (0, 2, 1, 3)) * -1
     del ints.tmp59
-    tmp1 = ints.tmp34.transpose((0, 3, 1, 2)).copy() * 0.5
+    tmp1 = np.copy(np.transpose(ints.tmp34, (0, 3, 1, 2))) * 0.5
     del ints.tmp34
-    tmp1 += ints.tmp48.transpose((0, 3, 1, 2))
+    tmp1 += np.transpose(ints.tmp48, (0, 3, 1, 2))
     del ints.tmp48
-    tmp1 += ints.tmp54.transpose((0, 3, 1, 2)) * 0.5
+    tmp1 += np.transpose(ints.tmp54, (0, 3, 1, 2)) * 0.5
     del ints.tmp54
     tmp1 += ints.tmp12 * -0.5
     del ints.tmp12
-    tmp1 += ints.tmp51.transpose((0, 2, 1, 3)) * -1
+    tmp1 += np.transpose(ints.tmp51, (0, 2, 1, 3)) * -1
     del ints.tmp51
     r2new.bbb = einsum(ints.tmp165, (0, 1, 2, 3), tmp44, (4, 1, 0), (3, 2, 4)) * 2
     del ints.tmp165, tmp44
     r2new.bbb += einsum(r2.bbb, (0, 1, 2), ints.tmp200, (3, 0, 4, 1), (3, 4, 2)) * -2
     del ints.tmp200
-    r2new.bbb += tmp50.transpose((1, 2, 0)) * -1
-    r2new.bbb += tmp50.transpose((2, 1, 0))
+    r2new.bbb += np.transpose(tmp50, (1, 2, 0)) * -1
+    r2new.bbb += np.transpose(tmp50, (2, 1, 0))
     del tmp50
-    r2new.bbb += tmp55.transpose((1, 2, 0))
-    r2new.bbb += tmp55.transpose((2, 1, 0)) * -1
+    r2new.bbb += np.transpose(tmp55, (1, 2, 0))
+    r2new.bbb += np.transpose(tmp55, (2, 1, 0)) * -1
     del tmp55
     r2new.bbb += einsum(tmp43, (0, 1), r2.bbb, (2, 3, 0), (2, 3, 1)) * -2
     r2new.bab = einsum(ints.tmp146, (0, 1, 2, 3), tmp38, (0, 4, 1), (3, 2, 4)) * -1
@@ -2904,11 +2904,11 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del ints.tmp110, tmp14
     r2new.aaa += einsum(ints.tmp126, (0, 1, 2, 3), r2.aaa, (3, 1, 4), (0, 2, 4)) * 2
     del ints.tmp126
-    r2new.aaa += tmp17.transpose((1, 2, 0))
-    r2new.aaa += tmp17.transpose((2, 1, 0)) * -1
+    r2new.aaa += np.transpose(tmp17, (1, 2, 0))
+    r2new.aaa += np.transpose(tmp17, (2, 1, 0)) * -1
     del tmp17
-    r2new.aaa += tmp29.transpose((1, 2, 0))
-    r2new.aaa += tmp29.transpose((2, 1, 0)) * -1
+    r2new.aaa += np.transpose(tmp29, (1, 2, 0))
+    r2new.aaa += np.transpose(tmp29, (2, 1, 0)) * -1
     del tmp29
     r2new.aaa += einsum(tmp30, (0, 1), r2.aaa, (2, 3, 0), (2, 3, 1)) * -2
     del tmp30

--- a/ebcc/codegen/UDFCCD.py
+++ b/ebcc/codegen/UDFCCD.py
@@ -909,9 +909,9 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.abab = pack_2e(rdm2.abab.oooo, rdm2.abab.ooov, rdm2.abab.oovo, rdm2.abab.ovoo, rdm2.abab.vooo, rdm2.abab.oovv, rdm2.abab.ovov, rdm2.abab.ovvo, rdm2.abab.voov, rdm2.abab.vovo, rdm2.abab.vvoo, rdm2.abab.ovvv, rdm2.abab.vovv, rdm2.abab.vvov, rdm2.abab.vvvo, rdm2.abab.vvvv)
     rdm2.bbbb = pack_2e(rdm2.bbbb.oooo, rdm2.bbbb.ooov, rdm2.bbbb.oovo, rdm2.bbbb.ovoo, rdm2.bbbb.vooo, rdm2.bbbb.oovv, rdm2.bbbb.ovov, rdm2.bbbb.ovvo, rdm2.bbbb.voov, rdm2.bbbb.vovo, rdm2.bbbb.vvoo, rdm2.bbbb.ovvv, rdm2.bbbb.vovv, rdm2.bbbb.vvov, rdm2.bbbb.vvvo, rdm2.bbbb.vvvv)
     rdm2 = Namespace(
-        aaaa=rdm2.aaaa.swapaxes(1, 2),
-        aabb=rdm2.abab.swapaxes(1, 2),
-        bbbb=rdm2.bbbb.swapaxes(1, 2),
+        aaaa=rdm2.aaaa.transpose(0, 2, 1, 3),
+        aabb=rdm2.abab.transpose(0, 2, 1, 3),
+        bbbb=rdm2.bbbb.transpose(0, 2, 1, 3),
     )
 
     return rdm2

--- a/ebcc/codegen/UDFCCSD.py
+++ b/ebcc/codegen/UDFCCSD.py
@@ -2506,9 +2506,9 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.abab = pack_2e(rdm2.abab.oooo, rdm2.abab.ooov, rdm2.abab.oovo, rdm2.abab.ovoo, rdm2.abab.vooo, rdm2.abab.oovv, rdm2.abab.ovov, rdm2.abab.ovvo, rdm2.abab.voov, rdm2.abab.vovo, rdm2.abab.vvoo, rdm2.abab.ovvv, rdm2.abab.vovv, rdm2.abab.vvov, rdm2.abab.vvvo, rdm2.abab.vvvv)
     rdm2.bbbb = pack_2e(rdm2.bbbb.oooo, rdm2.bbbb.ooov, rdm2.bbbb.oovo, rdm2.bbbb.ovoo, rdm2.bbbb.vooo, rdm2.bbbb.oovv, rdm2.bbbb.ovov, rdm2.bbbb.ovvo, rdm2.bbbb.voov, rdm2.bbbb.vovo, rdm2.bbbb.vvoo, rdm2.bbbb.ovvv, rdm2.bbbb.vovv, rdm2.bbbb.vvov, rdm2.bbbb.vvvo, rdm2.bbbb.vvvv)
     rdm2 = Namespace(
-        aaaa=rdm2.aaaa.swapaxes(1, 2),
-        aabb=rdm2.abab.swapaxes(1, 2),
-        bbbb=rdm2.bbbb.swapaxes(1, 2),
+        aaaa=rdm2.aaaa.transpose(0, 2, 1, 3),
+        aabb=rdm2.abab.transpose(0, 2, 1, 3),
+        bbbb=rdm2.bbbb.transpose(0, 2, 1, 3),
     )
 
     return rdm2

--- a/ebcc/codegen/UDFCCSD.py
+++ b/ebcc/codegen/UDFCCSD.py
@@ -42,13 +42,13 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp5 = einsum(v.baa.xov, (0, 1, 2), t1.aa, (3, 2), (0, 3, 1))
     tmp1 = einsum(v.baa.xov, (0, 1, 2), t1.aa, (1, 2), (0,)) * 0.5
     tmp1 += tmp0
-    tmp4 = f.bb.ov.copy()
+    tmp4 = np.copy(f.bb.ov)
     tmp4 += einsum(tmp3, (0, 1, 2), v.bbb.xov, (0, 1, 3), (2, 3)) * -0.5
     del tmp3
     tmp7 = einsum(v.bbb.xov, (0, 1, 2), t2.bbbb, (3, 1, 4, 2), (0, 3, 4))
     tmp7 += einsum(t1.bb, (0, 1), tmp0, (2,), (2, 0, 1)) * 0.5
     del tmp0
-    tmp6 = f.aa.ov.copy() * 2
+    tmp6 = np.copy(f.aa.ov) * 2
     tmp6 += einsum(tmp5, (0, 1, 2), v.baa.xov, (0, 1, 3), (2, 3)) * -1
     del tmp5
     tmp2 = einsum(t2.aaaa, (0, 1, 2, 3), v.baa.xov, (4, 1, 3), (4, 0, 2))
@@ -95,7 +95,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp5 = einsum(v.baa.xov, (0, 1, 2), t1.aa, (1, 2), (0,))
     tmp19 = einsum(t1.bb, (0, 1), v.bbb.xov, (2, 3, 1), (2, 0, 3))
     tmp0 = einsum(v.baa.xov, (0, 1, 2), t1.aa, (3, 2), (0, 3, 1))
-    tmp7 = tmp5.copy()
+    tmp7 = np.copy(tmp5)
     tmp7 += tmp6
     tmp30 = einsum(v.baa.xov, (0, 1, 2), t2.abab, (1, 3, 2, 4), (0, 3, 4))
     tmp34 = einsum(v.bbb.xov, (0, 1, 2), t2.bbbb, (3, 1, 4, 2), (0, 3, 4))
@@ -103,7 +103,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp148 = einsum(t1.bb, (0, 1), v.bbb.xov, (2, 0, 3), (2, 1, 3))
     tmp142 = einsum(t1.bb, (0, 1), tmp19, (2, 3, 0), (2, 3, 1))
     tmp40 = einsum(t1.bb, (0, 1), v.bbb.xvv, (2, 3, 1), (2, 0, 3))
-    tmp9 = tmp5.copy()
+    tmp9 = np.copy(tmp5)
     del tmp5
     tmp9 += tmp6
     del tmp6
@@ -113,25 +113,25 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp13 = einsum(tmp0, (0, 1, 2), v.baa.xov, (0, 1, 3), (2, 3))
     tmp3 = einsum(t2.abab, (0, 1, 2, 3), v.bbb.xov, (4, 1, 3), (4, 0, 2))
     tmp11 = einsum(t2.aaaa, (0, 1, 2, 3), v.baa.xov, (4, 1, 3), (4, 0, 2))
-    tmp35 = tmp30.copy()
+    tmp35 = np.copy(tmp30)
     tmp35 += tmp34 * 2
     tmp35 += einsum(t1.bb, (0, 1), tmp7, (2,), (2, 0, 1))
-    tmp189 = f.bb.ov.copy() * -1
+    tmp189 = np.copy(f.bb.ov) * -1
     tmp189 += tmp20
-    tmp199 = v.bbb.xvv.copy()
-    tmp199 += tmp148.transpose((0, 2, 1)) * -1
-    tmp165 = tmp40.copy()
+    tmp199 = np.copy(v.bbb.xvv)
+    tmp199 += np.transpose(tmp148, (0, 2, 1)) * -1
+    tmp165 = np.copy(tmp40)
     tmp165 += tmp142 * -1
     tmp33 = einsum(v.bbb.xov, (0, 1, 2), tmp9, (0,), (1, 2))
     tmp42 = einsum(v.bbb.xov, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (3, 4, 1, 2))
-    tmp85 = tmp17.copy()
+    tmp85 = np.copy(tmp17)
     tmp85 += tmp76 * -1
-    tmp87 = v.baa.xvv.copy()
-    tmp87 += tmp78.transpose((0, 2, 1)) * -1
+    tmp87 = np.copy(v.baa.xvv)
+    tmp87 += np.transpose(tmp78, (0, 2, 1)) * -1
     tmp18 = einsum(v.baa.xov, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 4, 1, 2))
-    tmp72 = f.aa.ov.copy() * -1
+    tmp72 = np.copy(f.aa.ov) * -1
     tmp72 += tmp13
-    tmp70 = tmp11.copy() * 2
+    tmp70 = np.copy(tmp11) * 2
     tmp70 += tmp3
     tmp70 += einsum(tmp7, (0,), t1.aa, (1, 2), (0, 1, 2))
     tmp99 = einsum(v.bbb.xov, (0, 1, 2), v.bbb.xov, (0, 3, 4), (3, 1, 4, 2))
@@ -146,30 +146,30 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp41 = einsum(v.baa.xov, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (1, 3, 4, 2))
     tmp94 = einsum(v.baa.xov, (0, 1, 2), v.baa.xov, (0, 3, 4), (1, 3, 2, 4))
     tmp217 = einsum(tmp19, (0, 1, 2), tmp19, (0, 3, 4), (3, 1, 4, 2))
-    tmp132 = f.bb.ov.copy()
+    tmp132 = np.copy(f.bb.ov)
     tmp132 += tmp20 * -1
     tmp132 += tmp33
     tmp185 = einsum(v.bbb.xoo, (0, 1, 2), tmp19, (0, 3, 4), (3, 1, 2, 4))
-    tmp194 = v.bbb.xvv.copy()
-    tmp194 += tmp148.transpose((0, 2, 1)) * -1
+    tmp194 = np.copy(v.bbb.xvv)
+    tmp194 += np.transpose(tmp148, (0, 2, 1)) * -1
     tmp158 = einsum(t1.bb, (0, 1), tmp42, (2, 0, 3, 4), (2, 3, 1, 4))
     tmp205 = einsum(v.bbb.xoo, (0, 1, 2), tmp199, (0, 3, 4), (1, 2, 3, 4))
     del tmp199
     tmp153 = einsum(t1.aa, (0, 1), v.baa.xoo, (2, 3, 0), (2, 3, 1))
     tmp145 = einsum(v.baa.xov, (0, 1, 2), v.bbb.xov, (0, 3, 4), (1, 3, 2, 4))
-    tmp37 = f.bb.ov.copy()
+    tmp37 = np.copy(f.bb.ov)
     tmp37 += tmp20 * -1
-    tmp55 = tmp17.copy()
+    tmp55 = np.copy(tmp17)
     tmp55 += tmp11 * 2
     tmp55 += tmp3
     tmp55 += einsum(tmp7, (0,), t1.aa, (1, 2), (0, 1, 2))
-    tmp14 = f.aa.ov.copy()
+    tmp14 = np.copy(f.aa.ov)
     tmp14 += tmp13 * -1
     tmp64 = einsum(tmp0, (0, 1, 2), v.baa.xoo, (0, 3, 4), (1, 3, 4, 2))
     tmp25 = einsum(tmp0, (0, 1, 2), v.baa.xoo, (0, 3, 1), (3, 2))
     tmp49 = einsum(tmp9, (0,), v.baa.xoo, (0, 1, 2), (1, 2))
-    tmp79 = v.baa.xvv.copy()
-    tmp79 += tmp78.transpose((0, 2, 1)) * -1
+    tmp79 = np.copy(v.baa.xvv)
+    tmp79 += np.transpose(tmp78, (0, 2, 1)) * -1
     tmp16 = einsum(v.bbb.xov, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 4, 1, 2))
     tmp86 = einsum(tmp85, (0, 1, 2), v.baa.xov, (0, 3, 4), (3, 1, 4, 2))
     tmp88 = einsum(tmp0, (0, 1, 2), tmp87, (0, 3, 4), (1, 2, 3, 4))
@@ -184,40 +184,40 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp111 = einsum(tmp0, (0, 1, 2), tmp0, (0, 3, 4), (3, 1, 4, 2))
     tmp224 = einsum(tmp99, (0, 1, 2, 3), t2.bbbb, (4, 5, 3, 2), (4, 5, 1, 0))
     tmp220 = einsum(tmp40, (0, 1, 2), tmp19, (0, 3, 4), (3, 1, 4, 2))
-    tmp197 = tmp40.copy() * -1
+    tmp197 = np.copy(tmp40) * -1
     tmp197 += tmp142
-    tmp191 = tmp36.transpose((1, 0)).copy()
-    tmp191 += tmp190.transpose((1, 0)) * -1
+    tmp191 = np.copy(np.transpose(tmp36, (1, 0)))
+    tmp191 += np.transpose(tmp190, (1, 0)) * -1
     del tmp190
     tmp183 = einsum(tmp40, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (1, 3, 4, 2))
-    tmp180 = tmp40.copy()
+    tmp180 = np.copy(tmp40)
     tmp180 += tmp30
     tmp180 += tmp34 * 2
     tmp180 += einsum(t1.bb, (0, 1), tmp7, (2,), (2, 0, 1))
-    tmp177 = f.bb.oo.copy()
-    tmp177 += tmp43.transpose((1, 0)) * -1
-    tmp177 += tmp176.transpose((1, 0))
+    tmp177 = np.copy(f.bb.oo)
+    tmp177 += np.transpose(tmp43, (1, 0)) * -1
+    tmp177 += np.transpose(tmp176, (1, 0))
     del tmp176
     tmp229 = einsum(v.bbb.xvv, (0, 1, 2), v.bbb.xov, (0, 3, 4), (3, 1, 2, 4))
-    tmp201 = tmp166.transpose((1, 0, 3, 2)).copy() * -1
-    tmp201 += tmp200.transpose((0, 1, 3, 2))
+    tmp201 = np.copy(np.transpose(tmp166, (1, 0, 3, 2))) * -1
+    tmp201 += np.transpose(tmp200, (0, 1, 3, 2))
     del tmp200
-    tmp129 = tmp30.copy()
+    tmp129 = np.copy(tmp30)
     tmp129 += tmp34 * 2
     tmp44 = einsum(v.bbb.xoo, (0, 1, 2), tmp7, (0,), (1, 2))
-    tmp104 = tmp99.transpose((1, 0, 2, 3)).copy() * -1
-    tmp104 += tmp99.transpose((1, 0, 3, 2))
-    tmp127 = tmp30.copy() * 0.5
+    tmp104 = np.copy(np.transpose(tmp99, (1, 0, 2, 3))) * -1
+    tmp104 += np.transpose(tmp99, (1, 0, 3, 2))
+    tmp127 = np.copy(tmp30) * 0.5
     tmp127 += tmp34
     tmp144 = einsum(t1.bb, (0, 1), tmp41, (2, 3, 0, 4), (2, 3, 4, 1))
-    tmp210 = tmp94.transpose((1, 0, 2, 3)).copy()
-    tmp210 += tmp94.transpose((1, 0, 3, 2)) * -1
+    tmp210 = np.copy(np.transpose(tmp94, (1, 0, 2, 3)))
+    tmp210 += np.transpose(tmp94, (1, 0, 3, 2)) * -1
     tmp28 = einsum(v.bbb.xov, (0, 1, 2), tmp19, (0, 3, 4), (3, 1, 4, 2))
-    tmp143 = v.bbb.xov.copy()
+    tmp143 = np.copy(v.bbb.xov)
     tmp143 += tmp40
     tmp143 += tmp142 * -1
-    tmp207 = tmp94.transpose((1, 0, 2, 3)).copy()
-    tmp207 += tmp94.transpose((1, 0, 3, 2)) * -1
+    tmp207 = np.copy(np.transpose(tmp94, (1, 0, 2, 3)))
+    tmp207 += np.transpose(tmp94, (1, 0, 3, 2)) * -1
     tmp222 = einsum(tmp217, (0, 1, 2, 3), t1.bb, (2, 4), (1, 0, 3, 4))
     tmp131 = einsum(v.bbb.xvv, (0, 1, 2), tmp9, (0,), (1, 2))
     tmp130 = einsum(tmp40, (0, 1, 2), v.bbb.xov, (0, 1, 3), (3, 2))
@@ -226,29 +226,29 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp187 = einsum(tmp185, (0, 1, 2, 3), t1.bb, (3, 4), (0, 1, 2, 4))
     tmp212 = einsum(tmp30, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (1, 3, 4, 2))
     tmp174 = einsum(v.bbb.xoo, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (1, 3, 4, 2))
-    tmp193 = tmp40.copy()
+    tmp193 = np.copy(tmp40)
     tmp193 += tmp142 * -1
     tmp226 = einsum(tmp194, (0, 1, 2), v.bbb.xov, (0, 3, 4), (3, 2, 1, 4))
-    tmp214 = tmp158.copy()
-    tmp214 += tmp205.transpose((1, 0, 3, 2))
-    tmp100 = tmp99.transpose((1, 0, 2, 3)).copy() * -1
-    tmp100 += tmp99.transpose((1, 0, 3, 2))
-    tmp154 = tmp153.copy() * -1
+    tmp214 = np.copy(tmp158)
+    tmp214 += np.transpose(tmp205, (1, 0, 3, 2))
+    tmp100 = np.copy(np.transpose(tmp99, (1, 0, 2, 3))) * -1
+    tmp100 += np.transpose(tmp99, (1, 0, 3, 2))
+    tmp154 = np.copy(tmp153) * -1
     del tmp153
     tmp154 += tmp11 * 2
     tmp154 += tmp3
-    tmp12 = tmp11.copy()
+    tmp12 = np.copy(tmp11)
     tmp12 += tmp3 * 0.5
     tmp12 += einsum(tmp7, (0,), t1.aa, (1, 2), (0, 1, 2)) * 0.5
     tmp169 = einsum(v.baa.xov, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 2, 3, 4))
-    tmp149 = v.bbb.xvv.copy()
+    tmp149 = np.copy(v.bbb.xvv)
     tmp149 += tmp148 * -1
-    tmp146 = v.baa.xvv.copy()
+    tmp146 = np.copy(v.baa.xvv)
     tmp146 += tmp78 * -1
-    tmp140 = v.baa.xvv.copy()
+    tmp140 = np.copy(v.baa.xvv)
     tmp140 += tmp78 * -1
     del tmp78
-    tmp162 = v.bbb.xvv.copy()
+    tmp162 = np.copy(v.bbb.xvv)
     tmp162 += tmp148 * -1
     del tmp148
     tmp161 = einsum(t1.bb, (0, 1), tmp145, (2, 0, 3, 4), (2, 3, 1, 4))
@@ -257,62 +257,62 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp55
     tmp57 = einsum(tmp7, (0,), v.baa.xvv, (0, 1, 2), (1, 2))
     tmp58 = einsum(tmp14, (0, 1), t1.aa, (0, 2), (2, 1))
-    tmp77 = tmp17.copy()
+    tmp77 = np.copy(tmp17)
     tmp77 += tmp76 * -1
-    tmp102 = tmp94.transpose((1, 0, 2, 3)).copy() * -1
-    tmp102 += tmp94.transpose((1, 0, 3, 2))
-    tmp52 = tmp11.copy() * 2
+    tmp102 = np.copy(np.transpose(tmp94, (1, 0, 2, 3))) * -1
+    tmp102 += np.transpose(tmp94, (1, 0, 3, 2))
+    tmp52 = np.copy(tmp11) * 2
     tmp52 += tmp3
     tmp68 = einsum(t1.aa, (0, 1), tmp64, (2, 3, 4, 0), (2, 3, 4, 1))
-    tmp83 = tmp17.copy() * -1
+    tmp83 = np.copy(tmp17) * -1
     tmp83 += tmp76
-    tmp50 = f.aa.oo.copy()
-    tmp50 += tmp25.transpose((1, 0)) * -1
-    tmp50 += tmp49.transpose((1, 0))
+    tmp50 = np.copy(f.aa.oo)
+    tmp50 += np.transpose(tmp25, (1, 0)) * -1
+    tmp50 += np.transpose(tmp49, (1, 0))
     del tmp49
     tmp120 = einsum(v.baa.xov, (0, 1, 2), tmp79, (0, 3, 4), (1, 4, 3, 2))
     tmp106 = einsum(tmp3, (0, 1, 2), v.baa.xoo, (0, 3, 4), (1, 3, 4, 2))
     tmp66 = einsum(tmp17, (0, 1, 2), v.baa.xoo, (0, 3, 4), (1, 3, 4, 2))
     tmp98 = einsum(tmp16, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3))
     tmp46 = einsum(v.baa.xoo, (0, 1, 2), v.baa.xoo, (0, 3, 4), (1, 3, 4, 2))
-    tmp95 = tmp94.transpose((1, 0, 2, 3)).copy() * -1
-    tmp95 += tmp94.transpose((1, 0, 3, 2))
-    tmp89 = tmp86.transpose((1, 0, 3, 2)).copy() * -1
-    tmp89 += tmp88.transpose((0, 1, 3, 2))
+    tmp95 = np.copy(np.transpose(tmp94, (1, 0, 2, 3))) * -1
+    tmp95 += np.transpose(tmp94, (1, 0, 3, 2))
+    tmp89 = np.copy(np.transpose(tmp86, (1, 0, 3, 2))) * -1
+    tmp89 += np.transpose(tmp88, (0, 1, 3, 2))
     del tmp88
-    tmp62 = f.aa.ov.copy()
+    tmp62 = np.copy(f.aa.ov)
     tmp62 += tmp13 * -1
     tmp62 += tmp10
-    tmp81 = v.baa.xov.copy()
+    tmp81 = np.copy(v.baa.xov)
     tmp81 += tmp17
     tmp81 += tmp76 * -1
     del tmp76
     tmp26 = einsum(tmp7, (0,), v.baa.xoo, (0, 1, 2), (1, 2))
-    tmp60 = tmp11.copy() * 2
+    tmp60 = np.copy(tmp11) * 2
     tmp60 += tmp3
     tmp1 = einsum(v.baa.xov, (0, 1, 2), tmp0, (0, 3, 4), (3, 1, 4, 2))
-    tmp108 = tmp92.copy()
-    tmp108 += tmp96.transpose((1, 0, 3, 2))
+    tmp108 = np.copy(tmp92)
+    tmp108 += np.transpose(tmp96, (1, 0, 3, 2))
     tmp118 = einsum(t2.aaaa, (0, 1, 2, 3), tmp94, (4, 5, 3, 2), (0, 1, 5, 4))
     tmp123 = einsum(v.baa.xov, (0, 1, 2), v.baa.xvv, (0, 3, 4), (1, 3, 4, 2))
-    tmp74 = tmp71.transpose((1, 0)).copy()
+    tmp74 = np.copy(np.transpose(tmp71, (1, 0)))
     del tmp71
     tmp74 += tmp73 * -1
     del tmp73
     tmp114 = einsum(tmp17, (0, 1, 2), tmp0, (0, 3, 4), (3, 1, 4, 2))
     tmp116 = einsum(t1.aa, (0, 1), tmp111, (2, 3, 0, 4), (3, 2, 4, 1))
-    tmp31 = t2.bbbb.copy()
+    tmp31 = np.copy(t2.bbbb)
     tmp31 += einsum(t1.bb, (0, 1), t1.bb, (2, 3), (2, 0, 1, 3)) * -0.5
     tmp23 = einsum(v.baa.xov, (0, 1, 2), tmp7, (0,), (1, 2))
     tmp21 = einsum(tmp7, (0,), v.bbb.xov, (0, 1, 2), (1, 2))
-    tmp4 = t2.aaaa.copy()
+    tmp4 = np.copy(t2.aaaa)
     tmp4 += einsum(t1.aa, (0, 1), t1.aa, (2, 3), (0, 2, 3, 1)) * -0.5
     tmp219 = einsum(tmp40, (0, 1, 2), tmp40, (0, 3, 4), (3, 1, 4, 2))
     tmp225 = einsum(t2.bbbb, (0, 1, 2, 3), tmp224, (4, 5, 0, 1), (5, 4, 2, 3)) * -1
     del tmp224
     tmp221 = einsum(t1.bb, (0, 1), tmp220, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp220
-    tmp173 = t2.bbbb.copy()
+    tmp173 = np.copy(t2.bbbb)
     tmp173 += einsum(t1.bb, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3)) * 2
     tmp198 = einsum(tmp197, (0, 1, 2), tmp30, (0, 3, 4), (1, 3, 2, 4))
     del tmp197
@@ -320,7 +320,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp191
     tmp184 = einsum(t1.bb, (0, 1), tmp183, (2, 0, 3, 4), (2, 3, 1, 4))
     del tmp183
-    tmp181 = f.bb.vv.copy() * -1
+    tmp181 = np.copy(f.bb.vv) * -1
     tmp181 += einsum(v.bbb.xov, (0, 1, 2), tmp180, (0, 1, 3), (2, 3))
     del tmp180
     tmp181 += einsum(tmp7, (0,), v.bbb.xvv, (0, 1, 2), (1, 2)) * -1
@@ -334,37 +334,37 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp202 = einsum(t2.bbbb, (0, 1, 2, 3), tmp201, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp201
     tmp182 = einsum(tmp129, (0, 1, 2), v.bbb.xov, (0, 3, 4), (3, 1, 4, 2))
-    tmp45 = f.bb.oo.copy()
-    tmp45 += tmp43.transpose((1, 0)) * -1
+    tmp45 = np.copy(f.bb.oo)
+    tmp45 += np.transpose(tmp43, (1, 0)) * -1
     del tmp43
-    tmp45 += tmp44.transpose((1, 0))
+    tmp45 += np.transpose(tmp44, (1, 0))
     del tmp44
     tmp218 = einsum(tmp217, (0, 1, 2, 3), t2.bbbb, (3, 2, 4, 5), (1, 0, 4, 5))
     del tmp217
-    tmp209 = tmp158.copy() * 0.5
+    tmp209 = np.copy(tmp158) * 0.5
     tmp209 += einsum(t2.bbbb, (0, 1, 2, 3), tmp104, (1, 4, 3, 5), (0, 4, 2, 5)) * -1
     tmp209 += einsum(tmp194, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (3, 4, 2, 1)) * 0.5
     tmp204 = einsum(tmp34, (0, 1, 2), tmp30, (0, 3, 4), (3, 1, 4, 2))
     tmp128 = einsum(tmp127, (0, 1, 2), v.bbb.xov, (0, 1, 3), (3, 2))
     del tmp127
-    tmp211 = tmp144.copy()
+    tmp211 = np.copy(tmp144)
     tmp211 += einsum(t2.abab, (0, 1, 2, 3), tmp210, (0, 4, 2, 5), (4, 1, 5, 3))
     del tmp210
     tmp228 = einsum(t1.bb, (0, 1), tmp28, (2, 3, 0, 4), (2, 3, 1, 4))
     tmp186 = einsum(tmp185, (0, 1, 2, 3), t2.bbbb, (1, 3, 4, 5), (0, 2, 4, 5))
     del tmp185
     tmp196 = einsum(tmp143, (0, 1, 2), v.bbb.xov, (0, 3, 4), (3, 1, 4, 2))
-    tmp208 = tmp144.copy()
+    tmp208 = np.copy(tmp144)
     tmp208 += einsum(t2.abab, (0, 1, 2, 3), tmp207, (0, 4, 2, 5), (4, 1, 5, 3))
     del tmp207
     tmp223 = einsum(t1.bb, (0, 1), tmp222, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp222
-    tmp134 = f.bb.vv.copy()
+    tmp134 = np.copy(f.bb.vv)
     tmp134 += tmp130 * -1
     del tmp130
-    tmp134 += tmp131.transpose((1, 0))
+    tmp134 += np.transpose(tmp131, (1, 0))
     del tmp131
-    tmp134 += tmp133.transpose((1, 0)) * -1
+    tmp134 += np.transpose(tmp133, (1, 0)) * -1
     del tmp133
     tmp188 = einsum(t1.bb, (0, 1), tmp187, (2, 0, 3, 4), (2, 3, 1, 4))
     del tmp187
@@ -383,16 +383,16 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp226
     tmp215 = einsum(t2.bbbb, (0, 1, 2, 3), tmp214, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp214
-    tmp206 = tmp158.copy()
+    tmp206 = np.copy(tmp158)
     tmp206 += einsum(t2.bbbb, (0, 1, 2, 3), tmp100, (1, 4, 3, 5), (0, 4, 2, 5)) * -2
-    tmp206 += tmp205.transpose((1, 0, 3, 2))
+    tmp206 += np.transpose(tmp205, (1, 0, 3, 2))
     del tmp205
     tmp156 = einsum(tmp99, (0, 1, 2, 3), t2.abab, (4, 0, 5, 3), (4, 1, 5, 2)) * -1
     del tmp99
     tmp156 += einsum(v.bbb.xov, (0, 1, 2), tmp154, (0, 3, 4), (3, 1, 4, 2))
     tmp152 = einsum(tmp0, (0, 1, 2), tmp19, (0, 3, 4), (1, 2, 3, 4))
     tmp171 = einsum(v.baa.xoo, (0, 1, 2), tmp40, (0, 3, 4), (1, 2, 3, 4))
-    tmp126 = t2.abab.copy()
+    tmp126 = np.copy(t2.abab)
     tmp126 += einsum(t1.bb, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1)) * 2
     tmp137 = einsum(tmp17, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (1, 3, 4, 2))
     tmp138 = einsum(tmp12, (0, 1, 2), v.baa.xov, (0, 3, 2), (3, 1))
@@ -402,15 +402,15 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp160 = einsum(tmp145, (0, 1, 2, 3), t2.abab, (4, 5, 2, 3), (4, 0, 5, 1))
     tmp170 = einsum(t2.abab, (0, 1, 2, 3), tmp169, (4, 2, 5, 3), (0, 4, 1, 5))
     del tmp169
-    tmp136 = t2.abab.copy()
+    tmp136 = np.copy(t2.abab)
     tmp136 += einsum(t1.bb, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
-    tmp167 = tmp166.transpose((1, 0, 2, 3)).copy() * -1
+    tmp167 = np.copy(np.transpose(tmp166, (1, 0, 2, 3))) * -1
     del tmp166
     tmp167 += einsum(tmp19, (0, 1, 2), tmp149, (0, 3, 4), (1, 2, 4, 3))
     tmp147 = einsum(t2.abab, (0, 1, 2, 3), tmp145, (0, 4, 5, 3), (4, 1, 5, 2))
     del tmp145
     tmp147 += einsum(tmp146, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (3, 4, 2, 1)) * -1
-    tmp159 = tmp158.transpose((1, 0, 3, 2)).copy()
+    tmp159 = np.copy(np.transpose(tmp158, (1, 0, 3, 2)))
     tmp159 += einsum(v.bbb.xoo, (0, 1, 2), tmp149, (0, 3, 4), (1, 2, 4, 3))
     tmp141 = einsum(tmp140, (0, 1, 2), tmp19, (0, 3, 4), (3, 4, 2, 1))
     del tmp140
@@ -419,26 +419,26 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp161
     tmp163 += einsum(v.baa.xvv, (0, 1, 2), tmp162, (0, 3, 4), (1, 2, 4, 3))
     del tmp162
-    tmp164 = tmp86.transpose((1, 0, 2, 3)).copy() * -1
+    tmp164 = np.copy(np.transpose(tmp86, (1, 0, 2, 3))) * -1
     del tmp86
     tmp164 += einsum(tmp0, (0, 1, 2), tmp146, (0, 3, 4), (1, 2, 4, 3))
-    tmp39 = tmp36.copy()
+    tmp39 = np.copy(tmp36)
     del tmp36
-    tmp39 += tmp38.transpose((1, 0))
+    tmp39 += np.transpose(tmp38, (1, 0))
     del tmp38
     tmp125 = einsum(v.bbb.xoo, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 4, 1, 2))
-    tmp151 = v.bbb.xov.copy()
+    tmp151 = np.copy(v.bbb.xov)
     tmp151 += tmp40
     tmp151 += tmp142 * -1
     del tmp142
     tmp2 = einsum(tmp0, (0, 1, 2), v.bbb.xov, (0, 3, 4), (1, 2, 3, 4))
     tmp135 = einsum(tmp19, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 4, 1, 2))
-    tmp59 = f.aa.vv.copy() * -1
+    tmp59 = np.copy(f.aa.vv) * -1
     tmp59 += tmp56
     del tmp56
-    tmp59 += tmp57.transpose((1, 0)) * -1
+    tmp59 += np.transpose(tmp57, (1, 0)) * -1
     del tmp57
-    tmp59 += tmp58.transpose((1, 0))
+    tmp59 += np.transpose(tmp58, (1, 0))
     del tmp58
     tmp168 = einsum(tmp0, (0, 1, 2), tmp149, (0, 3, 4), (1, 2, 4, 3))
     tmp155 = einsum(t2.aaaa, (0, 1, 2, 3), tmp94, (1, 4, 5, 3), (4, 0, 5, 2)) * 2
@@ -454,7 +454,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp80 += einsum(tmp0, (0, 1, 2), tmp79, (0, 3, 4), (1, 2, 4, 3))
     del tmp0
     tmp91 = einsum(tmp3, (0, 1, 2), tmp85, (0, 3, 4), (1, 3, 2, 4))
-    tmp103 = tmp92.copy()
+    tmp103 = np.copy(tmp92)
     tmp103 += einsum(tmp102, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 2), (4, 1, 5, 3)) * -2
     del tmp102
     tmp103 += einsum(v.baa.xoo, (0, 1, 2), tmp79, (0, 3, 4), (1, 2, 4, 3))
@@ -475,25 +475,25 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp66
     tmp65 = einsum(t2.aaaa, (0, 1, 2, 3), tmp64, (4, 0, 5, 1), (4, 5, 2, 3))
     del tmp64
-    tmp105 = tmp98.copy()
+    tmp105 = np.copy(tmp98)
     tmp105 += einsum(tmp104, (0, 1, 2, 3), t2.abab, (4, 0, 5, 2), (4, 1, 5, 3)) * -1
     del tmp104
     tmp93 = einsum(tmp3, (0, 1, 2), tmp11, (0, 3, 4), (3, 1, 4, 2))
     tmp54 = einsum(t1.aa, (0, 1), t1.aa, (2, 3), (0, 2, 3, 1)) * 2
     tmp54 += t2.aaaa * -1
-    tmp47 = t2.aaaa.copy()
+    tmp47 = np.copy(t2.aaaa)
     tmp47 += einsum(t1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1)) * 2
     tmp48 = einsum(t2.aaaa, (0, 1, 2, 3), tmp46, (4, 0, 5, 1), (5, 4, 2, 3))
-    tmp97 = tmp92.copy()
+    tmp97 = np.copy(tmp92)
     tmp97 += einsum(tmp95, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 2), (4, 1, 5, 3)) * -2
     del tmp95
-    tmp97 += tmp96.transpose((1, 0, 3, 2))
+    tmp97 += np.transpose(tmp96, (1, 0, 3, 2))
     del tmp96
     tmp90 = einsum(t2.aaaa, (0, 1, 2, 3), tmp89, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp89
     tmp112 = einsum(t2.aaaa, (0, 1, 2, 3), tmp111, (4, 5, 1, 0), (5, 4, 2, 3))
     del tmp111
-    tmp63 = f.aa.vv.copy()
+    tmp63 = np.copy(f.aa.vv)
     tmp63 += einsum(tmp17, (0, 1, 2), v.baa.xov, (0, 1, 3), (3, 2)) * -1
     tmp63 += einsum(v.baa.xvv, (0, 1, 2), tmp9, (0,), (1, 2))
     del tmp9
@@ -501,10 +501,10 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp62
     tmp82 = einsum(tmp81, (0, 1, 2), v.baa.xov, (0, 3, 4), (3, 1, 4, 2))
     del tmp81
-    tmp27 = f.aa.oo.copy()
-    tmp27 += tmp25.transpose((1, 0)) * -1
+    tmp27 = np.copy(f.aa.oo)
+    tmp27 += np.transpose(tmp25, (1, 0)) * -1
     del tmp25
-    tmp27 += tmp26.transpose((1, 0))
+    tmp27 += np.transpose(tmp26, (1, 0))
     del tmp26
     tmp61 = einsum(v.baa.xov, (0, 1, 2), tmp60, (0, 3, 4), (1, 3, 2, 4))
     tmp122 = einsum(tmp1, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
@@ -514,7 +514,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp118
     tmp124 = einsum(t2.aaaa, (0, 1, 2, 3), tmp123, (4, 5, 2, 3), (0, 1, 4, 5)) * -1
     del tmp123
-    tmp101 = tmp98.copy()
+    tmp101 = np.copy(tmp98)
     tmp101 += einsum(t2.abab, (0, 1, 2, 3), tmp100, (1, 4, 3, 5), (0, 4, 2, 5)) * -1
     del tmp100
     tmp110 = einsum(tmp17, (0, 1, 2), v.baa.xov, (0, 3, 4), (1, 3, 4, 2))
@@ -525,24 +525,24 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp114
     tmp117 = einsum(tmp116, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
     del tmp116
-    tmp32 = tmp30.copy() * 0.5
+    tmp32 = np.copy(tmp30) * 0.5
     del tmp30
     tmp32 += einsum(v.bbb.xov, (0, 1, 2), tmp31, (1, 3, 2, 4), (0, 3, 4))
     del tmp31
     tmp32 += einsum(t1.bb, (0, 1), tmp7, (2,), (2, 0, 1)) * 0.5
-    tmp24 = f.aa.ov.copy()
+    tmp24 = np.copy(f.aa.ov)
     tmp24 += tmp13 * -1
     del tmp13
     tmp24 += tmp23
     del tmp23
     tmp29 = einsum(v.baa.xov, (0, 1, 2), tmp19, (0, 3, 4), (1, 3, 4, 2))
     del tmp19
-    tmp22 = f.bb.ov.copy()
+    tmp22 = np.copy(f.bb.ov)
     tmp22 += tmp20 * -1
     del tmp20
     tmp22 += tmp21
     del tmp21
-    tmp8 = tmp3.copy() * 0.5
+    tmp8 = np.copy(tmp3) * 0.5
     del tmp3
     tmp8 += einsum(v.baa.xov, (0, 1, 2), tmp4, (1, 3, 2, 4), (0, 3, 4))
     del tmp4
@@ -555,11 +555,11 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new.bbbb = einsum(tmp45, (0, 1), t2.bbbb, (2, 0, 3, 4), (2, 1, 3, 4)) * -1
     t2new.bbbb += einsum(tmp174, (0, 1, 2, 3), tmp173, (0, 2, 4, 5), (1, 3, 5, 4)) * 0.5
     del tmp173
-    t2new.bbbb += tmp175.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp175, (0, 1, 3, 2)) * -1
     del tmp175
-    t2new.bbbb += tmp178.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp178, (1, 0, 3, 2)) * -1
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), tmp128, (3, 4), (0, 1, 2, 4)) * -4
-    t2new.bbbb += tmp178.transpose((0, 1, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp178, (0, 1, 3, 2)) * 2
     del tmp178
     t2new.bbbb += einsum(tmp174, (0, 1, 2, 3), tmp179, (0, 2, 4, 5), (1, 3, 5, 4)) * -0.5
     del tmp174, tmp179
@@ -567,89 +567,89 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp181
     t2new.bbbb += tmp182
     t2new.bbbb += einsum(tmp134, (0, 1), t2.bbbb, (2, 3, 4, 0), (2, 3, 4, 1)) * 2
-    t2new.bbbb += tmp182.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp184.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp186.transpose((1, 0, 3, 2)) * -2
-    t2new.bbbb += tmp188.transpose((1, 0, 2, 3))
-    t2new.bbbb += tmp188.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp192.transpose((1, 0, 3, 2)) * -2
-    t2new.bbbb += tmp184.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp184.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp186.transpose((0, 1, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp182, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp184, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp186, (1, 0, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp188, (1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp188, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp192, (1, 0, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp184, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp184, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp186, (0, 1, 3, 2)) * 2
     del tmp186
     t2new.bbbb += tmp188 * -1
-    t2new.bbbb += tmp188.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp188, (0, 1, 3, 2))
     del tmp188
-    t2new.bbbb += tmp192.transpose((0, 1, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp192, (0, 1, 3, 2)) * 2
     del tmp192
     t2new.bbbb += tmp184
     del tmp184
     t2new.bbbb += einsum(tmp195, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (4, 0, 2, 5)) * 2
     del tmp195
     t2new.bbbb += tmp196
-    t2new.bbbb += tmp198.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp198, (1, 0, 2, 3))
     t2new.bbbb += tmp202 * -2
-    t2new.bbbb += tmp196.transpose((1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp196, (1, 0, 2, 3)) * -1
     del tmp196
-    t2new.bbbb += tmp203.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp158.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp203, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp158, (0, 1, 3, 2))
     t2new.bbbb += tmp204 * 2
-    t2new.bbbb += tmp204.transpose((1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp204, (1, 0, 3, 2)) * 2
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), tmp206, (4, 1, 5, 3), (4, 0, 5, 2)) * -2
     del tmp206
     t2new.bbbb += einsum(t2.abab, (0, 1, 2, 3), tmp208, (0, 4, 2, 5), (4, 1, 5, 3)) * -1
     del tmp208
-    t2new.bbbb += tmp158.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp204.transpose((0, 1, 3, 2)) * -2
-    t2new.bbbb += tmp204.transpose((1, 0, 2, 3)) * -2
+    t2new.bbbb += np.transpose(tmp158, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp204, (0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp204, (1, 0, 2, 3)) * -2
     del tmp204
     t2new.bbbb += einsum(tmp209, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (4, 0, 2, 5)) * 4
     del tmp209
     t2new.bbbb += einsum(t2.abab, (0, 1, 2, 3), tmp211, (0, 4, 2, 5), (1, 4, 5, 3))
     del tmp211
     t2new.bbbb += tmp158 * -1
-    t2new.bbbb += tmp213.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp215.transpose((0, 1, 3, 2)) * 2
-    t2new.bbbb += tmp158.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp213, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp215, (0, 1, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp158, (1, 0, 2, 3))
     del tmp158
-    t2new.bbbb += tmp213.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp213, (0, 1, 3, 2)) * -1
     del tmp213
-    t2new.bbbb += tmp215.transpose((1, 0, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp215, (1, 0, 3, 2)) * -2
     del tmp215
-    t2new.bbbb += tmp216.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp218.transpose((0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp216, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp218, (0, 1, 3, 2)) * -2
     del tmp218
     t2new.bbbb += tmp219
-    t2new.bbbb += tmp219.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp219, (0, 1, 3, 2)) * -1
     del tmp219
-    t2new.bbbb += tmp221.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp221.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp221, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp221, (1, 0, 3, 2)) * -1
     t2new.bbbb += tmp223
-    t2new.bbbb += tmp223.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp223, (0, 1, 3, 2)) * -1
     del tmp223
-    t2new.bbbb += tmp216.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp216, (1, 0, 3, 2)) * -1
     del tmp216
     t2new.bbbb += tmp225 * 2
     del tmp225
     t2new.bbbb += einsum(tmp227, (0, 1, 2, 3), t2.bbbb, (4, 5, 0, 1), (4, 5, 3, 2)) * 2
     del tmp227
-    t2new.bbbb += tmp182.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp182.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp182, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp182, (1, 0, 3, 2))
     del tmp182
-    t2new.bbbb += tmp228.transpose((1, 0, 2, 3))
-    t2new.bbbb += tmp202.transpose((1, 0, 3, 2)) * -2
-    t2new.bbbb += tmp198.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp228, (1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp202, (1, 0, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp198, (1, 0, 3, 2)) * -1
     del tmp198
     t2new.bbbb += tmp228 * -1
     del tmp228
-    t2new.bbbb += tmp202.transpose((0, 1, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp202, (0, 1, 3, 2)) * 2
     del tmp202
-    t2new.bbbb += tmp203.transpose((1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp203, (1, 0, 2, 3)) * -1
     del tmp203
     t2new.bbbb += einsum(t1.bb, (0, 1), tmp230, (2, 3, 0, 4), (2, 3, 1, 4)) * -2
     del tmp230
     t2new.bbbb += tmp221 * -1
-    t2new.bbbb += tmp221.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp221, (1, 0, 2, 3))
     del tmp221
     t2new.abab = einsum(t2.abab, (0, 1, 2, 3), tmp45, (1, 4), (0, 4, 2, 3)) * -1
     t2new.abab += einsum(tmp126, (0, 1, 2, 3), tmp125, (0, 4, 1, 5), (4, 5, 2, 3)) * 0.5
@@ -724,12 +724,12 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new.aaaa = einsum(tmp27, (0, 1), t2.aaaa, (2, 0, 3, 4), (2, 1, 3, 4)) * -1
     t2new.aaaa += einsum(tmp47, (0, 1, 2, 3), tmp46, (0, 4, 1, 5), (4, 5, 3, 2)) * 0.5
     del tmp47
-    t2new.aaaa += tmp48.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp48, (0, 1, 3, 2)) * -1
     del tmp48
-    t2new.aaaa += tmp51.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp51, (0, 1, 3, 2)) * -1
     t2new.aaaa += einsum(tmp53, (0, 1), t2.aaaa, (2, 3, 4, 1), (2, 3, 4, 0)) * -2
     del tmp53
-    t2new.aaaa += tmp51.transpose((1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp51, (1, 0, 3, 2)) * 2
     del tmp51
     t2new.aaaa += einsum(tmp54, (0, 1, 2, 3), tmp46, (0, 4, 1, 5), (4, 5, 3, 2)) * -0.5
     del tmp46, tmp54
@@ -738,89 +738,89 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new.aaaa += tmp61
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp63, (3, 4), (0, 1, 2, 4)) * 2
     del tmp63
-    t2new.aaaa += tmp61.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp65.transpose((1, 0, 3, 2)) * -2
-    t2new.aaaa += tmp67.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp69.transpose((1, 0, 2, 3))
-    t2new.aaaa += tmp69.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp75.transpose((0, 1, 3, 2)) * -2
-    t2new.aaaa += tmp67.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp65.transpose((0, 1, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp61, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp65, (1, 0, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp67, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp69, (1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp69, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp75, (0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp67, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp65, (0, 1, 3, 2)) * 2
     del tmp65
-    t2new.aaaa += tmp67.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp67, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp69 * -1
-    t2new.aaaa += tmp69.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp69, (0, 1, 3, 2))
     del tmp69
-    t2new.aaaa += tmp75.transpose((1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp75, (1, 0, 3, 2)) * 2
     del tmp75
     t2new.aaaa += tmp67
     del tmp67
     t2new.aaaa += einsum(tmp80, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (4, 0, 2, 5)) * 2
     del tmp80
     t2new.aaaa += tmp82
-    t2new.aaaa += tmp84.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp90.transpose((1, 0, 3, 2)) * -2
-    t2new.aaaa += tmp82.transpose((1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp84, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp90, (1, 0, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp82, (1, 0, 2, 3)) * -1
     del tmp82
-    t2new.aaaa += tmp91.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp92.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp91, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp92, (0, 1, 3, 2))
     t2new.aaaa += tmp93 * 2
-    t2new.aaaa += tmp93.transpose((1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp93, (1, 0, 3, 2)) * 2
     t2new.aaaa += einsum(tmp97, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (0, 4, 2, 5)) * -2
     del tmp97
     t2new.aaaa += einsum(tmp101, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (0, 4, 2, 5)) * -1
     del tmp101
-    t2new.aaaa += tmp92.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp93.transpose((0, 1, 3, 2)) * -2
-    t2new.aaaa += tmp93.transpose((1, 0, 2, 3)) * -2
+    t2new.aaaa += np.transpose(tmp92, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp93, (0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp93, (1, 0, 2, 3)) * -2
     del tmp93
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp103, (4, 1, 5, 3), (0, 4, 5, 2)) * 2
     del tmp103
     t2new.aaaa += einsum(tmp105, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 2, 5))
     del tmp105
     t2new.aaaa += tmp92 * -1
-    t2new.aaaa += tmp107.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp109.transpose((1, 0, 2, 3)) * 2
-    t2new.aaaa += tmp92.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp107, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp109, (1, 0, 2, 3)) * 2
+    t2new.aaaa += np.transpose(tmp92, (1, 0, 2, 3))
     del tmp92
-    t2new.aaaa += tmp107.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp107, (0, 1, 3, 2)) * -1
     del tmp107
     t2new.aaaa += tmp109 * -2
     del tmp109
-    t2new.aaaa += tmp110.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp112.transpose((0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp110, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp112, (0, 1, 3, 2)) * -2
     del tmp112
     t2new.aaaa += tmp113
-    t2new.aaaa += tmp113.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp113, (0, 1, 3, 2)) * -1
     del tmp113
-    t2new.aaaa += tmp115.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp115.transpose((1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp115, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp115, (1, 0, 3, 2)) * -1
     t2new.aaaa += tmp117
-    t2new.aaaa += tmp117.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp117, (0, 1, 3, 2)) * -1
     del tmp117
-    t2new.aaaa += tmp110.transpose((1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp110, (1, 0, 3, 2)) * -1
     del tmp110
     t2new.aaaa += tmp119 * 2
     del tmp119
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp121, (2, 3, 4, 5), (0, 1, 5, 4)) * 2
     del tmp121
-    t2new.aaaa += tmp61.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp61.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp61, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp61, (1, 0, 3, 2))
     del tmp61
-    t2new.aaaa += tmp122.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp122, (1, 0, 2, 3))
     t2new.aaaa += tmp90 * -2
     t2new.aaaa += tmp84 * -1
     del tmp84
     t2new.aaaa += tmp122 * -1
     del tmp122
-    t2new.aaaa += tmp90.transpose((1, 0, 2, 3)) * 2
+    t2new.aaaa += np.transpose(tmp90, (1, 0, 2, 3)) * 2
     del tmp90
-    t2new.aaaa += tmp91.transpose((1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp91, (1, 0, 2, 3)) * -1
     del tmp91
     t2new.aaaa += einsum(tmp124, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3)) * -2
     del tmp124
     t2new.aaaa += tmp115 * -1
-    t2new.aaaa += tmp115.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp115, (1, 0, 2, 3))
     del tmp115
     t1new.bb = einsum(t2.bbbb, (0, 1, 2, 3), tmp28, (4, 1, 0, 3), (4, 2)) * -2
     del tmp28
@@ -844,7 +844,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t1new.bb += einsum(tmp22, (0, 1), t2.bbbb, (2, 0, 3, 1), (2, 3)) * 2
     t1new.bb += einsum(t1.bb, (0, 1), tmp45, (0, 2), (2, 1)) * -1
     del tmp45
-    t1new.aa = f.aa.ov.copy()
+    t1new.aa = np.copy(f.aa.ov)
     t1new.aa += einsum(tmp1, (0, 1, 2, 3), t2.aaaa, (2, 1, 4, 3), (0, 4)) * -2
     del tmp1
     t1new.aa += einsum(t2.abab, (0, 1, 2, 3), tmp2, (4, 0, 1, 3), (4, 2)) * -1
@@ -902,7 +902,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new = Namespace()
     tmp12 = einsum(v.baa.xov, (0, 1, 2), t1.aa, (1, 2), (0,))
     tmp13 = einsum(t1.bb, (0, 1), v.bbb.xov, (2, 0, 1), (2,))
-    tmp14 = tmp12.copy()
+    tmp14 = np.copy(tmp12)
     tmp14 += tmp13
     tmp4 = einsum(t1.bb, (0, 1), v.bbb.xov, (2, 3, 1), (2, 0, 3))
     tmp68 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 4, 0, 1), (3, 4))
@@ -925,42 +925,42 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp36 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 3, 4, 1), (0, 4))
     tmp35 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (4, 3, 0, 1), (4, 2))
     tmp63 = einsum(t1.bb, (0, 1), l2.abab, (2, 1, 3, 4), (3, 4, 0, 2))
-    tmp70 = tmp67.copy()
+    tmp70 = np.copy(tmp67)
     tmp70 += tmp68
     tmp70 += tmp69 * 2
     tmp65 = einsum(l2.bbbb, (0, 1, 2, 3), t1.bb, (4, 1), (2, 3, 4, 0))
     tmp52 = einsum(t1.aa, (0, 1), l2.abab, (1, 2, 3, 4), (3, 0, 4, 2))
-    tmp57 = tmp54.copy() * 0.5
+    tmp57 = np.copy(tmp54) * 0.5
     tmp57 += tmp55
     tmp57 += tmp56 * 0.5
     tmp50 = einsum(l2.aaaa, (0, 1, 2, 3), t1.aa, (4, 1), (2, 3, 4, 0))
-    tmp213 = tmp7.copy()
+    tmp213 = np.copy(tmp7)
     tmp213 += tmp8
     tmp213 += tmp9 * 2
-    tmp112 = f.bb.ov.copy()
+    tmp112 = np.copy(f.bb.ov)
     tmp112 += tmp110 * -1
     tmp112 += tmp111
-    tmp129 = tmp8.copy() * 0.5
+    tmp129 = np.copy(tmp8) * 0.5
     tmp129 += tmp9
-    tmp168 = v.bbb.xov.copy()
+    tmp168 = np.copy(v.bbb.xov)
     tmp168 += tmp7
     tmp168 += tmp8
     tmp168 += tmp9 * 2
-    tmp166 = v.baa.xov.copy()
+    tmp166 = np.copy(v.baa.xov)
     tmp166 += tmp27
     tmp166 += tmp24 * 2
     tmp166 += tmp25
-    tmp105 = tmp12.copy()
+    tmp105 = np.copy(tmp12)
     del tmp12
     tmp105 += tmp13
     del tmp13
-    tmp125 = tmp44.copy()
+    tmp125 = np.copy(tmp44)
     tmp125 += tmp45 * 2
     tmp15 = einsum(v.baa.xov, (0, 1, 2), tmp14, (0,), (1, 2))
     tmp11 = einsum(tmp1, (0, 1, 2), v.baa.xov, (0, 1, 3), (2, 3))
-    tmp37 = tmp35.copy()
+    tmp37 = np.copy(tmp35)
     tmp37 += tmp36 * 0.5
-    tmp179 = tmp27.copy() * 0.5
+    tmp179 = np.copy(tmp27) * 0.5
     tmp179 += tmp24
     tmp179 += tmp25 * 0.5
     tmp119 = einsum(v.bbb.xov, (0, 1, 2), v.bbb.xov, (0, 3, 4), (3, 1, 4, 2))
@@ -986,13 +986,13 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp129
     tmp128 = einsum(v.bbb.xoo, (0, 1, 2), tmp4, (0, 2, 3), (1, 3))
     tmp131 = einsum(v.bbb.xoo, (0, 1, 2), tmp14, (0,), (1, 2))
-    tmp204 = v.bbb.xoo.copy()
-    tmp204 += tmp4.transpose((0, 2, 1))
-    tmp89 = v.baa.xov.copy()
+    tmp204 = np.copy(v.bbb.xoo)
+    tmp204 += np.transpose(tmp4, (0, 2, 1))
+    tmp89 = np.copy(v.baa.xov)
     tmp89 += tmp27
     tmp89 += tmp24 * 2
     tmp89 += tmp25
-    tmp10 = v.bbb.xov.copy()
+    tmp10 = np.copy(v.bbb.xov)
     tmp10 += tmp7
     tmp10 += tmp8
     tmp10 += tmp9 * 2
@@ -1009,9 +1009,9 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp143 = einsum(t2.bbbb, (0, 1, 2, 3), l2.bbbb, (4, 3, 5, 1), (5, 0, 4, 2))
     tmp142 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 4, 0, 5), (5, 1, 4, 3))
     tmp197 = einsum(v.bbb.xov, (0, 1, 2), tmp125, (3, 2), (0, 1, 3)) * 0.5
-    tmp80 = tmp24.copy() * 2
+    tmp80 = np.copy(tmp24) * 2
     tmp80 += tmp25
-    tmp16 = f.aa.ov.copy()
+    tmp16 = np.copy(f.aa.ov)
     tmp16 += tmp11 * -1
     tmp16 += tmp15
     tmp99 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 3, 4, 5), (4, 0, 5, 1))
@@ -1031,86 +1031,86 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp101 = einsum(t1.aa, (0, 1), tmp50, (2, 3, 4, 1), (3, 2, 4, 0))
     tmp180 = einsum(tmp179, (0, 1, 2), v.baa.xov, (0, 1, 3), (2, 3)) * 2
     tmp181 = einsum(tmp14, (0,), v.baa.xvv, (0, 1, 2), (1, 2))
-    tmp157 = v.baa.xoo.copy()
-    tmp157 += tmp1.transpose((0, 2, 1))
+    tmp157 = np.copy(v.baa.xoo)
+    tmp157 += np.transpose(tmp1, (0, 2, 1))
     tmp93 = einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (4, 3, 5, 1), (2, 4, 0, 5))
     tmp94 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (4, 3, 5, 1), (5, 0, 4, 2))
-    tmp98 = v.bbb.xoo.copy()
-    tmp98 += tmp4.transpose((0, 2, 1))
+    tmp98 = np.copy(v.bbb.xoo)
+    tmp98 += np.transpose(tmp4, (0, 2, 1))
     tmp118 = einsum(v.bbb.xoo, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (1, 3, 4, 2))
     tmp120 = einsum(t2.bbbb, (0, 1, 2, 3), tmp119, (4, 5, 2, 3), (0, 1, 5, 4)) * -1
     tmp121 = einsum(tmp4, (0, 1, 2), tmp4, (0, 3, 4), (3, 1, 4, 2))
     tmp122 = einsum(tmp4, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (1, 3, 4, 2))
-    tmp5 = v.bbb.xoo.copy()
+    tmp5 = np.copy(v.bbb.xoo)
     tmp5 += tmp4
-    tmp2 = v.baa.xoo.copy()
+    tmp2 = np.copy(v.baa.xoo)
     tmp2 += tmp1
     tmp18 = einsum(t2.abab, (0, 1, 2, 3), tmp17, (4, 5, 2, 3), (0, 4, 1, 5))
-    tmp41 = tmp40.copy() * 0.5
+    tmp41 = np.copy(tmp40) * 0.5
     del tmp40
     tmp41 += tmp35
     del tmp35
-    tmp41 += tmp36.transpose((1, 0)) * 0.5
+    tmp41 += np.transpose(tmp36, (1, 0)) * 0.5
     del tmp36
-    tmp72 = l1.bb.transpose((1, 0)).copy() * -1
+    tmp72 = np.copy(np.transpose(l1.bb, (1, 0))) * -1
     tmp72 += t1.bb * -1
     tmp72 += tmp61 * -1
     tmp72 += tmp62 * -2
     tmp72 += tmp64
     tmp72 += tmp66 * 2
     tmp72 += tmp71
-    tmp46 = tmp43.copy()
+    tmp46 = np.copy(tmp43)
     del tmp43
-    tmp46 += tmp44.transpose((1, 0))
+    tmp46 += np.transpose(tmp44, (1, 0))
     del tmp44
-    tmp46 += tmp45.transpose((1, 0)) * 2
+    tmp46 += np.transpose(tmp45, (1, 0)) * 2
     del tmp45
-    tmp74 = tmp54.copy() * 0.5
+    tmp74 = np.copy(tmp54) * 0.5
     del tmp54
     tmp74 += tmp55
     del tmp55
-    tmp74 += tmp56.transpose((1, 0)) * 0.5
+    tmp74 += np.transpose(tmp56, (1, 0)) * 0.5
     del tmp56
-    tmp76 = tmp67.copy()
+    tmp76 = np.copy(tmp67)
     del tmp67
     tmp76 += tmp68
     del tmp68
-    tmp76 += tmp69.transpose((1, 0)) * 2
+    tmp76 += np.transpose(tmp69, (1, 0)) * 2
     del tmp69
-    tmp59 = l1.aa.transpose((1, 0)).copy() * -0.5
+    tmp59 = np.copy(np.transpose(l1.aa, (1, 0))) * -0.5
     tmp59 += t1.aa * -0.5
     tmp59 += tmp48 * -1
     tmp59 += tmp49 * -0.5
     tmp59 += tmp51
     tmp59 += tmp53 * 0.5
     tmp59 += tmp58
-    tmp19 = v.baa.xoo.copy()
-    tmp19 += tmp1.transpose((0, 2, 1))
+    tmp19 = np.copy(v.baa.xoo)
+    tmp19 += np.transpose(tmp1, (0, 2, 1))
     tmp30 = einsum(t2.aaaa, (0, 1, 2, 3), tmp29, (4, 5, 2, 3), (0, 1, 5, 4)) * -1
     tmp32 = einsum(v.baa.xoo, (0, 1, 2), tmp1, (0, 3, 4), (3, 1, 2, 4))
     tmp28 = einsum(v.baa.xoo, (0, 1, 2), v.baa.xoo, (0, 3, 4), (1, 3, 4, 2))
     tmp31 = einsum(tmp1, (0, 1, 2), tmp1, (0, 3, 4), (3, 1, 4, 2))
     tmp115 = einsum(v.bbb.xvv, (0, 1, 2), v.bbb.xov, (0, 3, 4), (3, 1, 2, 4))
-    tmp216 = f.bb.vv.copy() * -1
+    tmp216 = np.copy(f.bb.vv) * -1
     tmp216 += tmp214
     del tmp214
-    tmp216 += tmp215.transpose((1, 0)) * -1
+    tmp216 += np.transpose(tmp215, (1, 0)) * -1
     del tmp215
     tmp224 = einsum(v.bbb.xov, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (3, 4, 1, 2))
-    tmp133 = f.bb.oo.copy()
+    tmp133 = np.copy(f.bb.oo)
     tmp133 += tmp128 * -1
     del tmp128
     tmp133 += tmp130
     del tmp130
-    tmp133 += tmp131.transpose((1, 0))
+    tmp133 += np.transpose(tmp131, (1, 0))
     del tmp131
-    tmp133 += tmp132.transpose((1, 0))
+    tmp133 += np.transpose(tmp132, (1, 0))
     del tmp132
     tmp235 = einsum(v.bbb.xvv, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 3, 4, 2))
     tmp205 = einsum(tmp204, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 2, 3, 4))
     tmp138 = einsum(tmp89, (0, 1, 2), l2.abab, (2, 3, 1, 4), (0, 4, 3))
     tmp139 = einsum(tmp10, (0, 1, 2), l2.bbbb, (3, 2, 4, 1), (0, 4, 3)) * 2
-    tmp203 = tmp200.copy()
+    tmp203 = np.copy(tmp200)
     tmp203 += tmp134 * -1
     tmp203 += tmp135 * -2
     tmp203 += tmp136 * -1
@@ -1122,28 +1122,28 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp221 = einsum(v.bbb.xov, (0, 1, 2), tmp70, (3, 1), (0, 3, 2))
     tmp223 = einsum(v.bbb.xov, (0, 1, 2), tmp4, (0, 3, 4), (3, 1, 4, 2))
     tmp227 = einsum(v.bbb.xov, (0, 1, 2), tmp204, (0, 3, 4), (3, 4, 1, 2))
-    tmp217 = f.bb.ov.copy()
+    tmp217 = np.copy(f.bb.ov)
     tmp217 += tmp110 * -1
     tmp217 += tmp206
-    tmp150 = tmp148.transpose((1, 0, 3, 2)).copy()
+    tmp150 = np.copy(np.transpose(tmp148, (1, 0, 3, 2)))
     del tmp148
-    tmp150 += tmp149.transpose((0, 1, 3, 2)) * -1
+    tmp150 += np.transpose(tmp149, (0, 1, 3, 2)) * -1
     del tmp149
-    tmp245 = tmp142.copy()
+    tmp245 = np.copy(tmp142)
     tmp245 += tmp143 * 4
-    tmp198 = v.bbb.xov.copy() * 0.5
+    tmp198 = np.copy(v.bbb.xov) * 0.5
     tmp198 += tmp197 * -1
     tmp81 = einsum(v.baa.xov, (0, 1, 2), tmp80, (0, 3, 2), (1, 3))
     tmp79 = einsum(v.baa.xoo, (0, 1, 2), tmp1, (0, 2, 3), (1, 3))
     tmp82 = einsum(tmp14, (0,), v.baa.xoo, (0, 1, 2), (1, 2))
     tmp83 = einsum(tmp16, (0, 1), t1.aa, (2, 1), (2, 0))
-    tmp147 = tmp99.copy()
+    tmp147 = np.copy(tmp99)
     tmp147 += tmp91
     tmp209 = einsum(v.bbb.xvv, (0, 1, 2), v.baa.xvv, (0, 3, 4), (3, 4, 1, 2))
-    tmp155 = v.baa.xov.copy()
+    tmp155 = np.copy(v.baa.xov)
     tmp155 += tmp154 * -1
     tmp191 = einsum(v.baa.xov, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 4, 1, 2))
-    tmp170 = tmp161.copy()
+    tmp170 = np.copy(tmp161)
     tmp170 += tmp85 * -2
     tmp170 += tmp86 * -1
     tmp170 += tmp87 * -2
@@ -1152,22 +1152,22 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp167
     tmp170 += tmp169
     del tmp169
-    tmp184 = f.aa.ov.copy()
+    tmp184 = np.copy(f.aa.ov)
     tmp184 += tmp11 * -1
     tmp184 += tmp173
-    tmp102 = tmp100.transpose((1, 0, 3, 2)).copy()
+    tmp102 = np.copy(np.transpose(tmp100, (1, 0, 3, 2)))
     del tmp100
-    tmp102 += tmp101.transpose((0, 1, 3, 2)) * -1
+    tmp102 += np.transpose(tmp101, (0, 1, 3, 2)) * -1
     del tmp101
-    tmp182 = f.aa.vv.copy() * -1
+    tmp182 = np.copy(f.aa.vv) * -1
     tmp182 += tmp180
     del tmp180
-    tmp182 += tmp181.transpose((1, 0)) * -1
+    tmp182 += np.transpose(tmp181, (1, 0)) * -1
     del tmp181
     tmp189 = einsum(v.baa.xov, (0, 1, 2), tmp1, (0, 3, 4), (3, 1, 4, 2))
     tmp195 = einsum(tmp57, (0, 1), v.baa.xov, (2, 1, 3), (2, 0, 3)) * 2
     tmp158 = einsum(v.baa.xov, (0, 1, 2), tmp157, (0, 3, 4), (3, 4, 1, 2))
-    tmp193 = tmp93.copy() * 4
+    tmp193 = np.copy(tmp93) * 4
     tmp193 += tmp94
     tmp38 = einsum(v.baa.xov, (0, 1, 2), tmp37, (3, 2), (0, 1, 3))
     del tmp37
@@ -1179,14 +1179,14 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp145 = einsum(l1.bb, (0, 1), t2.bbbb, (2, 3, 4, 0), (1, 2, 3, 4)) * -1
     tmp145 += einsum(t2.abab, (0, 1, 2, 3), tmp63, (0, 4, 5, 2), (4, 5, 1, 3)) * 0.5
     tmp145 += einsum(t2.bbbb, (0, 1, 2, 3), tmp65, (4, 1, 5, 3), (4, 5, 0, 2)) * -2
-    tmp144 = tmp142.copy()
+    tmp144 = np.copy(tmp142)
     del tmp142
-    tmp144 += tmp143.transpose((0, 1, 3, 2)) * 4
+    tmp144 += np.transpose(tmp143, (0, 1, 3, 2)) * 4
     del tmp143
     tmp141 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (4, 3, 0, 5), (5, 1, 4, 2))
     tmp146 = einsum(l1.bb, (0, 1), t2.abab, (2, 3, 4, 0), (2, 1, 3, 4))
     tmp146 += einsum(tmp52, (0, 1, 2, 3), t2.abab, (0, 4, 5, 3), (1, 2, 4, 5)) * -1
-    tmp151 = t1.bb.copy() * -1
+    tmp151 = np.copy(t1.bb) * -1
     tmp151 += tmp61 * -1
     del tmp61
     tmp151 += tmp62 * -2
@@ -1198,12 +1198,12 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp151 += tmp71
     del tmp71
     tmp116 = einsum(v.bbb.xov, (0, 1, 2), tmp98, (0, 3, 4), (3, 4, 1, 2))
-    tmp123 = tmp118.transpose((3, 2, 1, 0)).copy()
-    tmp123 += tmp120.transpose((2, 3, 1, 0))
-    tmp123 += tmp121.transpose((2, 3, 1, 0))
-    tmp123 += tmp122.transpose((1, 3, 0, 2))
-    tmp123 += tmp122.transpose((3, 2, 0, 1)) * -1
-    tmp117 = v.bbb.xov.copy()
+    tmp123 = np.copy(np.transpose(tmp118, (3, 2, 1, 0)))
+    tmp123 += np.transpose(tmp120, (2, 3, 1, 0))
+    tmp123 += np.transpose(tmp121, (2, 3, 1, 0))
+    tmp123 += np.transpose(tmp122, (1, 3, 0, 2))
+    tmp123 += np.transpose(tmp122, (3, 2, 0, 1)) * -1
+    tmp117 = np.copy(v.bbb.xov)
     tmp117 += tmp8
     del tmp8
     tmp117 += tmp9 * 2
@@ -1211,7 +1211,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp109 = einsum(tmp5, (0, 1, 2), v.bbb.xov, (0, 3, 4), (2, 1, 3, 4))
     tmp108 = einsum(tmp2, (0, 1, 2), v.bbb.xov, (0, 3, 4), (2, 1, 3, 4))
     tmp107 = einsum(v.bbb.xov, (0, 1, 2), v.baa.xvv, (0, 3, 4), (1, 3, 4, 2))
-    tmp113 = tmp18.transpose((1, 0, 2, 3)).copy()
+    tmp113 = np.copy(np.transpose(tmp18, (1, 0, 2, 3)))
     tmp113 += einsum(tmp2, (0, 1, 2), tmp98, (0, 3, 4), (2, 1, 4, 3))
     tmp42 = einsum(tmp41, (0, 1), v.baa.xvv, (2, 1, 0), (2,)) * 2
     del tmp41
@@ -1227,21 +1227,21 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp59
     tmp3 = einsum(tmp2, (0, 1, 2), v.baa.xov, (0, 3, 4), (2, 1, 3, 4))
     tmp0 = einsum(v.baa.xov, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 2, 3, 4))
-    tmp20 = tmp18.transpose((0, 1, 3, 2)).copy()
+    tmp20 = np.copy(np.transpose(tmp18, (0, 1, 3, 2)))
     tmp20 += einsum(tmp5, (0, 1, 2), tmp19, (0, 3, 4), (4, 3, 2, 1))
     tmp6 = einsum(tmp5, (0, 1, 2), v.baa.xov, (0, 3, 4), (3, 2, 1, 4))
-    tmp33 = tmp28.transpose((3, 2, 1, 0)).copy()
-    tmp33 += tmp30.transpose((2, 3, 1, 0))
-    tmp33 += tmp31.transpose((2, 3, 1, 0))
-    tmp33 += tmp32.transpose((1, 3, 0, 2))
-    tmp33 += tmp32.transpose((3, 2, 0, 1)) * -1
+    tmp33 = np.copy(np.transpose(tmp28, (3, 2, 1, 0)))
+    tmp33 += np.transpose(tmp30, (2, 3, 1, 0))
+    tmp33 += np.transpose(tmp31, (2, 3, 1, 0))
+    tmp33 += np.transpose(tmp32, (1, 3, 0, 2))
+    tmp33 += np.transpose(tmp32, (3, 2, 0, 1)) * -1
     tmp23 = einsum(v.baa.xov, (0, 1, 2), tmp19, (0, 3, 4), (1, 3, 4, 2))
-    tmp26 = v.baa.xov.copy()
+    tmp26 = np.copy(v.baa.xov)
     tmp26 += tmp24 * 2
     del tmp24
     tmp26 += tmp25
     del tmp25
-    tmp103 = t1.aa.copy() * -0.5
+    tmp103 = np.copy(t1.aa) * -0.5
     tmp103 += tmp48 * -1
     del tmp48
     tmp103 += tmp49 * -0.5
@@ -1252,9 +1252,9 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp53
     tmp103 += tmp58
     del tmp58
-    tmp95 = tmp93.copy()
+    tmp95 = np.copy(tmp93)
     del tmp93
-    tmp95 += tmp94.transpose((0, 1, 3, 2)) * 0.25
+    tmp95 += np.transpose(tmp94, (0, 1, 3, 2)) * 0.25
     del tmp94
     tmp97 = einsum(t2.abab, (0, 1, 2, 3), l1.aa, (2, 4), (4, 0, 1, 3))
     tmp97 += einsum(tmp63, (0, 1, 2, 3), t2.abab, (4, 1, 3, 5), (0, 4, 2, 5)) * -1
@@ -1272,7 +1272,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp236 = einsum(tmp235, (0, 1, 2, 3), l2.bbbb, (3, 2, 4, 5), (4, 5, 0, 1))
     del tmp235
     tmp233 = einsum(tmp205, (0, 1, 2, 3), l2.bbbb, (4, 2, 5, 1), (0, 5, 3, 4))
-    tmp230 = tmp200.copy()
+    tmp230 = np.copy(tmp200)
     del tmp200
     tmp230 += tmp134 * -1
     tmp230 += tmp135 * -2
@@ -1283,44 +1283,44 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp234 = einsum(v.bbb.xov, (0, 1, 2), tmp203, (0, 3, 4), (3, 1, 4, 2))
     tmp247 = einsum(v.bbb.xov, (0, 1, 2), tmp221, (0, 3, 4), (3, 1, 4, 2))
     tmp244 = einsum(tmp65, (0, 1, 2, 3), tmp223, (1, 2, 4, 5), (0, 4, 3, 5))
-    tmp242 = tmp118.transpose((3, 2, 1, 0)).copy()
+    tmp242 = np.copy(np.transpose(tmp118, (3, 2, 1, 0)))
     del tmp118
-    tmp242 += tmp120.transpose((0, 3, 1, 2))
+    tmp242 += np.transpose(tmp120, (0, 3, 1, 2))
     del tmp120
-    tmp242 += tmp121.transpose((0, 3, 1, 2))
+    tmp242 += np.transpose(tmp121, (0, 3, 1, 2))
     del tmp121
     tmp228 = einsum(l1.bb, (0, 1), tmp227, (2, 1, 3, 4), (3, 2, 4, 0))
     tmp240 = einsum(tmp217, (0, 1), tmp65, (2, 3, 0, 4), (2, 3, 1, 4))
     tmp238 = einsum(tmp119, (0, 1, 2, 3), tmp150, (4, 5, 0, 1), (4, 5, 2, 3)) * 0.5
     tmp246 = einsum(tmp119, (0, 1, 2, 3), tmp245, (4, 0, 5, 3), (4, 1, 5, 2))
     del tmp245
-    tmp207 = f.bb.ov.copy()
+    tmp207 = np.copy(f.bb.ov)
     tmp207 += tmp206
     del tmp206
     tmp226 = einsum(v.bbb.xov, (0, 1, 2), tmp198, (0, 3, 4), (3, 1, 4, 2)) * 2
-    tmp232 = f.bb.ov.copy()
+    tmp232 = np.copy(f.bb.ov)
     tmp232 += tmp111
     del tmp111
-    tmp219 = tmp18.copy()
+    tmp219 = np.copy(tmp18)
     del tmp18
     tmp219 += einsum(tmp98, (0, 1, 2), tmp19, (0, 3, 4), (4, 3, 2, 1))
     tmp225 = einsum(l2.aaaa, (0, 1, 2, 3), t2.abab, (3, 4, 1, 5), (2, 4, 0, 5))
     tmp225 += einsum(t2.bbbb, (0, 1, 2, 3), l2.abab, (4, 3, 5, 1), (5, 0, 4, 2))
     tmp222 = einsum(t2.aaaa, (0, 1, 2, 3), l2.abab, (3, 4, 1, 5), (0, 5, 2, 4))
     tmp222 += einsum(l2.bbbb, (0, 1, 2, 3), t2.abab, (4, 3, 5, 1), (4, 2, 5, 0))
-    tmp174 = f.aa.ov.copy()
+    tmp174 = np.copy(f.aa.ov)
     tmp174 += tmp173
     del tmp173
-    tmp84 = f.aa.oo.copy()
+    tmp84 = np.copy(f.aa.oo)
     tmp84 += tmp79 * -1
-    tmp84 += tmp81.transpose((1, 0))
+    tmp84 += np.transpose(tmp81, (1, 0))
     del tmp81
-    tmp84 += tmp82.transpose((1, 0))
+    tmp84 += np.transpose(tmp82, (1, 0))
     del tmp82
     tmp84 += tmp83
     del tmp83
     tmp218 = einsum(v.bbb.xov, (0, 1, 2), tmp157, (0, 3, 4), (3, 4, 1, 2))
-    tmp212 = f.aa.vv.copy() * -0.5
+    tmp212 = np.copy(f.aa.vv) * -0.5
     tmp212 += einsum(tmp179, (0, 1, 2), v.baa.xov, (0, 1, 3), (2, 3))
     del tmp179
     tmp212 += einsum(v.baa.xvv, (0, 1, 2), tmp14, (0,), (1, 2)) * -0.5
@@ -1334,11 +1334,11 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp157
     tmp156 = einsum(v.baa.xov, (0, 1, 2), tmp155, (0, 3, 4), (3, 1, 4, 2))
     del tmp155
-    tmp187 = tmp28.transpose((3, 2, 1, 0)).copy()
+    tmp187 = np.copy(np.transpose(tmp28, (3, 2, 1, 0)))
     del tmp28
-    tmp187 += tmp30.transpose((0, 3, 1, 2))
+    tmp187 += np.transpose(tmp30, (0, 3, 1, 2))
     del tmp30
-    tmp187 += tmp31.transpose((0, 3, 1, 2))
+    tmp187 += np.transpose(tmp31, (0, 3, 1, 2))
     del tmp31
     tmp192 = einsum(tmp50, (0, 1, 2, 3), tmp191, (4, 0, 2, 5), (1, 4, 3, 5)) * -1
     tmp171 = einsum(tmp170, (0, 1, 2), v.baa.xov, (0, 3, 4), (1, 3, 2, 4))
@@ -1346,7 +1346,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp178 = einsum(tmp102, (0, 1, 2, 3), tmp29, (2, 3, 4, 5), (0, 1, 4, 5)) * 0.5
     tmp160 = einsum(v.baa.xvv, (0, 1, 2), tmp19, (0, 3, 4), (4, 3, 1, 2))
     del tmp19
-    tmp172 = f.aa.oo.copy() * 0.5
+    tmp172 = np.copy(f.aa.oo) * 0.5
     tmp172 += tmp79 * -0.5
     del tmp79
     tmp172 += einsum(v.baa.xov, (0, 1, 2), tmp80, (0, 3, 2), (3, 1)) * 0.5
@@ -1357,7 +1357,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp183 = einsum(tmp182, (0, 1), l2.aaaa, (2, 0, 3, 4), (3, 4, 1, 2)) * -1
     del tmp182
     tmp190 = einsum(tmp50, (0, 1, 2, 3), tmp189, (1, 2, 4, 5), (0, 4, 3, 5))
-    tmp162 = tmp161.copy()
+    tmp162 = np.copy(tmp161)
     del tmp161
     tmp162 += tmp85 * -2
     tmp162 += tmp86 * -1
@@ -1371,7 +1371,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp159 = einsum(tmp158, (0, 1, 2, 3), l1.aa, (4, 1), (2, 0, 3, 4))
     tmp194 = einsum(tmp29, (0, 1, 2, 3), tmp193, (4, 0, 5, 3), (4, 1, 5, 2))
     del tmp193
-    tmp163 = f.aa.ov.copy()
+    tmp163 = np.copy(f.aa.ov)
     tmp163 += tmp15
     del tmp15
     tmp188 = einsum(v.baa.xov, (0, 1, 2), tmp38, (0, 3, 4), (3, 1, 4, 2)) * -2
@@ -1379,7 +1379,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp177 = einsum(tmp176, (0, 1, 2, 3), l2.aaaa, (3, 2, 4, 5), (4, 5, 0, 1))
     del tmp176
     tmp175 = einsum(tmp50, (0, 1, 2, 3), tmp22, (2, 4, 3, 5), (1, 0, 5, 4))
-    tmp127 = tmp126.copy()
+    tmp127 = np.copy(tmp126)
     tmp127 += einsum(tmp5, (0, 1, 2), l1.bb, (3, 1), (0, 2, 3))
     tmp152 = einsum(tmp7, (0, 1, 2), l1.bb, (2, 3), (0, 1, 3))
     tmp152 += einsum(v.baa.xvv, (0, 1, 2), tmp141, (3, 4, 1, 2), (0, 4, 3))
@@ -1401,7 +1401,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp152 += einsum(v.bbb.xov, (0, 1, 2), tmp151, (3, 2), (0, 3, 1)) * -1
     del tmp151
     tmp152 += einsum(tmp70, (0, 1), v.bbb.xoo, (2, 3, 0), (2, 1, 3)) * -1
-    tmp140 = tmp134.copy() * -1
+    tmp140 = np.copy(tmp134) * -1
     del tmp134
     tmp140 += tmp135 * -2
     del tmp135
@@ -1423,7 +1423,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp7
     tmp124 += einsum(tmp123, (0, 1, 2, 3), t1.bb, (0, 4), (1, 3, 2, 4)) * -0.5
     del tmp123
-    tmp153 = f.bb.vv.copy()
+    tmp153 = np.copy(f.bb.vv)
     tmp153 += einsum(tmp105, (0,), v.bbb.xvv, (0, 1, 2), (1, 2))
     tmp114 = einsum(tmp107, (0, 1, 2, 3), t2.abab, (4, 5, 1, 3), (4, 0, 5, 2))
     tmp114 += einsum(tmp108, (0, 1, 2, 3), t2.abab, (0, 4, 5, 3), (1, 2, 4, 5)) * -1
@@ -1435,7 +1435,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp114 += einsum(tmp112, (0, 1), t2.abab, (2, 3, 4, 1), (2, 0, 3, 4))
     tmp114 += einsum(t1.aa, (0, 1), tmp113, (0, 2, 3, 4), (2, 4, 3, 1)) * -1
     del tmp113
-    tmp78 = tmp42.copy()
+    tmp78 = np.copy(tmp42)
     del tmp42
     tmp78 += tmp47
     del tmp47
@@ -1456,10 +1456,10 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp21 += einsum(t2.abab, (0, 1, 2, 3), tmp16, (4, 2), (4, 0, 1, 3))
     tmp21 += einsum(t1.bb, (0, 1), tmp20, (2, 3, 0, 4), (3, 2, 4, 1)) * -1
     del tmp20
-    tmp39 = tmp38.copy()
+    tmp39 = np.copy(tmp38)
     del tmp38
     tmp39 += einsum(tmp2, (0, 1, 2), l1.aa, (3, 1), (0, 2, 3)) * 0.5
-    tmp90 = tmp85.copy() * -0.5
+    tmp90 = np.copy(tmp85) * -0.5
     del tmp85
     tmp90 += tmp86 * -0.25
     del tmp86
@@ -1479,7 +1479,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp2
     tmp34 += einsum(t1.aa, (0, 1), tmp33, (0, 2, 3, 4), (2, 4, 3, 1)) * -1
     del tmp33
-    tmp106 = f.aa.vv.copy()
+    tmp106 = np.copy(f.aa.vv)
     tmp106 += einsum(v.baa.xvv, (0, 1, 2), tmp105, (0,), (1, 2))
     del tmp105
     tmp104 = einsum(tmp27, (0, 1, 2), l1.aa, (2, 3), (0, 1, 3)) * 0.25
@@ -1507,47 +1507,47 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     tmp104 += einsum(v.baa.xov, (0, 1, 2), tmp103, (3, 2), (0, 3, 1)) * -0.5
     del tmp103
     tmp104 += einsum(v.baa.xoo, (0, 1, 2), tmp57, (2, 3), (0, 3, 1)) * -0.5
-    l2new.bbbb = tmp226.transpose((3, 2, 1, 0)).copy()
+    l2new.bbbb = np.copy(np.transpose(tmp226, (3, 2, 1, 0)))
     l2new.bbbb += einsum(l1.bb, (0, 1), tmp116, (2, 1, 3, 4), (4, 0, 3, 2)) * -1
     del tmp116
-    l2new.bbbb += tmp226.transpose((2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp226, (2, 3, 1, 0)) * -1
     del tmp226
-    l2new.bbbb += tmp228.transpose((3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp228, (3, 2, 0, 1))
     l2new.bbbb += einsum(l2.bbbb, (0, 1, 2, 3), tmp229, (3, 4, 5, 1), (5, 0, 2, 4)) * 2
     del tmp229
     l2new.bbbb += einsum(tmp230, (0, 1, 2), v.bbb.xov, (0, 3, 4), (4, 2, 1, 3)) * -1
     del tmp230
-    l2new.bbbb += tmp231.transpose((3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp231, (3, 2, 1, 0)) * -1
     l2new.bbbb += einsum(l1.bb, (0, 1), tmp232, (2, 3), (3, 0, 1, 2)) * -1
     del tmp232
-    l2new.bbbb += tmp233.transpose((2, 3, 0, 1)) * -2
-    l2new.bbbb += tmp234.transpose((3, 2, 1, 0))
-    l2new.bbbb += tmp231.transpose((3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp233, (2, 3, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp234, (3, 2, 1, 0))
+    l2new.bbbb += np.transpose(tmp231, (3, 2, 0, 1))
     del tmp231
     l2new.bbbb += einsum(tmp207, (0, 1), l1.bb, (2, 3), (1, 2, 0, 3))
-    l2new.bbbb += tmp233.transpose((3, 2, 1, 0)) * -2
-    l2new.bbbb += tmp234.transpose((2, 3, 0, 1))
+    l2new.bbbb += np.transpose(tmp233, (3, 2, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp234, (2, 3, 0, 1))
     l2new.bbbb += einsum(l1.bb, (0, 1), tmp207, (2, 3), (0, 3, 1, 2))
-    l2new.bbbb += tmp233.transpose((3, 2, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp233, (3, 2, 0, 1)) * 2
     del tmp233
-    l2new.bbbb += tmp234.transpose((2, 3, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp234, (2, 3, 1, 0)) * -1
     del tmp234
     l2new.bbbb += einsum(tmp207, (0, 1), l1.bb, (2, 3), (2, 1, 0, 3)) * -1
-    l2new.bbbb += tmp236.transpose((2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp236, (2, 3, 1, 0)) * -2
     del tmp236
-    l2new.bbbb += tmp237.transpose((2, 3, 1, 0)) * 2
-    l2new.bbbb += tmp238.transpose((3, 2, 1, 0)) * 4
+    l2new.bbbb += np.transpose(tmp237, (2, 3, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp238, (3, 2, 1, 0)) * 4
     del tmp238
-    l2new.bbbb += tmp239.transpose((2, 3, 1, 0)) * 2
-    l2new.bbbb += tmp240.transpose((2, 3, 1, 0)) * -2
-    l2new.bbbb += tmp237.transpose((3, 2, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp239, (2, 3, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp240, (2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp237, (3, 2, 1, 0)) * -2
     del tmp237
-    l2new.bbbb += tmp239.transpose((3, 2, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp239, (3, 2, 1, 0)) * -2
     del tmp239
-    l2new.bbbb += tmp240.transpose((3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp240, (3, 2, 1, 0)) * 2
     del tmp240
-    l2new.bbbb += tmp241.transpose((2, 3, 0, 1)) * -2
-    l2new.bbbb += tmp241.transpose((2, 3, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp241, (2, 3, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp241, (2, 3, 1, 0)) * 2
     del tmp241
     l2new.bbbb += einsum(tmp242, (0, 1, 2, 3), l2.bbbb, (4, 5, 0, 2), (4, 5, 1, 3)) * -2
     del tmp242
@@ -1557,31 +1557,31 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp227
     l2new.bbbb += einsum(v.bbb.xov, (0, 1, 2), tmp197, (0, 3, 4), (4, 2, 3, 1)) * -2
     del tmp197
-    l2new.bbbb += tmp228.transpose((3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp228, (3, 2, 1, 0)) * -1
     del tmp228
     l2new.bbbb += einsum(l1.bb, (0, 1), tmp110, (2, 3), (3, 0, 1, 2))
-    l2new.bbbb += tmp243.transpose((3, 2, 0, 1)) * -2
-    l2new.bbbb += tmp244.transpose((3, 2, 0, 1)) * -2
-    l2new.bbbb += tmp246.transpose((3, 2, 0, 1))
-    l2new.bbbb += tmp247.transpose((2, 3, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp243, (3, 2, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp244, (3, 2, 0, 1)) * -2
+    l2new.bbbb += np.transpose(tmp246, (3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp247, (2, 3, 0, 1)) * -1
     l2new.bbbb += einsum(l1.bb, (0, 1), tmp110, (2, 3), (0, 3, 1, 2)) * -1
-    l2new.bbbb += tmp243.transpose((2, 3, 0, 1)) * 2
-    l2new.bbbb += tmp244.transpose((2, 3, 0, 1)) * 2
-    l2new.bbbb += tmp246.transpose((2, 3, 0, 1)) * -1
-    l2new.bbbb += tmp247.transpose((3, 2, 0, 1))
+    l2new.bbbb += np.transpose(tmp243, (2, 3, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp244, (2, 3, 0, 1)) * 2
+    l2new.bbbb += np.transpose(tmp246, (2, 3, 0, 1)) * -1
+    l2new.bbbb += np.transpose(tmp247, (3, 2, 0, 1))
     l2new.bbbb += einsum(tmp110, (0, 1), l1.bb, (2, 3), (1, 2, 0, 3)) * -1
-    l2new.bbbb += tmp243.transpose((3, 2, 1, 0)) * 2
-    l2new.bbbb += tmp244.transpose((3, 2, 1, 0)) * 2
-    l2new.bbbb += tmp246.transpose((3, 2, 1, 0)) * -1
-    l2new.bbbb += tmp247.transpose((2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp243, (3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp244, (3, 2, 1, 0)) * 2
+    l2new.bbbb += np.transpose(tmp246, (3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp247, (2, 3, 1, 0))
     l2new.bbbb += einsum(tmp110, (0, 1), l1.bb, (2, 3), (2, 1, 0, 3))
-    l2new.bbbb += tmp243.transpose((2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp243, (2, 3, 1, 0)) * -2
     del tmp243
-    l2new.bbbb += tmp244.transpose((2, 3, 1, 0)) * -2
+    l2new.bbbb += np.transpose(tmp244, (2, 3, 1, 0)) * -2
     del tmp244
-    l2new.bbbb += tmp246.transpose((2, 3, 1, 0))
+    l2new.bbbb += np.transpose(tmp246, (2, 3, 1, 0))
     del tmp246
-    l2new.bbbb += tmp247.transpose((3, 2, 1, 0)) * -1
+    l2new.bbbb += np.transpose(tmp247, (3, 2, 1, 0)) * -1
     del tmp247
     l2new.abab = einsum(tmp198, (0, 1, 2), v.baa.xov, (0, 3, 4), (4, 2, 3, 1)) * 2
     del tmp198
@@ -1603,9 +1603,9 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.abab += einsum(l2.abab, (0, 1, 2, 3), tmp133, (3, 4), (0, 1, 2, 4)) * -1
     l2new.abab += einsum(tmp0, (0, 1, 2, 3), tmp52, (4, 0, 5, 2), (1, 3, 4, 5)) * -1
     del tmp0
-    l2new.abab += tmp210.transpose((2, 3, 0, 1))
+    l2new.abab += np.transpose(tmp210, (2, 3, 0, 1))
     del tmp210
-    l2new.abab += tmp211.transpose((2, 3, 0, 1)) * 2
+    l2new.abab += np.transpose(tmp211, (2, 3, 0, 1)) * 2
     del tmp211
     l2new.abab += einsum(tmp212, (0, 1), l2.abab, (0, 2, 3, 4), (1, 2, 3, 4)) * -2
     del tmp212
@@ -1651,12 +1651,12 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp63, tmp224
     l2new.abab += einsum(tmp225, (0, 1, 2, 3), tmp119, (1, 4, 5, 3), (2, 5, 0, 4)) * -2
     del tmp119, tmp225
-    l2new.aaaa = tmp156.transpose((3, 2, 1, 0)).copy()
+    l2new.aaaa = np.copy(np.transpose(tmp156, (3, 2, 1, 0)))
     l2new.aaaa += einsum(tmp23, (0, 1, 2, 3), l1.aa, (4, 2), (3, 4, 0, 1)) * -1
     del tmp23
-    l2new.aaaa += tmp156.transpose((2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp156, (2, 3, 1, 0)) * -1
     del tmp156
-    l2new.aaaa += tmp159.transpose((3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp159, (3, 2, 0, 1))
     l2new.aaaa += einsum(l2.aaaa, (0, 1, 2, 3), tmp160, (3, 4, 5, 1), (5, 0, 2, 4)) * 2
     del tmp160
     l2new.aaaa += einsum(tmp162, (0, 1, 2), v.baa.xov, (0, 3, 4), (4, 2, 1, 3)) * -1
@@ -1664,71 +1664,71 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     l2new.aaaa += einsum(tmp84, (0, 1), l2.aaaa, (2, 3, 4, 0), (2, 3, 4, 1)) * -2
     l2new.aaaa += einsum(tmp163, (0, 1), l1.aa, (2, 3), (1, 2, 3, 0)) * -1
     del tmp163
-    l2new.aaaa += tmp165.transpose((2, 3, 0, 1)) * -2
-    l2new.aaaa += tmp171.transpose((3, 2, 1, 0))
+    l2new.aaaa += np.transpose(tmp165, (2, 3, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp171, (3, 2, 1, 0))
     l2new.aaaa += einsum(tmp172, (0, 1), l2.aaaa, (2, 3, 4, 0), (2, 3, 1, 4)) * 4
     del tmp172
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp174, (2, 3), (3, 0, 2, 1))
-    l2new.aaaa += tmp165.transpose((3, 2, 1, 0)) * -2
-    l2new.aaaa += tmp171.transpose((2, 3, 0, 1))
+    l2new.aaaa += np.transpose(tmp165, (3, 2, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp171, (2, 3, 0, 1))
     l2new.aaaa += einsum(tmp174, (0, 1), l1.aa, (2, 3), (2, 1, 3, 0))
-    l2new.aaaa += tmp165.transpose((3, 2, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp165, (3, 2, 0, 1)) * 2
     del tmp165
-    l2new.aaaa += tmp171.transpose((2, 3, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp171, (2, 3, 1, 0)) * -1
     del tmp171
     l2new.aaaa += einsum(tmp174, (0, 1), l1.aa, (2, 3), (2, 1, 0, 3)) * -1
     del tmp174
-    l2new.aaaa += tmp175.transpose((2, 3, 1, 0)) * 2
-    l2new.aaaa += tmp177.transpose((2, 3, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp175, (2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp177, (2, 3, 1, 0)) * -2
     del tmp177
-    l2new.aaaa += tmp178.transpose((3, 2, 1, 0)) * 4
+    l2new.aaaa += np.transpose(tmp178, (3, 2, 1, 0)) * 4
     del tmp178
-    l2new.aaaa += tmp183.transpose((2, 3, 1, 0)) * 2
-    l2new.aaaa += tmp185.transpose((2, 3, 1, 0)) * -2
-    l2new.aaaa += tmp175.transpose((3, 2, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp183, (2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp185, (2, 3, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp175, (3, 2, 1, 0)) * -2
     del tmp175
-    l2new.aaaa += tmp183.transpose((3, 2, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp183, (3, 2, 1, 0)) * -2
     del tmp183
-    l2new.aaaa += tmp185.transpose((3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp185, (3, 2, 1, 0)) * 2
     del tmp185
-    l2new.aaaa += tmp186.transpose((2, 3, 0, 1)) * -2
-    l2new.aaaa += tmp186.transpose((2, 3, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp186, (2, 3, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp186, (2, 3, 1, 0)) * 2
     del tmp186
     l2new.aaaa += einsum(tmp187, (0, 1, 2, 3), l2.aaaa, (4, 5, 0, 2), (4, 5, 1, 3)) * -2
     del tmp187
-    l2new.aaaa += tmp188.transpose((3, 2, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp188, (3, 2, 0, 1)) * -1
     l2new.aaaa += einsum(tmp158, (0, 1, 2, 3), l1.aa, (4, 1), (3, 4, 0, 2))
     del tmp158
-    l2new.aaaa += tmp188.transpose((2, 3, 0, 1))
+    l2new.aaaa += np.transpose(tmp188, (2, 3, 0, 1))
     del tmp188
-    l2new.aaaa += tmp159.transpose((3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp159, (3, 2, 1, 0)) * -1
     del tmp159
     l2new.aaaa += einsum(tmp11, (0, 1), l1.aa, (2, 3), (1, 2, 3, 0))
-    l2new.aaaa += tmp190.transpose((3, 2, 0, 1)) * -2
-    l2new.aaaa += tmp192.transpose((3, 2, 0, 1)) * -2
-    l2new.aaaa += tmp194.transpose((3, 2, 0, 1))
-    l2new.aaaa += tmp196.transpose((2, 3, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp190, (3, 2, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp192, (3, 2, 0, 1)) * -2
+    l2new.aaaa += np.transpose(tmp194, (3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp196, (2, 3, 0, 1)) * -1
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp11, (2, 3), (0, 3, 1, 2)) * -1
-    l2new.aaaa += tmp190.transpose((2, 3, 0, 1)) * 2
-    l2new.aaaa += tmp192.transpose((2, 3, 0, 1)) * 2
-    l2new.aaaa += tmp194.transpose((2, 3, 0, 1)) * -1
-    l2new.aaaa += tmp196.transpose((3, 2, 0, 1))
+    l2new.aaaa += np.transpose(tmp190, (2, 3, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp192, (2, 3, 0, 1)) * 2
+    l2new.aaaa += np.transpose(tmp194, (2, 3, 0, 1)) * -1
+    l2new.aaaa += np.transpose(tmp196, (3, 2, 0, 1))
     l2new.aaaa += einsum(l1.aa, (0, 1), tmp11, (2, 3), (3, 0, 2, 1)) * -1
-    l2new.aaaa += tmp190.transpose((3, 2, 1, 0)) * 2
-    l2new.aaaa += tmp192.transpose((3, 2, 1, 0)) * 2
-    l2new.aaaa += tmp194.transpose((3, 2, 1, 0)) * -1
-    l2new.aaaa += tmp196.transpose((2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp190, (3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp192, (3, 2, 1, 0)) * 2
+    l2new.aaaa += np.transpose(tmp194, (3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp196, (2, 3, 1, 0))
     l2new.aaaa += einsum(tmp11, (0, 1), l1.aa, (2, 3), (2, 1, 0, 3))
     del tmp11
-    l2new.aaaa += tmp190.transpose((2, 3, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp190, (2, 3, 1, 0)) * -2
     del tmp190
-    l2new.aaaa += tmp192.transpose((2, 3, 1, 0)) * -2
+    l2new.aaaa += np.transpose(tmp192, (2, 3, 1, 0)) * -2
     del tmp192
-    l2new.aaaa += tmp194.transpose((2, 3, 1, 0))
+    l2new.aaaa += np.transpose(tmp194, (2, 3, 1, 0))
     del tmp194
-    l2new.aaaa += tmp196.transpose((3, 2, 1, 0)) * -1
+    l2new.aaaa += np.transpose(tmp196, (3, 2, 1, 0)) * -1
     del tmp196
-    l1new.bb = f.bb.ov.transpose((1, 0)).copy()
+    l1new.bb = np.copy(np.transpose(f.bb.ov, (1, 0)))
     l1new.bb += einsum(l2.abab, (0, 1, 2, 3), tmp114, (2, 4, 3, 0), (1, 4)) * -1
     del tmp114
     l1new.bb += einsum(l2.bbbb, (0, 1, 2, 3), tmp124, (4, 2, 3, 1), (0, 4)) * 4
@@ -1746,7 +1746,7 @@ def update_lams(f=None, l1=None, l2=None, t1=None, t2=None, v=None, **kwargs):
     del tmp70, tmp112
     l1new.bb += einsum(l1.bb, (0, 1), tmp153, (0, 2), (2, 1))
     del tmp153
-    l1new.aa = f.aa.ov.transpose((1, 0)).copy()
+    l1new.aa = np.copy(np.transpose(f.aa.ov, (1, 0)))
     l1new.aa += einsum(tmp21, (0, 1, 2, 3), l2.abab, (4, 3, 1, 2), (4, 0)) * -1
     del tmp21
     l1new.aa += einsum(l2.aaaa, (0, 1, 2, 3), tmp34, (4, 2, 3, 1), (0, 4)) * 2
@@ -1803,11 +1803,11 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp0 = einsum(t1.aa, (0, 1), l1.aa, (1, 2), (2, 0))
     tmp1 = einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (4, 3, 0, 1), (2, 4))
     tmp9 = einsum(l2.bbbb, (0, 1, 2, 3), t1.bb, (4, 1), (2, 3, 4, 0))
-    tmp11 = tmp4.copy()
+    tmp11 = np.copy(tmp4)
     tmp11 += tmp5
     tmp11 += tmp3 * 2
     tmp10 = einsum(t1.bb, (0, 1), l2.abab, (2, 1, 3, 4), (3, 4, 0, 2))
-    tmp8 = tmp0.copy() * 0.5
+    tmp8 = np.copy(tmp0) * 0.5
     tmp8 += tmp1
     tmp8 += tmp2 * 0.5
     tmp7 = einsum(t1.aa, (0, 1), l2.abab, (1, 2, 3, 4), (3, 0, 4, 2))
@@ -1818,8 +1818,8 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm1.aa.vv = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 3, 4, 1), (0, 4))
     rdm1.aa.vv += einsum(t1.aa, (0, 1), l1.aa, (2, 0), (2, 1))
     rdm1.aa.vv += einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (4, 3, 0, 1), (4, 2)) * 2
-    rdm1.bb.vo = l1.bb.copy()
-    rdm1.aa.vo = l1.aa.copy()
+    rdm1.bb.vo = np.copy(l1.bb)
+    rdm1.aa.vo = np.copy(l1.aa)
     rdm1.bb.ov = einsum(t2.abab, (0, 1, 2, 3), l1.aa, (2, 0), (1, 3))
     rdm1.bb.ov += einsum(t2.bbbb, (0, 1, 2, 3), l1.bb, (3, 1), (0, 2)) * 2
     rdm1.bb.ov += t1.bb
@@ -1838,20 +1838,20 @@ def make_rdm1_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp7
     rdm1.aa.ov += einsum(tmp8, (0, 1), t1.aa, (0, 2), (1, 2)) * -2
     del tmp8
-    rdm1.bb.oo = tmp3.transpose((1, 0)).copy() * -2
+    rdm1.bb.oo = np.copy(np.transpose(tmp3, (1, 0))) * -2
     del tmp3
     rdm1.bb.oo += delta.bb.oo
-    rdm1.bb.oo += tmp4.transpose((1, 0)) * -1
+    rdm1.bb.oo += np.transpose(tmp4, (1, 0)) * -1
     del tmp4
-    rdm1.bb.oo += tmp5.transpose((1, 0)) * -1
+    rdm1.bb.oo += np.transpose(tmp5, (1, 0)) * -1
     del tmp5
-    rdm1.aa.oo = tmp0.transpose((1, 0)).copy() * -1
+    rdm1.aa.oo = np.copy(np.transpose(tmp0, (1, 0))) * -1
     del tmp0
     rdm1.aa.oo += delta.aa.oo
     del delta
-    rdm1.aa.oo += tmp1.transpose((1, 0)) * -2
+    rdm1.aa.oo += np.transpose(tmp1, (1, 0)) * -2
     del tmp1
-    rdm1.aa.oo += tmp2.transpose((1, 0)) * -1
+    rdm1.aa.oo += np.transpose(tmp2, (1, 0)) * -1
     del tmp2
     rdm1.aa = np.block([[rdm1.aa.oo, rdm1.aa.ov], [rdm1.aa.vo, rdm1.aa.vv]])
     rdm1.bb = np.block([[rdm1.bb.oo, rdm1.bb.ov], [rdm1.bb.vo, rdm1.bb.vv]])
@@ -1901,7 +1901,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp88 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 4, 0, 5), (5, 1, 4, 3))
     tmp68 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (4, 3, 5, 1), (5, 0, 4, 2))
     tmp72 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (4, 3, 5, 1), (5, 0, 4, 2))
-    tmp16 = tmp8.copy()
+    tmp16 = np.copy(tmp8)
     tmp16 += tmp9
     tmp16 += tmp10 * 2
     tmp17 = einsum(l2.bbbb, (0, 1, 2, 3), t2.bbbb, (4, 5, 0, 1), (2, 3, 4, 5))
@@ -1910,7 +1910,7 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp53 = einsum(t2.abab, (0, 1, 2, 3), tmp13, (0, 4, 5, 2), (4, 5, 1, 3))
     tmp12 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 3, 4, 5), (4, 0, 5, 1))
     tmp14 = einsum(t1.aa, (0, 1), tmp13, (2, 3, 4, 1), (2, 0, 3, 4))
-    tmp28 = tmp0.copy() * 0.5
+    tmp28 = np.copy(tmp0) * 0.5
     tmp28 += tmp1
     tmp28 += tmp2 * 0.5
     tmp32 = einsum(tmp6, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (0, 2, 4, 5)) * -1
@@ -1921,14 +1921,14 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp83 = einsum(l2.bbbb, (0, 1, 2, 3), t2.bbbb, (2, 3, 4, 1), (0, 4))
     tmp82 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (2, 4, 0, 1), (4, 3))
     tmp108 = einsum(l1.bb, (0, 1), t1.bb, (1, 2), (0, 2))
-    tmp90 = tmp88.copy()
+    tmp90 = np.copy(tmp88)
     tmp90 += tmp89 * 4
     tmp85 = einsum(l2.aaaa, (0, 1, 2, 3), t2.abab, (3, 4, 1, 5), (2, 4, 0, 5))
     tmp86 = einsum(t2.bbbb, (0, 1, 2, 3), l2.abab, (4, 3, 5, 1), (5, 0, 4, 2))
     tmp65 = einsum(t2.aaaa, (0, 1, 2, 3), l2.aaaa, (4, 3, 0, 1), (4, 2))
     tmp105 = einsum(t1.aa, (0, 1), l1.aa, (2, 0), (2, 1))
     tmp66 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (2, 3, 4, 1), (0, 4))
-    tmp119 = tmp68.copy() * 4
+    tmp119 = np.copy(tmp68) * 4
     tmp119 += tmp72
     tmp107 = einsum(tmp6, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 3, 4))
     tmp70 = einsum(l2.bbbb, (0, 1, 2, 3), t2.abab, (4, 3, 5, 1), (4, 2, 5, 0))
@@ -1940,29 +1940,29 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp35 = einsum(t2.abab, (0, 1, 2, 3), l1.aa, (2, 0), (1, 3))
     tmp49 = einsum(l1.bb, (0, 1), t2.bbbb, (2, 3, 4, 0), (1, 2, 3, 4))
     tmp50 = einsum(t1.bb, (0, 1), tmp16, (0, 2), (2, 1))
-    tmp54 = tmp17.transpose((1, 0, 3, 2)).copy()
-    tmp54 += tmp19.transpose((0, 1, 3, 2)) * -1
-    tmp103 = tmp53.copy()
+    tmp54 = np.copy(np.transpose(tmp17, (1, 0, 3, 2)))
+    tmp54 += np.transpose(tmp19, (0, 1, 3, 2)) * -1
+    tmp103 = np.copy(tmp53)
     tmp103 += tmp52 * 4
     tmp21 = einsum(l1.bb, (0, 1), t2.abab, (2, 1, 3, 0), (2, 3))
     tmp20 = einsum(l1.aa, (0, 1), t2.aaaa, (2, 1, 3, 0), (2, 3))
     tmp61 = einsum(t2.aaaa, (0, 1, 2, 3), tmp13, (1, 4, 5, 3), (0, 4, 5, 2))
     tmp60 = einsum(tmp18, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 2, 5)) * -1
-    tmp45 = tmp12.copy()
+    tmp45 = np.copy(tmp12)
     tmp45 += tmp14
     tmp43 = einsum(t2.bbbb, (0, 1, 2, 3), tmp26, (4, 5, 1, 3), (4, 5, 0, 2))
     tmp44 = einsum(tmp6, (0, 1, 2, 3), t2.abab, (1, 4, 3, 5), (0, 2, 4, 5)) * -1
     tmp25 = einsum(tmp6, (0, 1, 2, 3), t2.aaaa, (1, 0, 4, 3), (2, 4))
     tmp27 = einsum(t2.abab, (0, 1, 2, 3), tmp26, (0, 4, 1, 3), (4, 2))
     tmp58 = einsum(tmp28, (0, 1), t1.aa, (0, 2), (1, 2))
-    tmp80 = tmp32.copy() * 4
+    tmp80 = np.copy(tmp32) * 4
     tmp80 += tmp31
     tmp29 = einsum(tmp28, (0, 1), t1.aa, (0, 2), (1, 2)) * 2
     del tmp28
-    tmp33 = tmp5.transpose((1, 0, 3, 2)).copy()
-    tmp33 += tmp7.transpose((0, 1, 3, 2)) * -1
+    tmp33 = np.copy(np.transpose(tmp5, (1, 0, 3, 2)))
+    tmp33 += np.transpose(tmp7, (0, 1, 3, 2)) * -1
     tmp24 = einsum(t2.aaaa, (0, 1, 2, 3), l1.aa, (3, 4), (4, 0, 1, 2))
-    tmp4 = tmp0.copy()
+    tmp4 = np.copy(tmp0)
     tmp4 += tmp1 * 2
     tmp4 += tmp2
     tmp131 = einsum(l2.bbbb, (0, 1, 2, 3), t1.bb, (3, 4), (2, 0, 1, 4))
@@ -1972,60 +1972,60 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp132 = einsum(l2.aaaa, (0, 1, 2, 3), t2.aaaa, (2, 3, 4, 5), (0, 1, 4, 5))
     tmp127 = einsum(tmp18, (0, 1, 2, 3), t2.bbbb, (1, 0, 4, 5), (2, 3, 4, 5)) * -1
     tmp128 = einsum(t1.bb, (0, 1), tmp112, (0, 2, 3, 4), (2, 3, 4, 1)) * -1
-    tmp109 = tmp108.copy()
+    tmp109 = np.copy(tmp108)
     tmp109 += tmp82
     tmp109 += tmp83 * 2
     tmp124 = einsum(t2.bbbb, (0, 1, 2, 3), l1.bb, (4, 1), (0, 4, 2, 3))
     tmp126 = einsum(t1.bb, (0, 1), tmp90, (0, 2, 3, 4), (2, 1, 3, 4))
     tmp116 = einsum(t1.bb, (0, 1), tmp13, (2, 0, 3, 4), (2, 3, 4, 1))
     tmp91 = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (4, 3, 0, 5), (5, 1, 4, 2))
-    tmp87 = tmp85.copy()
+    tmp87 = np.copy(tmp85)
     tmp87 += tmp86
-    tmp106 = tmp105.copy() * 0.5
+    tmp106 = np.copy(tmp105) * 0.5
     tmp106 += tmp65
     tmp106 += tmp66 * 0.5
     tmp120 = einsum(t1.aa, (0, 1), tmp119, (0, 2, 3, 4), (2, 1, 3, 4))
     del tmp119
     tmp121 = einsum(t2.aaaa, (0, 1, 2, 3), tmp6, (1, 0, 4, 5), (4, 5, 2, 3)) * -1
     tmp122 = einsum(tmp107, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 3, 4)) * -1
-    tmp113 = tmp105.copy()
+    tmp113 = np.copy(tmp105)
     del tmp105
     tmp113 += tmp65 * 2
     tmp113 += tmp66
     tmp117 = einsum(t2.aaaa, (0, 1, 2, 3), l1.aa, (4, 1), (0, 4, 2, 3))
-    tmp125 = tmp88.copy()
+    tmp125 = np.copy(tmp88)
     tmp125 += tmp89 * 4
     tmp110 = einsum(l2.abab, (0, 1, 2, 3), t2.abab, (4, 3, 0, 5), (2, 4, 1, 5))
-    tmp123 = tmp114.copy()
+    tmp123 = np.copy(tmp114)
     tmp123 += tmp70
     tmp115 = einsum(t1.aa, (0, 1), tmp26, (0, 2, 3, 4), (2, 3, 1, 4))
-    tmp118 = tmp68.copy() * 4
+    tmp118 = np.copy(tmp68) * 4
     tmp118 += tmp72
-    tmp111 = tmp108.copy() * 0.5
+    tmp111 = np.copy(tmp108) * 0.5
     del tmp108
     tmp111 += tmp82 * 0.5
     tmp111 += tmp83
-    tmp42 = tmp39.copy() * 0.5
+    tmp42 = np.copy(tmp39) * 0.5
     tmp42 += tmp40
     tmp42 += tmp41
     del tmp41
-    tmp37 = t1.bb.copy()
+    tmp37 = np.copy(t1.bb)
     tmp37 += tmp35
     tmp37 += tmp36 * 2
     tmp100 = einsum(t2.bbbb, (0, 1, 2, 3), tmp16, (1, 4), (0, 4, 2, 3)) * -1
-    tmp48 = t1.bb.copy()
+    tmp48 = np.copy(t1.bb)
     tmp48 += tmp35
     tmp48 += tmp36 * 2
-    tmp84 = tmp82.copy() * 0.5
+    tmp84 = np.copy(tmp82) * 0.5
     tmp84 += tmp83
     tmp99 = einsum(t1.bb, (0, 1), tmp49, (0, 2, 3, 4), (2, 3, 1, 4))
-    tmp94 = tmp82.copy()
+    tmp94 = np.copy(tmp82)
     del tmp82
     tmp94 += tmp83 * 2
     del tmp83
-    tmp98 = tmp35.copy()
+    tmp98 = np.copy(tmp35)
     tmp98 += tmp36 * 2
-    tmp51 = tmp39.copy()
+    tmp51 = np.copy(tmp39)
     del tmp39
     tmp51 += tmp40 * 2
     del tmp40
@@ -2039,25 +2039,25 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp104 = einsum(t1.bb, (0, 1), tmp103, (0, 2, 3, 4), (2, 3, 1, 4))
     del tmp103
     tmp57 = einsum(l1.bb, (0, 1), t2.abab, (2, 3, 4, 0), (2, 1, 3, 4))
-    tmp67 = tmp65.copy()
+    tmp67 = np.copy(tmp65)
     tmp67 += tmp66 * 0.5
-    tmp74 = tmp20.copy() * 2
+    tmp74 = np.copy(tmp20) * 2
     tmp74 += tmp21
-    tmp93 = tmp61.copy()
+    tmp93 = np.copy(tmp61)
     tmp93 += tmp60
     tmp47 = einsum(tmp13, (0, 1, 2, 3), t2.abab, (4, 1, 3, 5), (0, 4, 2, 5))
     tmp63 = einsum(t2.abab, (0, 1, 2, 3), tmp26, (0, 4, 5, 3), (4, 5, 1, 2))
     tmp46 = einsum(t1.bb, (0, 1), tmp45, (2, 3, 0, 4), (2, 3, 4, 1))
-    tmp92 = tmp44.copy()
+    tmp92 = np.copy(tmp44)
     tmp92 += tmp43
     tmp38 = einsum(t2.abab, (0, 1, 2, 3), l1.aa, (2, 4), (4, 0, 1, 3))
-    tmp59 = tmp25.copy()
+    tmp59 = np.copy(tmp25)
     tmp59 += tmp27 * 0.5
     tmp59 += tmp58
     del tmp58
     tmp81 = einsum(t1.aa, (0, 1), tmp80, (0, 2, 3, 4), (2, 3, 1, 4))
     del tmp80
-    tmp30 = tmp25.copy() * 2
+    tmp30 = np.copy(tmp25) * 2
     del tmp25
     tmp30 += tmp27
     del tmp27
@@ -2067,102 +2067,102 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     tmp71 = einsum(t2.abab, (0, 1, 2, 3), tmp70, (4, 1, 5, 3), (4, 0, 5, 2))
     tmp69 = einsum(t2.aaaa, (0, 1, 2, 3), tmp68, (1, 4, 3, 5), (4, 0, 5, 2))
     tmp73 = einsum(tmp72, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 2), (4, 1, 5, 3))
-    tmp76 = tmp65.copy() * 2
+    tmp76 = np.copy(tmp65) * 2
     del tmp65
     tmp76 += tmp66
     del tmp66
-    tmp23 = t1.aa.copy()
+    tmp23 = np.copy(t1.aa)
     tmp23 += tmp20 * 2
     tmp23 += tmp21
     tmp75 = einsum(tmp24, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3))
     tmp78 = einsum(t2.aaaa, (0, 1, 2, 3), tmp33, (0, 1, 4, 5), (4, 5, 2, 3))
     tmp77 = einsum(tmp4, (0, 1), t2.aaaa, (2, 0, 3, 4), (1, 2, 3, 4)) * -1
-    tmp56 = t1.aa.copy()
+    tmp56 = np.copy(t1.aa)
     tmp56 += tmp20 * 2
     tmp56 += tmp21
-    tmp62 = tmp8.copy() * 0.5
+    tmp62 = np.copy(tmp8) * 0.5
     tmp62 += tmp9 * 0.5
     tmp62 += tmp10
     tmp55 = einsum(tmp54, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 3, 4)) * 2
     del tmp54
-    tmp64 = t1.bb.copy() * 0.5
+    tmp64 = np.copy(t1.bb) * 0.5
     tmp64 += tmp35 * 0.5
     del tmp35
     tmp64 += tmp36
     del tmp36
     tmp34 = einsum(t1.aa, (0, 1), tmp33, (0, 2, 3, 4), (2, 3, 4, 1)) * 2
     del tmp33
-    tmp22 = t1.aa.copy() * 0.5
+    tmp22 = np.copy(t1.aa) * 0.5
     tmp22 += tmp20
     del tmp20
     tmp22 += tmp21 * 0.5
     del tmp21
-    tmp15 = delta.bb.oo.copy() * -0.5
+    tmp15 = np.copy(delta.bb.oo) * -0.5
     tmp15 += tmp8 * 0.5
     tmp15 += tmp9 * 0.5
     tmp15 += tmp10
-    tmp11 = delta.bb.oo.copy() * -1
+    tmp11 = np.copy(delta.bb.oo) * -1
     tmp11 += tmp8
     del tmp8
     tmp11 += tmp9
     del tmp9
     tmp11 += tmp10 * 2
     del tmp10
-    tmp3 = delta.aa.oo.copy() * -0.5
+    tmp3 = np.copy(delta.aa.oo) * -0.5
     tmp3 += tmp0 * 0.5
     del tmp0
     tmp3 += tmp1
     del tmp1
     tmp3 += tmp2 * 0.5
     del tmp2
-    rdm2.bbbb.vvvv = tmp133.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.bbbb.vvvv = np.copy(np.transpose(tmp133, (1, 0, 3, 2))) * 2
     del tmp133
     rdm2.bbbb.vvvv += einsum(tmp131, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 4, 3)) * 2
     rdm2.abab.vvvv = einsum(t2.abab, (0, 1, 2, 3), l2.abab, (4, 5, 0, 1), (4, 5, 2, 3))
     rdm2.abab.vvvv += einsum(t1.aa, (0, 1), tmp130, (0, 2, 3, 4), (2, 3, 1, 4))
-    rdm2.aaaa.vvvv = tmp132.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.aaaa.vvvv = np.copy(np.transpose(tmp132, (1, 0, 3, 2))) * 2
     del tmp132
     rdm2.aaaa.vvvv += einsum(tmp129, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3)) * 2
-    rdm2.bbbb.vvvo = tmp131.transpose((2, 1, 3, 0)).copy() * 2
+    rdm2.bbbb.vvvo = np.copy(np.transpose(tmp131, (2, 1, 3, 0))) * 2
     rdm2.abab.vvvo = einsum(t1.aa, (0, 1), l2.abab, (2, 3, 0, 4), (2, 3, 1, 4))
-    rdm2.aaaa.vvvo = tmp129.transpose((2, 1, 3, 0)).copy() * 2
-    rdm2.bbbb.vvov = tmp131.transpose((2, 1, 0, 3)).copy() * -2
+    rdm2.aaaa.vvvo = np.copy(np.transpose(tmp129, (2, 1, 3, 0))) * 2
+    rdm2.bbbb.vvov = np.copy(np.transpose(tmp131, (2, 1, 0, 3))) * -2
     del tmp131
-    rdm2.abab.vvov = tmp130.transpose((1, 2, 0, 3)).copy()
+    rdm2.abab.vvov = np.copy(np.transpose(tmp130, (1, 2, 0, 3)))
     del tmp130
-    rdm2.aaaa.vvov = tmp129.transpose((2, 1, 0, 3)).copy() * -2
+    rdm2.aaaa.vvov = np.copy(np.transpose(tmp129, (2, 1, 0, 3))) * -2
     del tmp129
-    rdm2.bbbb.vovv = tmp124.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.bbbb.vovv = np.copy(np.transpose(tmp124, (1, 0, 3, 2))) * 2
     rdm2.bbbb.vovv += einsum(tmp109, (0, 1), t1.bb, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.bbbb.vovv += einsum(t1.bb, (0, 1), tmp109, (2, 3), (2, 0, 3, 1))
-    rdm2.bbbb.vovv += tmp126.transpose((2, 0, 1, 3))
-    rdm2.bbbb.vovv += tmp126.transpose((2, 0, 3, 1)) * -1
-    rdm2.bbbb.vovv += tmp127.transpose((1, 0, 3, 2)) * 2
-    rdm2.bbbb.vovv += tmp128.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.vovv += np.transpose(tmp126, (2, 0, 1, 3))
+    rdm2.bbbb.vovv += np.transpose(tmp126, (2, 0, 3, 1)) * -1
+    rdm2.bbbb.vovv += np.transpose(tmp127, (1, 0, 3, 2)) * 2
+    rdm2.bbbb.vovv += np.transpose(tmp128, (1, 0, 3, 2)) * 2
     rdm2.abab.vovv = einsum(l1.aa, (0, 1), t2.abab, (1, 2, 3, 4), (0, 2, 3, 4))
     rdm2.abab.vovv += einsum(tmp106, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3)) * 2
     rdm2.abab.vovv += einsum(tmp87, (0, 1, 2, 3), t1.aa, (0, 4), (2, 1, 4, 3)) * 2
     rdm2.abab.vovv += einsum(t1.bb, (0, 1), tmp91, (0, 2, 3, 4), (3, 2, 4, 1)) * -1
     rdm2.abab.vovv += einsum(tmp13, (0, 1, 2, 3), t2.abab, (0, 1, 4, 5), (3, 2, 4, 5)) * -1
     rdm2.abab.vovv += einsum(t1.aa, (0, 1), tmp116, (0, 2, 3, 4), (3, 2, 1, 4)) * -1
-    rdm2.aaaa.vovv = tmp117.transpose((1, 0, 3, 2)).copy() * 2
+    rdm2.aaaa.vovv = np.copy(np.transpose(tmp117, (1, 0, 3, 2))) * 2
     rdm2.aaaa.vovv += einsum(tmp113, (0, 1), t1.aa, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.aaaa.vovv += einsum(tmp113, (0, 1), t1.aa, (2, 3), (0, 2, 1, 3))
-    rdm2.aaaa.vovv += tmp120.transpose((2, 0, 1, 3))
-    rdm2.aaaa.vovv += tmp120.transpose((2, 0, 3, 1)) * -1
-    rdm2.aaaa.vovv += tmp121.transpose((1, 0, 3, 2)) * 2
-    rdm2.aaaa.vovv += tmp122.transpose((1, 0, 3, 2)) * 2
-    rdm2.bbbb.ovvv = tmp124.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.aaaa.vovv += np.transpose(tmp120, (2, 0, 1, 3))
+    rdm2.aaaa.vovv += np.transpose(tmp120, (2, 0, 3, 1)) * -1
+    rdm2.aaaa.vovv += np.transpose(tmp121, (1, 0, 3, 2)) * 2
+    rdm2.aaaa.vovv += np.transpose(tmp122, (1, 0, 3, 2)) * 2
+    rdm2.bbbb.ovvv = np.copy(np.transpose(tmp124, (0, 1, 3, 2))) * -2
     del tmp124
     rdm2.bbbb.ovvv += einsum(tmp109, (0, 1), t1.bb, (2, 3), (2, 0, 3, 1))
     rdm2.bbbb.ovvv += einsum(t1.bb, (0, 1), tmp109, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.bbbb.ovvv += einsum(tmp125, (0, 1, 2, 3), t1.bb, (0, 4), (1, 2, 4, 3)) * -1
     del tmp125
-    rdm2.bbbb.ovvv += tmp126.transpose((0, 2, 3, 1))
+    rdm2.bbbb.ovvv += np.transpose(tmp126, (0, 2, 3, 1))
     del tmp126
-    rdm2.bbbb.ovvv += tmp127.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.ovvv += np.transpose(tmp127, (0, 1, 3, 2)) * -2
     del tmp127
-    rdm2.bbbb.ovvv += tmp128.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.ovvv += np.transpose(tmp128, (0, 1, 3, 2)) * -2
     del tmp128
     rdm2.abab.ovvv = einsum(l1.bb, (0, 1), t2.abab, (2, 1, 3, 4), (2, 0, 3, 4))
     rdm2.abab.ovvv += einsum(t1.aa, (0, 1), tmp109, (2, 3), (0, 2, 1, 3))
@@ -2171,106 +2171,106 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp123
     rdm2.abab.ovvv += einsum(tmp26, (0, 1, 2, 3), t2.abab, (0, 2, 4, 5), (1, 3, 4, 5)) * -1
     rdm2.abab.ovvv += einsum(tmp115, (0, 1, 2, 3), t1.bb, (1, 4), (0, 3, 2, 4)) * -1
-    rdm2.aaaa.ovvv = tmp117.transpose((0, 1, 3, 2)).copy() * -2
+    rdm2.aaaa.ovvv = np.copy(np.transpose(tmp117, (0, 1, 3, 2))) * -2
     del tmp117
     rdm2.aaaa.ovvv += einsum(tmp113, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
     rdm2.aaaa.ovvv += einsum(tmp113, (0, 1), t1.aa, (2, 3), (2, 0, 1, 3)) * -1
     rdm2.aaaa.ovvv += einsum(t1.aa, (0, 1), tmp118, (0, 2, 3, 4), (2, 3, 1, 4)) * -1
     del tmp118
-    rdm2.aaaa.ovvv += tmp120.transpose((0, 2, 3, 1))
+    rdm2.aaaa.ovvv += np.transpose(tmp120, (0, 2, 3, 1))
     del tmp120
-    rdm2.aaaa.ovvv += tmp121.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.ovvv += np.transpose(tmp121, (0, 1, 3, 2)) * -2
     del tmp121
-    rdm2.aaaa.ovvv += tmp122.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.ovvv += np.transpose(tmp122, (0, 1, 3, 2)) * -2
     del tmp122
-    rdm2.bbbb.vvoo = l2.bbbb.copy() * 2
-    rdm2.abab.vvoo = l2.abab.copy()
-    rdm2.aaaa.vvoo = l2.aaaa.copy() * 2
+    rdm2.bbbb.vvoo = np.copy(l2.bbbb) * 2
+    rdm2.abab.vvoo = np.copy(l2.abab)
+    rdm2.aaaa.vvoo = np.copy(l2.aaaa) * 2
     rdm2.bbbb.vovo = einsum(tmp109, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3))
-    rdm2.bbbb.vovo += tmp88.transpose((2, 1, 3, 0)) * -1
-    rdm2.bbbb.vovo += tmp89.transpose((2, 1, 3, 0)) * -4
+    rdm2.bbbb.vovo += np.transpose(tmp88, (2, 1, 3, 0)) * -1
+    rdm2.bbbb.vovo += np.transpose(tmp89, (2, 1, 3, 0)) * -4
     rdm2.bbbb.vovo += einsum(t1.bb, (0, 1), l1.bb, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.bbbb.vovo += tmp112.transpose((2, 1, 3, 0)) * 2
+    rdm2.bbbb.vovo += np.transpose(tmp112, (2, 1, 3, 0)) * 2
     rdm2.abab.vovo = einsum(tmp106, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3)) * 2
-    rdm2.abab.vovo += tmp91.transpose((2, 1, 3, 0)) * -1
+    rdm2.abab.vovo += np.transpose(tmp91, (2, 1, 3, 0)) * -1
     rdm2.abab.vovo += einsum(tmp13, (0, 1, 2, 3), t1.aa, (0, 4), (3, 2, 4, 1)) * -1
     rdm2.aaaa.vovo = einsum(tmp113, (0, 1), delta.aa.oo, (2, 3), (0, 2, 1, 3))
-    rdm2.aaaa.vovo += tmp72.transpose((2, 1, 3, 0)) * -1
+    rdm2.aaaa.vovo += np.transpose(tmp72, (2, 1, 3, 0)) * -1
     rdm2.aaaa.vovo += einsum(t1.aa, (0, 1), l1.aa, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.aaaa.vovo += tmp68.transpose((2, 1, 3, 0)) * -4
-    rdm2.aaaa.vovo += tmp107.transpose((2, 1, 3, 0)) * 2
+    rdm2.aaaa.vovo += np.transpose(tmp68, (2, 1, 3, 0)) * -4
+    rdm2.aaaa.vovo += np.transpose(tmp107, (2, 1, 3, 0)) * 2
     rdm2.bbbb.voov = einsum(tmp111, (0, 1), delta.bb.oo, (2, 3), (0, 2, 3, 1)) * -2
-    rdm2.bbbb.voov += tmp88.transpose((2, 1, 0, 3))
+    rdm2.bbbb.voov += np.transpose(tmp88, (2, 1, 0, 3))
     rdm2.bbbb.voov += einsum(t1.bb, (0, 1), l1.bb, (2, 3), (2, 0, 3, 1))
-    rdm2.bbbb.voov += tmp89.transpose((2, 1, 0, 3)) * 4
-    rdm2.bbbb.voov += tmp112.transpose((2, 1, 0, 3)) * -2
-    rdm2.abab.voov = tmp85.transpose((2, 1, 0, 3)).copy() * 2
+    rdm2.bbbb.voov += np.transpose(tmp89, (2, 1, 0, 3)) * 4
+    rdm2.bbbb.voov += np.transpose(tmp112, (2, 1, 0, 3)) * -2
+    rdm2.abab.voov = np.copy(np.transpose(tmp85, (2, 1, 0, 3))) * 2
     del tmp85
     rdm2.abab.voov += einsum(t1.bb, (0, 1), l1.aa, (2, 3), (2, 0, 3, 1))
-    rdm2.abab.voov += tmp86.transpose((2, 1, 0, 3)) * 2
+    rdm2.abab.voov += np.transpose(tmp86, (2, 1, 0, 3)) * 2
     del tmp86
-    rdm2.abab.voov += tmp116.transpose((2, 1, 0, 3)) * -1
+    rdm2.abab.voov += np.transpose(tmp116, (2, 1, 0, 3)) * -1
     del tmp116
     rdm2.aaaa.voov = einsum(tmp106, (0, 1), delta.aa.oo, (2, 3), (0, 2, 3, 1)) * -2
-    rdm2.aaaa.voov += tmp72.transpose((2, 1, 0, 3))
+    rdm2.aaaa.voov += np.transpose(tmp72, (2, 1, 0, 3))
     rdm2.aaaa.voov += einsum(t1.aa, (0, 1), l1.aa, (2, 3), (2, 0, 3, 1))
-    rdm2.aaaa.voov += tmp68.transpose((2, 1, 0, 3)) * 4
-    rdm2.aaaa.voov += tmp107.transpose((2, 1, 0, 3)) * -2
+    rdm2.aaaa.voov += np.transpose(tmp68, (2, 1, 0, 3)) * 4
+    rdm2.aaaa.voov += np.transpose(tmp107, (2, 1, 0, 3)) * -2
     rdm2.bbbb.ovvo = einsum(tmp109, (0, 1), delta.bb.oo, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.bbbb.ovvo += tmp88.transpose((1, 2, 3, 0))
+    rdm2.bbbb.ovvo += np.transpose(tmp88, (1, 2, 3, 0))
     rdm2.bbbb.ovvo += einsum(t1.bb, (0, 1), l1.bb, (2, 3), (0, 2, 1, 3))
-    rdm2.bbbb.ovvo += tmp89.transpose((1, 2, 3, 0)) * 4
-    rdm2.bbbb.ovvo += tmp112.transpose((1, 2, 3, 0)) * -2
-    rdm2.abab.ovvo = tmp114.transpose((0, 3, 2, 1)).copy() * 2
+    rdm2.bbbb.ovvo += np.transpose(tmp89, (1, 2, 3, 0)) * 4
+    rdm2.bbbb.ovvo += np.transpose(tmp112, (1, 2, 3, 0)) * -2
+    rdm2.abab.ovvo = np.copy(np.transpose(tmp114, (0, 3, 2, 1))) * 2
     del tmp114
     rdm2.abab.ovvo += einsum(l1.bb, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
-    rdm2.abab.ovvo += tmp70.transpose((0, 3, 2, 1)) * 2
+    rdm2.abab.ovvo += np.transpose(tmp70, (0, 3, 2, 1)) * 2
     del tmp70
-    rdm2.abab.ovvo += tmp115.transpose((0, 3, 2, 1)) * -1
+    rdm2.abab.ovvo += np.transpose(tmp115, (0, 3, 2, 1)) * -1
     del tmp115
     rdm2.aaaa.ovvo = einsum(tmp113, (0, 1), delta.aa.oo, (2, 3), (2, 0, 1, 3)) * -1
     del tmp113
-    rdm2.aaaa.ovvo += tmp72.transpose((1, 2, 3, 0))
+    rdm2.aaaa.ovvo += np.transpose(tmp72, (1, 2, 3, 0))
     rdm2.aaaa.ovvo += einsum(t1.aa, (0, 1), l1.aa, (2, 3), (0, 2, 1, 3))
-    rdm2.aaaa.ovvo += tmp68.transpose((1, 2, 3, 0)) * 4
-    rdm2.aaaa.ovvo += tmp107.transpose((1, 2, 3, 0)) * -2
+    rdm2.aaaa.ovvo += np.transpose(tmp68, (1, 2, 3, 0)) * 4
+    rdm2.aaaa.ovvo += np.transpose(tmp107, (1, 2, 3, 0)) * -2
     rdm2.bbbb.ovov = einsum(tmp111, (0, 1), delta.bb.oo, (2, 3), (2, 0, 3, 1)) * 2
     del tmp111
-    rdm2.bbbb.ovov += tmp88.transpose((1, 2, 0, 3)) * -1
+    rdm2.bbbb.ovov += np.transpose(tmp88, (1, 2, 0, 3)) * -1
     del tmp88
-    rdm2.bbbb.ovov += tmp89.transpose((1, 2, 0, 3)) * -4
+    rdm2.bbbb.ovov += np.transpose(tmp89, (1, 2, 0, 3)) * -4
     del tmp89
     rdm2.bbbb.ovov += einsum(t1.bb, (0, 1), l1.bb, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.bbbb.ovov += tmp112.transpose((1, 2, 0, 3)) * 2
+    rdm2.bbbb.ovov += np.transpose(tmp112, (1, 2, 0, 3)) * 2
     del tmp112
     rdm2.abab.ovov = einsum(delta.aa.oo, (0, 1), tmp109, (2, 3), (0, 2, 1, 3))
     del tmp109
-    rdm2.abab.ovov += tmp110.transpose((1, 2, 0, 3)) * -1
+    rdm2.abab.ovov += np.transpose(tmp110, (1, 2, 0, 3)) * -1
     del tmp110
     rdm2.abab.ovov += einsum(t1.bb, (0, 1), tmp26, (2, 3, 0, 4), (3, 4, 2, 1)) * -1
     rdm2.aaaa.ovov = einsum(tmp106, (0, 1), delta.aa.oo, (2, 3), (2, 0, 3, 1)) * 2
     del tmp106
-    rdm2.aaaa.ovov += tmp72.transpose((1, 2, 0, 3)) * -1
+    rdm2.aaaa.ovov += np.transpose(tmp72, (1, 2, 0, 3)) * -1
     del tmp72
     rdm2.aaaa.ovov += einsum(t1.aa, (0, 1), l1.aa, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.aaaa.ovov += tmp68.transpose((1, 2, 0, 3)) * -4
+    rdm2.aaaa.ovov += np.transpose(tmp68, (1, 2, 0, 3)) * -4
     del tmp68
-    rdm2.aaaa.ovov += tmp107.transpose((1, 2, 0, 3)) * 2
+    rdm2.aaaa.ovov += np.transpose(tmp107, (1, 2, 0, 3)) * 2
     del tmp107
-    rdm2.bbbb.oovv = t2.bbbb.copy() * 2
+    rdm2.bbbb.oovv = np.copy(t2.bbbb) * 2
     rdm2.bbbb.oovv += einsum(t2.bbbb, (0, 1, 2, 3), tmp94, (3, 4), (0, 1, 2, 4)) * -2
     del tmp94
-    rdm2.bbbb.oovv += tmp95.transpose((0, 1, 3, 2)) * -2
-    rdm2.bbbb.oovv += tmp96.transpose((0, 1, 3, 2)) * -8
-    rdm2.bbbb.oovv += tmp97.transpose((0, 1, 3, 2)) * -2
-    rdm2.bbbb.oovv += tmp97.transpose((1, 0, 2, 3)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp95, (0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp96, (0, 1, 3, 2)) * -8
+    rdm2.bbbb.oovv += np.transpose(tmp97, (0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp97, (1, 0, 2, 3)) * -2
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp48, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.bbbb.oovv += tmp95.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp95, (1, 0, 3, 2)) * 2
     del tmp95
     rdm2.bbbb.oovv += tmp96 * 8
     del tmp96
     rdm2.bbbb.oovv += tmp97 * 2
-    rdm2.bbbb.oovv += tmp97.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp97, (1, 0, 3, 2)) * 2
     del tmp97
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp37, (2, 3), (0, 2, 1, 3))
     rdm2.bbbb.oovv += einsum(tmp98, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3))
@@ -2278,25 +2278,25 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     del tmp98
     rdm2.bbbb.oovv += tmp99 * 2
     rdm2.bbbb.oovv += einsum(t2.bbbb, (0, 1, 2, 3), tmp84, (3, 4), (0, 1, 4, 2)) * 4
-    rdm2.bbbb.oovv += tmp99.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp99, (0, 1, 3, 2)) * -2
     del tmp99
-    rdm2.bbbb.oovv += tmp100.transpose((0, 1, 3, 2)) * -2
+    rdm2.bbbb.oovv += np.transpose(tmp100, (0, 1, 3, 2)) * -2
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp51, (2, 3), (0, 2, 1, 3)) * -1
     rdm2.bbbb.oovv += einsum(tmp42, (0, 1), t1.bb, (2, 3), (2, 0, 1, 3)) * 2
-    rdm2.bbbb.oovv += tmp100.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp100, (1, 0, 3, 2)) * 2
     del tmp100
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp51, (2, 3), (2, 0, 1, 3))
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp42, (2, 3), (2, 0, 3, 1)) * -2
-    rdm2.bbbb.oovv += tmp101.transpose((1, 0, 3, 2)) * 2
+    rdm2.bbbb.oovv += np.transpose(tmp101, (1, 0, 3, 2)) * 2
     del tmp101
     rdm2.bbbb.oovv += einsum(t1.bb, (0, 1), tmp102, (0, 2, 3, 4), (2, 3, 1, 4)) * 2
     del tmp102
-    rdm2.bbbb.oovv += tmp104.transpose((1, 0, 2, 3))
+    rdm2.bbbb.oovv += np.transpose(tmp104, (1, 0, 2, 3))
     rdm2.bbbb.oovv += tmp104 * -1
-    rdm2.bbbb.oovv += tmp104.transpose((1, 0, 3, 2)) * -1
-    rdm2.bbbb.oovv += tmp104.transpose((0, 1, 3, 2))
+    rdm2.bbbb.oovv += np.transpose(tmp104, (1, 0, 3, 2)) * -1
+    rdm2.bbbb.oovv += np.transpose(tmp104, (0, 1, 3, 2))
     del tmp104
-    rdm2.abab.oovv = t2.abab.copy()
+    rdm2.abab.oovv = np.copy(t2.abab)
     rdm2.abab.oovv += einsum(t2.abab, (0, 1, 2, 3), tmp84, (3, 4), (0, 1, 2, 4)) * -2
     del tmp84
     rdm2.abab.oovv += einsum(tmp87, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 2), (4, 1, 5, 3)) * 4
@@ -2322,20 +2322,20 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.abab.oovv += einsum(t1.bb, (0, 1), tmp93, (2, 0, 3, 4), (2, 3, 4, 1)) * -2
     del tmp93
     rdm2.abab.oovv += einsum(t1.bb, (0, 1), tmp63, (2, 0, 3, 4), (2, 3, 4, 1))
-    rdm2.aaaa.oovv = t2.aaaa.copy() * 2
+    rdm2.aaaa.oovv = np.copy(t2.aaaa) * 2
     rdm2.aaaa.oovv += einsum(tmp67, (0, 1), t2.aaaa, (2, 3, 4, 0), (2, 3, 4, 1)) * -4
     del tmp67
-    rdm2.aaaa.oovv += tmp69.transpose((0, 1, 3, 2)) * -8
-    rdm2.aaaa.oovv += tmp71.transpose((0, 1, 3, 2)) * -2
-    rdm2.aaaa.oovv += tmp73.transpose((0, 1, 3, 2)) * -2
-    rdm2.aaaa.oovv += tmp73.transpose((1, 0, 2, 3)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp69, (0, 1, 3, 2)) * -8
+    rdm2.aaaa.oovv += np.transpose(tmp71, (0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp73, (0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp73, (1, 0, 2, 3)) * -2
     rdm2.aaaa.oovv += einsum(tmp56, (0, 1), t1.aa, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.aaaa.oovv += tmp69 * 8
     del tmp69
     rdm2.aaaa.oovv += tmp71 * 2
     del tmp71
     rdm2.aaaa.oovv += tmp73 * 2
-    rdm2.aaaa.oovv += tmp73.transpose((1, 0, 3, 2)) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp73, (1, 0, 3, 2)) * 2
     del tmp73
     rdm2.aaaa.oovv += einsum(tmp23, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
     rdm2.aaaa.oovv += einsum(t1.aa, (0, 1), tmp74, (2, 3), (2, 0, 3, 1))
@@ -2344,136 +2344,136 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.aaaa.oovv += tmp75 * 2
     rdm2.aaaa.oovv += einsum(t2.aaaa, (0, 1, 2, 3), tmp76, (3, 4), (0, 1, 4, 2)) * 2
     del tmp76
-    rdm2.aaaa.oovv += tmp75.transpose((0, 1, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp75, (0, 1, 3, 2)) * -2
     del tmp75
-    rdm2.aaaa.oovv += tmp77.transpose((1, 0, 3, 2)) * -2
+    rdm2.aaaa.oovv += np.transpose(tmp77, (1, 0, 3, 2)) * -2
     rdm2.aaaa.oovv += einsum(tmp59, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1)) * -2
     rdm2.aaaa.oovv += einsum(t1.aa, (0, 1), tmp30, (2, 3), (0, 2, 3, 1))
-    rdm2.aaaa.oovv += tmp77.transpose((0, 1, 3, 2)) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp77, (0, 1, 3, 2)) * 2
     del tmp77
     rdm2.aaaa.oovv += einsum(tmp59, (0, 1), t1.aa, (2, 3), (0, 2, 3, 1)) * 2
     rdm2.aaaa.oovv += einsum(t1.aa, (0, 1), tmp30, (2, 3), (2, 0, 3, 1)) * -1
-    rdm2.aaaa.oovv += tmp78.transpose((1, 0, 3, 2)) * 2
+    rdm2.aaaa.oovv += np.transpose(tmp78, (1, 0, 3, 2)) * 2
     del tmp78
     rdm2.aaaa.oovv += einsum(tmp79, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3)) * 2
     del tmp79
-    rdm2.aaaa.oovv += tmp81.transpose((1, 0, 2, 3))
+    rdm2.aaaa.oovv += np.transpose(tmp81, (1, 0, 2, 3))
     rdm2.aaaa.oovv += tmp81 * -1
-    rdm2.aaaa.oovv += tmp81.transpose((1, 0, 3, 2)) * -1
-    rdm2.aaaa.oovv += tmp81.transpose((0, 1, 3, 2))
+    rdm2.aaaa.oovv += np.transpose(tmp81, (1, 0, 3, 2)) * -1
+    rdm2.aaaa.oovv += np.transpose(tmp81, (0, 1, 3, 2))
     del tmp81
     rdm2.bbbb.vooo = einsum(delta.bb.oo, (0, 1), l1.bb, (2, 3), (2, 0, 3, 1))
     rdm2.bbbb.vooo += einsum(l1.bb, (0, 1), delta.bb.oo, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.bbbb.vooo += tmp18.transpose((3, 2, 1, 0)) * 2
+    rdm2.bbbb.vooo += np.transpose(tmp18, (3, 2, 1, 0)) * 2
     rdm2.abab.vooo = einsum(l1.aa, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3))
-    rdm2.abab.vooo += tmp13.transpose((3, 2, 0, 1)) * -1
+    rdm2.abab.vooo += np.transpose(tmp13, (3, 2, 0, 1)) * -1
     del tmp13
     rdm2.aaaa.vooo = einsum(delta.aa.oo, (0, 1), l1.aa, (2, 3), (2, 0, 3, 1))
     rdm2.aaaa.vooo += einsum(delta.aa.oo, (0, 1), l1.aa, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.aaaa.vooo += tmp6.transpose((3, 2, 1, 0)) * 2
+    rdm2.aaaa.vooo += np.transpose(tmp6, (3, 2, 1, 0)) * 2
     rdm2.bbbb.ovoo = einsum(delta.bb.oo, (0, 1), l1.bb, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.bbbb.ovoo += einsum(l1.bb, (0, 1), delta.bb.oo, (2, 3), (2, 0, 3, 1))
-    rdm2.bbbb.ovoo += tmp18.transpose((2, 3, 1, 0)) * -2
+    rdm2.bbbb.ovoo += np.transpose(tmp18, (2, 3, 1, 0)) * -2
     del tmp18
     rdm2.abab.ovoo = einsum(delta.aa.oo, (0, 1), l1.bb, (2, 3), (0, 2, 1, 3))
-    rdm2.abab.ovoo += tmp26.transpose((1, 3, 0, 2)) * -1
+    rdm2.abab.ovoo += np.transpose(tmp26, (1, 3, 0, 2)) * -1
     del tmp26
     rdm2.aaaa.ovoo = einsum(delta.aa.oo, (0, 1), l1.aa, (2, 3), (0, 2, 3, 1)) * -1
     rdm2.aaaa.ovoo += einsum(delta.aa.oo, (0, 1), l1.aa, (2, 3), (0, 2, 1, 3))
-    rdm2.aaaa.ovoo += tmp6.transpose((2, 3, 1, 0)) * -2
+    rdm2.aaaa.ovoo += np.transpose(tmp6, (2, 3, 1, 0)) * -2
     del tmp6
     rdm2.bbbb.oovo = einsum(tmp64, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3)) * 2
     del tmp64
     rdm2.bbbb.oovo += einsum(tmp37, (0, 1), delta.bb.oo, (2, 3), (2, 0, 1, 3)) * -1
-    rdm2.bbbb.oovo += tmp49.transpose((2, 1, 3, 0)) * 2
+    rdm2.bbbb.oovo += np.transpose(tmp49, (2, 1, 3, 0)) * 2
     rdm2.bbbb.oovo += einsum(delta.bb.oo, (0, 1), tmp42, (2, 3), (2, 0, 3, 1)) * -2
     rdm2.bbbb.oovo += einsum(tmp42, (0, 1), delta.bb.oo, (2, 3), (2, 0, 1, 3)) * 2
-    rdm2.bbbb.oovo += tmp52.transpose((1, 2, 3, 0)) * 4
-    rdm2.bbbb.oovo += tmp53.transpose((1, 2, 3, 0))
+    rdm2.bbbb.oovo += np.transpose(tmp52, (1, 2, 3, 0)) * 4
+    rdm2.bbbb.oovo += np.transpose(tmp53, (1, 2, 3, 0))
     rdm2.bbbb.oovo += einsum(t1.bb, (0, 1), tmp62, (2, 3), (3, 0, 1, 2)) * 2
-    rdm2.bbbb.oovo += tmp52.transpose((2, 1, 3, 0)) * -4
-    rdm2.bbbb.oovo += tmp53.transpose((2, 1, 3, 0)) * -1
+    rdm2.bbbb.oovo += np.transpose(tmp52, (2, 1, 3, 0)) * -4
+    rdm2.bbbb.oovo += np.transpose(tmp53, (2, 1, 3, 0)) * -1
     rdm2.bbbb.oovo += einsum(tmp62, (0, 1), t1.bb, (2, 3), (2, 1, 3, 0)) * -2
-    rdm2.bbbb.oovo += tmp55.transpose((2, 1, 3, 0)) * -1
+    rdm2.bbbb.oovo += np.transpose(tmp55, (2, 1, 3, 0)) * -1
     rdm2.abab.oovo = einsum(delta.bb.oo, (0, 1), tmp56, (2, 3), (2, 0, 3, 1))
-    rdm2.abab.oovo += tmp57.transpose((0, 2, 3, 1)) * -1
+    rdm2.abab.oovo += np.transpose(tmp57, (0, 2, 3, 1)) * -1
     del tmp57
     rdm2.abab.oovo += einsum(tmp59, (0, 1), delta.bb.oo, (2, 3), (0, 2, 1, 3)) * -2
     del tmp59
-    rdm2.abab.oovo += tmp60.transpose((0, 2, 3, 1)) * -2
+    rdm2.abab.oovo += np.transpose(tmp60, (0, 2, 3, 1)) * -2
     del tmp60
-    rdm2.abab.oovo += tmp61.transpose((0, 2, 3, 1)) * -2
+    rdm2.abab.oovo += np.transpose(tmp61, (0, 2, 3, 1)) * -2
     del tmp61
     rdm2.abab.oovo += einsum(t1.aa, (0, 1), tmp62, (2, 3), (0, 3, 1, 2)) * -2
     del tmp62
     rdm2.abab.oovo += einsum(tmp45, (0, 1, 2, 3), t1.aa, (0, 4), (1, 3, 4, 2))
     del tmp45
-    rdm2.abab.oovo += tmp63.transpose((0, 2, 3, 1))
+    rdm2.abab.oovo += np.transpose(tmp63, (0, 2, 3, 1))
     del tmp63
     rdm2.aaaa.oovo = einsum(delta.aa.oo, (0, 1), tmp56, (2, 3), (2, 0, 3, 1))
     del tmp56
     rdm2.aaaa.oovo += einsum(delta.aa.oo, (0, 1), tmp23, (2, 3), (0, 2, 3, 1)) * -1
-    rdm2.aaaa.oovo += tmp24.transpose((2, 1, 3, 0)) * 2
+    rdm2.aaaa.oovo += np.transpose(tmp24, (2, 1, 3, 0)) * 2
     rdm2.aaaa.oovo += einsum(delta.aa.oo, (0, 1), tmp30, (2, 3), (2, 0, 3, 1)) * -1
     rdm2.aaaa.oovo += einsum(tmp30, (0, 1), delta.aa.oo, (2, 3), (2, 0, 1, 3))
-    rdm2.aaaa.oovo += tmp31.transpose((1, 2, 3, 0))
-    rdm2.aaaa.oovo += tmp32.transpose((1, 2, 3, 0)) * 4
+    rdm2.aaaa.oovo += np.transpose(tmp31, (1, 2, 3, 0))
+    rdm2.aaaa.oovo += np.transpose(tmp32, (1, 2, 3, 0)) * 4
     rdm2.aaaa.oovo += einsum(t1.aa, (0, 1), tmp4, (2, 3), (3, 0, 1, 2))
-    rdm2.aaaa.oovo += tmp31.transpose((2, 1, 3, 0)) * -1
-    rdm2.aaaa.oovo += tmp32.transpose((2, 1, 3, 0)) * -4
+    rdm2.aaaa.oovo += np.transpose(tmp31, (2, 1, 3, 0)) * -1
+    rdm2.aaaa.oovo += np.transpose(tmp32, (2, 1, 3, 0)) * -4
     rdm2.aaaa.oovo += einsum(t1.aa, (0, 1), tmp4, (2, 3), (0, 3, 1, 2)) * -1
-    rdm2.aaaa.oovo += tmp34.transpose((2, 1, 3, 0)) * -1
+    rdm2.aaaa.oovo += np.transpose(tmp34, (2, 1, 3, 0)) * -1
     rdm2.bbbb.ooov = einsum(delta.bb.oo, (0, 1), tmp48, (2, 3), (2, 0, 1, 3)) * -1
     del tmp48
     rdm2.bbbb.ooov += einsum(tmp37, (0, 1), delta.bb.oo, (2, 3), (2, 0, 3, 1))
-    rdm2.bbbb.ooov += tmp49.transpose((2, 1, 0, 3)) * -2
+    rdm2.bbbb.ooov += np.transpose(tmp49, (2, 1, 0, 3)) * -2
     del tmp49
     rdm2.bbbb.ooov += einsum(delta.bb.oo, (0, 1), tmp51, (2, 3), (2, 0, 1, 3))
     rdm2.bbbb.ooov += einsum(delta.bb.oo, (0, 1), tmp51, (2, 3), (0, 2, 1, 3)) * -1
     del tmp51
-    rdm2.bbbb.ooov += tmp52.transpose((1, 2, 0, 3)) * -4
-    rdm2.bbbb.ooov += tmp53.transpose((1, 2, 0, 3)) * -1
+    rdm2.bbbb.ooov += np.transpose(tmp52, (1, 2, 0, 3)) * -4
+    rdm2.bbbb.ooov += np.transpose(tmp53, (1, 2, 0, 3)) * -1
     rdm2.bbbb.ooov += einsum(t1.bb, (0, 1), tmp16, (2, 3), (3, 0, 2, 1)) * -1
-    rdm2.bbbb.ooov += tmp52.transpose((2, 1, 0, 3)) * 4
+    rdm2.bbbb.ooov += np.transpose(tmp52, (2, 1, 0, 3)) * 4
     del tmp52
-    rdm2.bbbb.ooov += tmp53.transpose((2, 1, 0, 3))
+    rdm2.bbbb.ooov += np.transpose(tmp53, (2, 1, 0, 3))
     del tmp53
     rdm2.bbbb.ooov += einsum(t1.bb, (0, 1), tmp16, (2, 3), (0, 3, 2, 1))
-    rdm2.bbbb.ooov += tmp55.transpose((2, 1, 0, 3))
+    rdm2.bbbb.ooov += np.transpose(tmp55, (2, 1, 0, 3))
     del tmp55
     rdm2.abab.ooov = einsum(delta.aa.oo, (0, 1), tmp37, (2, 3), (0, 2, 1, 3))
     del tmp37
-    rdm2.abab.ooov += tmp38.transpose((1, 2, 0, 3)) * -1
+    rdm2.abab.ooov += np.transpose(tmp38, (1, 2, 0, 3)) * -1
     del tmp38
     rdm2.abab.ooov += einsum(delta.aa.oo, (0, 1), tmp42, (2, 3), (0, 2, 1, 3)) * -2
     del tmp42
-    rdm2.abab.ooov += tmp43.transpose((1, 2, 0, 3)) * -2
+    rdm2.abab.ooov += np.transpose(tmp43, (1, 2, 0, 3)) * -2
     del tmp43
-    rdm2.abab.ooov += tmp44.transpose((1, 2, 0, 3)) * -2
+    rdm2.abab.ooov += np.transpose(tmp44, (1, 2, 0, 3)) * -2
     del tmp44
     rdm2.abab.ooov += einsum(t1.bb, (0, 1), tmp4, (2, 3), (3, 0, 2, 1)) * -1
-    rdm2.abab.ooov += tmp46.transpose((1, 2, 0, 3))
+    rdm2.abab.ooov += np.transpose(tmp46, (1, 2, 0, 3))
     del tmp46
-    rdm2.abab.ooov += tmp47.transpose((1, 2, 0, 3))
+    rdm2.abab.ooov += np.transpose(tmp47, (1, 2, 0, 3))
     del tmp47
     rdm2.aaaa.ooov = einsum(delta.aa.oo, (0, 1), tmp22, (2, 3), (2, 0, 1, 3)) * -2
     del tmp22
     rdm2.aaaa.ooov += einsum(delta.aa.oo, (0, 1), tmp23, (2, 3), (0, 2, 1, 3))
     del tmp23
-    rdm2.aaaa.ooov += tmp24.transpose((2, 1, 0, 3)) * -2
+    rdm2.aaaa.ooov += np.transpose(tmp24, (2, 1, 0, 3)) * -2
     del tmp24
     rdm2.aaaa.ooov += einsum(delta.aa.oo, (0, 1), tmp30, (2, 3), (2, 0, 1, 3))
     rdm2.aaaa.ooov += einsum(tmp30, (0, 1), delta.aa.oo, (2, 3), (2, 0, 3, 1)) * -1
     del tmp30
-    rdm2.aaaa.ooov += tmp31.transpose((1, 2, 0, 3)) * -1
-    rdm2.aaaa.ooov += tmp32.transpose((1, 2, 0, 3)) * -4
+    rdm2.aaaa.ooov += np.transpose(tmp31, (1, 2, 0, 3)) * -1
+    rdm2.aaaa.ooov += np.transpose(tmp32, (1, 2, 0, 3)) * -4
     rdm2.aaaa.ooov += einsum(t1.aa, (0, 1), tmp4, (2, 3), (3, 0, 2, 1)) * -1
-    rdm2.aaaa.ooov += tmp31.transpose((2, 1, 0, 3))
+    rdm2.aaaa.ooov += np.transpose(tmp31, (2, 1, 0, 3))
     del tmp31
-    rdm2.aaaa.ooov += tmp32.transpose((2, 1, 0, 3)) * 4
+    rdm2.aaaa.ooov += np.transpose(tmp32, (2, 1, 0, 3)) * 4
     del tmp32
     rdm2.aaaa.ooov += einsum(t1.aa, (0, 1), tmp4, (2, 3), (0, 3, 2, 1))
-    rdm2.aaaa.ooov += tmp34.transpose((2, 1, 0, 3))
+    rdm2.aaaa.ooov += np.transpose(tmp34, (2, 1, 0, 3))
     del tmp34
     rdm2.bbbb.oooo = einsum(tmp15, (0, 1), delta.bb.oo, (2, 3), (2, 1, 3, 0)) * -2
     rdm2.bbbb.oooo += einsum(delta.bb.oo, (0, 1), tmp15, (2, 3), (3, 0, 1, 2)) * 2
@@ -2481,16 +2481,16 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.bbbb.oooo += einsum(tmp16, (0, 1), delta.bb.oo, (2, 3), (1, 2, 0, 3)) * -1
     rdm2.bbbb.oooo += einsum(delta.bb.oo, (0, 1), tmp16, (2, 3), (0, 3, 2, 1))
     del tmp16
-    rdm2.bbbb.oooo += tmp17.transpose((3, 2, 1, 0)) * 2
+    rdm2.bbbb.oooo += np.transpose(tmp17, (3, 2, 1, 0)) * 2
     del tmp17
-    rdm2.bbbb.oooo += tmp19.transpose((2, 3, 1, 0)) * -2
+    rdm2.bbbb.oooo += np.transpose(tmp19, (2, 3, 1, 0)) * -2
     del tmp19
     rdm2.abab.oooo = einsum(delta.aa.oo, (0, 1), tmp11, (2, 3), (0, 3, 1, 2)) * -1
     del tmp11
     rdm2.abab.oooo += einsum(tmp4, (0, 1), delta.bb.oo, (2, 3), (1, 2, 0, 3)) * -1
-    rdm2.abab.oooo += tmp12.transpose((1, 3, 0, 2))
+    rdm2.abab.oooo += np.transpose(tmp12, (1, 3, 0, 2))
     del tmp12
-    rdm2.abab.oooo += tmp14.transpose((1, 3, 0, 2))
+    rdm2.abab.oooo += np.transpose(tmp14, (1, 3, 0, 2))
     del tmp14
     rdm2.aaaa.oooo = einsum(tmp3, (0, 1), delta.aa.oo, (2, 3), (2, 1, 3, 0)) * -2
     rdm2.aaaa.oooo += einsum(delta.aa.oo, (0, 1), tmp3, (2, 3), (3, 0, 1, 2)) * 2
@@ -2498,17 +2498,17 @@ def make_rdm2_f(l1=None, l2=None, t1=None, t2=None, **kwargs):
     rdm2.aaaa.oooo += einsum(delta.aa.oo, (0, 1), tmp4, (2, 3), (3, 0, 2, 1)) * -1
     rdm2.aaaa.oooo += einsum(delta.aa.oo, (0, 1), tmp4, (2, 3), (0, 3, 2, 1))
     del tmp4, delta
-    rdm2.aaaa.oooo += tmp5.transpose((3, 2, 1, 0)) * 2
+    rdm2.aaaa.oooo += np.transpose(tmp5, (3, 2, 1, 0)) * 2
     del tmp5
-    rdm2.aaaa.oooo += tmp7.transpose((2, 3, 1, 0)) * -2
+    rdm2.aaaa.oooo += np.transpose(tmp7, (2, 3, 1, 0)) * -2
     del tmp7
     rdm2.aaaa = pack_2e(rdm2.aaaa.oooo, rdm2.aaaa.ooov, rdm2.aaaa.oovo, rdm2.aaaa.ovoo, rdm2.aaaa.vooo, rdm2.aaaa.oovv, rdm2.aaaa.ovov, rdm2.aaaa.ovvo, rdm2.aaaa.voov, rdm2.aaaa.vovo, rdm2.aaaa.vvoo, rdm2.aaaa.ovvv, rdm2.aaaa.vovv, rdm2.aaaa.vvov, rdm2.aaaa.vvvo, rdm2.aaaa.vvvv)
     rdm2.abab = pack_2e(rdm2.abab.oooo, rdm2.abab.ooov, rdm2.abab.oovo, rdm2.abab.ovoo, rdm2.abab.vooo, rdm2.abab.oovv, rdm2.abab.ovov, rdm2.abab.ovvo, rdm2.abab.voov, rdm2.abab.vovo, rdm2.abab.vvoo, rdm2.abab.ovvv, rdm2.abab.vovv, rdm2.abab.vvov, rdm2.abab.vvvo, rdm2.abab.vvvv)
     rdm2.bbbb = pack_2e(rdm2.bbbb.oooo, rdm2.bbbb.ooov, rdm2.bbbb.oovo, rdm2.bbbb.ovoo, rdm2.bbbb.vooo, rdm2.bbbb.oovv, rdm2.bbbb.ovov, rdm2.bbbb.ovvo, rdm2.bbbb.voov, rdm2.bbbb.vovo, rdm2.bbbb.vvoo, rdm2.bbbb.ovvv, rdm2.bbbb.vovv, rdm2.bbbb.vvov, rdm2.bbbb.vvvo, rdm2.bbbb.vvvv)
     rdm2 = Namespace(
-        aaaa=rdm2.aaaa.transpose(0, 2, 1, 3),
-        aabb=rdm2.abab.transpose(0, 2, 1, 3),
-        bbbb=rdm2.bbbb.transpose(0, 2, 1, 3),
+        aaaa=np.transpose(rdm2.aaaa, (0, 2, 1, 3)),
+        aabb=np.transpose(rdm2.abab, (0, 2, 1, 3)),
+        bbbb=np.transpose(rdm2.bbbb, (0, 2, 1, 3)),
     )
 
     return rdm2
@@ -3009,17 +3009,17 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp48 = einsum(r2.bbb, (0, 1, 2), v.bbb.xov, (3, 1, 2), (3, 0))
     tmp12 = einsum(v.bbb.xov, (0, 1, 2), r2.bab, (1, 3, 2), (0, 3)) * -1
     tmp11 = einsum(v.baa.xov, (0, 1, 2), r2.aaa, (3, 1, 2), (0, 3))
-    tmp49 = tmp47.copy() * -1
+    tmp49 = np.copy(tmp47) * -1
     tmp49 += tmp48 * 2
-    tmp77 = tmp47.copy() * -0.5
+    tmp77 = np.copy(tmp47) * -0.5
     tmp77 += tmp48
-    tmp65 = ints.tmp37.copy()
-    tmp65 += ints.tmp47.transpose((0, 2, 1, 3))
-    tmp24 = ints.tmp22.copy()
-    tmp24 += ints.tmp2.transpose((0, 2, 1, 3))
-    tmp21 = tmp11.copy() * 2
+    tmp65 = np.copy(ints.tmp37)
+    tmp65 += np.transpose(ints.tmp47, (0, 2, 1, 3))
+    tmp24 = np.copy(ints.tmp22)
+    tmp24 += np.transpose(ints.tmp2, (0, 2, 1, 3))
+    tmp21 = np.copy(tmp11) * 2
     tmp21 += tmp12
-    tmp27 = tmp11.copy()
+    tmp27 = np.copy(tmp11)
     tmp27 += tmp12 * 0.5
     tmp76 = einsum(tmp49, (0, 1), ints.tmp16, (0, 2, 3), (1, 2, 3))
     tmp78 = einsum(v.bbb.xoo, (0, 1, 2), tmp77, (0, 3), (3, 1, 2)) * 2
@@ -3028,119 +3028,119 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp25 = einsum(tmp24, (0, 1, 2, 3), r2.aaa, (4, 2, 3), (4, 0, 1)) * -1
     tmp26 = einsum(tmp21, (0, 1), v.baa.xoo, (0, 2, 3), (2, 3, 1)) * 0.5
     tmp28 = einsum(ints.tmp6, (0, 1, 2), tmp27, (0, 3), (1, 2, 3))
-    tmp2 = f.bb.ov.copy()
+    tmp2 = np.copy(f.bb.ov)
     tmp2 += ints.tmp18
     tmp2 += ints.tmp21
     tmp2 += ints.tmp17 * -1
     del ints.tmp17
-    tmp92 = ints.tmp389.copy()
+    tmp92 = np.copy(ints.tmp389)
     del ints.tmp389
-    tmp92 += ints.tmp403.transpose((1, 2, 0, 3))
+    tmp92 += np.transpose(ints.tmp403, (1, 2, 0, 3))
     del ints.tmp403
-    tmp92 += ints.tmp418.transpose((0, 2, 1, 3))
+    tmp92 += np.transpose(ints.tmp418, (0, 2, 1, 3))
     del ints.tmp418
-    tmp92 += ints.tmp447.transpose((0, 2, 1, 3))
+    tmp92 += np.transpose(ints.tmp447, (0, 2, 1, 3))
     del ints.tmp447
     tmp92 += ints.tmp459
     del ints.tmp459
-    tmp92 += ints.tmp416.transpose((0, 2, 1, 3)) * 2
+    tmp92 += np.transpose(ints.tmp416, (0, 2, 1, 3)) * 2
     del ints.tmp416
     tmp92 += ints.tmp455 * 2
     del ints.tmp455
-    tmp90 = f.bb.oo.copy()
+    tmp90 = np.copy(f.bb.oo)
     tmp90 += ints.tmp36
-    tmp90 += ints.tmp42.transpose((1, 0))
-    tmp90 += ints.tmp43.transpose((1, 0))
-    tmp90 += ints.tmp58.transpose((1, 0))
-    tmp90 += ints.tmp59.transpose((1, 0))
-    tmp58 = ints.tmp335.copy()
+    tmp90 += np.transpose(ints.tmp42, (1, 0))
+    tmp90 += np.transpose(ints.tmp43, (1, 0))
+    tmp90 += np.transpose(ints.tmp58, (1, 0))
+    tmp90 += np.transpose(ints.tmp59, (1, 0))
+    tmp58 = np.copy(ints.tmp335)
     del ints.tmp335
     tmp58 += ints.tmp345
     del ints.tmp345
     tmp58 += ints.tmp298 * 2
     del ints.tmp298
-    tmp88 = ints.tmp276.copy()
+    tmp88 = np.copy(ints.tmp276)
     tmp88 += ints.tmp54
     tmp88 += ints.tmp51 * 2
-    tmp79 = tmp75.transpose((1, 2, 0)).copy() * -1
+    tmp79 = np.copy(np.transpose(tmp75, (1, 2, 0))) * -1
     del tmp75
-    tmp79 += tmp76.transpose((1, 2, 0)) * -1
+    tmp79 += np.transpose(tmp76, (1, 2, 0)) * -1
     del tmp76
-    tmp79 += tmp78.transpose((0, 2, 1))
+    tmp79 += np.transpose(tmp78, (0, 2, 1))
     del tmp78
-    tmp81 = ints.tmp37.copy()
-    tmp81 += ints.tmp385.transpose((0, 2, 1, 3))
+    tmp81 = np.copy(ints.tmp37)
+    tmp81 += np.transpose(ints.tmp385, (0, 2, 1, 3))
     del ints.tmp385
-    tmp81 += ints.tmp414.transpose((0, 2, 1, 3)) * 2
+    tmp81 += np.transpose(ints.tmp414, (0, 2, 1, 3)) * 2
     del ints.tmp414
-    tmp81 += ints.tmp453.transpose((0, 2, 1, 3)) * 2
+    tmp81 += np.transpose(ints.tmp453, (0, 2, 1, 3)) * 2
     del ints.tmp453
-    tmp81 += ints.tmp457.transpose((0, 2, 1, 3))
+    tmp81 += np.transpose(ints.tmp457, (0, 2, 1, 3))
     del ints.tmp457
     tmp81 += ints.tmp461
     del ints.tmp461
-    tmp81 += ints.tmp47.transpose((0, 2, 1, 3))
-    tmp83 = ints.tmp52.copy() * 2
+    tmp81 += np.transpose(ints.tmp47, (0, 2, 1, 3))
+    tmp83 = np.copy(ints.tmp52) * 2
     tmp83 += ints.tmp55
     tmp83 += ints.tmp41 * -1
     tmp83 += ints.tmp57 * -1
-    tmp73 = ints.tmp276.copy()
+    tmp73 = np.copy(ints.tmp276)
     tmp73 += ints.tmp51 * 2
     tmp73 += ints.tmp54
-    tmp3 = f.aa.ov.copy()
+    tmp3 = np.copy(f.aa.ov)
     tmp3 += ints.tmp14
     tmp3 += ints.tmp19
     tmp3 += ints.tmp12 * -1
     del ints.tmp12
-    tmp29 = tmp25.transpose((1, 2, 0)).copy() * -1
+    tmp29 = np.copy(np.transpose(tmp25, (1, 2, 0))) * -1
     del tmp25
-    tmp29 += tmp26.transpose((2, 1, 0))
+    tmp29 += np.transpose(tmp26, (2, 1, 0))
     del tmp26
     tmp29 += tmp28 * -1
     del tmp28
-    tmp31 = ints.tmp118.copy()
+    tmp31 = np.copy(ints.tmp118)
     del ints.tmp118
     tmp31 += ints.tmp179
     del ints.tmp179
     tmp31 += ints.tmp183 * 0.5
     del ints.tmp183
-    tmp31 += ints.tmp189.transpose((0, 2, 1, 3)) * 0.5
+    tmp31 += np.transpose(ints.tmp189, (0, 2, 1, 3)) * 0.5
     del ints.tmp189
     tmp31 += ints.tmp22 * 0.5
-    tmp31 += ints.tmp2.transpose((0, 2, 1, 3)) * 0.5
+    tmp31 += np.transpose(ints.tmp2, (0, 2, 1, 3)) * 0.5
     tmp31 += ints.tmp83 * 0.5
     del ints.tmp83
-    tmp22 = ints.tmp26.copy()
+    tmp22 = np.copy(ints.tmp26)
     tmp22 += ints.tmp29 * 0.5
     tmp22 += ints.tmp69 * 0.5
-    tmp33 = ints.tmp27.copy() * 2
+    tmp33 = np.copy(ints.tmp27) * 2
     tmp33 += ints.tmp30
     tmp33 += ints.tmp32 * -1
     tmp33 += ints.tmp7 * -1
-    tmp15 = f.aa.oo.copy()
-    tmp15 += ints.tmp11.transpose((1, 0))
+    tmp15 = np.copy(f.aa.oo)
+    tmp15 += np.transpose(ints.tmp11, (1, 0))
     tmp15 += ints.tmp1
-    tmp15 += ints.tmp33.transpose((1, 0))
-    tmp15 += ints.tmp34.transpose((1, 0))
-    tmp15 += ints.tmp9.transpose((1, 0))
-    tmp17 = ints.tmp105.copy()
+    tmp15 += np.transpose(ints.tmp33, (1, 0))
+    tmp15 += np.transpose(ints.tmp34, (1, 0))
+    tmp15 += np.transpose(ints.tmp9, (1, 0))
+    tmp17 = np.copy(ints.tmp105)
     del ints.tmp105
-    tmp17 += ints.tmp122.transpose((1, 0, 2, 3))
+    tmp17 += np.transpose(ints.tmp122, (1, 0, 2, 3))
     del ints.tmp122
-    tmp17 += ints.tmp171.transpose((1, 0, 2, 3))
+    tmp17 += np.transpose(ints.tmp171, (1, 0, 2, 3))
     del ints.tmp171
-    tmp17 += ints.tmp187.transpose((2, 0, 1, 3))
+    tmp17 += np.transpose(ints.tmp187, (2, 0, 1, 3))
     del ints.tmp187
-    tmp17 += ints.tmp87.transpose((2, 0, 1, 3))
+    tmp17 += np.transpose(ints.tmp87, (2, 0, 1, 3))
     del ints.tmp87
-    tmp17 += ints.tmp120.transpose((1, 0, 2, 3)) * 2
+    tmp17 += np.transpose(ints.tmp120, (1, 0, 2, 3)) * 2
     del ints.tmp120
-    tmp17 += ints.tmp181.transpose((2, 0, 1, 3)) * 2
+    tmp17 += np.transpose(ints.tmp181, (2, 0, 1, 3)) * 2
     del ints.tmp181
-    tmp9 = ints.tmp168.copy()
+    tmp9 = np.copy(ints.tmp168)
     tmp9 += ints.tmp74
     tmp9 += ints.tmp128 * 2
-    tmp13 = tmp11.copy() * 2
+    tmp13 = np.copy(tmp11) * 2
     del tmp11
     tmp13 += tmp12
     del tmp12
@@ -3173,16 +3173,16 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp92
     tmp40 = einsum(r2.bab, (0, 1, 2), ints.tmp156, (1, 0, 3, 2), (3,)) * -1
     del ints.tmp156
-    tmp1 = ints.tmp24.copy()
+    tmp1 = np.copy(ints.tmp24)
     tmp1 += ints.tmp4
-    tmp66 = ints.tmp16.copy()
+    tmp66 = np.copy(ints.tmp16)
     del ints.tmp16
     tmp66 += v.bbb.xoo
     tmp37 = einsum(t1.aa, (0, 1), tmp3, (0, 2), (2, 1))
-    tmp53 = ints.tmp6.copy()
+    tmp53 = np.copy(ints.tmp6)
     del ints.tmp6
     tmp53 += v.baa.xoo
-    tmp52 = ints.tmp39.copy()
+    tmp52 = np.copy(ints.tmp39)
     tmp52 += ints.tmp49
     tmp30 = einsum(tmp29, (0, 1, 2), t1.aa, (1, 3), (0, 2, 3)) * 2
     del tmp29
@@ -3203,20 +3203,20 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp9
     tmp14 = einsum(v.baa.xov, (0, 1, 2), tmp13, (0, 3), (1, 3, 2))
     del tmp13
-    tmp63 = ints.tmp277.copy()
+    tmp63 = np.copy(ints.tmp277)
     del ints.tmp277
-    tmp63 += ints.tmp318.transpose((1, 0)) * 2
+    tmp63 += np.transpose(ints.tmp318, (1, 0)) * 2
     del ints.tmp318
-    tmp63 += ints.tmp320.transpose((1, 0))
+    tmp63 += np.transpose(ints.tmp320, (1, 0))
     del ints.tmp320
     tmp63 += f.bb.vv * -1
-    tmp63 += ints.tmp275.transpose((1, 0)) * -1
+    tmp63 += np.transpose(ints.tmp275, (1, 0)) * -1
     del ints.tmp275
-    tmp63 += ints.tmp278.transpose((1, 0)) * -1
+    tmp63 += np.transpose(ints.tmp278, (1, 0)) * -1
     del ints.tmp278
     tmp63 += tmp62
     del tmp62
-    tmp69 = ints.tmp302.copy()
+    tmp69 = np.copy(ints.tmp302)
     del ints.tmp302
     tmp69 += ints.tmp304 * 2
     del ints.tmp304
@@ -3279,9 +3279,9 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp341
     tmp69 += ints.tmp372 * -1
     del ints.tmp372
-    tmp94 = tmp86.copy() * 2
+    tmp94 = np.copy(tmp86) * 2
     del tmp86
-    tmp94 += tmp87.transpose((1, 0, 2)) * -2
+    tmp94 += np.transpose(tmp87, (1, 0, 2)) * -2
     del tmp87
     tmp94 += tmp89
     del tmp89
@@ -3289,19 +3289,19 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp91
     tmp94 += tmp93
     del tmp93
-    tmp57 = tmp55.copy() * 0.5
+    tmp57 = np.copy(tmp55) * 0.5
     del tmp55
     tmp57 += tmp56
     del tmp56
-    tmp95 = ints.tmp387.copy()
+    tmp95 = np.copy(ints.tmp387)
     del ints.tmp387
     tmp95 += ints.tmp394
     del ints.tmp394
-    tmp95 += ints.tmp401.transpose((0, 2, 1, 3)) * -1
+    tmp95 += np.transpose(ints.tmp401, (0, 2, 1, 3)) * -1
     del ints.tmp401
-    tmp96 = ints.tmp396.copy()
+    tmp96 = np.copy(ints.tmp396)
     del ints.tmp396
-    tmp96 += ints.tmp434.transpose((1, 2, 0, 3))
+    tmp96 += np.transpose(ints.tmp434, (1, 2, 0, 3))
     del ints.tmp434
     tmp96 += ints.tmp440
     del ints.tmp440
@@ -3311,7 +3311,7 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp392
     tmp96 += ints.tmp438 * -1
     del ints.tmp438
-    tmp85 = tmp70.copy()
+    tmp85 = np.copy(tmp70)
     del tmp70
     tmp85 += tmp71 * 2
     del tmp71
@@ -3325,53 +3325,53 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp82
     tmp85 += tmp84
     del tmp84
-    tmp7 = f.bb.oo.copy()
+    tmp7 = np.copy(f.bb.oo)
     tmp7 += ints.tmp36
     del ints.tmp36
-    tmp7 += ints.tmp42.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp42, (1, 0))
     del ints.tmp42
-    tmp7 += ints.tmp43.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp43, (1, 0))
     del ints.tmp43
-    tmp7 += ints.tmp52.transpose((1, 0)) * 2
+    tmp7 += np.transpose(ints.tmp52, (1, 0)) * 2
     del ints.tmp52
-    tmp7 += ints.tmp55.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp55, (1, 0))
     del ints.tmp55
-    tmp7 += ints.tmp58.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp58, (1, 0))
     del ints.tmp58
-    tmp7 += ints.tmp59.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp59, (1, 0))
     del ints.tmp59
-    tmp7 += ints.tmp41.transpose((1, 0)) * -1
+    tmp7 += np.transpose(ints.tmp41, (1, 0)) * -1
     del ints.tmp41
-    tmp7 += ints.tmp57.transpose((1, 0)) * -1
+    tmp7 += np.transpose(ints.tmp57, (1, 0)) * -1
     del ints.tmp57
-    tmp4 = f.aa.oo.copy()
-    tmp4 += ints.tmp11.transpose((1, 0))
+    tmp4 = np.copy(f.aa.oo)
+    tmp4 += np.transpose(ints.tmp11, (1, 0))
     del ints.tmp11
     tmp4 += ints.tmp1
     del ints.tmp1
-    tmp4 += ints.tmp27.transpose((1, 0)) * 2
+    tmp4 += np.transpose(ints.tmp27, (1, 0)) * 2
     del ints.tmp27
-    tmp4 += ints.tmp30.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp30, (1, 0))
     del ints.tmp30
-    tmp4 += ints.tmp33.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp33, (1, 0))
     del ints.tmp33
-    tmp4 += ints.tmp34.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp34, (1, 0))
     del ints.tmp34
-    tmp4 += ints.tmp9.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp9, (1, 0))
     del ints.tmp9
-    tmp4 += ints.tmp32.transpose((1, 0)) * -1
+    tmp4 += np.transpose(ints.tmp32, (1, 0)) * -1
     del ints.tmp32
-    tmp4 += ints.tmp7.transpose((1, 0)) * -1
+    tmp4 += np.transpose(ints.tmp7, (1, 0)) * -1
     del ints.tmp7
-    tmp68 = tmp39.copy() * 2
+    tmp68 = np.copy(tmp39) * 2
     tmp68 += tmp40 * -1
-    tmp59 = ints.tmp279.copy()
+    tmp59 = np.copy(ints.tmp279)
     del ints.tmp279
     tmp59 += ints.tmp357
     del ints.tmp357
     tmp59 += ints.tmp322 * -1
     del ints.tmp322
-    tmp61 = ints.tmp276.copy()
+    tmp61 = np.copy(ints.tmp276)
     del ints.tmp276
     tmp61 += ints.tmp51 * 2
     del ints.tmp51
@@ -3383,15 +3383,15 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp65
     tmp67 += einsum(tmp21, (0, 1), tmp66, (0, 2, 3), (1, 3, 2))
     del tmp21, tmp66
-    tmp64 = ints.tmp24.copy()
+    tmp64 = np.copy(ints.tmp24)
     del ints.tmp24
     tmp64 += ints.tmp281
     del ints.tmp281
-    tmp64 += ints.tmp292.transpose((1, 0, 2, 3))
+    tmp64 += np.transpose(ints.tmp292, (1, 0, 2, 3))
     del ints.tmp292
-    tmp64 += ints.tmp293.transpose((1, 0, 2, 3)) * 2
+    tmp64 += np.transpose(ints.tmp293, (1, 0, 2, 3)) * 2
     del ints.tmp293
-    tmp64 += ints.tmp310.transpose((1, 0, 2, 3))
+    tmp64 += np.transpose(ints.tmp310, (1, 0, 2, 3))
     del ints.tmp310
     tmp64 += ints.tmp326
     del ints.tmp326
@@ -3403,13 +3403,13 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp350
     tmp64 += ints.tmp352 * 2
     del ints.tmp352
-    tmp64 += ints.tmp358.transpose((1, 0, 2, 3))
+    tmp64 += np.transpose(ints.tmp358, (1, 0, 2, 3))
     del ints.tmp358
     tmp64 += ints.tmp4
     del ints.tmp4
     tmp64 += ints.tmp284 * -1
     del ints.tmp284
-    tmp64 += ints.tmp289.transpose((1, 0, 2, 3)) * -1
+    tmp64 += np.transpose(ints.tmp289, (1, 0, 2, 3)) * -1
     del ints.tmp289
     tmp64 += ints.tmp291 * -1
     del ints.tmp291
@@ -3425,33 +3425,33 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp354
     tmp64 += ints.tmp364 * -1
     del ints.tmp364
-    tmp64 += ints.tmp367.transpose((1, 0, 2, 3)) * -1
+    tmp64 += np.transpose(ints.tmp367, (1, 0, 2, 3)) * -1
     del ints.tmp367
-    tmp60 = ints.tmp210.copy()
+    tmp60 = np.copy(ints.tmp210)
     tmp60 += ints.tmp214
     tmp60 += ints.tmp249
-    tmp60 += ints.tmp252.transpose((1, 0, 2, 3))
-    tmp60 += ints.tmp264.transpose((0, 1, 3, 2))
-    tmp44 = ints.tmp206.copy()
+    tmp60 += np.transpose(ints.tmp252, (1, 0, 2, 3))
+    tmp60 += np.transpose(ints.tmp264, (0, 1, 3, 2))
+    tmp44 = np.copy(ints.tmp206)
     del ints.tmp206
     tmp44 += ints.tmp262
     del ints.tmp262
     tmp44 += ints.tmp236 * -1
     del ints.tmp236
-    tmp38 = ints.tmp124.transpose((1, 0)).copy() * 2
+    tmp38 = np.copy(np.transpose(ints.tmp124, (1, 0))) * 2
     del ints.tmp124
-    tmp38 += ints.tmp126.transpose((1, 0))
+    tmp38 += np.transpose(ints.tmp126, (1, 0))
     del ints.tmp126
     tmp38 += ints.tmp70
     del ints.tmp70
     tmp38 += f.aa.vv * -1
-    tmp38 += ints.tmp67.transpose((1, 0)) * -1
+    tmp38 += np.transpose(ints.tmp67, (1, 0)) * -1
     del ints.tmp67
-    tmp38 += ints.tmp72.transpose((1, 0)) * -1
+    tmp38 += np.transpose(ints.tmp72, (1, 0)) * -1
     del ints.tmp72
     tmp38 += tmp37
     del tmp37
-    tmp43 = ints.tmp116.copy() * 2
+    tmp43 = np.copy(ints.tmp116) * 2
     del ints.tmp116
     tmp43 += ints.tmp117
     del ints.tmp117
@@ -3514,36 +3514,36 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp80
     tmp43 += ints.tmp82 * -1
     del ints.tmp82
-    tmp46 = ints.tmp210.copy()
+    tmp46 = np.copy(ints.tmp210)
     del ints.tmp210
     tmp46 += ints.tmp214
     del ints.tmp214
     tmp46 += ints.tmp249
     del ints.tmp249
-    tmp46 += ints.tmp252.transpose((1, 0, 2, 3))
+    tmp46 += np.transpose(ints.tmp252, (1, 0, 2, 3))
     del ints.tmp252
-    tmp46 += ints.tmp264.transpose((0, 1, 3, 2))
+    tmp46 += np.transpose(ints.tmp264, (0, 1, 3, 2))
     del ints.tmp264
-    tmp50 = ints.tmp29.copy()
+    tmp50 = np.copy(ints.tmp29)
     del ints.tmp29
     tmp50 += ints.tmp69
     del ints.tmp69
     tmp50 += v.baa.xov
     tmp50 += ints.tmp26 * 2
     del ints.tmp26
-    tmp45 = ints.tmp128.copy() * 2
+    tmp45 = np.copy(ints.tmp128) * 2
     del ints.tmp128
     tmp45 += ints.tmp168
     del ints.tmp168
     tmp45 += ints.tmp74
     del ints.tmp74
-    tmp51 = ints.tmp208.copy()
+    tmp51 = np.copy(ints.tmp208)
     del ints.tmp208
-    tmp51 += ints.tmp219.transpose((0, 2, 1, 3))
+    tmp51 += np.transpose(ints.tmp219, (0, 2, 1, 3))
     del ints.tmp219
-    tmp51 += ints.tmp220.transpose((0, 2, 1, 3)) * 2
+    tmp51 += np.transpose(ints.tmp220, (0, 2, 1, 3)) * 2
     del ints.tmp220
-    tmp51 += ints.tmp228.transpose((0, 2, 1, 3))
+    tmp51 += np.transpose(ints.tmp228, (0, 2, 1, 3))
     del ints.tmp228
     tmp51 += ints.tmp242
     del ints.tmp242
@@ -3555,13 +3555,13 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp256
     tmp51 += ints.tmp258 * 2
     del ints.tmp258
-    tmp51 += ints.tmp263.transpose((0, 2, 1, 3))
+    tmp51 += np.transpose(ints.tmp263, (0, 2, 1, 3))
     del ints.tmp263
     tmp51 += ints.tmp39
     tmp51 += ints.tmp49
     tmp51 += ints.tmp212 * -1
     del ints.tmp212
-    tmp51 += ints.tmp216.transpose((0, 2, 1, 3)) * -1
+    tmp51 += np.transpose(ints.tmp216, (0, 2, 1, 3)) * -1
     del ints.tmp216
     tmp51 += ints.tmp218 * -1
     del ints.tmp218
@@ -3577,7 +3577,7 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp260
     tmp51 += ints.tmp268 * -1
     del ints.tmp268
-    tmp51 += ints.tmp269.transpose((0, 2, 1, 3)) * -1
+    tmp51 += np.transpose(ints.tmp269, (0, 2, 1, 3)) * -1
     del ints.tmp269
     tmp54 = einsum(r2.aba, (0, 1, 2), tmp24, (3, 4, 0, 2), (3, 4, 1))
     del tmp24
@@ -3585,65 +3585,65 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp52
     tmp54 += einsum(tmp53, (0, 1, 2), tmp49, (0, 3), (1, 2, 3))
     del tmp53
-    tmp42 = ints.tmp152.copy()
+    tmp42 = np.copy(ints.tmp152)
     del ints.tmp152
-    tmp42 += ints.tmp161.transpose((2, 0, 1, 3))
+    tmp42 += np.transpose(ints.tmp161, (2, 0, 1, 3))
     del ints.tmp161
-    tmp42 += ints.tmp163.transpose((2, 0, 1, 3))
+    tmp42 += np.transpose(ints.tmp163, (2, 0, 1, 3))
     del ints.tmp163
-    tmp42 += ints.tmp95.transpose((2, 0, 1, 3))
+    tmp42 += np.transpose(ints.tmp95, (2, 0, 1, 3))
     del ints.tmp95
-    tmp42 += ints.tmp159.transpose((2, 0, 1, 3)) * -1
+    tmp42 += np.transpose(ints.tmp159, (2, 0, 1, 3)) * -1
     del ints.tmp159
-    tmp42 += ints.tmp90.transpose((2, 0, 1, 3)) * -1
+    tmp42 += np.transpose(ints.tmp90, (2, 0, 1, 3)) * -1
     del ints.tmp90
-    tmp35 = tmp20.copy() * 2
+    tmp35 = np.copy(tmp20) * 2
     del tmp20
-    tmp35 += tmp23.transpose((1, 0, 2))
+    tmp35 += np.transpose(tmp23, (1, 0, 2))
     del tmp23
     tmp35 += tmp30
     del tmp30
     tmp35 += tmp32
     del tmp32
-    tmp35 += tmp34.transpose((1, 0, 2))
+    tmp35 += np.transpose(tmp34, (1, 0, 2))
     del tmp34
-    tmp36 = ints.tmp85.transpose((0, 2, 1, 3)).copy()
+    tmp36 = np.copy(np.transpose(ints.tmp85, (0, 2, 1, 3)))
     del ints.tmp85
-    tmp36 += ints.tmp93.transpose((0, 2, 1, 3))
+    tmp36 += np.transpose(ints.tmp93, (0, 2, 1, 3))
     del ints.tmp93
     tmp36 += ints.tmp103 * -1
     del ints.tmp103
-    tmp41 = tmp39.copy()
+    tmp41 = np.copy(tmp39)
     del tmp39
     tmp41 += tmp40 * -0.5
     del tmp40
-    tmp19 = tmp8.copy()
+    tmp19 = np.copy(tmp8)
     del tmp8
-    tmp19 += tmp10.transpose((1, 0, 2)) * -2
+    tmp19 += np.transpose(tmp10, (1, 0, 2)) * -2
     del tmp10
-    tmp19 += tmp14.transpose((1, 0, 2))
+    tmp19 += np.transpose(tmp14, (1, 0, 2))
     del tmp14
-    tmp19 += tmp16.transpose((1, 0, 2)) * -2
+    tmp19 += np.transpose(tmp16, (1, 0, 2)) * -2
     del tmp16
     tmp19 += tmp18
     del tmp18
-    tmp5 = ints.tmp37.copy()
+    tmp5 = np.copy(ints.tmp37)
     del ints.tmp37
     tmp5 += ints.tmp47 * -1
     del ints.tmp47
-    tmp6 = ints.tmp39.copy()
+    tmp6 = np.copy(ints.tmp39)
     del ints.tmp39
     tmp6 += ints.tmp49
     del ints.tmp49
-    tmp0 = ints.tmp22.copy()
+    tmp0 = np.copy(ints.tmp22)
     del ints.tmp22
     tmp0 += ints.tmp2 * -1
     del ints.tmp2
-    r2new.bbb = tmp85.copy() * -1
-    r2new.bbb += tmp85.transpose((1, 0, 2))
+    r2new.bbb = np.copy(tmp85) * -1
+    r2new.bbb += np.transpose(tmp85, (1, 0, 2))
     del tmp85
     r2new.bbb += tmp94
-    r2new.bbb += tmp94.transpose((1, 0, 2)) * -1
+    r2new.bbb += np.transpose(tmp94, (1, 0, 2)) * -1
     del tmp94
     r2new.bbb += einsum(r2.bbb, (0, 1, 2), tmp95, (3, 4, 0, 1), (3, 4, 2)) * 2
     del tmp95
@@ -3695,11 +3695,11 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     r2new.aba += einsum(t2.abab, (0, 1, 2, 3), tmp57, (3,), (0, 1, 2)) * -2
     del tmp57
     r2new.aba += einsum(r1.b, (0,), tmp43, (1, 2), (1, 0, 2))
-    r2new.aaa = tmp19.copy()
-    r2new.aaa += tmp19.transpose((1, 0, 2)) * -1
+    r2new.aaa = np.copy(tmp19)
+    r2new.aaa += np.transpose(tmp19, (1, 0, 2)) * -1
     del tmp19
     r2new.aaa += tmp35 * -1
-    r2new.aaa += tmp35.transpose((1, 0, 2))
+    r2new.aaa += np.transpose(tmp35, (1, 0, 2))
     del tmp35
     r2new.aaa += einsum(tmp36, (0, 1, 2, 3), r2.aaa, (3, 1, 4), (0, 2, 4)) * -2
     del tmp36
@@ -4133,48 +4133,48 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp62 = einsum(v.baa.xov, (0, 1, 2), r2.aba, (2, 3, 1), (0, 3))
     tmp18 = einsum(v.baa.xov, (0, 1, 2), r2.aaa, (3, 2, 1), (0, 3))
     tmp19 = einsum(r2.bab, (0, 1, 2), v.bbb.xov, (3, 2, 0), (3, 1)) * -1
-    tmp64 = tmp62.copy() * -1
+    tmp64 = np.copy(tmp62) * -1
     tmp64 += tmp63 * 2
-    tmp82 = ints.tmp17.copy()
+    tmp82 = np.copy(ints.tmp17)
     del ints.tmp17
     tmp82 += v.bbb.xoo
-    tmp120 = f.bb.ov.copy()
+    tmp120 = np.copy(f.bb.ov)
     tmp120 += ints.tmp19
     tmp120 += ints.tmp22
-    tmp122 = ints.tmp298.copy()
+    tmp122 = np.copy(ints.tmp298)
     tmp122 += ints.tmp319
     tmp122 += ints.tmp383 * 2
     tmp116 = einsum(r1.b, (0,), ints.tmp360, (1, 2, 3, 0), (1, 2, 3))
-    tmp103 = ints.tmp430.copy()
+    tmp103 = np.copy(ints.tmp430)
     del ints.tmp430
-    tmp103 += ints.tmp485.transpose((0, 1, 3, 2))
+    tmp103 += np.transpose(ints.tmp485, (0, 1, 3, 2))
     del ints.tmp485
     tmp103 += ints.tmp51
     tmp103 += ints.tmp425 * 2
     del ints.tmp425
     tmp99 = einsum(r1.b, (0,), ints.tmp343, (1, 2, 3, 0), (1, 2, 3))
-    tmp101 = ints.tmp343.copy()
-    tmp101 += ints.tmp360.transpose((0, 2, 1, 3))
+    tmp101 = np.copy(ints.tmp343)
+    tmp101 += np.transpose(ints.tmp360, (0, 2, 1, 3))
     tmp23 = einsum(r1.a, (0,), ints.tmp177, (1, 2, 3, 0), (1, 2, 3))
-    tmp25 = ints.tmp130.copy()
-    tmp25 += ints.tmp177.transpose((0, 2, 1, 3))
-    tmp27 = ints.tmp105.copy()
+    tmp25 = np.copy(ints.tmp130)
+    tmp25 += np.transpose(ints.tmp177, (0, 2, 1, 3))
+    tmp27 = np.copy(ints.tmp105)
     del ints.tmp105
-    tmp27 += ints.tmp190.transpose((0, 1, 3, 2))
+    tmp27 += np.transpose(ints.tmp190, (0, 1, 3, 2))
     del ints.tmp190
     tmp27 += ints.tmp23
     tmp27 += ints.tmp100 * 2
     del ints.tmp100
     tmp39 = einsum(ints.tmp130, (0, 1, 2, 3), r1.a, (3,), (0, 1, 2))
-    tmp42 = ints.tmp12.copy()
+    tmp42 = np.copy(ints.tmp12)
     del ints.tmp12
     tmp42 += v.baa.xoo
-    tmp34 = tmp18.copy()
+    tmp34 = np.copy(tmp18)
     tmp34 += tmp19 * 0.5
-    tmp46 = ints.tmp117.copy()
+    tmp46 = np.copy(ints.tmp117)
     tmp46 += ints.tmp167
     tmp46 += ints.tmp86 * 2
-    tmp44 = f.aa.ov.copy()
+    tmp44 = np.copy(f.aa.ov)
     tmp44 += ints.tmp15
     tmp44 += ints.tmp20
     tmp119 = einsum(tmp64, (0, 1), tmp82, (0, 2, 3), (2, 3, 1))
@@ -4207,61 +4207,61 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp45 = einsum(tmp44, (0, 1), r2.aaa, (2, 1, 3), (3, 0, 2)) * -2
     del tmp44
     tmp41 = einsum(r2.aaa, (0, 1, 2), ints.tmp2, (3, 4, 0, 1), (3, 2, 4))
-    tmp126 = ints.tmp411.copy()
+    tmp126 = np.copy(ints.tmp411)
     del ints.tmp411
     tmp126 += ints.tmp415 * 0.5
     del ints.tmp415
-    tmp124 = tmp117.transpose((1, 0, 2)).copy()
+    tmp124 = np.copy(np.transpose(tmp117, (1, 0, 2)))
     del tmp117
     tmp124 += tmp118 * 2
     del tmp118
-    tmp124 += tmp119.transpose((1, 0, 2))
+    tmp124 += np.transpose(tmp119, (1, 0, 2))
     del tmp119
     tmp124 += tmp121 * -1
     del tmp121
-    tmp124 += tmp123.transpose((1, 0, 2))
+    tmp124 += np.transpose(tmp123, (1, 0, 2))
     del tmp123
-    tmp112 = ints.tmp45.copy() * 0.5
+    tmp112 = np.copy(ints.tmp45) * 0.5
     tmp112 += ints.tmp56
     tmp112 += ints.tmp59 * 0.5
-    tmp114 = f.bb.vv.copy() * 0.5
-    tmp114 += ints.tmp44.transpose((1, 0)) * 0.5
-    tmp114 += ints.tmp47.transpose((1, 0)) * 0.5
-    tmp114 += ints.tmp57.transpose((1, 0)) * -1
-    tmp114 += ints.tmp60.transpose((1, 0)) * -0.5
-    tmp96 = ints.tmp45.copy()
+    tmp114 = np.copy(f.bb.vv) * 0.5
+    tmp114 += np.transpose(ints.tmp44, (1, 0)) * 0.5
+    tmp114 += np.transpose(ints.tmp47, (1, 0)) * 0.5
+    tmp114 += np.transpose(ints.tmp57, (1, 0)) * -1
+    tmp114 += np.transpose(ints.tmp60, (1, 0)) * -0.5
+    tmp96 = np.copy(ints.tmp45)
     tmp96 += ints.tmp59
     tmp96 += ints.tmp56 * 2
-    tmp94 = ints.tmp298.copy()
+    tmp94 = np.copy(ints.tmp298)
     tmp94 += ints.tmp319
     tmp94 += ints.tmp383 * 2
-    tmp107 = ints.tmp40.copy()
-    tmp107 += ints.tmp471.transpose((0, 2, 1, 3))
+    tmp107 = np.copy(ints.tmp40)
+    tmp107 += np.transpose(ints.tmp471, (0, 2, 1, 3))
     del ints.tmp471
     tmp107 += ints.tmp413 * 2
     del ints.tmp413
-    tmp105 = tmp98.copy() * 2
+    tmp105 = np.copy(tmp98) * 2
     del tmp98
-    tmp105 += tmp100.transpose((1, 0, 2))
+    tmp105 += np.transpose(tmp100, (1, 0, 2))
     del tmp100
-    tmp105 += tmp102.transpose((1, 0, 2)) * -2
+    tmp105 += np.transpose(tmp102, (1, 0, 2)) * -2
     del tmp102
-    tmp105 += tmp104.transpose((1, 0, 2))
+    tmp105 += np.transpose(tmp104, (1, 0, 2))
     del tmp104
-    tmp0 = f.bb.ov.copy()
+    tmp0 = np.copy(f.bb.ov)
     tmp0 += ints.tmp19
     tmp0 += ints.tmp22
     tmp0 += ints.tmp18 * -1
     del ints.tmp18
-    tmp1 = f.aa.ov.copy()
+    tmp1 = np.copy(f.aa.ov)
     tmp1 += ints.tmp15
     tmp1 += ints.tmp20
     tmp1 += ints.tmp13 * -1
     del ints.tmp13
     tmp56 = einsum(ints.tmp26, (0, 1, 2, 3), r2.aba, (2, 3, 4), (0, 4, 1))
-    tmp73 = ints.tmp136.copy()
-    tmp73 += ints.tmp179.transpose((1, 0, 2, 3))
-    tmp29 = tmp22.transpose((1, 0, 2)).copy() * 2
+    tmp73 = np.copy(ints.tmp136)
+    tmp73 += np.transpose(ints.tmp179, (1, 0, 2, 3))
+    tmp29 = np.copy(np.transpose(tmp22, (1, 0, 2))) * 2
     del tmp22
     tmp29 += tmp24
     del tmp24
@@ -4269,37 +4269,37 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp26
     tmp29 += tmp28
     del tmp28
-    tmp20 = tmp18.copy() * 2
+    tmp20 = np.copy(tmp18) * 2
     del tmp18
     tmp20 += tmp19
     del tmp19
-    tmp31 = ints.tmp162.copy()
+    tmp31 = np.copy(ints.tmp162)
     del ints.tmp162
-    tmp31 += ints.tmp2.transpose((0, 2, 1, 3))
-    tmp31 += ints.tmp80.transpose((0, 2, 1, 3)) * 2
+    tmp31 += np.transpose(ints.tmp2, (0, 2, 1, 3))
+    tmp31 += np.transpose(ints.tmp80, (0, 2, 1, 3)) * 2
     del ints.tmp80
-    tmp16 = ints.tmp117.copy()
+    tmp16 = np.copy(ints.tmp117)
     tmp16 += ints.tmp167
     tmp16 += ints.tmp86 * 2
-    tmp35 = ints.tmp29.copy() * 2
+    tmp35 = np.copy(ints.tmp29) * 2
     tmp35 += ints.tmp32
     tmp35 += ints.tmp8
-    tmp48 = tmp40.transpose((1, 0, 2)).copy()
+    tmp48 = np.copy(np.transpose(tmp40, (1, 0, 2)))
     del tmp40
     tmp48 += tmp41 * 2
     del tmp41
-    tmp48 += tmp43.transpose((1, 0, 2))
+    tmp48 += np.transpose(tmp43, (1, 0, 2))
     del tmp43
-    tmp48 += tmp45.transpose((1, 0, 2)) * -1
+    tmp48 += np.transpose(tmp45, (1, 0, 2)) * -1
     del tmp45
-    tmp48 += tmp47.transpose((1, 0, 2))
+    tmp48 += np.transpose(tmp47, (1, 0, 2))
     del tmp47
-    tmp37 = f.aa.vv.copy() * 0.5
-    tmp37 += ints.tmp11.transpose((1, 0)) * 0.5
-    tmp37 += ints.tmp7.transpose((1, 0)) * 0.5
-    tmp37 += ints.tmp30.transpose((1, 0)) * -1
-    tmp37 += ints.tmp33.transpose((1, 0)) * -0.5
-    tmp50 = ints.tmp78.copy()
+    tmp37 = np.copy(f.aa.vv) * 0.5
+    tmp37 += np.transpose(ints.tmp11, (1, 0)) * 0.5
+    tmp37 += np.transpose(ints.tmp7, (1, 0)) * 0.5
+    tmp37 += np.transpose(ints.tmp30, (1, 0)) * -1
+    tmp37 += np.transpose(ints.tmp33, (1, 0)) * -0.5
+    tmp50 = np.copy(ints.tmp78)
     del ints.tmp78
     tmp50 += ints.tmp82 * 0.5
     del ints.tmp82
@@ -4332,13 +4332,13 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp68 = einsum(tmp1, (0, 1), t1.aa, (0, 2), (2, 1))
     tmp66 = einsum(tmp0, (0, 1), t1.bb, (0, 2), (1, 2))
     tmp76 = einsum(ints.tmp26, (0, 1, 2, 3), r2.bab, (3, 2, 4), (0, 1, 4)) * -1
-    tmp78 = r2.bab.transpose((2, 1, 0)).copy() * -1
+    tmp78 = np.copy(np.transpose(r2.bab, (2, 1, 0))) * -1
     tmp78 += einsum(t1.bb, (0, 1), r1.a, (2,), (0, 2, 1))
-    tmp85 = ints.tmp303.copy()
+    tmp85 = np.copy(ints.tmp303)
     del ints.tmp303
     tmp85 += ints.tmp327
     del ints.tmp327
-    tmp86 = ints.tmp26.copy()
+    tmp86 = np.copy(ints.tmp26)
     tmp86 += ints.tmp333
     del ints.tmp333
     tmp86 += ints.tmp393
@@ -4346,18 +4346,18 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp86 += ints.tmp396 * 2
     del ints.tmp396
     tmp86 += ints.tmp380 * -1
-    tmp80 = ints.tmp343.copy()
+    tmp80 = np.copy(ints.tmp343)
     del ints.tmp343
-    tmp80 += ints.tmp360.transpose((0, 2, 1, 3))
+    tmp80 += np.transpose(ints.tmp360, (0, 2, 1, 3))
     del ints.tmp360
     tmp3 = einsum(r2.aaa, (0, 1, 2), ints.tmp23, (2, 3, 0, 1), (3,))
     tmp4 = einsum(ints.tmp26, (0, 1, 2, 3), r2.bab, (3, 2, 1), (0,)) * -1
     tmp5 = einsum(r1.a, (0,), tmp1, (1, 0), (1,))
-    tmp60 = ints.tmp130.copy()
+    tmp60 = np.copy(ints.tmp130)
     del ints.tmp130
-    tmp60 += ints.tmp177.transpose((0, 2, 1, 3))
+    tmp60 += np.transpose(ints.tmp177, (0, 2, 1, 3))
     del ints.tmp177
-    tmp72 = ints.tmp245.copy()
+    tmp72 = np.copy(ints.tmp245)
     del ints.tmp245
     tmp72 += ints.tmp26
     del ints.tmp26
@@ -4366,11 +4366,11 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp72 += ints.tmp279 * 2
     del ints.tmp279
     tmp72 += ints.tmp89 * -1
-    tmp71 = ints.tmp136.copy()
+    tmp71 = np.copy(ints.tmp136)
     del ints.tmp136
     tmp71 += ints.tmp179
     del ints.tmp179
-    tmp74 = tmp56.copy() * -1
+    tmp74 = np.copy(tmp56) * -1
     tmp74 += einsum(r1.b, (0,), tmp73, (1, 2, 3, 0), (1, 2, 3))
     del tmp73
     tmp30 = einsum(t1.aa, (0, 1), tmp29, (2, 0, 3), (2, 1, 3))
@@ -4394,7 +4394,7 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp51 = einsum(tmp50, (0, 1, 2, 3), r1.a, (2,), (0, 1, 3)) * 2
     del tmp50
     tmp91 = einsum(t1.bb, (0, 1), tmp90, (2, 0, 3), (2, 3, 1))
-    tmp128 = tmp110.copy()
+    tmp128 = np.copy(tmp110)
     del tmp110
     tmp128 += tmp111
     del tmp111
@@ -4406,7 +4406,7 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp125
     tmp128 += tmp127
     del tmp127
-    tmp109 = tmp92.copy() * 2
+    tmp109 = np.copy(tmp92) * 2
     del tmp92
     tmp109 += tmp93 * 2
     del tmp93
@@ -4418,36 +4418,36 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp106
     tmp109 += tmp108
     del tmp108
-    tmp129 = ints.tmp453.copy()
+    tmp129 = np.copy(ints.tmp453)
     del ints.tmp453
     tmp129 += ints.tmp481 * -1
     del ints.tmp481
-    tmp11 = tmp8.copy()
+    tmp11 = np.copy(tmp8)
     del tmp8
     tmp11 += tmp9 * 2
     del tmp9
     tmp11 += tmp10 * -1
     del tmp10
-    tmp88 = f.bb.oo.copy()
-    tmp88 += ints.tmp301.transpose((1, 0))
+    tmp88 = np.copy(f.bb.oo)
+    tmp88 += np.transpose(ints.tmp301, (1, 0))
     del ints.tmp301
-    tmp88 += ints.tmp302.transpose((1, 0))
+    tmp88 += np.transpose(ints.tmp302, (1, 0))
     del ints.tmp302
     tmp88 += ints.tmp316
     del ints.tmp316
-    tmp88 += ints.tmp323.transpose((1, 0)) * 2
+    tmp88 += np.transpose(ints.tmp323, (1, 0)) * 2
     del ints.tmp323
-    tmp88 += ints.tmp325.transpose((1, 0))
+    tmp88 += np.transpose(ints.tmp325, (1, 0))
     del ints.tmp325
-    tmp88 += ints.tmp336.transpose((1, 0))
+    tmp88 += np.transpose(ints.tmp336, (1, 0))
     del ints.tmp336
-    tmp88 += ints.tmp337.transpose((1, 0))
+    tmp88 += np.transpose(ints.tmp337, (1, 0))
     del ints.tmp337
-    tmp88 += ints.tmp300.transpose((1, 0)) * -1
+    tmp88 += np.transpose(ints.tmp300, (1, 0)) * -1
     del ints.tmp300
-    tmp88 += ints.tmp335.transpose((1, 0)) * -1
+    tmp88 += np.transpose(ints.tmp335, (1, 0)) * -1
     del ints.tmp335
-    tmp89 = ints.tmp299.copy()
+    tmp89 = np.copy(ints.tmp299)
     del ints.tmp299
     tmp89 += ints.tmp321 * 2
     del ints.tmp321
@@ -4510,35 +4510,35 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp391
     tmp89 += ints.tmp392 * -2
     del ints.tmp392
-    tmp69 = ints.tmp30.transpose((1, 0)).copy() * 2
-    tmp69 += ints.tmp33.transpose((1, 0))
+    tmp69 = np.copy(np.transpose(ints.tmp30, (1, 0))) * 2
+    tmp69 += np.transpose(ints.tmp33, (1, 0))
     tmp69 += ints.tmp9
     tmp69 += f.aa.vv * -1
-    tmp69 += ints.tmp11.transpose((1, 0)) * -1
-    tmp69 += ints.tmp7.transpose((1, 0)) * -1
-    tmp69 += tmp68.transpose((1, 0))
+    tmp69 += np.transpose(ints.tmp11, (1, 0)) * -1
+    tmp69 += np.transpose(ints.tmp7, (1, 0)) * -1
+    tmp69 += np.transpose(tmp68, (1, 0))
     del tmp68
-    tmp84 = ints.tmp305.copy()
+    tmp84 = np.copy(ints.tmp305)
     del ints.tmp305
-    tmp84 += ints.tmp318.transpose((0, 2, 1, 3))
+    tmp84 += np.transpose(ints.tmp318, (0, 2, 1, 3))
     del ints.tmp318
     tmp84 += ints.tmp328
     del ints.tmp328
-    tmp84 += ints.tmp374.transpose((0, 2, 1, 3))
+    tmp84 += np.transpose(ints.tmp374, (0, 2, 1, 3))
     del ints.tmp374
-    tmp84 += ints.tmp376.transpose((0, 2, 1, 3)) * 2
+    tmp84 += np.transpose(ints.tmp376, (0, 2, 1, 3)) * 2
     del ints.tmp376
     tmp84 += ints.tmp4
     tmp84 += ints.tmp290 * -1
     del ints.tmp290
-    tmp84 += ints.tmp375.transpose((0, 2, 1, 3)) * -1
+    tmp84 += np.transpose(ints.tmp375, (0, 2, 1, 3)) * -1
     del ints.tmp375
-    tmp67 = ints.tmp46.copy()
-    tmp67 += ints.tmp57.transpose((1, 0)) * 2
-    tmp67 += ints.tmp60.transpose((1, 0))
+    tmp67 = np.copy(ints.tmp46)
+    tmp67 += np.transpose(ints.tmp57, (1, 0)) * 2
+    tmp67 += np.transpose(ints.tmp60, (1, 0))
     tmp67 += f.bb.vv * -1
-    tmp67 += ints.tmp44.transpose((1, 0)) * -1
-    tmp67 += ints.tmp47.transpose((1, 0)) * -1
+    tmp67 += np.transpose(ints.tmp44, (1, 0)) * -1
+    tmp67 += np.transpose(ints.tmp47, (1, 0)) * -1
     tmp67 += tmp66
     del tmp66
     tmp87 = einsum(ints.tmp42, (0, 1, 2, 3), r2.bab, (3, 1, 4), (0, 4, 2))
@@ -4547,7 +4547,7 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp85
     tmp87 += einsum(tmp86, (0, 1, 2, 3), r1.a, (2,), (0, 1, 3)) * -1
     del tmp86
-    tmp81 = ints.tmp298.copy()
+    tmp81 = np.copy(ints.tmp298)
     del ints.tmp298
     tmp81 += ints.tmp319
     del ints.tmp319
@@ -4555,7 +4555,7 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp383
     tmp81 += einsum(t1.bb, (0, 1), tmp80, (2, 0, 3, 4), (2, 3, 1, 4)) * -1
     del tmp80
-    tmp83 = ints.tmp45.copy()
+    tmp83 = np.copy(ints.tmp45)
     del ints.tmp45
     tmp83 += ints.tmp56 * 2
     del ints.tmp56
@@ -4565,41 +4565,41 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp83 += einsum(t1.bb, (0, 1), tmp82, (2, 3, 0), (2, 3, 1)) * -1
     del tmp82
     tmp77 = einsum(r2.bab, (0, 1, 2), ints.tmp4, (3, 4, 1, 0), (3, 2, 4)) * -1
-    tmp79 = ints.tmp342.copy()
+    tmp79 = np.copy(ints.tmp342)
     del ints.tmp342
     tmp79 += ints.tmp357
     del ints.tmp357
     tmp79 += ints.tmp293 * -1
     del ints.tmp293
-    tmp6 = tmp3.copy() * -2
+    tmp6 = np.copy(tmp3) * -2
     del tmp3
     tmp6 += tmp4
     del tmp4
     tmp6 += tmp5
     del tmp5
-    tmp58 = r2.aba.transpose((2, 0, 1)).copy()
+    tmp58 = np.copy(np.transpose(r2.aba, (2, 0, 1)))
     tmp58 += einsum(r1.b, (0,), t1.aa, (1, 2), (1, 2, 0)) * -1
-    tmp53 = f.aa.oo.copy()
-    tmp53 += ints.tmp124.transpose((1, 0))
+    tmp53 = np.copy(f.aa.oo)
+    tmp53 += np.transpose(ints.tmp124, (1, 0))
     del ints.tmp124
-    tmp53 += ints.tmp126.transpose((1, 0))
+    tmp53 += np.transpose(ints.tmp126, (1, 0))
     del ints.tmp126
     tmp53 += ints.tmp157
     del ints.tmp157
-    tmp53 += ints.tmp173.transpose((1, 0)) * 2
+    tmp53 += np.transpose(ints.tmp173, (1, 0)) * 2
     del ints.tmp173
-    tmp53 += ints.tmp175.transpose((1, 0))
+    tmp53 += np.transpose(ints.tmp175, (1, 0))
     del ints.tmp175
-    tmp53 += ints.tmp195.transpose((1, 0))
+    tmp53 += np.transpose(ints.tmp195, (1, 0))
     del ints.tmp195
-    tmp53 += ints.tmp197.transpose((1, 0))
+    tmp53 += np.transpose(ints.tmp197, (1, 0))
     del ints.tmp197
-    tmp53 += ints.tmp122.transpose((1, 0)) * -1
+    tmp53 += np.transpose(ints.tmp122, (1, 0)) * -1
     del ints.tmp122
-    tmp53 += ints.tmp193.transpose((1, 0)) * -1
+    tmp53 += np.transpose(ints.tmp193, (1, 0)) * -1
     del ints.tmp193
     tmp57 = einsum(ints.tmp42, (0, 1, 2, 3), r2.aba, (1, 3, 4), (0, 4, 2))
-    tmp65 = ints.tmp29.copy() * 2
+    tmp65 = np.copy(ints.tmp29) * 2
     del ints.tmp29
     tmp65 += ints.tmp32
     del ints.tmp32
@@ -4608,22 +4608,22 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     tmp65 += v.baa.xov
     tmp65 += einsum(t1.aa, (0, 1), tmp42, (2, 3, 0), (2, 3, 1)) * -1
     del tmp42
-    tmp70 = ints.tmp227.copy()
+    tmp70 = np.copy(ints.tmp227)
     del ints.tmp227
-    tmp70 += ints.tmp239.transpose((0, 1, 3, 2))
+    tmp70 += np.transpose(ints.tmp239, (0, 1, 3, 2))
     del ints.tmp239
     tmp70 += ints.tmp243
     del ints.tmp243
-    tmp70 += ints.tmp265.transpose((0, 1, 3, 2))
+    tmp70 += np.transpose(ints.tmp265, (0, 1, 3, 2))
     del ints.tmp265
-    tmp70 += ints.tmp267.transpose((0, 1, 3, 2)) * 2
+    tmp70 += np.transpose(ints.tmp267, (0, 1, 3, 2)) * 2
     del ints.tmp267
     tmp70 += ints.tmp42
     tmp70 += ints.tmp218 * -1
     del ints.tmp218
-    tmp70 += ints.tmp266.transpose((0, 1, 3, 2)) * -1
+    tmp70 += np.transpose(ints.tmp266, (0, 1, 3, 2)) * -1
     del ints.tmp266
-    tmp61 = ints.tmp117.copy()
+    tmp61 = np.copy(ints.tmp117)
     del ints.tmp117
     tmp61 += ints.tmp167
     del ints.tmp167
@@ -4631,7 +4631,7 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp86
     tmp61 += einsum(tmp60, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3)) * -1
     del tmp60
-    tmp55 = ints.tmp115.copy()
+    tmp55 = np.copy(ints.tmp115)
     del ints.tmp115
     tmp55 += ints.tmp119
     del ints.tmp119
@@ -4694,7 +4694,7 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del ints.tmp98
     tmp55 += ints.tmp99 * -1
     del ints.tmp99
-    tmp59 = ints.tmp250.copy()
+    tmp59 = np.copy(ints.tmp250)
     del ints.tmp250
     tmp59 += ints.tmp256
     del ints.tmp256
@@ -4707,52 +4707,52 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp72
     tmp75 += einsum(t1.aa, (0, 1), tmp74, (0, 2, 3), (2, 3, 1)) * -1
     del tmp74
-    tmp54 = ints.tmp138.copy()
+    tmp54 = np.copy(ints.tmp138)
     del ints.tmp138
     tmp54 += ints.tmp181 * -1
     del ints.tmp181
-    tmp33 = tmp14.copy() * 2
+    tmp33 = np.copy(tmp14) * 2
     del tmp14
     tmp33 += tmp15
     del tmp15
-    tmp33 += tmp17.transpose((0, 2, 1)) * -2
+    tmp33 += np.transpose(tmp17, (0, 2, 1)) * -2
     del tmp17
-    tmp33 += tmp21.transpose((0, 2, 1))
+    tmp33 += np.transpose(tmp21, (0, 2, 1))
     del tmp21
-    tmp33 += tmp30.transpose((0, 2, 1))
+    tmp33 += np.transpose(tmp30, (0, 2, 1))
     del tmp30
     tmp33 += tmp32
     del tmp32
     tmp13 = einsum(tmp12, (0, 1, 2), t1.aa, (1, 3), (0, 2, 3))
-    tmp52 = tmp36.copy()
+    tmp52 = np.copy(tmp36)
     del tmp36
-    tmp52 += tmp38.transpose((0, 2, 1)) * -1
+    tmp52 += np.transpose(tmp38, (0, 2, 1)) * -1
     del tmp38
-    tmp52 += tmp49.transpose((0, 2, 1))
+    tmp52 += np.transpose(tmp49, (0, 2, 1))
     del tmp49
     tmp52 += tmp51
     del tmp51
-    tmp7 = ints.tmp46.copy()
+    tmp7 = np.copy(ints.tmp46)
     del ints.tmp46
-    tmp7 += ints.tmp57.transpose((1, 0)) * 2
+    tmp7 += np.transpose(ints.tmp57, (1, 0)) * 2
     del ints.tmp57
-    tmp7 += ints.tmp60.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp60, (1, 0))
     del ints.tmp60
     tmp7 += f.bb.vv * -1
-    tmp7 += ints.tmp44.transpose((1, 0)) * -1
+    tmp7 += np.transpose(ints.tmp44, (1, 0)) * -1
     del ints.tmp44
-    tmp7 += ints.tmp47.transpose((1, 0)) * -1
+    tmp7 += np.transpose(ints.tmp47, (1, 0)) * -1
     del ints.tmp47
-    tmp2 = ints.tmp30.transpose((1, 0)).copy() * 2
+    tmp2 = np.copy(np.transpose(ints.tmp30, (1, 0))) * 2
     del ints.tmp30
-    tmp2 += ints.tmp33.transpose((1, 0))
+    tmp2 += np.transpose(ints.tmp33, (1, 0))
     del ints.tmp33
     tmp2 += ints.tmp9
     del ints.tmp9
     tmp2 += f.aa.vv * -1
-    tmp2 += ints.tmp11.transpose((1, 0)) * -1
+    tmp2 += np.transpose(ints.tmp11, (1, 0)) * -1
     del ints.tmp11
-    tmp2 += ints.tmp7.transpose((1, 0)) * -1
+    tmp2 += np.transpose(ints.tmp7, (1, 0)) * -1
     del ints.tmp7
     r2new.bbb = einsum(r2.bbb, (0, 1, 2), ints.tmp469, (3, 0, 4, 1), (3, 4, 2)) * -2
     del ints.tmp469
@@ -4760,11 +4760,11 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp90
     r2new.bbb += einsum(t1.bb, (0, 1), tmp91, (0, 2, 3), (3, 1, 2)) * -2
     del tmp91
-    r2new.bbb += tmp109.transpose((1, 2, 0))
-    r2new.bbb += tmp109.transpose((2, 1, 0)) * -1
+    r2new.bbb += np.transpose(tmp109, (1, 2, 0))
+    r2new.bbb += np.transpose(tmp109, (2, 1, 0)) * -1
     del tmp109
-    r2new.bbb += tmp128.transpose((1, 2, 0)) * -1
-    r2new.bbb += tmp128.transpose((2, 1, 0))
+    r2new.bbb += np.transpose(tmp128, (1, 2, 0)) * -1
+    r2new.bbb += np.transpose(tmp128, (2, 1, 0))
     del tmp128
     r2new.bbb += einsum(r2.bbb, (0, 1, 2), tmp88, (2, 3), (0, 1, 3)) * -2
     r2new.bbb += einsum(tmp11, (0,), t2.bbbb, (1, 0, 2, 3), (2, 3, 1)) * -2
@@ -4827,11 +4827,11 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs)
     del tmp13
     r2new.aaa += einsum(r2.aaa, (0, 1, 2), ints.tmp160, (3, 0, 4, 1), (3, 4, 2)) * -2
     del ints.tmp160
-    r2new.aaa += tmp33.transpose((1, 2, 0))
-    r2new.aaa += tmp33.transpose((2, 1, 0)) * -1
+    r2new.aaa += np.transpose(tmp33, (1, 2, 0))
+    r2new.aaa += np.transpose(tmp33, (2, 1, 0)) * -1
     del tmp33
-    r2new.aaa += tmp52.transpose((1, 2, 0)) * -1
-    r2new.aaa += tmp52.transpose((2, 1, 0))
+    r2new.aaa += np.transpose(tmp52, (1, 2, 0)) * -1
+    r2new.aaa += np.transpose(tmp52, (2, 1, 0))
     del tmp52
     r2new.aaa += einsum(r2.aaa, (0, 1, 2), tmp53, (2, 3), (0, 1, 3)) * -2
     del tmp53
@@ -5359,24 +5359,24 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     r1new = Namespace()
     r2new = Namespace()
     tmp52 = einsum(t1.bb, (0, 1), r2.bbb, (2, 3, 1), (2, 3, 0))
-    tmp33 = ints.tmp106.copy()
+    tmp33 = np.copy(ints.tmp106)
     del ints.tmp106
     tmp33 += v.bbb.xoo
-    tmp50 = ints.tmp41.copy()
+    tmp50 = np.copy(ints.tmp41)
     tmp50 += ints.tmp56 * 2
     tmp50 += ints.tmp59
     tmp50 += v.baa.xov
-    tmp30 = ints.tmp27.copy()
+    tmp30 = np.copy(ints.tmp27)
     del ints.tmp27
     tmp30 += v.baa.xoo
     tmp47 = einsum(t1.aa, (0, 1), r2.aba, (2, 3, 1), (2, 0, 3))
     tmp32 = einsum(t1.bb, (0, 1), r2.bab, (2, 3, 1), (3, 2, 0)) * -1
     tmp27 = einsum(r2.aaa, (0, 1, 2), t1.aa, (3, 2), (0, 1, 3))
-    tmp16 = ints.tmp45.copy()
+    tmp16 = np.copy(ints.tmp45)
     tmp16 += ints.tmp77
     tmp16 += v.bbb.xov
     tmp16 += ints.tmp82 * 2
-    tmp14 = ints.tmp41.copy()
+    tmp14 = np.copy(ints.tmp41)
     del ints.tmp41
     tmp14 += ints.tmp59
     del ints.tmp59
@@ -5393,28 +5393,28 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp17 = einsum(tmp16, (0, 1, 2), r2.bab, (1, 3, 2), (0, 3)) * -1
     tmp15 = einsum(tmp14, (0, 1, 2), r2.aaa, (3, 1, 2), (0, 3)) * -1
     del tmp14
-    tmp80 = ints.tmp158.copy() * 2
+    tmp80 = np.copy(ints.tmp158) * 2
     tmp80 += ints.tmp161
     tmp80 += ints.tmp181 * -1
     tmp80 += ints.tmp219 * -1
-    tmp57 = tmp55.copy() * -0.5
+    tmp57 = np.copy(tmp55) * -0.5
     del tmp55
     tmp57 += tmp56
     del tmp56
-    tmp62 = ints.tmp137.copy()
-    tmp62 += ints.tmp64.transpose((0, 2, 1, 3))
-    tmp77 = tmp74.copy()
+    tmp62 = np.copy(ints.tmp137)
+    tmp62 += np.transpose(ints.tmp64, (0, 2, 1, 3))
+    tmp77 = np.copy(tmp74)
     del tmp74
     tmp77 += tmp75 * -1
     del tmp75
     tmp77 += tmp76 * -1
     del tmp76
-    tmp64 = f.bb.ov.copy()
+    tmp64 = np.copy(f.bb.ov)
     tmp64 += ints.tmp44
     tmp64 += ints.tmp47
     tmp64 += ints.tmp107 * -1
     del ints.tmp107
-    tmp58 = ints.tmp464.copy()
+    tmp58 = np.copy(ints.tmp464)
     del ints.tmp464
     tmp58 += ints.tmp467
     del ints.tmp467
@@ -5422,37 +5422,37 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp471
     tmp85 = einsum(tmp16, (0, 1, 2), r2.bbb, (3, 1, 2), (0, 3)) * -1
     del tmp16
-    tmp87 = f.bb.oo.copy()
+    tmp87 = np.copy(f.bb.oo)
     tmp87 += ints.tmp183
     tmp87 += ints.tmp187
-    tmp87 += ints.tmp21.transpose((1, 0))
+    tmp87 += np.transpose(ints.tmp21, (1, 0))
     tmp87 += ints.tmp221
     tmp87 += ints.tmp225
-    tmp41 = f.aa.ov.copy()
+    tmp41 = np.copy(f.aa.ov)
     tmp41 += ints.tmp39
     tmp41 += ints.tmp48
     tmp41 += ints.tmp99 * -1
     del ints.tmp99
-    tmp37 = ints.tmp57.copy() * 2
+    tmp37 = np.copy(ints.tmp57) * 2
     tmp37 += ints.tmp60
     tmp37 += ints.tmp174 * -1
     tmp37 += ints.tmp28 * -1
-    tmp35 = tmp31.copy() * -1
+    tmp35 = np.copy(tmp31) * -1
     tmp35 += tmp34
     tmp25 = einsum(t2.aaaa, (0, 1, 2, 3), r2.aaa, (0, 1, 3), (2,))
-    tmp28 = ints.tmp23.copy()
-    tmp28 += ints.tmp50.transpose((0, 2, 1, 3))
-    tmp20 = f.aa.oo.copy()
+    tmp28 = np.copy(ints.tmp23)
+    tmp28 += np.transpose(ints.tmp50, (0, 2, 1, 3))
+    tmp20 = np.copy(f.aa.oo)
     tmp20 += ints.tmp175
     tmp20 += ints.tmp176
-    tmp20 += ints.tmp1.transpose((1, 0))
+    tmp20 += np.transpose(ints.tmp1, (1, 0))
     tmp20 += ints.tmp30
     tmp20 += ints.tmp32
-    tmp12 = ints.tmp358.copy()
+    tmp12 = np.copy(ints.tmp358)
     tmp12 += ints.tmp369
     tmp12 += ints.tmp375 * 2
     tmp10 = einsum(t2.abab, (0, 1, 2, 3), r2.bab, (1, 0, 3), (2,)) * -1
-    tmp18 = tmp15.copy() * -2
+    tmp18 = np.copy(tmp15) * -2
     del tmp15
     tmp18 += tmp17
     del tmp17
@@ -5474,7 +5474,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp85
     tmp88 = einsum(r2.bbb, (0, 1, 2), tmp87, (1, 3), (0, 3, 2)) * -1
     del tmp87
-    tmp51 = ints.tmp45.copy()
+    tmp51 = np.copy(ints.tmp45)
     del ints.tmp45
     tmp51 += ints.tmp77
     del ints.tmp77
@@ -5502,27 +5502,27 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp19 = einsum(v.baa.xov, (0, 1, 2), tmp18, (0, 3), (1, 3, 2))
     del tmp18
     tmp9 = einsum(ints.tmp377, (0, 1, 2, 3), r2.bab, (1, 4, 3), (0, 4, 2)) * -1
-    tmp82 = tmp70.copy()
+    tmp82 = np.copy(tmp70)
     del tmp70
     tmp82 += tmp71
     del tmp71
     tmp82 += tmp72 * 2
     del tmp72
-    tmp82 += tmp73.transpose((1, 0, 2)) * -1
+    tmp82 += np.transpose(tmp73, (1, 0, 2)) * -1
     del tmp73
-    tmp82 += tmp78.transpose((1, 0, 2))
+    tmp82 += np.transpose(tmp78, (1, 0, 2))
     del tmp78
     tmp82 += tmp79 * -1
     del tmp79
-    tmp82 += tmp81.transpose((1, 0, 2))
+    tmp82 += np.transpose(tmp81, (1, 0, 2))
     del tmp81
-    tmp90 = ints.tmp326.transpose((2, 3, 0, 1)).copy()
+    tmp90 = np.copy(np.transpose(ints.tmp326, (2, 3, 0, 1)))
     del ints.tmp326
-    tmp90 += ints.tmp351.transpose((2, 3, 0, 1))
+    tmp90 += np.transpose(ints.tmp351, (2, 3, 0, 1))
     del ints.tmp351
     tmp90 += ints.tmp246 * -1
     del ints.tmp246
-    tmp66 = ints.tmp486.transpose((1, 0)).copy()
+    tmp66 = np.copy(np.transpose(ints.tmp486, (1, 0)))
     del ints.tmp486
     tmp66 += ints.tmp487 * 2
     del ints.tmp487
@@ -5535,77 +5535,77 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp206
     tmp66 += tmp65
     del tmp65
-    tmp89 = tmp83.copy()
+    tmp89 = np.copy(tmp83)
     del tmp83
-    tmp89 += tmp84.transpose((1, 0, 2)) * -2
+    tmp89 += np.transpose(tmp84, (1, 0, 2)) * -2
     del tmp84
-    tmp89 += tmp86.transpose((1, 0, 2)) * 2
+    tmp89 += np.transpose(tmp86, (1, 0, 2)) * 2
     del tmp86
-    tmp89 += tmp88.transpose((1, 0, 2)) * -2
+    tmp89 += np.transpose(tmp88, (1, 0, 2)) * -2
     del tmp88
-    tmp69 = ints.tmp25.copy()
-    tmp69 += ints.tmp54.transpose((1, 0, 2, 3))
-    tmp67 = f.bb.oo.copy()
+    tmp69 = np.copy(ints.tmp25)
+    tmp69 += np.transpose(ints.tmp54, (1, 0, 2, 3))
+    tmp67 = np.copy(f.bb.oo)
     tmp67 += ints.tmp158 * 2
     tmp67 += ints.tmp161
     tmp67 += ints.tmp183
     tmp67 += ints.tmp187
-    tmp67 += ints.tmp21.transpose((1, 0))
+    tmp67 += np.transpose(ints.tmp21, (1, 0))
     tmp67 += ints.tmp221
     tmp67 += ints.tmp225
     tmp67 += ints.tmp181 * -1
     tmp67 += ints.tmp219 * -1
-    tmp60 = ints.tmp171.copy()
+    tmp60 = np.copy(ints.tmp171)
     tmp60 += ints.tmp194
-    tmp60 += ints.tmp196.transpose((1, 0, 2, 3))
+    tmp60 += np.transpose(ints.tmp196, (1, 0, 2, 3))
     tmp60 += ints.tmp230
-    tmp60 += ints.tmp36.transpose((1, 0, 2, 3))
+    tmp60 += np.transpose(ints.tmp36, (1, 0, 2, 3))
     tmp63 = einsum(tmp50, (0, 1, 2), r2.aaa, (3, 1, 2), (0, 3))
     tmp63 += einsum(tmp51, (0, 1, 2), r2.bab, (1, 3, 2), (0, 3)) * -0.5
     tmp63 += tmp31
     del tmp31
     tmp63 += tmp34 * -1
     del tmp34
-    tmp68 = tmp25.copy() * 2
+    tmp68 = np.copy(tmp25) * 2
     del tmp25
     tmp68 += tmp10
     del tmp10
-    tmp61 = ints.tmp25.copy()
-    tmp61 += ints.tmp54.transpose((1, 0, 2, 3))
-    tmp4 = f.aa.oo.copy()
+    tmp61 = np.copy(ints.tmp25)
+    tmp61 += np.transpose(ints.tmp54, (1, 0, 2, 3))
+    tmp4 = np.copy(f.aa.oo)
     tmp4 += ints.tmp175
     tmp4 += ints.tmp176
-    tmp4 += ints.tmp1.transpose((1, 0))
-    tmp4 += ints.tmp30.transpose((1, 0))
-    tmp4 += ints.tmp32.transpose((1, 0))
+    tmp4 += np.transpose(ints.tmp1, (1, 0))
+    tmp4 += np.transpose(ints.tmp30, (1, 0))
+    tmp4 += np.transpose(ints.tmp32, (1, 0))
     tmp4 += ints.tmp57 * 2
     tmp4 += ints.tmp60
     tmp4 += ints.tmp174 * -1
     tmp4 += ints.tmp28 * -1
-    tmp59 = ints.tmp491.copy()
+    tmp59 = np.copy(ints.tmp491)
     del ints.tmp491
-    tmp59 += ints.tmp492.transpose((1, 0, 2, 3))
+    tmp59 += np.transpose(ints.tmp492, (1, 0, 2, 3))
     del ints.tmp492
-    tmp59 += ints.tmp493.transpose((1, 0, 2, 3)) * -1
+    tmp59 += np.transpose(ints.tmp493, (1, 0, 2, 3)) * -1
     del ints.tmp493
-    tmp49 = ints.tmp23.copy()
-    tmp49 += ints.tmp50.transpose((0, 2, 1, 3))
-    tmp44 = ints.tmp461.copy()
+    tmp49 = np.copy(ints.tmp23)
+    tmp49 += np.transpose(ints.tmp50, (0, 2, 1, 3))
+    tmp44 = np.copy(ints.tmp461)
     del ints.tmp461
-    tmp44 += ints.tmp462.transpose((1, 0, 2, 3))
+    tmp44 += np.transpose(ints.tmp462, (1, 0, 2, 3))
     del ints.tmp462
-    tmp44 += ints.tmp463.transpose((1, 0, 2, 3)) * -1
+    tmp44 += np.transpose(ints.tmp463, (1, 0, 2, 3)) * -1
     del ints.tmp463
-    tmp7 = f.bb.oo.copy()
+    tmp7 = np.copy(f.bb.oo)
     tmp7 += ints.tmp158 * 2
     del ints.tmp158
     tmp7 += ints.tmp161
     del ints.tmp161
-    tmp7 += ints.tmp183.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp183, (1, 0))
     del ints.tmp183
-    tmp7 += ints.tmp187.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp187, (1, 0))
     del ints.tmp187
-    tmp7 += ints.tmp21.transpose((1, 0))
+    tmp7 += np.transpose(ints.tmp21, (1, 0))
     del ints.tmp21
     tmp7 += ints.tmp221
     del ints.tmp221
@@ -5615,7 +5615,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp181
     tmp7 += ints.tmp219 * -1
     del ints.tmp219
-    tmp43 = ints.tmp415.transpose((1, 0)).copy()
+    tmp43 = np.copy(np.transpose(ints.tmp415, (1, 0)))
     del ints.tmp415
     tmp43 += ints.tmp418 * 2
     del ints.tmp418
@@ -5628,17 +5628,17 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp208
     tmp43 += tmp42
     del tmp42
-    tmp48 = ints.tmp142.copy()
-    tmp48 += ints.tmp67.transpose((0, 2, 1, 3))
-    tmp46 = ints.tmp171.copy()
+    tmp48 = np.copy(ints.tmp142)
+    tmp48 += np.transpose(ints.tmp67, (0, 2, 1, 3))
+    tmp46 = np.copy(ints.tmp171)
     del ints.tmp171
-    tmp46 += ints.tmp194.transpose((0, 1, 3, 2))
+    tmp46 += np.transpose(ints.tmp194, (0, 1, 3, 2))
     del ints.tmp194
-    tmp46 += ints.tmp196.transpose((1, 0, 2, 3))
+    tmp46 += np.transpose(ints.tmp196, (1, 0, 2, 3))
     del ints.tmp196
     tmp46 += ints.tmp230
     del ints.tmp230
-    tmp46 += ints.tmp36.transpose((0, 1, 3, 2))
+    tmp46 += np.transpose(ints.tmp36, (0, 1, 3, 2))
     del ints.tmp36
     tmp53 = einsum(tmp50, (0, 1, 2), r2.aba, (1, 3, 2), (0, 3)) * -1
     del tmp50
@@ -5648,18 +5648,18 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp30
     tmp53 += einsum(tmp52, (0, 1, 2), tmp33, (3, 0, 2), (3, 1)) * 2
     del tmp52, tmp33
-    tmp45 = ints.tmp358.copy()
+    tmp45 = np.copy(ints.tmp358)
     del ints.tmp358
     tmp45 += ints.tmp369
     del ints.tmp369
     tmp45 += ints.tmp375 * 2
     del ints.tmp375
-    tmp54 = f.aa.oo.copy()
+    tmp54 = np.copy(f.aa.oo)
     tmp54 += ints.tmp175
     del ints.tmp175
     tmp54 += ints.tmp176
     del ints.tmp176
-    tmp54 += ints.tmp1.transpose((1, 0))
+    tmp54 += np.transpose(ints.tmp1, (1, 0))
     del ints.tmp1
     tmp54 += ints.tmp30
     del ints.tmp30
@@ -5673,41 +5673,41 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp174
     tmp54 += ints.tmp28 * -1
     del ints.tmp28
-    tmp40 = ints.tmp167.copy()
+    tmp40 = np.copy(ints.tmp167)
     del ints.tmp167
     tmp40 += ints.tmp227
     del ints.tmp227
-    tmp40 += ints.tmp33.transpose((2, 3, 0, 1)) * -1
+    tmp40 += np.transpose(ints.tmp33, (2, 3, 0, 1)) * -1
     del ints.tmp33
-    tmp39 = tmp23.copy()
+    tmp39 = np.copy(tmp23)
     del tmp23
     tmp39 += tmp24 * 2
     del tmp24
     tmp39 += tmp26 * -2
     del tmp26
-    tmp39 += tmp29.transpose((1, 0, 2)) * -1
+    tmp39 += np.transpose(tmp29, (1, 0, 2)) * -1
     del tmp29
-    tmp39 += tmp36.transpose((1, 0, 2))
+    tmp39 += np.transpose(tmp36, (1, 0, 2))
     del tmp36
-    tmp39 += tmp38.transpose((1, 0, 2))
+    tmp39 += np.transpose(tmp38, (1, 0, 2))
     del tmp38
-    tmp22 = tmp8.copy()
+    tmp22 = np.copy(tmp8)
     del tmp8
     tmp22 += tmp9
     del tmp9
     tmp22 += tmp11
     del tmp11
-    tmp22 += tmp13.transpose((1, 0, 2)) * -2
+    tmp22 += np.transpose(tmp13, (1, 0, 2)) * -2
     del tmp13
-    tmp22 += tmp19.transpose((1, 0, 2))
+    tmp22 += np.transpose(tmp19, (1, 0, 2))
     del tmp19
-    tmp22 += tmp21.transpose((1, 0, 2)) * -2
+    tmp22 += np.transpose(tmp21, (1, 0, 2)) * -2
     del tmp21
-    tmp5 = ints.tmp142.copy()
+    tmp5 = np.copy(ints.tmp142)
     del ints.tmp142
-    tmp5 += ints.tmp239.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp239, (0, 2, 1, 3))
     del ints.tmp239
-    tmp5 += ints.tmp257.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp257, (0, 2, 1, 3))
     del ints.tmp257
     tmp5 += ints.tmp267
     del ints.tmp267
@@ -5725,9 +5725,9 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp316
     tmp5 += ints.tmp346
     del ints.tmp346
-    tmp5 += ints.tmp67.transpose((0, 2, 1, 3))
+    tmp5 += np.transpose(ints.tmp67, (0, 2, 1, 3))
     del ints.tmp67
-    tmp5 += ints.tmp249.transpose((0, 2, 1, 3)) * -1
+    tmp5 += np.transpose(ints.tmp249, (0, 2, 1, 3)) * -1
     del ints.tmp249
     tmp5 += ints.tmp264 * -1
     del ints.tmp264
@@ -5743,11 +5743,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp329
     tmp5 += ints.tmp339 * -1
     del ints.tmp339
-    tmp5 += ints.tmp340.transpose((0, 2, 1, 3)) * -1
+    tmp5 += np.transpose(ints.tmp340, (0, 2, 1, 3)) * -1
     del ints.tmp340
     tmp5 += ints.tmp354 * -1
     del ints.tmp354
-    tmp3 = ints.tmp100.copy()
+    tmp3 = np.copy(ints.tmp100)
     del ints.tmp100
     tmp3 += ints.tmp108 * 0.5
     del ints.tmp108
@@ -5810,11 +5810,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp8
     tmp3 += ints.tmp91 * -0.5
     del ints.tmp91
-    tmp6 = ints.tmp241.transpose((1, 2, 0, 3)).copy()
+    tmp6 = np.copy(np.transpose(ints.tmp241, (1, 2, 0, 3)))
     del ints.tmp241
-    tmp6 += ints.tmp247.transpose((0, 2, 1, 3))
+    tmp6 += np.transpose(ints.tmp247, (0, 2, 1, 3))
     del ints.tmp247
-    tmp6 += ints.tmp255.transpose((0, 2, 1, 3))
+    tmp6 += np.transpose(ints.tmp255, (0, 2, 1, 3))
     del ints.tmp255
     tmp6 += ints.tmp268 * 2
     del ints.tmp268
@@ -5844,13 +5844,13 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp311
     tmp6 += ints.tmp318 * -1
     del ints.tmp318
-    tmp6 += ints.tmp337.transpose((0, 2, 1, 3)) * -1
+    tmp6 += np.transpose(ints.tmp337, (0, 2, 1, 3)) * -1
     del ints.tmp337
     tmp6 += ints.tmp344 * -1
     del ints.tmp344
-    tmp6 += ints.tmp64.transpose((1, 2, 0, 3)) * -1
+    tmp6 += np.transpose(ints.tmp64, (1, 2, 0, 3)) * -1
     del ints.tmp64
-    tmp2 = ints.tmp102.copy() * 0.5
+    tmp2 = np.copy(ints.tmp102) * 0.5
     del ints.tmp102
     tmp2 += ints.tmp110
     del ints.tmp110
@@ -5913,7 +5913,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp7
     tmp2 += ints.tmp89 * -0.5
     del ints.tmp89
-    tmp0 = ints.tmp129.copy()
+    tmp0 = np.copy(ints.tmp129)
     del ints.tmp129
     tmp0 += ints.tmp133
     del ints.tmp133
@@ -5921,15 +5921,15 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp147
     tmp0 += ints.tmp153 * 2
     del ints.tmp153
-    tmp0 += ints.tmp17.transpose((1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp17, (1, 0, 2, 3))
     del ints.tmp17
     tmp0 += ints.tmp213
     del ints.tmp213
-    tmp0 += ints.tmp25.transpose((1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp25, (1, 0, 2, 3))
     del ints.tmp25
     tmp0 += ints.tmp54
     del ints.tmp54
-    tmp0 += ints.tmp55.transpose((1, 0, 2, 3))
+    tmp0 += np.transpose(ints.tmp55, (1, 0, 2, 3))
     del ints.tmp55
     tmp0 += ints.tmp78
     del ints.tmp78
@@ -5947,7 +5947,7 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp172
     tmp0 += ints.tmp195 * -1
     del ints.tmp195
-    tmp0 += ints.tmp197.transpose((1, 0, 2, 3)) * -1
+    tmp0 += np.transpose(ints.tmp197, (1, 0, 2, 3)) * -1
     del ints.tmp197
     tmp0 += ints.tmp231 * -1
     del ints.tmp231
@@ -5957,13 +5957,13 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp74
     tmp0 += ints.tmp79 * -1
     del ints.tmp79
-    tmp1 = ints.tmp127.copy()
+    tmp1 = np.copy(ints.tmp127)
     del ints.tmp127
     tmp1 += ints.tmp131
     del ints.tmp131
     tmp1 += ints.tmp148 * 2
     del ints.tmp148
-    tmp1 += ints.tmp15.transpose((1, 2, 0, 3))
+    tmp1 += np.transpose(ints.tmp15, (1, 2, 0, 3))
     del ints.tmp15
     tmp1 += ints.tmp168
     del ints.tmp168
@@ -5971,9 +5971,9 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp190
     tmp1 += ints.tmp228
     del ints.tmp228
-    tmp1 += ints.tmp34.transpose((0, 2, 1, 3))
+    tmp1 += np.transpose(ints.tmp34, (0, 2, 1, 3))
     del ints.tmp34
-    tmp1 += ints.tmp52.transpose((0, 2, 1, 3))
+    tmp1 += np.transpose(ints.tmp52, (0, 2, 1, 3))
     del ints.tmp52
     tmp1 += ints.tmp75 * 2
     del ints.tmp75
@@ -5985,11 +5985,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp145
     tmp1 += ints.tmp151 * -1
     del ints.tmp151
-    tmp1 += ints.tmp192.transpose((0, 2, 1, 3)) * -1
+    tmp1 += np.transpose(ints.tmp192, (0, 2, 1, 3)) * -1
     del ints.tmp192
     tmp1 += ints.tmp211 * -1
     del ints.tmp211
-    tmp1 += ints.tmp23.transpose((1, 2, 0, 3)) * -1
+    tmp1 += np.transpose(ints.tmp23, (1, 2, 0, 3)) * -1
     del ints.tmp23
     tmp1 += ints.tmp50 * -1
     del ints.tmp50
@@ -5997,11 +5997,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp72
     tmp1 += ints.tmp94 * -1
     del ints.tmp94
-    r2new.bbb = tmp82.copy() * -1
-    r2new.bbb += tmp82.transpose((1, 0, 2))
+    r2new.bbb = np.copy(tmp82) * -1
+    r2new.bbb += np.transpose(tmp82, (1, 0, 2))
     del tmp82
     r2new.bbb += tmp89
-    r2new.bbb += tmp89.transpose((1, 0, 2)) * -1
+    r2new.bbb += np.transpose(tmp89, (1, 0, 2)) * -1
     del tmp89
     r2new.bbb += einsum(tmp90, (0, 1, 2, 3), r2.bbb, (3, 2, 4), (0, 1, 4)) * -2
     del tmp90
@@ -6055,11 +6055,11 @@ def hbar_lmatvec_ip(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     r2new.aba += einsum(tmp48, (0, 1, 2, 3), r1.b, (1,), (0, 2, 3))
     del tmp48
     r2new.aba += einsum(r1.b, (0,), tmp41, (1, 2), (1, 0, 2)) * -1
-    r2new.aaa = tmp22.copy()
-    r2new.aaa += tmp22.transpose((1, 0, 2)) * -1
+    r2new.aaa = np.copy(tmp22)
+    r2new.aaa += np.transpose(tmp22, (1, 0, 2)) * -1
     del tmp22
     r2new.aaa += tmp39 * -1
-    r2new.aaa += tmp39.transpose((1, 0, 2))
+    r2new.aaa += np.transpose(tmp39, (1, 0, 2))
     del tmp39
     r2new.aaa += einsum(tmp40, (0, 1, 2, 3), r2.aaa, (1, 0, 4), (2, 3, 4)) * -2
     del tmp40
@@ -6485,35 +6485,35 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     ints = kwargs["ints"]
     r1new = Namespace()
     r2new = Namespace()
-    tmp58 = ints.tmp101.copy()
+    tmp58 = np.copy(ints.tmp101)
     del ints.tmp101
     tmp58 += v.baa.xoo
     tmp74 = einsum(tmp58, (0, 1, 2), t1.aa, (2, 3), (0, 1, 3))
-    tmp75 = ints.tmp30.copy()
+    tmp75 = np.copy(ints.tmp30)
     tmp75 += ints.tmp57 * 2
     tmp75 += ints.tmp60
     tmp75 += v.baa.xov
     tmp75 += tmp74 * -1
     del tmp74
     tmp22 = einsum(t1.bb, (0, 1), r2.bbb, (2, 1, 3), (3, 0, 2))
-    tmp60 = ints.tmp109.copy()
+    tmp60 = np.copy(ints.tmp109)
     del ints.tmp109
     tmp60 += v.bbb.xoo
-    tmp102 = f.bb.ov.copy()
+    tmp102 = np.copy(f.bb.ov)
     tmp102 += ints.tmp38
     tmp102 += ints.tmp41
-    tmp46 = ints.tmp39.copy()
+    tmp46 = np.copy(ints.tmp39)
     tmp46 += ints.tmp84
     tmp46 += v.bbb.xov
     tmp46 += ints.tmp81 * 2
-    tmp44 = ints.tmp30.copy()
+    tmp44 = np.copy(ints.tmp30)
     del ints.tmp30
     tmp44 += ints.tmp60
     del ints.tmp60
     tmp44 += v.baa.xov
     tmp44 += ints.tmp57 * 2
     del ints.tmp57
-    tmp50 = f.aa.ov.copy()
+    tmp50 = np.copy(f.aa.ov)
     tmp50 += ints.tmp34
     tmp50 += ints.tmp42
     tmp2 = einsum(t1.aa, (0, 1), r2.aaa, (2, 1, 3), (3, 0, 2))
@@ -6537,69 +6537,69 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp15 = einsum(t1.aa, (0, 1), r1.a, (1,), (0,))
     tmp16 = einsum(t2.aaaa, (0, 1, 2, 3), r2.aaa, (2, 3, 1), (0,))
     tmp64 = einsum(t1.aa, (0, 1), ints.tmp102, (0, 2), (2, 1))
-    tmp111 = tmp76.copy()
+    tmp111 = np.copy(tmp76)
     tmp111 += tmp110
     del tmp110
-    tmp87 = ints.tmp135.copy()
-    tmp87 += ints.tmp66.transpose((0, 2, 1, 3))
-    tmp114 = f.bb.vv.copy() * 0.5
+    tmp87 = np.copy(ints.tmp135)
+    tmp87 += np.transpose(ints.tmp66, (0, 2, 1, 3))
+    tmp114 = np.copy(f.bb.vv) * 0.5
     tmp114 += ints.tmp194 * 0.5
     tmp114 += ints.tmp197 * 0.5
     tmp114 += ints.tmp255 * -1
     tmp114 += ints.tmp257 * -0.5
-    tmp114 += tmp113.transpose((1, 0)) * 0.5
+    tmp114 += np.transpose(tmp113, (1, 0)) * 0.5
     del tmp113
-    tmp116 = tmp34.copy() * 0.5
+    tmp116 = np.copy(tmp34) * 0.5
     tmp116 += tmp36
-    tmp98 = ints.tmp246.copy()
+    tmp98 = np.copy(ints.tmp246)
     tmp98 += ints.tmp330
     tmp98 += ints.tmp313 * 2
     tmp35 = einsum(t2.abab, (0, 1, 2, 3), r2.aba, (2, 3, 0), (1,))
     tmp100 = einsum(tmp46, (0, 1, 2), r2.bbb, (3, 2, 1), (0, 3)) * -1
     del tmp46
-    tmp104 = ints.tmp239.copy()
+    tmp104 = np.copy(ints.tmp239)
     tmp104 += tmp103
     del tmp103
     tmp77 = einsum(t1.bb, (0, 1), tmp60, (2, 3, 0), (2, 3, 1))
     del tmp60
-    tmp38 = f.bb.ov.copy()
+    tmp38 = np.copy(f.bb.ov)
     tmp38 += ints.tmp38
     tmp38 += ints.tmp41
     tmp38 += ints.tmp110 * -1
     del ints.tmp110
-    tmp19 = f.aa.ov.copy()
+    tmp19 = np.copy(f.aa.ov)
     tmp19 += ints.tmp34
     tmp19 += ints.tmp42
     tmp19 += ints.tmp102 * -1
     del ints.tmp102
-    tmp48 = tmp45.copy() * -2
+    tmp48 = np.copy(tmp45) * -2
     del tmp45
     tmp48 += tmp47
     del tmp47
-    tmp52 = ints.tmp31.copy()
-    tmp52 += tmp51.transpose((1, 0))
+    tmp52 = np.copy(ints.tmp31)
+    tmp52 += np.transpose(tmp51, (1, 0))
     del tmp51
-    tmp42 = ints.tmp201.copy()
+    tmp42 = np.copy(ints.tmp201)
     tmp42 += ints.tmp47
     tmp42 += ints.tmp163 * 2
-    tmp62 = tmp59.copy()
+    tmp62 = np.copy(tmp59)
     del tmp59
     tmp62 += tmp61
     del tmp61
-    tmp56 = ints.tmp132.copy()
-    tmp56 += ints.tmp63.transpose((0, 2, 1, 3))
-    tmp18 = tmp15.copy() * 0.5
+    tmp56 = np.copy(ints.tmp132)
+    tmp56 += np.transpose(ints.tmp63, (0, 2, 1, 3))
+    tmp18 = np.copy(tmp15) * 0.5
     del tmp15
     tmp18 += tmp16
     del tmp16
     tmp18 += tmp17 * 0.5
     del tmp17
-    tmp65 = f.aa.vv.copy() * 0.5
+    tmp65 = np.copy(f.aa.vv) * 0.5
     tmp65 += ints.tmp29 * 0.5
     tmp65 += ints.tmp33 * 0.5
     tmp65 += ints.tmp58 * -1
     tmp65 += ints.tmp61 * -0.5
-    tmp65 += tmp64.transpose((1, 0)) * 0.5
+    tmp65 += np.transpose(tmp64, (1, 0)) * 0.5
     del tmp64
     tmp112 = einsum(v.bbb.xov, (0, 1, 2), tmp111, (0, 3), (1, 3, 2)) * 2
     del tmp111
@@ -6618,7 +6618,7 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp96 = einsum(r1.b, (0,), ints.tmp236, (1, 2, 0, 3), (1, 2, 3))
     tmp105 = einsum(r2.bbb, (0, 1, 2), tmp104, (3, 1), (2, 3, 0)) * -1
     del tmp104
-    tmp78 = ints.tmp39.copy()
+    tmp78 = np.copy(ints.tmp39)
     del ints.tmp39
     tmp78 += ints.tmp81 * 2
     del ints.tmp81
@@ -6627,15 +6627,15 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp78 += v.bbb.xov
     tmp78 += tmp77 * -1
     del tmp77
-    tmp85 = ints.tmp141.copy()
+    tmp85 = np.copy(ints.tmp141)
     tmp85 += ints.tmp69
     tmp80 = einsum(tmp38, (0, 1), t1.bb, (0, 2), (2, 1))
-    tmp89 = t2.abab.copy()
+    tmp89 = np.copy(t2.abab)
     tmp89 += einsum(t1.bb, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
     tmp82 = einsum(t1.aa, (0, 1), tmp19, (0, 2), (1, 2))
-    tmp72 = t2.abab.copy()
+    tmp72 = np.copy(t2.abab)
     tmp72 += einsum(t1.bb, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
-    tmp30 = ints.tmp138.copy()
+    tmp30 = np.copy(ints.tmp138)
     del ints.tmp138
     tmp30 += ints.tmp72
     del ints.tmp72
@@ -6656,7 +6656,7 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp65
     tmp26 = einsum(r2.aba, (0, 1, 2), t1.aa, (3, 0), (2, 3, 1))
     tmp31 = einsum(t1.bb, (0, 1), tmp22, (2, 3, 1), (2, 3, 0)) * -1
-    tmp94 = f.bb.oo.copy()
+    tmp94 = np.copy(f.bb.oo)
     tmp94 += ints.tmp151 * 2
     del ints.tmp151
     tmp94 += ints.tmp154
@@ -6669,14 +6669,14 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp215
     tmp94 += ints.tmp220
     del ints.tmp220
-    tmp94 += ints.tmp22.transpose((1, 0))
+    tmp94 += np.transpose(ints.tmp22, (1, 0))
     del ints.tmp22
     tmp94 += ints.tmp177 * -1
     del ints.tmp177
     tmp94 += ints.tmp213 * -1
     del ints.tmp213
     tmp95 = einsum(t2.bbbb, (0, 1, 2, 3), r2.bbb, (2, 3, 4), (4, 0, 1))
-    tmp118 = tmp107.copy()
+    tmp118 = np.copy(tmp107)
     del tmp107
     tmp118 += tmp108 * 2
     del tmp108
@@ -6688,7 +6688,7 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp115
     tmp118 += tmp117
     del tmp117
-    tmp106 = tmp96.copy()
+    tmp106 = np.copy(tmp96)
     del tmp96
     tmp106 += tmp97
     del tmp97
@@ -6701,12 +6701,12 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp91 = einsum(tmp75, (0, 1, 2), r2.aaa, (3, 2, 1), (0, 3))
     del tmp75
     tmp91 += einsum(r2.bab, (0, 1, 2), tmp78, (3, 2, 0), (3, 1)) * -0.5
-    tmp86 = ints.tmp170.copy()
-    tmp86 += ints.tmp205.transpose((0, 1, 3, 2)) * -1
-    tmp86 += ints.tmp52.transpose((0, 1, 3, 2)) * -1
+    tmp86 = np.copy(ints.tmp170)
+    tmp86 += np.transpose(ints.tmp205, (0, 1, 3, 2)) * -1
+    tmp86 += np.transpose(ints.tmp52, (0, 1, 3, 2)) * -1
     tmp86 += einsum(tmp85, (0, 1, 2, 3), t1.aa, (0, 4), (1, 2, 4, 3))
     del tmp85
-    tmp93 = ints.tmp239.transpose((1, 0)).copy()
+    tmp93 = np.copy(np.transpose(ints.tmp239, (1, 0)))
     tmp93 += ints.tmp255 * 2
     tmp93 += ints.tmp257
     tmp93 += f.bb.vv * -1
@@ -6715,20 +6715,20 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp93 += tmp80
     tmp90 = einsum(tmp89, (0, 1, 2, 3), r2.bab, (3, 2, 4), (0, 4, 1)) * -1
     del tmp89
-    tmp92 = ints.tmp31.transpose((1, 0)).copy()
+    tmp92 = np.copy(np.transpose(ints.tmp31, (1, 0)))
     tmp92 += ints.tmp58 * 2
     tmp92 += ints.tmp61
     tmp92 += f.aa.vv * -1
-    tmp92 += ints.tmp29.transpose((1, 0)) * -1
-    tmp92 += ints.tmp33.transpose((1, 0)) * -1
+    tmp92 += np.transpose(ints.tmp29, (1, 0)) * -1
+    tmp92 += np.transpose(ints.tmp33, (1, 0)) * -1
     tmp92 += tmp82
     tmp4 = einsum(r2.bab, (0, 1, 2), t1.aa, (3, 1), (3, 2, 0)) * -1
-    tmp88 = ints.tmp246.copy()
+    tmp88 = np.copy(ints.tmp246)
     tmp88 += ints.tmp313 * 2
     tmp88 += ints.tmp330
     tmp88 += einsum(t1.bb, (0, 1), tmp87, (2, 0, 3, 4), (2, 3, 1, 4)) * -1
     del tmp87
-    tmp69 = f.aa.oo.copy()
+    tmp69 = np.copy(f.aa.oo)
     tmp69 += ints.tmp148 * 2
     del ints.tmp148
     tmp69 += ints.tmp157
@@ -6737,7 +6737,7 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp174
     tmp69 += ints.tmp181
     del ints.tmp181
-    tmp69 += ints.tmp19.transpose((1, 0))
+    tmp69 += np.transpose(ints.tmp19, (1, 0))
     del ints.tmp19
     tmp69 += ints.tmp210
     del ints.tmp210
@@ -6747,29 +6747,29 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp171
     tmp69 += ints.tmp207 * -1
     del ints.tmp207
-    tmp84 = tmp34.copy()
+    tmp84 = np.copy(tmp34)
     tmp84 += tmp35 * -1
     tmp84 += tmp36 * 2
     tmp73 = einsum(r2.aba, (0, 1, 2), tmp72, (3, 4, 0, 1), (2, 3, 4))
     del tmp72
-    tmp70 = ints.tmp319.transpose((0, 1, 3, 2)).copy()
+    tmp70 = np.copy(np.transpose(ints.tmp319, (0, 1, 3, 2)))
     tmp70 += ints.tmp250 * -1
     tmp70 += ints.tmp334 * -1
     tmp70 += einsum(tmp30, (0, 1, 2, 3), t1.bb, (2, 4), (0, 1, 3, 4))
-    tmp81 = ints.tmp239.transpose((1, 0)).copy()
+    tmp81 = np.copy(np.transpose(ints.tmp239, (1, 0)))
     tmp81 += ints.tmp255 * 2
     tmp81 += ints.tmp257
     tmp81 += f.bb.vv * -1
-    tmp81 += ints.tmp194.transpose((1, 0)) * -1
-    tmp81 += ints.tmp197.transpose((1, 0)) * -1
+    tmp81 += np.transpose(ints.tmp194, (1, 0)) * -1
+    tmp81 += np.transpose(ints.tmp197, (1, 0)) * -1
     tmp81 += tmp80
     del tmp80
-    tmp71 = ints.tmp163.copy() * 2
+    tmp71 = np.copy(ints.tmp163) * 2
     tmp71 += ints.tmp201
     tmp71 += ints.tmp47
     tmp71 += einsum(tmp56, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3)) * -1
     del tmp56
-    tmp83 = ints.tmp31.transpose((1, 0)).copy()
+    tmp83 = np.copy(np.transpose(ints.tmp31, (1, 0)))
     tmp83 += ints.tmp58 * 2
     tmp83 += ints.tmp61
     tmp83 += f.aa.vv * -1
@@ -6777,58 +6777,58 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp83 += ints.tmp33 * -1
     tmp83 += tmp82
     del tmp82
-    tmp79 = tmp76.copy() * -1
+    tmp79 = np.copy(tmp76) * -1
     del tmp76
     tmp79 += einsum(tmp78, (0, 1, 2), r2.bbb, (3, 2, 1), (0, 3))
     del tmp78
     tmp24 = einsum(t1.bb, (0, 1), r2.aba, (2, 1, 3), (3, 0, 2))
-    tmp54 = tmp40.copy()
+    tmp54 = np.copy(tmp40)
     del tmp40
     tmp54 += tmp41
     del tmp41
-    tmp54 += tmp43.transpose((0, 2, 1)) * -2
+    tmp54 += np.transpose(tmp43, (0, 2, 1)) * -2
     del tmp43
-    tmp54 += tmp49.transpose((0, 2, 1))
+    tmp54 += np.transpose(tmp49, (0, 2, 1))
     del tmp49
-    tmp54 += tmp53.transpose((0, 2, 1)) * -2
+    tmp54 += np.transpose(tmp53, (0, 2, 1)) * -2
     del tmp53
     tmp39 = einsum(t2.aaaa, (0, 1, 2, 3), r2.aaa, (2, 3, 4), (4, 0, 1))
-    tmp68 = tmp55.copy() * 2
+    tmp68 = np.copy(tmp55) * 2
     del tmp55
-    tmp68 += tmp57.transpose((0, 2, 1))
+    tmp68 += np.transpose(tmp57, (0, 2, 1))
     del tmp57
-    tmp68 += tmp63.transpose((0, 2, 1))
+    tmp68 += np.transpose(tmp63, (0, 2, 1))
     del tmp63
-    tmp68 += tmp66.transpose((0, 2, 1)) * -1
+    tmp68 += np.transpose(tmp66, (0, 2, 1)) * -1
     del tmp66
     tmp68 += tmp67
     del tmp67
     tmp12 = einsum(tmp2, (0, 1, 2), t1.aa, (3, 2), (0, 1, 3)) * -1
-    tmp32 = ints.tmp135.copy()
+    tmp32 = np.copy(ints.tmp135)
     del ints.tmp135
     tmp32 += ints.tmp66 * -1
     del ints.tmp66
-    tmp23 = ints.tmp243.copy()
+    tmp23 = np.copy(ints.tmp243)
     tmp23 += ints.tmp310 * 2
     del ints.tmp310
     tmp23 += ints.tmp317
     del ints.tmp317
-    tmp23 += ints.tmp332.transpose((0, 1, 3, 2))
+    tmp23 += np.transpose(ints.tmp332, (0, 1, 3, 2))
     del ints.tmp332
-    tmp23 += ints.tmp246.transpose((0, 1, 3, 2)) * -1
+    tmp23 += np.transpose(ints.tmp246, (0, 1, 3, 2)) * -1
     del ints.tmp246
     tmp23 += ints.tmp313 * -2
     del ints.tmp313
-    tmp23 += ints.tmp330.transpose((0, 1, 3, 2)) * -1
+    tmp23 += np.transpose(ints.tmp330, (0, 1, 3, 2)) * -1
     del ints.tmp330
     tmp29 = einsum(t1.bb, (0, 1), tmp26, (2, 3, 1), (2, 3, 0))
-    tmp37 = tmp34.copy() * 0.5
+    tmp37 = np.copy(tmp34) * 0.5
     del tmp34
     tmp37 += tmp35 * -0.5
     del tmp35
     tmp37 += tmp36
     del tmp36
-    tmp25 = ints.tmp309.copy()
+    tmp25 = np.copy(ints.tmp309)
     del ints.tmp309
     tmp25 += ints.tmp315 * 2
     del ints.tmp315
@@ -6836,38 +6836,38 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp335
     tmp25 += ints.tmp49
     tmp25 += ints.tmp312 * -1
-    tmp33 = ints.tmp239.transpose((1, 0)).copy()
+    tmp33 = np.copy(np.transpose(ints.tmp239, (1, 0)))
     del ints.tmp239
     tmp33 += ints.tmp255 * 2
     del ints.tmp255
     tmp33 += ints.tmp257
     del ints.tmp257
     tmp33 += f.bb.vv * -1
-    tmp33 += ints.tmp194.transpose((1, 0)) * -1
+    tmp33 += np.transpose(ints.tmp194, (1, 0)) * -1
     del ints.tmp194
-    tmp33 += ints.tmp197.transpose((1, 0)) * -1
+    tmp33 += np.transpose(ints.tmp197, (1, 0)) * -1
     del ints.tmp197
-    tmp27 = ints.tmp250.copy()
+    tmp27 = np.copy(ints.tmp250)
     del ints.tmp250
     tmp27 += ints.tmp334
     del ints.tmp334
-    tmp27 += ints.tmp319.transpose((0, 1, 3, 2)) * -1
+    tmp27 += np.transpose(ints.tmp319, (0, 1, 3, 2)) * -1
     del ints.tmp319
-    tmp21 = ints.tmp236.copy() * 0.5
+    tmp21 = np.copy(ints.tmp236) * 0.5
     del ints.tmp236
     tmp21 += ints.tmp251 * 0.5
     del ints.tmp251
-    tmp21 += ints.tmp275.transpose((0, 2, 1, 3))
+    tmp21 += np.transpose(ints.tmp275, (0, 2, 1, 3))
     del ints.tmp275
-    tmp21 += ints.tmp301.transpose((0, 3, 1, 2)) * 0.5
+    tmp21 += np.transpose(ints.tmp301, (0, 3, 1, 2)) * 0.5
     del ints.tmp301
-    tmp21 += ints.tmp263.transpose((0, 3, 1, 2)) * -0.5
+    tmp21 += np.transpose(ints.tmp263, (0, 3, 1, 2)) * -0.5
     del ints.tmp263
-    tmp21 += ints.tmp272.transpose((0, 3, 1, 2)) * -1
+    tmp21 += np.transpose(ints.tmp272, (0, 3, 1, 2)) * -1
     del ints.tmp272
-    tmp21 += ints.tmp279.transpose((0, 3, 1, 2)) * -0.5
+    tmp21 += np.transpose(ints.tmp279, (0, 3, 1, 2)) * -0.5
     del ints.tmp279
-    tmp9 = ints.tmp103.copy() * 2
+    tmp9 = np.copy(ints.tmp103) * 2
     del ints.tmp103
     tmp9 += ints.tmp111
     del ints.tmp111
@@ -6930,22 +6930,22 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp87
     tmp9 += ints.tmp8 * -2
     del ints.tmp8
-    tmp20 = ints.tmp253.copy()
+    tmp20 = np.copy(ints.tmp253)
     del ints.tmp253
-    tmp20 += ints.tmp265.transpose((0, 1, 3, 2))
+    tmp20 += np.transpose(ints.tmp265, (0, 1, 3, 2))
     del ints.tmp265
-    tmp20 += ints.tmp271.transpose((0, 1, 3, 2))
+    tmp20 += np.transpose(ints.tmp271, (0, 1, 3, 2))
     del ints.tmp271
-    tmp20 += ints.tmp277.transpose((0, 1, 3, 2)) * 2
+    tmp20 += np.transpose(ints.tmp277, (0, 1, 3, 2)) * 2
     del ints.tmp277
-    tmp20 += ints.tmp303.transpose((0, 1, 3, 2))
+    tmp20 += np.transpose(ints.tmp303, (0, 1, 3, 2))
     del ints.tmp303
     tmp20 += ints.tmp99
     tmp20 += ints.tmp274 * -1
     del ints.tmp274
-    tmp20 += ints.tmp281.transpose((0, 1, 3, 2)) * -1
+    tmp20 += np.transpose(ints.tmp281, (0, 1, 3, 2)) * -1
     del ints.tmp281
-    tmp28 = ints.tmp105.copy()
+    tmp28 = np.copy(ints.tmp105)
     tmp28 += ints.tmp113 * 2
     tmp28 += ints.tmp136 * 2
     tmp28 += ints.tmp142
@@ -6977,31 +6977,31 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp28 += ints.tmp41 * -1
     tmp28 += ints.tmp7 * -1
     tmp28 += ints.tmp85 * -1
-    tmp14 = ints.tmp31.transpose((1, 0)).copy()
+    tmp14 = np.copy(np.transpose(ints.tmp31, (1, 0)))
     del ints.tmp31
     tmp14 += ints.tmp58 * 2
     del ints.tmp58
     tmp14 += ints.tmp61
     del ints.tmp61
     tmp14 += f.aa.vv * -1
-    tmp14 += ints.tmp29.transpose((1, 0)) * -1
+    tmp14 += np.transpose(ints.tmp29, (1, 0)) * -1
     del ints.tmp29
-    tmp14 += ints.tmp33.transpose((1, 0)) * -1
+    tmp14 += np.transpose(ints.tmp33, (1, 0)) * -1
     del ints.tmp33
-    tmp3 = ints.tmp160.copy() * 2
+    tmp3 = np.copy(ints.tmp160) * 2
     del ints.tmp160
     tmp3 += ints.tmp166
     del ints.tmp166
-    tmp3 += ints.tmp203.transpose((0, 1, 3, 2))
+    tmp3 += np.transpose(ints.tmp203, (0, 1, 3, 2))
     del ints.tmp203
     tmp3 += ints.tmp44
     tmp3 += ints.tmp163 * -2
     del ints.tmp163
-    tmp3 += ints.tmp201.transpose((0, 1, 3, 2)) * -1
+    tmp3 += np.transpose(ints.tmp201, (0, 1, 3, 2)) * -1
     del ints.tmp201
-    tmp3 += ints.tmp47.transpose((0, 1, 3, 2)) * -1
+    tmp3 += np.transpose(ints.tmp47, (0, 1, 3, 2)) * -1
     del ints.tmp47
-    tmp8 = ints.tmp105.copy() * 0.5
+    tmp8 = np.copy(ints.tmp105) * 0.5
     del ints.tmp105
     tmp8 += ints.tmp113
     del ints.tmp113
@@ -7064,13 +7064,13 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp7
     tmp8 += ints.tmp85 * -0.5
     del ints.tmp85
-    tmp1 = ints.tmp144.copy() * 0.5
+    tmp1 = np.copy(ints.tmp144) * 0.5
     del ints.tmp144
-    tmp1 += ints.tmp24.transpose((0, 2, 3, 1)) * 0.5
+    tmp1 += np.transpose(ints.tmp24, (0, 2, 3, 1)) * 0.5
     del ints.tmp24
-    tmp1 += ints.tmp53.transpose((0, 2, 3, 1)) * 0.5
+    tmp1 += np.transpose(ints.tmp53, (0, 2, 3, 1)) * 0.5
     del ints.tmp53
-    tmp1 += ints.tmp92.transpose((0, 1, 3, 2))
+    tmp1 += np.transpose(ints.tmp92, (0, 1, 3, 2))
     del ints.tmp92
     tmp1 += ints.tmp75 * -0.5
     del ints.tmp75
@@ -7079,7 +7079,7 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     tmp1 += ints.tmp95 * -0.5
     del ints.tmp95
     tmp10 = einsum(t1.aa, (0, 1), tmp6, (2, 3, 1), (0, 2, 3))
-    tmp5 = ints.tmp162.copy()
+    tmp5 = np.copy(ints.tmp162)
     del ints.tmp162
     tmp5 += ints.tmp168 * 2
     del ints.tmp168
@@ -7087,10 +7087,10 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp206
     tmp5 += ints.tmp49
     tmp5 += ints.tmp165 * -1
-    tmp0 = ints.tmp146.copy()
+    tmp0 = np.copy(ints.tmp146)
     del ints.tmp146
-    tmp0 += ints.tmp26.transpose((0, 2, 1, 3))
-    tmp0 += ints.tmp55.transpose((0, 2, 1, 3))
+    tmp0 += np.transpose(ints.tmp26, (0, 2, 1, 3))
+    tmp0 += np.transpose(ints.tmp55, (0, 2, 1, 3))
     del ints.tmp55
     tmp0 += ints.tmp77
     del ints.tmp77
@@ -7100,19 +7100,19 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp97
     tmp0 += ints.tmp100 * -1
     del ints.tmp100
-    tmp0 += ints.tmp94.transpose((0, 2, 1, 3)) * -1
+    tmp0 += np.transpose(ints.tmp94, (0, 2, 1, 3)) * -1
     del ints.tmp94
-    tmp7 = ints.tmp205.transpose((0, 1, 3, 2)).copy()
+    tmp7 = np.copy(np.transpose(ints.tmp205, (0, 1, 3, 2)))
     del ints.tmp205
-    tmp7 += ints.tmp52.transpose((0, 1, 3, 2))
+    tmp7 += np.transpose(ints.tmp52, (0, 1, 3, 2))
     del ints.tmp52
     tmp7 += ints.tmp170 * -1
     del ints.tmp170
-    tmp11 = ints.tmp141.copy()
+    tmp11 = np.copy(ints.tmp141)
     del ints.tmp141
     tmp11 += ints.tmp69
     del ints.tmp69
-    tmp13 = ints.tmp132.copy()
+    tmp13 = np.copy(ints.tmp132)
     del ints.tmp132
     tmp13 += ints.tmp63 * -1
     del ints.tmp63
@@ -7122,11 +7122,11 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del tmp95
     r2new.bbb += einsum(ints.tmp243, (0, 1, 2, 3), tmp31, (4, 1, 0), (3, 2, 4)) * 2
     del ints.tmp243
-    r2new.bbb += tmp106.transpose((1, 2, 0))
-    r2new.bbb += tmp106.transpose((2, 1, 0)) * -1
+    r2new.bbb += np.transpose(tmp106, (1, 2, 0))
+    r2new.bbb += np.transpose(tmp106, (2, 1, 0)) * -1
     del tmp106
-    r2new.bbb += tmp118.transpose((1, 2, 0)) * -1
-    r2new.bbb += tmp118.transpose((2, 1, 0))
+    r2new.bbb += np.transpose(tmp118, (1, 2, 0)) * -1
+    r2new.bbb += np.transpose(tmp118, (2, 1, 0))
     del tmp118
     r2new.bbb += einsum(tmp94, (0, 1), r2.bbb, (2, 3, 0), (2, 3, 1)) * -2
     r2new.bbb += einsum(r1.b, (0,), tmp38, (1, 2), (0, 2, 1))
@@ -7184,11 +7184,11 @@ def hbar_lmatvec_ea(f=None, r1=None, r2=None, t1=None, t2=None, v=None, **kwargs
     del ints.tmp44
     r2new.aaa += einsum(r2.aaa, (0, 1, 2), ints.tmp387, (3, 4, 0, 1), (4, 3, 2)) * 2
     del ints.tmp387
-    r2new.aaa += tmp54.transpose((1, 2, 0))
-    r2new.aaa += tmp54.transpose((2, 1, 0)) * -1
+    r2new.aaa += np.transpose(tmp54, (1, 2, 0))
+    r2new.aaa += np.transpose(tmp54, (2, 1, 0)) * -1
     del tmp54
-    r2new.aaa += tmp68.transpose((1, 2, 0)) * -1
-    r2new.aaa += tmp68.transpose((2, 1, 0))
+    r2new.aaa += np.transpose(tmp68, (1, 2, 0)) * -1
+    r2new.aaa += np.transpose(tmp68, (2, 1, 0))
     del tmp68
     r2new.aaa += einsum(r2.aaa, (0, 1, 2), tmp69, (2, 3), (0, 1, 3)) * -2
     del tmp69

--- a/ebcc/codegen/UDFDCD.py
+++ b/ebcc/codegen/UDFDCD.py
@@ -69,9 +69,9 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp0 = einsum(t2.aaaa, (0, 1, 2, 3), v.baa.xov, (4, 1, 3), (0, 2, 4))
     tmp1 = einsum(v.bbb.xov, (0, 1, 2), t2.abab, (3, 1, 4, 2), (3, 4, 0))
     t2new.aaaa = einsum(tmp1, (0, 1, 2), tmp1, (3, 4, 2), (3, 0, 4, 1)) * 0.5
-    tmp40 = tmp23.copy() * 0.5
+    tmp40 = np.copy(tmp23) * 0.5
     tmp40 += tmp24
-    tmp2 = tmp0.copy() * 2
+    tmp2 = np.copy(tmp0) * 2
     tmp2 += tmp1
     tmp47 = einsum(v.bbb.xov, (0, 1, 2), tmp40, (1, 3, 0), (3, 2))
     tmp41 = einsum(v.bbb.xov, (0, 1, 2), tmp40, (3, 2, 0), (3, 1))
@@ -80,105 +80,105 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp10 = einsum(v.baa.xov, (0, 1, 2), tmp2, (1, 3, 0), (2, 3)) * 0.5
     del tmp2
     tmp55 = einsum(v.bbb.xvv, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 3, 4, 2))
-    tmp48 = f.bb.vv.copy() * -1
+    tmp48 = np.copy(f.bb.vv) * -1
     tmp48 += tmp47
     del tmp47
-    tmp57 = v.bbb.xov.transpose((1, 2, 0)).copy()
+    tmp57 = np.copy(np.transpose(v.bbb.xov, (1, 2, 0)))
     tmp57 += tmp24
     tmp44 = einsum(v.bbb.xoo, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (1, 3, 4, 2))
-    tmp53 = v.bbb.xov.transpose((1, 2, 0)).copy()
+    tmp53 = np.copy(np.transpose(v.bbb.xov, (1, 2, 0)))
     tmp53 += tmp23
     tmp53 += tmp24 * 2
-    tmp42 = f.bb.oo.copy()
+    tmp42 = np.copy(f.bb.oo)
     tmp42 += tmp41
     del tmp41
     tmp38 = einsum(v.bbb.xvv, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (3, 4, 1, 2))
     t2new.abab = einsum(tmp38, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 5, 2)) * -1
-    tmp25 = tmp23.copy()
+    tmp25 = np.copy(tmp23)
     tmp25 += tmp24 * 2
     tmp34 = einsum(v.baa.xvv, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 2, 3, 4))
-    tmp28 = tmp0.copy()
+    tmp28 = np.copy(tmp0)
     tmp28 += tmp1 * 0.5
     tmp8 = einsum(v.baa.xoo, (0, 1, 2), v.baa.xvv, (0, 3, 4), (1, 2, 3, 4))
     t2new.abab += einsum(tmp8, (0, 1, 2, 3), t2.abab, (1, 4, 3, 5), (0, 4, 2, 5)) * -1
-    tmp16 = v.baa.xov.transpose((1, 2, 0)).copy() * 2
+    tmp16 = np.copy(np.transpose(v.baa.xov, (1, 2, 0))) * 2
     tmp16 += tmp1
     tmp6 = einsum(v.baa.xoo, (0, 1, 2), v.baa.xoo, (0, 3, 4), (1, 3, 4, 2))
-    tmp4 = f.aa.oo.copy()
-    tmp4 += tmp3.transpose((1, 0))
+    tmp4 = np.copy(f.aa.oo)
+    tmp4 += np.transpose(tmp3, (1, 0))
     del tmp3
-    tmp11 = f.aa.vv.copy() * -1
-    tmp11 += tmp10.transpose((1, 0))
+    tmp11 = np.copy(f.aa.vv) * -1
+    tmp11 += np.transpose(tmp10, (1, 0))
     del tmp10
-    tmp21 = v.baa.xov.transpose((1, 2, 0)).copy()
+    tmp21 = np.copy(np.transpose(v.baa.xov, (1, 2, 0)))
     tmp21 += tmp0
     tmp19 = einsum(v.baa.xvv, (0, 1, 2), v.baa.xvv, (0, 3, 4), (3, 1, 2, 4))
     tmp56 = einsum(tmp55, (0, 1, 2, 3), t2.bbbb, (4, 5, 1, 3), (4, 5, 2, 0))
     del tmp55
-    t2new.bbbb = tmp56.transpose((0, 1, 3, 2)).copy() * -1
-    t2new.bbbb += tmp56.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb = np.copy(np.transpose(tmp56, (0, 1, 3, 2))) * -1
+    t2new.bbbb += np.transpose(tmp56, (0, 1, 3, 2)) * -1
     del tmp56
     tmp49 = einsum(t2.bbbb, (0, 1, 2, 3), tmp48, (4, 3), (0, 1, 2, 4)) * -2
     del tmp48
-    t2new.bbbb += tmp49.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp49.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp49, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp49, (1, 0, 3, 2))
     del tmp49
     tmp58 = einsum(tmp24, (0, 1, 2), tmp57, (3, 4, 2), (0, 3, 1, 4)) * 2
     del tmp57
-    t2new.bbbb += tmp58.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp58, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp58
     del tmp58
     tmp45 = einsum(t2.bbbb, (0, 1, 2, 3), tmp44, (4, 0, 5, 1), (5, 4, 2, 3))
     del tmp44
-    t2new.bbbb += tmp45.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp45.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp45, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp45, (0, 1, 3, 2)) * -1
     del tmp45
-    tmp60 = v.bbb.xov.transpose((1, 2, 0)).copy() * 2
+    tmp60 = np.copy(np.transpose(v.bbb.xov, (1, 2, 0))) * 2
     tmp60 += tmp23
     t2new.bbbb += einsum(tmp60, (0, 1, 2), tmp23, (3, 4, 2), (3, 0, 1, 4)) * -0.5
     del tmp60
     tmp54 = einsum(v.bbb.xov, (0, 1, 2), tmp53, (3, 4, 0), (3, 1, 4, 2))
     del tmp53
-    t2new.bbbb += tmp54.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp54.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp54, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp54, (1, 0, 3, 2))
     del tmp54
     tmp43 = einsum(tmp42, (0, 1), t2.bbbb, (2, 1, 3, 4), (2, 0, 3, 4)) * -1
     del tmp42
-    t2new.bbbb += tmp43.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp43.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp43.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp43.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp43, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp43, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp43, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp43, (0, 1, 3, 2)) * -1
     del tmp43
-    tmp59 = v.bbb.xov.transpose((1, 2, 0)).copy()
+    tmp59 = np.copy(np.transpose(v.bbb.xov, (1, 2, 0)))
     tmp59 += tmp23 * 0.5
     t2new.bbbb += einsum(tmp59, (0, 1, 2), tmp23, (3, 4, 2), (3, 0, 4, 1))
     del tmp59
     tmp46 = einsum(t2.bbbb, (0, 1, 2, 3), tmp38, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp38
-    t2new.bbbb += tmp46.transpose((0, 1, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp46, (0, 1, 3, 2)) * 2
     t2new.bbbb += tmp46 * -2
-    t2new.bbbb += tmp46.transpose((1, 0, 2, 3)) * 2
-    t2new.bbbb += tmp46.transpose((1, 0, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp46, (1, 0, 2, 3)) * 2
+    t2new.bbbb += np.transpose(tmp46, (1, 0, 3, 2)) * -2
     del tmp46
     tmp52 = einsum(tmp23, (0, 1, 2), tmp24, (3, 4, 2), (0, 3, 1, 4))
-    t2new.bbbb += tmp52.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp52.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp52.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp52, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp52, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp52, (1, 0, 3, 2))
     t2new.bbbb += tmp52
-    t2new.bbbb += tmp52.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp52.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp52.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp52, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp52, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp52, (1, 0, 3, 2))
     t2new.bbbb += tmp52
     del tmp52
     tmp50 = einsum(tmp23, (0, 1, 2), tmp23, (3, 4, 2), (0, 3, 1, 4))
-    t2new.bbbb += tmp50.transpose((0, 1, 3, 2)) * -0.5
-    t2new.bbbb += tmp50.transpose((1, 0, 3, 2)) * 0.5
+    t2new.bbbb += np.transpose(tmp50, (0, 1, 3, 2)) * -0.5
+    t2new.bbbb += np.transpose(tmp50, (1, 0, 3, 2)) * 0.5
     del tmp50
     tmp51 = einsum(tmp24, (0, 1, 2), tmp24, (3, 4, 2), (0, 3, 1, 4))
-    t2new.bbbb += tmp51.transpose((0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp51, (0, 1, 3, 2)) * -2
     t2new.bbbb += tmp51 * 2
     del tmp51
-    tmp36 = tmp0.copy() * 2
+    tmp36 = np.copy(tmp0) * 2
     tmp36 += tmp1
     tmp39 = einsum(v.baa.xvv, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (3, 4, 1, 2))
     t2new.abab += einsum(tmp39, (0, 1, 2, 3), t2.abab, (4, 1, 3, 5), (4, 0, 2, 5)) * -1
@@ -186,11 +186,11 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp27 = einsum(v.baa.xoo, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (1, 2, 3, 4))
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp27, (4, 0, 5, 1), (4, 5, 2, 3))
     del tmp27
-    tmp26 = f.bb.oo.copy()
+    tmp26 = np.copy(f.bb.oo)
     tmp26 += einsum(v.bbb.xov, (0, 1, 2), tmp25, (3, 2, 0), (1, 3)) * 0.5
     t2new.abab += einsum(tmp26, (0, 1), t2.abab, (2, 0, 3, 4), (2, 1, 3, 4)) * -1
     del tmp26
-    tmp33 = v.baa.xov.transpose((1, 2, 0)).copy() * 2
+    tmp33 = np.copy(np.transpose(v.baa.xov, (1, 2, 0))) * 2
     tmp33 += tmp0 * 2
     tmp33 += tmp1
     t2new.abab += einsum(tmp33, (0, 1, 2), tmp25, (3, 4, 2), (0, 3, 1, 4)) * 0.5
@@ -203,63 +203,63 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     tmp31 = einsum(v.baa.xoo, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 2, 3, 4))
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp31, (4, 0, 5, 3), (4, 1, 2, 5)) * -1
     del tmp31
-    tmp37 = v.bbb.xov.transpose((1, 2, 0)).copy()
+    tmp37 = np.copy(np.transpose(v.bbb.xov, (1, 2, 0)))
     tmp37 += tmp23 * 0.5
     del tmp23
     tmp37 += tmp24
     del tmp24
     t2new.abab += einsum(tmp37, (0, 1, 2), tmp36, (3, 4, 2), (3, 0, 4, 1))
     del tmp37, tmp36
-    tmp32 = f.bb.vv.copy() * -2
+    tmp32 = np.copy(f.bb.vv) * -2
     tmp32 += einsum(v.bbb.xov, (0, 1, 2), tmp25, (1, 3, 0), (2, 3))
     del tmp25
     t2new.abab += einsum(tmp32, (0, 1), t2.abab, (2, 3, 4, 0), (2, 3, 4, 1)) * -0.5
     del tmp32
-    tmp29 = f.aa.oo.copy()
+    tmp29 = np.copy(f.aa.oo)
     tmp29 += einsum(v.baa.xov, (0, 1, 2), tmp28, (3, 2, 0), (1, 3))
     t2new.abab += einsum(tmp29, (0, 1), t2.abab, (0, 2, 3, 4), (1, 2, 3, 4)) * -1
     del tmp29
-    tmp30 = f.aa.vv.copy() * -1
+    tmp30 = np.copy(f.aa.vv) * -1
     tmp30 += einsum(tmp28, (0, 1, 2), v.baa.xov, (2, 0, 3), (3, 1))
     del tmp28
     t2new.abab += einsum(tmp30, (0, 1), t2.abab, (2, 3, 0, 4), (2, 3, 1, 4)) * -1
     del tmp30
     tmp9 = einsum(tmp8, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp8
-    t2new.aaaa += tmp9.transpose((0, 1, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp9, (0, 1, 3, 2)) * 2
     t2new.aaaa += tmp9 * -2
-    t2new.aaaa += tmp9.transpose((1, 0, 2, 3)) * 2
-    t2new.aaaa += tmp9.transpose((1, 0, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp9, (1, 0, 2, 3)) * 2
+    t2new.aaaa += np.transpose(tmp9, (1, 0, 3, 2)) * -2
     del tmp9
     tmp17 = einsum(tmp1, (0, 1, 2), tmp16, (3, 4, 2), (3, 0, 4, 1)) * 0.5
     del tmp16
-    t2new.aaaa += tmp17.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp17.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp17.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp17, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp17, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp17, (0, 1, 3, 2)) * -1
     del tmp17
     tmp14 = einsum(tmp0, (0, 1, 2), tmp1, (3, 4, 2), (0, 3, 1, 4))
-    t2new.aaaa += tmp14.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp14.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp14.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp14, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp14, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp14, (1, 0, 3, 2))
     t2new.aaaa += tmp14
-    t2new.aaaa += tmp14.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp14.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp14.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp14, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp14, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp14, (1, 0, 3, 2))
     t2new.aaaa += tmp14
     del tmp14
     tmp7 = einsum(tmp6, (0, 1, 2, 3), t2.aaaa, (1, 3, 4, 5), (2, 0, 4, 5))
     del tmp6
-    t2new.aaaa += tmp7.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp7.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp7, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp7, (0, 1, 3, 2)) * -1
     del tmp7
     tmp5 = einsum(tmp4, (0, 1), t2.aaaa, (2, 1, 3, 4), (2, 0, 3, 4)) * -1
     del tmp4
-    t2new.aaaa += tmp5.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp5.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp5.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp5.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp5, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp5, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp5, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp5, (0, 1, 3, 2)) * -1
     del tmp5
-    tmp15 = v.baa.xov.transpose((1, 2, 0)).copy()
+    tmp15 = np.copy(np.transpose(v.baa.xov, (1, 2, 0)))
     tmp15 += tmp0 * 2
     tmp15 += tmp1
     del tmp1
@@ -267,24 +267,24 @@ def update_amps(f=None, t2=None, v=None, **kwargs):
     del tmp15
     tmp12 = einsum(t2.aaaa, (0, 1, 2, 3), tmp11, (4, 3), (0, 1, 2, 4)) * -2
     del tmp11
-    t2new.aaaa += tmp12.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp12.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp12, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp12, (1, 0, 3, 2))
     del tmp12
     tmp13 = einsum(tmp0, (0, 1, 2), tmp0, (3, 4, 2), (0, 3, 1, 4))
-    t2new.aaaa += tmp13.transpose((0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp13, (0, 1, 3, 2)) * -2
     t2new.aaaa += tmp13 * 2
     del tmp13
     tmp22 = einsum(tmp21, (0, 1, 2), tmp0, (3, 4, 2), (0, 3, 1, 4)) * 2
     del tmp21
-    t2new.aaaa += tmp22.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp22.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp22, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp22, (1, 0, 3, 2))
     del tmp22
     tmp20 = einsum(t2.aaaa, (0, 1, 2, 3), tmp19, (4, 2, 5, 3), (0, 1, 5, 4))
     del tmp19
-    t2new.aaaa += tmp20.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp20.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp20, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp20, (0, 1, 3, 2)) * -1
     del tmp20
-    tmp18 = v.baa.xov.transpose((1, 2, 0)).copy()
+    tmp18 = np.copy(np.transpose(v.baa.xov, (1, 2, 0)))
     tmp18 += tmp0 * 2
     del tmp0
     t2new.aaaa += einsum(tmp18, (0, 1, 2), v.baa.xov, (2, 3, 4), (3, 0, 1, 4)) * -1

--- a/ebcc/codegen/UDFDCSD.py
+++ b/ebcc/codegen/UDFDCSD.py
@@ -42,7 +42,7 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp1 = einsum(v.baa.xov, (0, 1, 2), t1.aa, (1, 2), (0,))
     tmp1 += tmp0 * 2
     tmp3 = einsum(t1.aa, (0, 1), v.baa.xov, (2, 3, 1), (0, 3, 2))
-    tmp6 = f.bb.ov.copy() * 2
+    tmp6 = np.copy(f.bb.ov) * 2
     tmp6 += einsum(tmp5, (0, 1, 2), v.bbb.xov, (2, 0, 3), (1, 3)) * -1
     del tmp5
     e_cc = einsum(t1.bb, (0, 1), tmp6, (0, 1), ()) * 0.5
@@ -58,7 +58,7 @@ def energy(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp0
     e_cc += einsum(v.bbb.xov, (0, 1, 2), tmp7, (1, 2, 0), ())
     del tmp7
-    tmp4 = f.aa.ov.copy() * 2
+    tmp4 = np.copy(f.aa.ov) * 2
     tmp4 += einsum(tmp3, (0, 1, 2), v.baa.xov, (2, 0, 3), (1, 3)) * -1
     del tmp3
     e_cc += einsum(t1.aa, (0, 1), tmp4, (0, 1), ()) * 0.5
@@ -99,10 +99,10 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp130 = einsum(t1.bb, (0, 1), tmp21, (2, 0, 3), (2, 1, 3))
     tmp39 = einsum(v.bbb.xvv, (0, 1, 2), t1.bb, (3, 2), (3, 1, 0))
     t1new.bb = einsum(tmp39, (0, 1, 2), v.bbb.xoo, (2, 3, 0), (3, 1)) * -1
-    tmp9 = tmp5.copy()
+    tmp9 = np.copy(tmp5)
     tmp9 += tmp6
     tmp22 = einsum(tmp21, (0, 1, 2), v.bbb.xov, (2, 0, 3), (1, 3))
-    tmp7 = tmp5.copy()
+    tmp7 = np.copy(tmp5)
     del tmp5
     tmp7 += tmp6
     del tmp6
@@ -117,45 +117,45 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp42 = einsum(v.baa.xoo, (0, 1, 2), t1.aa, (2, 3), (1, 3, 0))
     tmp3 = einsum(v.bbb.xov, (0, 1, 2), t2.abab, (3, 1, 4, 2), (3, 4, 0))
     tmp13 = einsum(v.baa.xov, (0, 1, 2), tmp0, (1, 3, 0), (3, 2))
-    tmp176 = v.bbb.xvv.transpose((1, 2, 0)).copy()
-    tmp176 += tmp134.transpose((1, 0, 2)) * -1
-    tmp146 = tmp39.copy()
+    tmp176 = np.copy(np.transpose(v.bbb.xvv, (1, 2, 0)))
+    tmp176 += np.transpose(tmp134, (1, 0, 2)) * -1
+    tmp146 = np.copy(tmp39)
     tmp146 += tmp130 * -1
     t2new.abab = einsum(tmp11, (0, 1, 2), tmp146, (3, 4, 2), (0, 3, 1, 4)) * 2
     tmp32 = einsum(v.bbb.xov, (0, 1, 2), tmp9, (0,), (1, 2))
     t1new.bb += tmp32
-    tmp35 = f.bb.ov.copy()
+    tmp35 = np.copy(f.bb.ov)
     tmp35 += tmp22 * -1
-    tmp118 = tmp39.copy()
+    tmp118 = np.copy(tmp39)
     tmp118 += tmp29 * 0.5
     tmp118 += tmp33
     tmp118 += einsum(t1.bb, (0, 1), tmp7, (2,), (0, 1, 2))
-    tmp183 = tmp110.copy()
+    tmp183 = np.copy(tmp110)
     tmp183 += tmp33 * -1
-    tmp171 = v.bbb.xvv.transpose((1, 2, 0)).copy()
-    tmp171 += tmp134.transpose((1, 0, 2)) * -1
-    tmp111 = tmp110.copy() * -1
+    tmp171 = np.copy(np.transpose(v.bbb.xvv, (1, 2, 0)))
+    tmp171 += np.transpose(tmp134, (1, 0, 2)) * -1
+    tmp111 = np.copy(tmp110) * -1
     tmp111 += tmp29 * 0.5
     tmp111 += tmp33
     t2new.abab += einsum(tmp11, (0, 1, 2), tmp111, (3, 4, 2), (0, 3, 1, 4)) * 2
-    tmp79 = tmp16.copy()
+    tmp79 = np.copy(tmp16)
     tmp79 += tmp70 * -1
     t2new.abab += einsum(tmp79, (0, 1, 2), tmp33, (3, 4, 2), (0, 3, 1, 4)) * 2
-    tmp81 = v.baa.xvv.transpose((1, 2, 0)).copy()
-    tmp81 += tmp72.transpose((1, 0, 2)) * -1
-    tmp43 = tmp42.copy() * -1
+    tmp81 = np.copy(np.transpose(v.baa.xvv, (1, 2, 0)))
+    tmp81 += np.transpose(tmp72, (1, 0, 2)) * -1
+    tmp43 = np.copy(tmp42) * -1
     tmp43 += tmp11
     tmp43 += tmp3 * 0.5
     t2new.abab += einsum(tmp43, (0, 1, 2), tmp33, (3, 4, 2), (0, 3, 1, 4)) * 2
-    tmp88 = tmp42.copy()
+    tmp88 = np.copy(tmp42)
     tmp88 += tmp11 * -1
-    tmp73 = v.baa.xvv.transpose((1, 2, 0)).copy()
-    tmp73 += tmp72.transpose((1, 0, 2)) * -1
-    tmp52 = tmp16.copy()
+    tmp73 = np.copy(np.transpose(v.baa.xvv, (1, 2, 0)))
+    tmp73 += np.transpose(tmp72, (1, 0, 2)) * -1
+    tmp52 = np.copy(tmp16)
     tmp52 += tmp11
     tmp52 += tmp3 * 0.5
     tmp52 += einsum(t1.aa, (0, 1), tmp7, (2,), (0, 1, 2))
-    tmp14 = f.aa.ov.copy()
+    tmp14 = np.copy(f.aa.ov)
     tmp14 += tmp13 * -1
     tmp10 = einsum(v.baa.xov, (0, 1, 2), tmp9, (0,), (1, 2))
     del tmp9
@@ -165,7 +165,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp147 = einsum(v.bbb.xov, (0, 1, 2), tmp146, (3, 4, 0), (1, 3, 2, 4))
     tmp163 = einsum(v.bbb.xoo, (0, 1, 2), tmp21, (3, 4, 0), (3, 1, 2, 4))
     tmp23 = einsum(v.bbb.xov, (0, 1, 2), tmp7, (0,), (1, 2))
-    tmp167 = f.bb.ov.copy()
+    tmp167 = np.copy(f.bb.ov)
     tmp167 += tmp22 * -1
     tmp167 += tmp32
     del tmp32
@@ -194,22 +194,22 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp52
     tmp54 = einsum(tmp7, (0,), v.baa.xvv, (0, 1, 2), (1, 2))
     tmp55 = einsum(tmp14, (0, 1), t1.aa, (0, 2), (2, 1))
-    tmp67 = f.aa.ov.copy()
+    tmp67 = np.copy(f.aa.ov)
     tmp67 += tmp13 * -1
     tmp67 += tmp10
     del tmp10
     tmp62 = einsum(tmp0, (0, 1, 2), v.baa.xoo, (2, 3, 4), (0, 3, 4, 1))
-    tmp178 = tmp147.transpose((1, 0, 3, 2)).copy() * -1
-    tmp178 += tmp177.transpose((0, 1, 3, 2))
+    tmp178 = np.copy(np.transpose(tmp147, (1, 0, 3, 2))) * -1
+    tmp178 += np.transpose(tmp177, (0, 1, 3, 2))
     del tmp177
-    tmp174 = tmp39.copy() * -1
+    tmp174 = np.copy(tmp39) * -1
     tmp174 += tmp130
     tmp165 = einsum(t1.bb, (0, 1), tmp163, (2, 3, 4, 0), (2, 3, 4, 1))
-    tmp188 = tmp110.copy()
+    tmp188 = np.copy(tmp110)
     tmp188 += tmp29 * -0.5
     tmp200 = einsum(v.bbb.xov, (0, 1, 2), tmp171, (3, 4, 0), (1, 4, 3, 2))
     tmp198 = einsum(tmp21, (0, 1, 2), tmp39, (3, 4, 2), (0, 3, 1, 4))
-    tmp24 = f.bb.ov.copy()
+    tmp24 = np.copy(f.bb.ov)
     tmp24 += tmp22 * -1
     del tmp22
     tmp24 += tmp23
@@ -221,82 +221,82 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp168 = einsum(t1.bb, (0, 1), tmp167, (2, 1), (2, 0))
     del tmp167
     tmp196 = einsum(tmp192, (0, 1, 2, 3), t1.bb, (2, 4), (1, 0, 3, 4))
-    tmp131 = v.bbb.xov.transpose((1, 2, 0)).copy()
+    tmp131 = np.copy(np.transpose(v.bbb.xov, (1, 2, 0)))
     tmp131 += tmp39
     tmp131 += tmp130 * -1
     t2new.abab += einsum(v.baa.xov, (0, 1, 2), tmp131, (3, 4, 0), (1, 3, 2, 4))
-    tmp190 = tmp110.copy() * 2
+    tmp190 = np.copy(tmp110) * 2
     del tmp110
     tmp190 += tmp29 * -1
     tmp155 = einsum(v.bbb.xoo, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (3, 1, 2, 4))
     tmp28 = einsum(tmp21, (0, 1, 2), v.bbb.xov, (2, 3, 4), (0, 3, 1, 4))
     t1new.bb += einsum(tmp28, (0, 1, 2, 3), t2.bbbb, (2, 1, 4, 3), (0, 4)) * -2
-    tmp122 = f.bb.vv.copy() * -1
+    tmp122 = np.copy(f.bb.vv) * -1
     tmp122 += tmp119
     del tmp119
-    tmp122 += tmp120.transpose((1, 0)) * -1
+    tmp122 += np.transpose(tmp120, (1, 0)) * -1
     del tmp120
-    tmp122 += tmp121.transpose((1, 0))
+    tmp122 += np.transpose(tmp121, (1, 0))
     del tmp121
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp122, (3, 4), (0, 1, 2, 4)) * -1
-    tmp117 = tmp29.copy()
+    tmp117 = np.copy(tmp29)
     tmp117 += tmp33 * 2
     t2new.abab += einsum(v.baa.xov, (0, 1, 2), tmp117, (3, 4, 0), (1, 3, 2, 4))
-    tmp186 = tmp184.copy() * -1
+    tmp186 = np.copy(tmp184) * -1
     del tmp184
-    tmp186 += tmp185.transpose((1, 0, 3, 2)) * -1
+    tmp186 += np.transpose(tmp185, (1, 0, 3, 2)) * -1
     del tmp185
-    tmp170 = tmp39.copy()
+    tmp170 = np.copy(tmp39)
     tmp170 += tmp130 * -1
-    tmp113 = f.bb.oo.copy()
+    tmp113 = np.copy(f.bb.oo)
     tmp113 += tmp112
     del tmp112
-    tmp113 += tmp40.transpose((1, 0))
+    tmp113 += np.transpose(tmp40, (1, 0))
     t2new.abab += einsum(tmp113, (0, 1), t2.abab, (2, 0, 3, 4), (2, 1, 3, 4)) * -1
     tmp161 = einsum(v.bbb.xoo, (0, 1, 2), tmp39, (3, 4, 0), (3, 1, 2, 4))
     tmp203 = einsum(v.bbb.xov, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 3, 4, 2))
-    tmp128 = v.baa.xvv.transpose((1, 2, 0)).copy()
+    tmp128 = np.copy(np.transpose(v.baa.xvv, (1, 2, 0)))
     tmp128 += tmp72 * -1
     tmp150 = einsum(v.baa.xov, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 2, 3, 4))
-    tmp132 = v.baa.xvv.transpose((1, 2, 0)).copy()
+    tmp132 = np.copy(np.transpose(v.baa.xvv, (1, 2, 0)))
     tmp132 += tmp72 * -1
     del tmp72
-    tmp140 = v.bbb.xvv.transpose((1, 2, 0)).copy()
+    tmp140 = np.copy(np.transpose(v.bbb.xvv, (1, 2, 0)))
     tmp140 += tmp134 * -1
     tmp143 = einsum(tmp142, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 4, 3))
     del tmp142
-    tmp135 = v.bbb.xvv.transpose((1, 2, 0)).copy()
+    tmp135 = np.copy(np.transpose(v.bbb.xvv, (1, 2, 0)))
     tmp135 += tmp134 * -1
     del tmp134
     tmp25 = einsum(v.baa.xoo, (0, 1, 2), tmp7, (0,), (1, 2))
-    tmp83 = tmp80.transpose((1, 0, 3, 2)).copy() * -1
-    tmp83 += tmp82.transpose((0, 1, 3, 2))
+    tmp83 = np.copy(np.transpose(tmp80, (1, 0, 3, 2))) * -1
+    tmp83 += np.transpose(tmp82, (0, 1, 3, 2))
     del tmp82
-    tmp46 = f.aa.oo.copy() * 2
+    tmp46 = np.copy(f.aa.oo) * 2
     tmp46 += tmp44
     del tmp44
-    tmp46 += tmp45.transpose((1, 0))
+    tmp46 += np.transpose(tmp45, (1, 0))
     del tmp45
     tmp103 = einsum(tmp98, (0, 1, 2, 3), t1.aa, (2, 4), (1, 0, 3, 4))
-    tmp58 = tmp11.copy() * 2
+    tmp58 = np.copy(tmp11) * 2
     tmp58 += tmp3
     t2new.abab += einsum(tmp58, (0, 1, 2), v.bbb.xov, (2, 3, 4), (0, 3, 1, 4))
-    tmp91 = tmp89.transpose((1, 0, 3, 2)).copy() * -1
+    tmp91 = np.copy(np.transpose(tmp89, (1, 0, 3, 2))) * -1
     del tmp89
-    tmp91 += tmp90.transpose((1, 0, 3, 2)) * -1
+    tmp91 += np.transpose(tmp90, (1, 0, 3, 2)) * -1
     del tmp90
     tmp1 = einsum(v.baa.xov, (0, 1, 2), tmp0, (3, 4, 0), (3, 1, 4, 2))
     t1new.aa += einsum(tmp1, (0, 1, 2, 3), t2.aaaa, (2, 1, 4, 3), (0, 4)) * -2
     tmp105 = einsum(tmp73, (0, 1, 2), v.baa.xov, (2, 3, 4), (3, 1, 0, 4))
-    tmp93 = tmp42.copy()
+    tmp93 = np.copy(tmp42)
     tmp93 += tmp3 * -0.5
     tmp17 = einsum(v.baa.xov, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 4, 1, 2))
     t1new.aa += einsum(tmp17, (0, 1, 2, 3), t2.aaaa, (1, 2, 4, 3), (0, 4)) * -2
     tmp101 = einsum(tmp0, (0, 1, 2), tmp16, (3, 4, 2), (0, 3, 1, 4))
-    tmp75 = v.baa.xov.transpose((1, 2, 0)).copy()
+    tmp75 = np.copy(np.transpose(v.baa.xov, (1, 2, 0)))
     tmp75 += tmp16
     tmp75 += tmp70 * -1
-    tmp20 = f.aa.ov.copy()
+    tmp20 = np.copy(f.aa.ov)
     tmp20 += tmp13 * -1
     del tmp13
     tmp20 += tmp19
@@ -304,67 +304,67 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t1new.bb += einsum(t2.abab, (0, 1, 2, 3), tmp20, (0, 2), (1, 3))
     t1new.aa += einsum(t2.aaaa, (0, 1, 2, 3), tmp20, (1, 3), (0, 2)) * 2
     tmp60 = einsum(v.baa.xoo, (0, 1, 2), tmp16, (3, 4, 0), (3, 1, 2, 4))
-    tmp77 = tmp16.copy() * -1
+    tmp77 = np.copy(tmp16) * -1
     tmp77 += tmp70
-    tmp56 = f.aa.vv.copy() * -1
+    tmp56 = np.copy(f.aa.vv) * -1
     tmp56 += tmp53
     del tmp53
-    tmp56 += tmp54.transpose((1, 0)) * -1
+    tmp56 += np.transpose(tmp54, (1, 0)) * -1
     del tmp54
-    tmp56 += tmp55.transpose((1, 0))
+    tmp56 += np.transpose(tmp55, (1, 0))
     del tmp55
     t2new.abab += einsum(tmp56, (0, 1), t2.abab, (2, 3, 0, 4), (2, 3, 1, 4)) * -1
     tmp48 = einsum(v.baa.xoo, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 1, 2, 4))
     tmp108 = einsum(v.baa.xov, (0, 1, 2), v.baa.xvv, (0, 3, 4), (1, 3, 4, 2))
-    tmp95 = tmp42.copy() * 2
+    tmp95 = np.copy(tmp42) * 2
     del tmp42
     tmp95 += tmp3 * -1
     tmp68 = einsum(tmp67, (0, 1), t1.aa, (2, 1), (2, 0))
     del tmp67
     t2new.abab += einsum(tmp68, (0, 1), t2.abab, (1, 2, 3, 4), (0, 2, 3, 4)) * -1
-    tmp71 = tmp16.copy()
+    tmp71 = np.copy(tmp16)
     tmp71 += tmp70 * -1
     del tmp70
     tmp64 = einsum(tmp62, (0, 1, 2, 3), t1.aa, (3, 4), (0, 1, 2, 4))
-    tmp30 = t2.bbbb.copy() * 2
+    tmp30 = np.copy(t2.bbbb) * 2
     tmp30 += einsum(t1.bb, (0, 1), t1.bb, (2, 3), (2, 0, 1, 3)) * -1
-    tmp34 = tmp29.copy()
+    tmp34 = np.copy(tmp29)
     tmp34 += tmp33 * 2
     tmp34 += einsum(t1.bb, (0, 1), tmp7, (2,), (0, 1, 2))
-    tmp4 = t2.aaaa.copy() * 2
+    tmp4 = np.copy(t2.aaaa) * 2
     tmp4 += einsum(t1.aa, (0, 1), t1.aa, (2, 3), (0, 2, 3, 1)) * -1
-    tmp12 = tmp11.copy()
+    tmp12 = np.copy(tmp11)
     tmp12 += tmp3 * 0.5
     tmp12 += einsum(t1.aa, (0, 1), tmp7, (2,), (0, 1, 2)) * 0.5
     tmp179 = einsum(tmp178, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp178
-    t2new.bbbb = tmp179.transpose((0, 1, 3, 2)).copy() * 2
-    t2new.bbbb += tmp179.transpose((1, 0, 3, 2)) * -2
+    t2new.bbbb = np.copy(np.transpose(tmp179, (0, 1, 3, 2))) * 2
+    t2new.bbbb += np.transpose(tmp179, (1, 0, 3, 2)) * -2
     t2new.bbbb += tmp179 * -2
     del tmp179
-    tmp156 = t2.bbbb.copy()
+    tmp156 = np.copy(t2.bbbb)
     tmp156 += einsum(t1.bb, (0, 1), t1.bb, (2, 3), (0, 2, 1, 3)) * 2
     t2new.bbbb += einsum(tmp155, (0, 1, 2, 3), tmp156, (0, 2, 4, 5), (1, 3, 5, 4)) * 0.5
     del tmp156
     tmp195 = einsum(tmp39, (0, 1, 2), tmp39, (3, 4, 2), (3, 0, 4, 1))
-    t2new.bbbb += tmp195.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp195, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp195
     del tmp195
     tmp175 = einsum(tmp174, (0, 1, 2), tmp29, (3, 4, 2), (0, 3, 1, 4))
     del tmp174
-    t2new.bbbb += tmp175.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp175.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp175, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp175, (1, 0, 2, 3))
     del tmp175
     tmp166 = einsum(t1.bb, (0, 1), tmp165, (2, 0, 3, 4), (2, 3, 1, 4))
     del tmp165
-    t2new.bbbb += tmp166.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp166, (0, 1, 3, 2))
     t2new.bbbb += tmp166 * -1
-    t2new.bbbb += tmp166.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp166.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp166, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp166, (1, 0, 2, 3))
     del tmp166
     tmp189 = einsum(tmp188, (0, 1, 2), tmp29, (3, 4, 2), (0, 3, 1, 4))
     del tmp188
-    t2new.bbbb += tmp189.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp189, (1, 0, 2, 3))
     t2new.bbbb += tmp189 * -1
     del tmp189
     tmp201 = einsum(v.bbb.xvv, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (3, 1, 2, 4))
@@ -374,15 +374,15 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp201
     tmp180 = einsum(tmp29, (0, 1, 2), tmp146, (3, 4, 2), (0, 3, 1, 4))
     del tmp146
-    t2new.bbbb += tmp180.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp180.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp180, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp180, (1, 0, 3, 2))
     del tmp180
     tmp199 = einsum(t1.bb, (0, 1), tmp198, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp198
-    t2new.bbbb += tmp199.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp199, (1, 0, 2, 3))
     t2new.bbbb += tmp199 * -1
-    t2new.bbbb += tmp199.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp199.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp199, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp199, (0, 1, 3, 2))
     del tmp199
     tmp123 = einsum(tmp24, (0, 1), t1.bb, (2, 1), (2, 0))
     del tmp24
@@ -391,31 +391,31 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp123
     tmp181 = einsum(t1.bb, (0, 1), tmp37, (2, 0, 3, 4), (2, 3, 1, 4))
     del tmp37
-    t2new.bbbb += tmp181.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp181, (1, 0, 2, 3))
     t2new.bbbb += tmp181 * -1
-    t2new.bbbb += tmp181.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp181.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp181, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp181, (0, 1, 3, 2))
     del tmp181
     tmp169 = einsum(tmp168, (0, 1), t2.bbbb, (2, 0, 3, 4), (1, 2, 3, 4)) * -1
     del tmp168
-    t2new.bbbb += tmp169.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp169.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp169.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp169, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp169, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp169, (1, 0, 3, 2)) * -1
     del tmp169
     tmp197 = einsum(t1.bb, (0, 1), tmp196, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp196
-    t2new.bbbb += tmp197.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp197, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp197
     del tmp197
     tmp182 = einsum(tmp33, (0, 1, 2), tmp29, (3, 4, 2), (3, 0, 4, 1))
     del tmp33
-    t2new.bbbb += tmp182.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp182, (1, 0, 3, 2))
     t2new.bbbb += tmp182
-    t2new.bbbb += tmp182.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp182.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp182.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp182.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp182.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp182, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp182, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp182, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp182, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp182, (1, 0, 3, 2))
     t2new.bbbb += tmp182
     del tmp182
     tmp158 = einsum(t1.bb, (0, 1), t1.bb, (2, 3), (2, 0, 1, 3)) * 2
@@ -424,46 +424,46 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp158
     tmp173 = einsum(v.bbb.xov, (0, 1, 2), tmp131, (3, 4, 0), (1, 3, 2, 4))
     del tmp131
-    t2new.bbbb += tmp173.transpose((1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp173, (1, 0, 2, 3)) * -1
     t2new.bbbb += tmp173
     del tmp173
     tmp191 = einsum(tmp29, (0, 1, 2), tmp190, (3, 4, 2), (3, 0, 4, 1)) * 0.5
     del tmp190
-    t2new.bbbb += tmp191.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp191.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp191, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp191, (0, 1, 3, 2))
     del tmp191
     tmp157 = einsum(tmp155, (0, 1, 2, 3), t2.bbbb, (1, 3, 4, 5), (2, 0, 4, 5))
     del tmp155
-    t2new.bbbb += tmp157.transpose((0, 1, 3, 2)) * -0.5
-    t2new.bbbb += tmp157.transpose((0, 1, 3, 2)) * -0.5
+    t2new.bbbb += np.transpose(tmp157, (0, 1, 3, 2)) * -0.5
+    t2new.bbbb += np.transpose(tmp157, (0, 1, 3, 2)) * -0.5
     del tmp157
     tmp202 = einsum(t1.bb, (0, 1), tmp28, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp28
     t2new.bbbb += tmp202 * -1
-    t2new.bbbb += tmp202.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp202, (1, 0, 2, 3))
     del tmp202
     tmp159 = einsum(t2.bbbb, (0, 1, 2, 3), tmp122, (3, 4), (0, 1, 2, 4)) * -2
     del tmp122
-    t2new.bbbb += tmp159.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp159.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp159, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp159, (1, 0, 3, 2))
     del tmp159
     tmp193 = einsum(t2.bbbb, (0, 1, 2, 3), tmp192, (4, 5, 1, 0), (5, 4, 2, 3))
     del tmp192
-    t2new.bbbb += tmp193.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp193.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp193, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp193, (0, 1, 3, 2)) * -1
     del tmp193
     tmp160 = einsum(v.bbb.xov, (0, 1, 2), tmp117, (3, 4, 0), (1, 3, 2, 4))
     del tmp117
-    t2new.bbbb += tmp160.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp160.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp160.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp160, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp160, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp160, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp160
     del tmp160
     tmp187 = einsum(tmp186, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (0, 4, 2, 5)) * 2
     del tmp186
-    t2new.bbbb += tmp187.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp187.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp187.transpose((1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp187, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp187, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp187, (1, 0, 2, 3)) * -1
     t2new.bbbb += tmp187
     del tmp187
     tmp172 = einsum(tmp170, (0, 1, 2), v.bbb.xov, (2, 3, 4), (0, 3, 1, 4)) * -1
@@ -474,32 +474,32 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp172
     tmp154 = einsum(t2.bbbb, (0, 1, 2, 3), tmp113, (1, 4), (0, 4, 2, 3)) * -1
     del tmp113
-    t2new.bbbb += tmp154.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp154.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp154.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp154.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp154, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp154, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp154, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp154, (0, 1, 3, 2)) * -1
     del tmp154
     tmp162 = einsum(t1.bb, (0, 1), tmp161, (2, 0, 3, 4), (2, 3, 1, 4))
     del tmp161
     t2new.bbbb += tmp162
-    t2new.bbbb += tmp162.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp162.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp162.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp162, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp162, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp162, (1, 0, 3, 2))
     del tmp162
     tmp204 = einsum(tmp203, (0, 1, 2, 3), t2.bbbb, (4, 5, 2, 3), (4, 5, 0, 1)) * -1
     del tmp203
     t2new.bbbb += einsum(t1.bb, (0, 1), tmp204, (2, 3, 0, 4), (2, 3, 1, 4)) * -2
     del tmp204
     tmp194 = einsum(tmp39, (0, 1, 2), v.bbb.xov, (2, 3, 4), (0, 3, 4, 1))
-    t2new.bbbb += tmp194.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp194.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp194, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp194, (0, 1, 3, 2))
     del tmp194
     tmp164 = einsum(tmp163, (0, 1, 2, 3), t2.bbbb, (1, 3, 4, 5), (0, 2, 4, 5))
     del tmp163
-    t2new.bbbb += tmp164.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp164.transpose((0, 1, 3, 2))
-    t2new.bbbb += tmp164.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp164.transpose((1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp164, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp164, (0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp164, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp164, (1, 0, 3, 2)) * -1
     del tmp164
     tmp139 = einsum(tmp43, (0, 1, 2), v.baa.xov, (2, 3, 4), (3, 0, 4, 1))
     tmp139 += einsum(v.baa.xoo, (0, 1, 2), tmp128, (3, 4, 0), (1, 2, 4, 3)) * -1
@@ -510,7 +510,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp150
     t2new.abab += einsum(tmp151, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3)) * -1
     del tmp151
-    tmp115 = t2.abab.copy()
+    tmp115 = np.copy(t2.abab)
     tmp115 += einsum(t1.bb, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1)) * 2
     tmp133 = einsum(v.bbb.xoo, (0, 1, 2), tmp132, (3, 4, 0), (1, 2, 4, 3))
     t2new.abab += einsum(tmp133, (0, 1, 2, 3), t2.abab, (4, 0, 2, 5), (4, 1, 3, 5)) * -1
@@ -539,7 +539,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new.abab += einsum(tmp2, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3)) * -1
     t1new.aa += einsum(tmp2, (0, 1, 2, 3), t2.abab, (1, 2, 4, 3), (0, 4)) * -1
     del tmp2
-    tmp148 = tmp147.transpose((1, 0, 2, 3)).copy() * -1
+    tmp148 = np.copy(np.transpose(tmp147, (1, 0, 2, 3))) * -1
     del tmp147
     tmp148 += einsum(tmp21, (0, 1, 2), tmp135, (3, 4, 2), (0, 1, 4, 3))
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp148, (4, 1, 3, 5), (0, 4, 2, 5)) * -1
@@ -552,7 +552,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new.abab += einsum(tmp149, (0, 1, 2, 3), t2.abab, (1, 4, 5, 2), (0, 4, 5, 3)) * -1
     del tmp149
     tmp124 = einsum(v.baa.xoo, (0, 1, 2), tmp21, (3, 4, 0), (1, 2, 3, 4))
-    tmp145 = tmp80.transpose((1, 0, 2, 3)).copy() * -1
+    tmp145 = np.copy(np.transpose(tmp80, (1, 0, 2, 3))) * -1
     del tmp80
     tmp145 += einsum(tmp0, (0, 1, 2), tmp132, (3, 4, 2), (0, 1, 4, 3))
     del tmp132
@@ -565,16 +565,16 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp153 = einsum(tmp0, (0, 1, 2), tmp39, (3, 4, 2), (0, 1, 3, 4))
     t2new.abab += einsum(tmp153, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3)) * -1
     del tmp153
-    tmp125 = t2.abab.copy()
+    tmp125 = np.copy(t2.abab)
     tmp125 += einsum(t1.bb, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1))
     t2new.abab += einsum(tmp138, (0, 1, 2, 3), tmp125, (1, 3, 4, 5), (0, 2, 4, 5))
     del tmp138
     t2new.abab += einsum(tmp125, (0, 1, 2, 3), tmp124, (4, 0, 5, 1), (4, 5, 2, 3))
     del tmp124
-    tmp116 = f.aa.oo.copy()
+    tmp116 = np.copy(f.aa.oo)
     tmp116 += einsum(v.baa.xov, (0, 1, 2), tmp43, (3, 2, 0), (1, 3))
     del tmp43
-    tmp116 += tmp25.transpose((1, 0))
+    tmp116 += np.transpose(tmp25, (1, 0))
     t2new.abab += einsum(tmp116, (0, 1), t2.abab, (0, 2, 3, 4), (1, 2, 3, 4)) * -1
     del tmp116
     tmp126 = einsum(v.bbb.xoo, (0, 1, 2), tmp16, (3, 4, 0), (3, 1, 2, 4))
@@ -589,7 +589,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp140
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp141, (1, 4, 3, 5), (0, 4, 2, 5))
     del tmp141
-    tmp137 = v.bbb.xov.transpose((1, 2, 0)).copy()
+    tmp137 = np.copy(np.transpose(v.bbb.xov, (1, 2, 0)))
     tmp137 += tmp39
     del tmp39
     tmp137 += tmp130 * -1
@@ -598,20 +598,20 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp137
     tmp84 = einsum(t2.aaaa, (0, 1, 2, 3), tmp83, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp83
-    t2new.aaaa = tmp84.transpose((1, 0, 2, 3)).copy() * 2
+    t2new.aaaa = np.copy(np.transpose(tmp84, (1, 0, 2, 3))) * 2
     t2new.aaaa += tmp84 * -2
-    t2new.aaaa += tmp84.transpose((1, 0, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp84, (1, 0, 3, 2)) * -2
     del tmp84
     tmp47 = einsum(tmp46, (0, 1), t2.aaaa, (2, 0, 3, 4), (2, 1, 3, 4)) * -0.5
     del tmp46
-    t2new.aaaa += tmp47.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp47.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp47.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp47.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp47, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp47, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp47, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp47, (0, 1, 3, 2)) * -1
     del tmp47
     tmp97 = einsum(v.baa.xov, (0, 1, 2), tmp16, (3, 4, 0), (3, 1, 2, 4))
-    t2new.aaaa += tmp97.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp97.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp97, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp97, (0, 1, 3, 2))
     del tmp97
     tmp51 = einsum(t1.aa, (0, 1), t1.aa, (2, 3), (0, 2, 3, 1)) * 2
     tmp51 += t2.aaaa * -1
@@ -619,27 +619,27 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp51
     tmp104 = einsum(tmp103, (0, 1, 2, 3), t1.aa, (2, 4), (0, 1, 4, 3))
     del tmp103
-    t2new.aaaa += tmp104.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp104, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp104
     del tmp104
     tmp59 = einsum(tmp58, (0, 1, 2), v.baa.xov, (2, 3, 4), (3, 0, 4, 1))
     del tmp58
-    t2new.aaaa += tmp59.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp59.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp59.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp59, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp59, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp59, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp59
     del tmp59
     tmp92 = einsum(t2.aaaa, (0, 1, 2, 3), tmp91, (4, 1, 5, 3), (0, 4, 2, 5)) * 2
     del tmp91
     t2new.aaaa += tmp92
-    t2new.aaaa += tmp92.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp92.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp92.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp92, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp92, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp92, (1, 0, 3, 2))
     del tmp92
     tmp107 = einsum(t1.aa, (0, 1), tmp1, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp1
     t2new.aaaa += tmp107 * -1
-    t2new.aaaa += tmp107.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp107, (1, 0, 2, 3))
     del tmp107
     tmp106 = einsum(v.baa.xvv, (0, 1, 2), v.baa.xvv, (0, 3, 4), (3, 1, 2, 4))
     tmp106 += einsum(t1.aa, (0, 1), tmp105, (0, 2, 3, 4), (4, 3, 1, 2))
@@ -648,26 +648,26 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp106
     tmp94 = einsum(tmp93, (0, 1, 2), tmp3, (3, 4, 2), (3, 0, 4, 1))
     del tmp93
-    t2new.aaaa += tmp94.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp94.transpose((1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp94, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp94, (1, 0, 3, 2)) * -1
     del tmp94
     tmp86 = einsum(t1.aa, (0, 1), tmp17, (2, 0, 3, 4), (2, 3, 1, 4))
     del tmp17
-    t2new.aaaa += tmp86.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp86, (1, 0, 2, 3))
     t2new.aaaa += tmp86 * -1
-    t2new.aaaa += tmp86.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp86.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp86, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp86, (0, 1, 3, 2))
     del tmp86
     tmp102 = einsum(t1.aa, (0, 1), tmp101, (2, 3, 0, 4), (2, 3, 1, 4))
     del tmp101
-    t2new.aaaa += tmp102.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp102, (1, 0, 2, 3))
     t2new.aaaa += tmp102 * -1
-    t2new.aaaa += tmp102.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp102.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp102, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp102, (0, 1, 3, 2))
     del tmp102
     tmp76 = einsum(v.baa.xov, (0, 1, 2), tmp75, (3, 4, 0), (1, 3, 2, 4))
     del tmp75
-    t2new.aaaa += tmp76.transpose((1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp76, (1, 0, 2, 3)) * -1
     t2new.aaaa += tmp76
     del tmp76
     tmp66 = einsum(tmp20, (0, 1), t1.aa, (2, 1), (2, 0))
@@ -677,28 +677,28 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp61 = einsum(tmp60, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3))
     del tmp60
     t2new.aaaa += tmp61
-    t2new.aaaa += tmp61.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp61.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp61.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp61, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp61, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp61, (1, 0, 3, 2))
     del tmp61
     tmp78 = einsum(tmp77, (0, 1, 2), tmp3, (3, 4, 2), (3, 0, 4, 1))
     del tmp77
     t2new.aaaa += tmp78 * -1
-    t2new.aaaa += tmp78.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp78, (0, 1, 3, 2))
     del tmp78
     tmp85 = einsum(tmp79, (0, 1, 2), tmp3, (3, 4, 2), (3, 0, 4, 1))
     del tmp79
-    t2new.aaaa += tmp85.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp85.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp85, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp85, (1, 0, 3, 2))
     del tmp85
     tmp57 = einsum(tmp56, (0, 1), t2.aaaa, (2, 3, 4, 0), (2, 3, 4, 1)) * -2
     del tmp56
-    t2new.aaaa += tmp57.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp57.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp57, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp57, (1, 0, 3, 2))
     del tmp57
     tmp50 = einsum(t2.aaaa, (0, 1, 2, 3), tmp48, (4, 0, 5, 1), (5, 4, 2, 3))
-    t2new.aaaa += tmp50.transpose((0, 1, 3, 2)) * -0.5
-    t2new.aaaa += tmp50.transpose((0, 1, 3, 2)) * -0.5
+    t2new.aaaa += np.transpose(tmp50, (0, 1, 3, 2)) * -0.5
+    t2new.aaaa += np.transpose(tmp50, (0, 1, 3, 2)) * -0.5
     del tmp50
     tmp109 = einsum(t2.aaaa, (0, 1, 2, 3), tmp108, (4, 5, 2, 3), (0, 1, 4, 5)) * -1
     del tmp108
@@ -707,40 +707,40 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp96 = einsum(tmp95, (0, 1, 2), tmp3, (3, 4, 2), (3, 0, 4, 1)) * 0.5
     del tmp95
     t2new.aaaa += tmp96 * -1
-    t2new.aaaa += tmp96.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp96, (1, 0, 2, 3))
     del tmp96
-    tmp49 = t2.aaaa.copy()
+    tmp49 = np.copy(t2.aaaa)
     tmp49 += einsum(t1.aa, (0, 1), t1.aa, (2, 3), (2, 0, 3, 1)) * 2
     t2new.aaaa += einsum(tmp48, (0, 1, 2, 3), tmp49, (0, 2, 4, 5), (1, 3, 5, 4)) * 0.5
     del tmp48, tmp49
     tmp99 = einsum(tmp98, (0, 1, 2, 3), t2.aaaa, (3, 2, 4, 5), (1, 0, 4, 5))
     del tmp98
-    t2new.aaaa += tmp99.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp99.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp99, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp99, (0, 1, 3, 2)) * -1
     del tmp99
     tmp69 = einsum(t2.aaaa, (0, 1, 2, 3), tmp68, (4, 1), (0, 4, 2, 3)) * -1
     del tmp68
-    t2new.aaaa += tmp69.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp69.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp69.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp69, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp69, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp69, (0, 1, 3, 2)) * -1
     del tmp69
     tmp87 = einsum(tmp3, (0, 1, 2), tmp11, (3, 4, 2), (3, 0, 4, 1))
     del tmp11
-    t2new.aaaa += tmp87.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp87, (1, 0, 3, 2))
     t2new.aaaa += tmp87
-    t2new.aaaa += tmp87.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp87.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp87.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp87.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp87.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp87, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp87, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp87, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp87, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp87, (1, 0, 3, 2))
     t2new.aaaa += tmp87
     del tmp87
     tmp63 = einsum(tmp62, (0, 1, 2, 3), t2.aaaa, (1, 3, 4, 5), (0, 2, 4, 5))
     del tmp62
-    t2new.aaaa += tmp63.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp63.transpose((0, 1, 3, 2))
-    t2new.aaaa += tmp63.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp63.transpose((1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp63, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp63, (0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp63, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp63, (1, 0, 3, 2)) * -1
     del tmp63
     tmp74 = einsum(v.baa.xov, (0, 1, 2), tmp71, (3, 4, 0), (3, 1, 4, 2)) * -1
     del tmp71
@@ -750,23 +750,23 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp74
     tmp100 = einsum(tmp16, (0, 1, 2), tmp16, (3, 4, 2), (0, 3, 1, 4))
     del tmp16
-    t2new.aaaa += tmp100.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp100, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp100
     del tmp100
     tmp65 = einsum(t1.aa, (0, 1), tmp64, (2, 0, 3, 4), (2, 3, 1, 4))
     del tmp64
-    t2new.aaaa += tmp65.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp65, (0, 1, 3, 2))
     t2new.aaaa += tmp65 * -1
-    t2new.aaaa += tmp65.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp65.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp65, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp65, (1, 0, 2, 3))
     del tmp65
-    tmp41 = f.bb.oo.copy()
+    tmp41 = np.copy(f.bb.oo)
     tmp41 += einsum(v.bbb.xoo, (0, 1, 2), tmp21, (2, 3, 0), (3, 1)) * -1
-    tmp41 += tmp40.transpose((1, 0))
+    tmp41 += np.transpose(tmp40, (1, 0))
     del tmp40
     t1new.bb += einsum(t1.bb, (0, 1), tmp41, (0, 2), (2, 1)) * -1
     del tmp41
-    tmp31 = tmp29.copy()
+    tmp31 = np.copy(tmp29)
     del tmp29
     tmp31 += einsum(tmp30, (0, 1, 2, 3), v.bbb.xov, (4, 0, 2), (1, 3, 4))
     del tmp30
@@ -783,14 +783,14 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp21
     t1new.bb += einsum(tmp27, (0, 1, 2, 3), t2.abab, (0, 2, 3, 4), (1, 4)) * -1
     del tmp27
-    tmp26 = f.aa.oo.copy()
+    tmp26 = np.copy(f.aa.oo)
     tmp26 += einsum(tmp0, (0, 1, 2), v.baa.xoo, (2, 3, 0), (1, 3)) * -1
     del tmp0
-    tmp26 += tmp25.transpose((1, 0))
+    tmp26 += np.transpose(tmp25, (1, 0))
     del tmp25
     t1new.aa += einsum(tmp26, (0, 1), t1.aa, (0, 2), (1, 2)) * -1
     del tmp26
-    tmp8 = tmp3.copy() * 0.5
+    tmp8 = np.copy(tmp3) * 0.5
     del tmp3
     tmp8 += einsum(v.baa.xov, (0, 1, 2), tmp4, (1, 3, 2, 4), (3, 4, 0)) * 0.5
     del tmp4

--- a/ebcc/codegen/UDFQCISD.py
+++ b/ebcc/codegen/UDFQCISD.py
@@ -70,14 +70,14 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new = Namespace()
     tmp40 = einsum(v.bbb.xov, (0, 1, 2), v.bbb.xov, (0, 3, 4), (3, 1, 4, 2))
     tmp35 = einsum(v.baa.xov, (0, 1, 2), v.baa.xov, (0, 3, 4), (3, 1, 4, 2))
-    tmp77 = tmp40.transpose((1, 0, 2, 3)).copy()
-    tmp77 += tmp40.transpose((1, 0, 3, 2)) * -1
+    tmp77 = np.copy(np.transpose(tmp40, (1, 0, 2, 3)))
+    tmp77 += np.transpose(tmp40, (1, 0, 3, 2)) * -1
     tmp26 = einsum(v.baa.xov, (0, 1, 2), t2.abab, (1, 3, 2, 4), (3, 4, 0))
     tmp27 = einsum(v.bbb.xov, (0, 1, 2), t2.bbbb, (3, 1, 4, 2), (3, 4, 0))
     tmp16 = einsum(v.baa.xov, (0, 1, 2), t2.aaaa, (3, 1, 4, 2), (3, 4, 0))
     tmp17 = einsum(v.bbb.xov, (0, 1, 2), t2.abab, (3, 1, 4, 2), (3, 4, 0))
-    tmp36 = tmp35.transpose((1, 0, 2, 3)).copy() * -1
-    tmp36 += tmp35.transpose((1, 0, 3, 2))
+    tmp36 = np.copy(np.transpose(tmp35, (1, 0, 2, 3))) * -1
+    tmp36 += np.transpose(tmp35, (1, 0, 3, 2))
     tmp6 = einsum(v.bbb.xov, (0, 1, 2), t1.bb, (1, 2), (0,))
     tmp5 = einsum(v.baa.xov, (0, 1, 2), t1.aa, (1, 2), (0,))
     tmp78 = einsum(t2.bbbb, (0, 1, 2, 3), tmp77, (1, 4, 5, 3), (0, 4, 2, 5))
@@ -86,53 +86,53 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new.abab = einsum(tmp71, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 5, 2)) * -1
     tmp22 = einsum(v.bbb.xvv, (0, 1, 2), t1.bb, (3, 2), (3, 1, 0))
     t1new.bb = einsum(tmp22, (0, 1, 2), v.bbb.xoo, (2, 3, 0), (3, 1)) * -1
-    tmp28 = tmp26.copy() * 0.5
+    tmp28 = np.copy(tmp26) * 0.5
     tmp28 += tmp27
     t1new.bb += einsum(tmp28, (0, 1, 2), v.bbb.xvv, (2, 3, 1), (0, 3)) * 2
-    tmp53 = tmp16.copy() * 2
+    tmp53 = np.copy(tmp16) * 2
     tmp53 += tmp17
-    tmp18 = tmp16.copy() * 2
+    tmp18 = np.copy(tmp16) * 2
     tmp18 += tmp17
     t1new.aa = einsum(tmp18, (0, 1, 2), v.baa.xvv, (2, 3, 1), (0, 3))
     tmp34 = einsum(v.baa.xvv, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 4, 1, 2))
     tmp37 = einsum(t2.aaaa, (0, 1, 2, 3), tmp36, (1, 4, 3, 5), (0, 4, 2, 5))
-    tmp41 = tmp40.transpose((1, 0, 2, 3)).copy() * -1
-    tmp41 += tmp40.transpose((1, 0, 3, 2))
+    tmp41 = np.copy(np.transpose(tmp40, (1, 0, 2, 3))) * -1
+    tmp41 += np.transpose(tmp40, (1, 0, 3, 2))
     tmp1 = einsum(v.baa.xvv, (0, 1, 2), t1.aa, (3, 2), (3, 1, 0))
     t2new.abab += einsum(v.bbb.xov, (0, 1, 2), tmp1, (3, 4, 0), (3, 1, 4, 2))
     t1new.aa += einsum(tmp1, (0, 1, 2), v.baa.xoo, (2, 3, 0), (3, 1)) * -1
-    tmp7 = tmp5.copy()
+    tmp7 = np.copy(tmp5)
     tmp7 += tmp6
     tmp3 = einsum(v.baa.xov, (0, 1, 2), t1.aa, (3, 2), (3, 1, 0))
     tmp10 = einsum(v.bbb.xov, (0, 1, 2), t1.bb, (3, 2), (3, 1, 0))
     tmp81 = einsum(t2.abab, (0, 1, 2, 3), tmp36, (0, 4, 2, 5), (4, 1, 5, 3))
     del tmp36
     tmp85 = einsum(t2.bbbb, (0, 1, 2, 3), tmp40, (4, 5, 3, 2), (0, 1, 5, 4))
-    tmp79 = tmp71.transpose((1, 0, 3, 2)).copy()
+    tmp79 = np.copy(np.transpose(tmp71, (1, 0, 3, 2)))
     tmp79 += tmp78 * -2
     del tmp78
-    tmp58 = v.bbb.xov.transpose((1, 2, 0)).copy()
+    tmp58 = np.copy(np.transpose(v.bbb.xov, (1, 2, 0)))
     tmp58 += tmp22
     t2new.abab += einsum(v.baa.xov, (0, 1, 2), tmp58, (3, 4, 0), (1, 3, 2, 4))
     tmp21 = einsum(v.bbb.xov, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (3, 4, 1, 2))
     t1new.bb += einsum(tmp21, (0, 1, 2, 3), t2.bbbb, (1, 2, 4, 3), (0, 4)) * -2
-    tmp65 = tmp26.copy()
+    tmp65 = np.copy(tmp26)
     tmp65 += tmp27 * 2
     t2new.abab += einsum(tmp65, (0, 1, 2), v.baa.xov, (2, 3, 4), (3, 0, 4, 1))
     tmp94 = einsum(tmp28, (0, 1, 2), v.bbb.xov, (2, 3, 1), (3, 0)) * 2
     tmp88 = einsum(v.bbb.xoo, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (1, 3, 4, 2))
     tmp91 = einsum(tmp28, (0, 1, 2), v.bbb.xov, (2, 0, 3), (3, 1))
     t2new.bbbb = einsum(t2.bbbb, (0, 1, 2, 3), tmp91, (3, 4), (0, 1, 2, 4)) * -4
-    tmp66 = tmp16.copy()
+    tmp66 = np.copy(tmp16)
     tmp66 += tmp17 * 0.5
     tmp59 = einsum(v.bbb.xov, (0, 1, 2), v.baa.xov, (0, 3, 4), (3, 1, 4, 2))
     tmp69 = einsum(v.bbb.xov, (0, 1, 2), tmp53, (3, 4, 0), (3, 1, 4, 2))
     t2new.abab += tmp69
     tmp54 = einsum(tmp53, (0, 1, 2), v.baa.xov, (2, 3, 4), (3, 0, 4, 1))
     del tmp53
-    t2new.aaaa = tmp54.transpose((1, 0, 3, 2)).copy()
-    t2new.aaaa += tmp54.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp54.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa = np.copy(np.transpose(tmp54, (1, 0, 3, 2)))
+    t2new.aaaa += np.transpose(tmp54, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp54, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp54
     tmp62 = einsum(v.baa.xoo, (0, 1, 2), v.bbb.xoo, (0, 3, 4), (1, 2, 3, 4))
     tmp49 = einsum(v.baa.xoo, (0, 1, 2), v.baa.xoo, (0, 3, 4), (3, 1, 2, 4))
@@ -141,12 +141,12 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp47 = einsum(t2.aaaa, (0, 1, 2, 3), tmp35, (4, 5, 3, 2), (0, 1, 5, 4))
     tmp2 = einsum(v.baa.xoo, (0, 1, 2), v.baa.xov, (0, 3, 4), (1, 2, 3, 4))
     t1new.aa += einsum(t2.aaaa, (0, 1, 2, 3), tmp2, (4, 0, 1, 3), (4, 2)) * -2
-    tmp38 = tmp34.transpose((1, 0, 3, 2)).copy()
+    tmp38 = np.copy(np.transpose(tmp34, (1, 0, 3, 2)))
     tmp38 += tmp37 * -2
     del tmp37
     tmp42 = einsum(tmp41, (0, 1, 2, 3), t2.abab, (4, 0, 5, 3), (4, 1, 5, 2))
     del tmp41
-    tmp30 = v.baa.xov.transpose((1, 2, 0)).copy()
+    tmp30 = np.copy(np.transpose(v.baa.xov, (1, 2, 0)))
     tmp30 += tmp1
     tmp8 = einsum(tmp7, (0,), v.baa.xov, (0, 1, 2), (1, 2))
     tmp4 = einsum(v.baa.xov, (0, 1, 2), tmp3, (1, 3, 0), (3, 2))
@@ -155,7 +155,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp11 = einsum(v.bbb.xov, (0, 1, 2), tmp10, (1, 3, 0), (3, 2))
     tmp82 = einsum(tmp81, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (4, 1, 5, 3))
     del tmp81
-    t2new.bbbb += tmp82.transpose((1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp82, (1, 0, 2, 3)) * -1
     t2new.bbbb += tmp82
     del tmp82
     tmp87 = einsum(v.bbb.xvv, (0, 1, 2), v.bbb.xvv, (0, 3, 4), (1, 3, 4, 2))
@@ -163,76 +163,76 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp87
     tmp86 = einsum(tmp85, (0, 1, 2, 3), t2.bbbb, (2, 3, 4, 5), (1, 0, 4, 5)) * -1
     del tmp85
-    t2new.bbbb += tmp86.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp86.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp86, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp86, (0, 1, 3, 2)) * -1
     del tmp86
     tmp80 = einsum(t2.bbbb, (0, 1, 2, 3), tmp79, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp79
-    t2new.bbbb += tmp80.transpose((0, 1, 3, 2)) * 2
-    t2new.bbbb += tmp80.transpose((1, 0, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp80, (0, 1, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp80, (1, 0, 3, 2)) * -2
     del tmp80
     tmp74 = einsum(tmp58, (0, 1, 2), v.bbb.xov, (2, 3, 4), (3, 0, 4, 1))
     del tmp58
-    t2new.bbbb += tmp74.transpose((1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp74, (1, 0, 2, 3)) * -1
     t2new.bbbb += tmp74
     del tmp74
     tmp76 = einsum(tmp26, (0, 1, 2), tmp27, (3, 4, 2), (0, 3, 1, 4))
     del tmp26, tmp27
-    t2new.bbbb += tmp76.transpose((1, 0, 2, 3)) * -2
-    t2new.bbbb += tmp76.transpose((0, 1, 3, 2)) * -2
-    t2new.bbbb += tmp76.transpose((1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp76, (1, 0, 2, 3)) * -2
+    t2new.bbbb += np.transpose(tmp76, (0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp76, (1, 0, 3, 2)) * 2
     t2new.bbbb += tmp76 * 2
     del tmp76
     tmp75 = einsum(tmp21, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 4, 3))
     del tmp21
-    t2new.bbbb += tmp75.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp75, (1, 0, 2, 3))
     t2new.bbbb += tmp75 * -1
-    t2new.bbbb += tmp75.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp75.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp75, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp75, (0, 1, 3, 2))
     del tmp75
     tmp83 = einsum(tmp71, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp71
     t2new.bbbb += tmp83 * -2
-    t2new.bbbb += tmp83.transpose((1, 0, 2, 3)) * 2
+    t2new.bbbb += np.transpose(tmp83, (1, 0, 2, 3)) * 2
     del tmp83
     tmp92 = einsum(v.bbb.xov, (0, 1, 2), tmp65, (3, 4, 0), (1, 3, 2, 4))
     del tmp65
-    t2new.bbbb += tmp92.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp92.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp92.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp92, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp92, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp92, (0, 1, 3, 2)) * -1
     t2new.bbbb += tmp92
     del tmp92
     tmp95 = einsum(tmp94, (0, 1), t2.bbbb, (2, 0, 3, 4), (2, 1, 3, 4)) * -1
     del tmp94
-    t2new.bbbb += tmp95.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp95.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp95.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp95.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp95, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp95, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp95, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp95, (0, 1, 3, 2)) * -1
     del tmp95
     tmp89 = einsum(tmp88, (0, 1, 2, 3), t2.bbbb, (1, 3, 4, 5), (2, 0, 4, 5))
     del tmp88
-    t2new.bbbb += tmp89.transpose((0, 1, 3, 2)) * -0.5
-    t2new.bbbb += tmp89.transpose((0, 1, 3, 2)) * -0.5
-    t2new.bbbb += tmp89.transpose((0, 1, 3, 2)) * -0.5
-    t2new.bbbb += tmp89.transpose((0, 1, 3, 2)) * -0.5
+    t2new.bbbb += np.transpose(tmp89, (0, 1, 3, 2)) * -0.5
+    t2new.bbbb += np.transpose(tmp89, (0, 1, 3, 2)) * -0.5
+    t2new.bbbb += np.transpose(tmp89, (0, 1, 3, 2)) * -0.5
+    t2new.bbbb += np.transpose(tmp89, (0, 1, 3, 2)) * -0.5
     del tmp89
     tmp90 = einsum(f.bb.oo, (0, 1), t2.bbbb, (2, 1, 3, 4), (0, 2, 3, 4))
-    t2new.bbbb += tmp90.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp90.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp90.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp90.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp90, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp90, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp90, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp90, (1, 0, 3, 2))
     del tmp90
     tmp84 = einsum(v.bbb.xov, (0, 1, 2), tmp22, (3, 4, 0), (3, 1, 2, 4))
     del tmp22
-    t2new.bbbb += tmp84.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp84.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp84, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp84, (0, 1, 3, 2))
     del tmp84
-    tmp93 = f.bb.vv.copy() * -0.5
-    tmp93 += tmp91.transpose((1, 0))
+    tmp93 = np.copy(f.bb.vv) * -0.5
+    tmp93 += np.transpose(tmp91, (1, 0))
     del tmp91
     t2new.bbbb += einsum(t2.bbbb, (0, 1, 2, 3), tmp93, (4, 3), (0, 1, 4, 2)) * 4
     del tmp93
-    tmp67 = f.aa.vv.copy() * -1
+    tmp67 = np.copy(f.aa.vv) * -1
     tmp67 += einsum(v.baa.xov, (0, 1, 2), tmp66, (1, 3, 0), (2, 3)) * 2
     del tmp66
     t2new.abab += einsum(tmp67, (0, 1), t2.abab, (2, 3, 0, 4), (2, 3, 1, 4)) * -1
@@ -254,7 +254,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp59
     t2new.abab += einsum(tmp73, (0, 1, 2, 3), t2.abab, (1, 3, 4, 5), (0, 2, 4, 5))
     del tmp73
-    tmp68 = tmp34.transpose((1, 0, 3, 2)).copy()
+    tmp68 = np.copy(np.transpose(tmp34, (1, 0, 3, 2)))
     tmp68 += einsum(tmp35, (0, 1, 2, 3), t2.aaaa, (4, 0, 5, 3), (1, 4, 2, 5)) * 2
     del tmp35
     tmp68 += tmp54 * -1
@@ -287,79 +287,79 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp29
     tmp50 = einsum(tmp49, (0, 1, 2, 3), t2.aaaa, (1, 3, 4, 5), (2, 0, 4, 5))
     del tmp49
-    t2new.aaaa += tmp50.transpose((0, 1, 3, 2)) * -0.5
-    t2new.aaaa += tmp50.transpose((0, 1, 3, 2)) * -0.5
-    t2new.aaaa += tmp50.transpose((0, 1, 3, 2)) * -0.5
-    t2new.aaaa += tmp50.transpose((0, 1, 3, 2)) * -0.5
+    t2new.aaaa += np.transpose(tmp50, (0, 1, 3, 2)) * -0.5
+    t2new.aaaa += np.transpose(tmp50, (0, 1, 3, 2)) * -0.5
+    t2new.aaaa += np.transpose(tmp50, (0, 1, 3, 2)) * -0.5
+    t2new.aaaa += np.transpose(tmp50, (0, 1, 3, 2)) * -0.5
     del tmp50
     tmp45 = einsum(v.baa.xov, (0, 1, 2), tmp1, (3, 4, 0), (3, 1, 2, 4))
     del tmp1
-    t2new.aaaa += tmp45.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp45.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp45, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp45, (0, 1, 3, 2))
     del tmp45
     tmp44 = einsum(t2.aaaa, (0, 1, 2, 3), tmp34, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp34
     t2new.aaaa += tmp44 * -2
-    t2new.aaaa += tmp44.transpose((1, 0, 2, 3)) * 2
+    t2new.aaaa += np.transpose(tmp44, (1, 0, 2, 3)) * 2
     del tmp44
     tmp57 = einsum(t2.aaaa, (0, 1, 2, 3), tmp56, (1, 4), (0, 4, 2, 3)) * -2
     del tmp56
-    t2new.aaaa += tmp57.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp57.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp57.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp57.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp57, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp57, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp57, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp57, (0, 1, 3, 2)) * -1
     del tmp57
     tmp48 = einsum(tmp47, (0, 1, 2, 3), t2.aaaa, (2, 3, 4, 5), (1, 0, 4, 5)) * -1
     del tmp47
-    t2new.aaaa += tmp48.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp48.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp48, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp48, (0, 1, 3, 2)) * -1
     del tmp48
     tmp46 = einsum(v.baa.xvv, (0, 1, 2), v.baa.xvv, (0, 3, 4), (1, 3, 4, 2))
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp46, (4, 2, 5, 3), (0, 1, 4, 5)) * -2
     del tmp46
     tmp32 = einsum(tmp2, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3))
     del tmp2
-    t2new.aaaa += tmp32.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp32, (1, 0, 2, 3))
     t2new.aaaa += tmp32 * -1
-    t2new.aaaa += tmp32.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp32.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp32, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp32, (0, 1, 3, 2))
     del tmp32
     tmp52 = einsum(tmp18, (0, 1, 2), v.baa.xov, (2, 0, 3), (1, 3)) * 0.5
     t2new.aaaa += einsum(tmp52, (0, 1), t2.aaaa, (2, 3, 4, 1), (2, 3, 4, 0)) * -4
     del tmp52
     tmp39 = einsum(t2.aaaa, (0, 1, 2, 3), tmp38, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp38
-    t2new.aaaa += tmp39.transpose((0, 1, 3, 2)) * 2
-    t2new.aaaa += tmp39.transpose((1, 0, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp39, (0, 1, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp39, (1, 0, 3, 2)) * -2
     del tmp39
     tmp43 = einsum(tmp42, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 5, 2)) * -1
     del tmp42
-    t2new.aaaa += tmp43.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp43, (0, 1, 3, 2)) * -1
     t2new.aaaa += tmp43
     del tmp43
     tmp51 = einsum(f.aa.oo, (0, 1), t2.aaaa, (2, 1, 3, 4), (0, 2, 3, 4))
-    t2new.aaaa += tmp51.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp51.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp51.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp51.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp51, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp51, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp51, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp51, (1, 0, 3, 2))
     del tmp51
     tmp31 = einsum(tmp30, (0, 1, 2), v.baa.xov, (2, 3, 4), (3, 0, 4, 1))
     del tmp30
-    t2new.aaaa += tmp31.transpose((1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp31, (1, 0, 2, 3)) * -1
     t2new.aaaa += tmp31
     del tmp31
     tmp33 = einsum(tmp17, (0, 1, 2), tmp16, (3, 4, 2), (3, 0, 4, 1))
     del tmp16, tmp17
-    t2new.aaaa += tmp33.transpose((1, 0, 2, 3)) * -2
-    t2new.aaaa += tmp33.transpose((0, 1, 3, 2)) * -2
-    t2new.aaaa += tmp33.transpose((1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp33, (1, 0, 2, 3)) * -2
+    t2new.aaaa += np.transpose(tmp33, (0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp33, (1, 0, 3, 2)) * 2
     t2new.aaaa += tmp33 * 2
     del tmp33
-    tmp55 = f.aa.vv.copy() * -1
+    tmp55 = np.copy(f.aa.vv) * -1
     tmp55 += einsum(tmp18, (0, 1, 2), v.baa.xov, (2, 0, 3), (1, 3))
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp55, (4, 3), (0, 1, 4, 2)) * 2
     del tmp55
-    tmp9 = f.aa.ov.copy()
+    tmp9 = np.copy(f.aa.ov)
     tmp9 += tmp4 * -1
     del tmp4
     tmp9 += tmp8
@@ -367,14 +367,14 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t1new.bb += einsum(t2.abab, (0, 1, 2, 3), tmp9, (0, 2), (1, 3))
     t1new.aa += einsum(tmp9, (0, 1), t2.aaaa, (2, 0, 3, 1), (2, 3)) * 2
     del tmp9
-    tmp19 = tmp5.copy()
+    tmp19 = np.copy(tmp5)
     del tmp5
     tmp19 += tmp6
     del tmp6
     t1new.bb += einsum(v.bbb.xov, (0, 1, 2), tmp19, (0,), (1, 2))
     t1new.aa += einsum(v.baa.xov, (0, 1, 2), tmp19, (0,), (1, 2))
     del tmp19
-    tmp13 = f.bb.ov.copy()
+    tmp13 = np.copy(f.bb.ov)
     tmp13 += tmp11 * -1
     del tmp11
     tmp13 += tmp12

--- a/ebcc/codegen/UMP2.py
+++ b/ebcc/codegen/UMP2.py
@@ -103,12 +103,12 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.aaaa = Namespace()
     rdm2.abab = Namespace()
     rdm2.bbbb = Namespace()
-    rdm2.bbbb.vvoo = l2.bbbb.copy() * 2
-    rdm2.abab.vvoo = l2.abab.copy()
-    rdm2.aaaa.vvoo = l2.aaaa.copy() * 2
-    rdm2.bbbb.oovv = t2.bbbb.copy() * 2
-    rdm2.abab.oovv = t2.abab.copy()
-    rdm2.aaaa.oovv = t2.aaaa.copy() * 2
+    rdm2.bbbb.vvoo = np.copy(l2.bbbb) * 2
+    rdm2.abab.vvoo = np.copy(l2.abab)
+    rdm2.aaaa.vvoo = np.copy(l2.aaaa) * 2
+    rdm2.bbbb.oovv = np.copy(t2.bbbb) * 2
+    rdm2.abab.oovv = np.copy(t2.abab)
+    rdm2.aaaa.oovv = np.copy(t2.aaaa) * 2
     rdm2.aaaa.oooo = np.zeros((t2.aaaa.shape[0], t2.aaaa.shape[0], t2.aaaa.shape[0], t2.aaaa.shape[0]))
     rdm2.aaaa.ooov = np.zeros((t2.aaaa.shape[0], t2.aaaa.shape[0], t2.aaaa.shape[0], t2.aaaa.shape[-1]))
     rdm2.aaaa.oovo = np.zeros((t2.aaaa.shape[0], t2.aaaa.shape[0], t2.aaaa.shape[-1], t2.aaaa.shape[0]))
@@ -155,9 +155,9 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.abab = pack_2e(rdm2.abab.oooo, rdm2.abab.ooov, rdm2.abab.oovo, rdm2.abab.ovoo, rdm2.abab.vooo, rdm2.abab.oovv, rdm2.abab.ovov, rdm2.abab.ovvo, rdm2.abab.voov, rdm2.abab.vovo, rdm2.abab.vvoo, rdm2.abab.ovvv, rdm2.abab.vovv, rdm2.abab.vvov, rdm2.abab.vvvo, rdm2.abab.vvvv)
     rdm2.bbbb = pack_2e(rdm2.bbbb.oooo, rdm2.bbbb.ooov, rdm2.bbbb.oovo, rdm2.bbbb.ovoo, rdm2.bbbb.vooo, rdm2.bbbb.oovv, rdm2.bbbb.ovov, rdm2.bbbb.ovvo, rdm2.bbbb.voov, rdm2.bbbb.vovo, rdm2.bbbb.vvoo, rdm2.bbbb.ovvv, rdm2.bbbb.vovv, rdm2.bbbb.vvov, rdm2.bbbb.vvvo, rdm2.bbbb.vvvv)
     rdm2 = Namespace(
-        aaaa=rdm2.aaaa.transpose(0, 2, 1, 3),
-        aabb=rdm2.abab.transpose(0, 2, 1, 3),
-        bbbb=rdm2.bbbb.transpose(0, 2, 1, 3),
+        aaaa=np.transpose(rdm2.aaaa, (0, 2, 1, 3)),
+        aabb=np.transpose(rdm2.abab, (0, 2, 1, 3)),
+        bbbb=np.transpose(rdm2.bbbb, (0, 2, 1, 3)),
     )
     rdm1 = make_rdm1_f(t2=t2, l2=l2)
     delta = Namespace(
@@ -236,11 +236,11 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, v=None, **kwargs):
     ints = kwargs["ints"]
     r1new = Namespace()
     r2new = Namespace()
-    tmp2 = ints.tmp10.copy() * 2
+    tmp2 = np.copy(ints.tmp10) * 2
     del ints.tmp10
     tmp2 += ints.tmp12
     del ints.tmp12
-    tmp0 = ints.tmp2.copy() * 2
+    tmp0 = np.copy(ints.tmp2) * 2
     del ints.tmp2
     tmp0 += ints.tmp4
     del ints.tmp4
@@ -248,20 +248,20 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, v=None, **kwargs):
     tmp7 = einsum(f.bb.oo, (0, 1), r2.bbb, (2, 1, 3), (0, 2, 3))
     tmp4 = einsum(v.aaaa.ooov, (0, 1, 2, 3), r1.a, (1,), (0, 2, 3))
     tmp5 = einsum(f.aa.oo, (0, 1), r2.aaa, (2, 1, 3), (0, 2, 3))
-    tmp3 = f.bb.oo.copy() * 2
+    tmp3 = np.copy(f.bb.oo) * 2
     tmp3 += tmp2
-    tmp3 += tmp2.transpose((1, 0))
+    tmp3 += np.transpose(tmp2, (1, 0))
     del tmp2
-    tmp1 = f.aa.oo.copy() * 2
+    tmp1 = np.copy(f.aa.oo) * 2
     tmp1 += tmp0
-    tmp1 += tmp0.transpose((1, 0))
+    tmp1 += np.transpose(tmp0, (1, 0))
     del tmp0
     r2new.bbb = einsum(f.bb.vv, (0, 1), r2.bbb, (2, 3, 1), (2, 3, 0)) * 2
     r2new.bbb += tmp6 * -1
-    r2new.bbb += tmp6.transpose((1, 0, 2))
+    r2new.bbb += np.transpose(tmp6, (1, 0, 2))
     del tmp6
     r2new.bbb += tmp7 * 2
-    r2new.bbb += tmp7.transpose((1, 0, 2)) * -2
+    r2new.bbb += np.transpose(tmp7, (1, 0, 2)) * -2
     del tmp7
     r2new.bab = einsum(r2.bab, (0, 1, 2), f.bb.vv, (3, 2), (0, 1, 3))
     r2new.bab += einsum(f.bb.oo, (0, 1), r2.bab, (1, 2, 3), (0, 2, 3)) * -1
@@ -273,10 +273,10 @@ def hbar_matvec_ip(f=None, r1=None, r2=None, v=None, **kwargs):
     r2new.aba += einsum(f.aa.oo, (0, 1), r2.aba, (1, 2, 3), (0, 2, 3)) * -1
     r2new.aaa = einsum(r2.aaa, (0, 1, 2), f.aa.vv, (3, 2), (0, 1, 3)) * 2
     r2new.aaa += tmp4 * -1
-    r2new.aaa += tmp4.transpose((1, 0, 2))
+    r2new.aaa += np.transpose(tmp4, (1, 0, 2))
     del tmp4
     r2new.aaa += tmp5 * 2
-    r2new.aaa += tmp5.transpose((1, 0, 2)) * -2
+    r2new.aaa += np.transpose(tmp5, (1, 0, 2)) * -2
     del tmp5
     r1new.b = einsum(v.aabb.ovoo, (0, 1, 2, 3), r2.aba, (0, 3, 1), (2,))
     r1new.b += einsum(v.bbbb.ooov, (0, 1, 2, 3), r2.bbb, (1, 2, 3), (0,)) * -2
@@ -345,33 +345,33 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, v=None, **kwargs):
     tmp7 = einsum(f.bb.vv, (0, 1), r2.bbb, (2, 1, 3), (3, 0, 2))
     tmp5 = einsum(v.aaaa.ovvv, (0, 1, 2, 3), r1.a, (3,), (0, 1, 2))
     tmp4 = einsum(f.aa.vv, (0, 1), r2.aaa, (2, 1, 3), (3, 0, 2))
-    tmp2 = ints.tmp10.copy()
+    tmp2 = np.copy(ints.tmp10)
     del ints.tmp10
     tmp2 += ints.tmp12 * 0.5
     del ints.tmp12
-    tmp0 = ints.tmp2.copy()
+    tmp0 = np.copy(ints.tmp2)
     del ints.tmp2
     tmp0 += ints.tmp4 * 0.5
     del ints.tmp4
-    tmp9 = tmp7.copy() * 2
+    tmp9 = np.copy(tmp7) * 2
     del tmp7
     tmp9 += tmp8
     del tmp8
-    tmp6 = tmp4.copy() * 2
+    tmp6 = np.copy(tmp4) * 2
     del tmp4
     tmp6 += tmp5
     del tmp5
-    tmp3 = f.bb.vv.copy() * -1
+    tmp3 = np.copy(f.bb.vv) * -1
     tmp3 += tmp2
-    tmp3 += tmp2.transpose((1, 0))
+    tmp3 += np.transpose(tmp2, (1, 0))
     del tmp2
-    tmp1 = f.aa.vv.copy() * -1
+    tmp1 = np.copy(f.aa.vv) * -1
     tmp1 += tmp0
-    tmp1 += tmp0.transpose((1, 0))
+    tmp1 += np.transpose(tmp0, (1, 0))
     del tmp0
     r2new.bbb = einsum(f.bb.oo, (0, 1), r2.bbb, (2, 3, 1), (2, 3, 0)) * -2
-    r2new.bbb += tmp9.transpose((1, 2, 0)) * -1
-    r2new.bbb += tmp9.transpose((2, 1, 0))
+    r2new.bbb += np.transpose(tmp9, (1, 2, 0)) * -1
+    r2new.bbb += np.transpose(tmp9, (2, 1, 0))
     del tmp9
     r2new.bab = einsum(r2.bab, (0, 1, 2), f.bb.vv, (3, 0), (3, 1, 2))
     r2new.bab += einsum(f.aa.vv, (0, 1), r2.bab, (2, 1, 3), (2, 0, 3))
@@ -382,8 +382,8 @@ def hbar_matvec_ea(f=None, r1=None, r2=None, v=None, **kwargs):
     r2new.aba += einsum(r1.b, (0,), v.aabb.ovvv, (1, 2, 3, 0), (2, 3, 1)) * -1
     r2new.aba += einsum(f.aa.oo, (0, 1), r2.aba, (2, 3, 1), (2, 3, 0)) * -1
     r2new.aaa = einsum(f.aa.oo, (0, 1), r2.aaa, (2, 3, 1), (2, 3, 0)) * -2
-    r2new.aaa += tmp6.transpose((1, 2, 0)) * -1
-    r2new.aaa += tmp6.transpose((2, 1, 0))
+    r2new.aaa += np.transpose(tmp6, (1, 2, 0)) * -1
+    r2new.aaa += np.transpose(tmp6, (2, 1, 0))
     del tmp6
     r1new.b = einsum(v.bbbb.ovvv, (0, 1, 2, 3), r2.bbb, (3, 1, 0), (2,)) * 2
     r1new.b += einsum(r2.aba, (0, 1, 2), v.aabb.ovvv, (2, 0, 3, 1), (3,)) * -1
@@ -458,10 +458,10 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     ints = kwargs["ints"]
     r1new = Namespace()
     r2new = Namespace()
-    tmp5 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp5 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp1 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp1 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp5 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp5 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
+    tmp1 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1))) * -1
+    tmp1 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp20 = einsum(v.bbbb.ovvv, (0, 1, 2, 3), r1.bb, (4, 3), (4, 0, 1, 2))
     tmp19 = einsum(r1.bb, (0, 1), v.bbbb.ooov, (2, 0, 3, 4), (2, 3, 1, 4))
     tmp15 = einsum(v.aaaa.ovvv, (0, 1, 2, 3), r1.aa, (4, 3), (4, 0, 1, 2))
@@ -474,56 +474,56 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp1
     tmp23 = einsum(f.bb.vv, (0, 1), r2.bbbb, (2, 3, 4, 1), (2, 3, 0, 4))
     tmp22 = einsum(f.bb.oo, (0, 1), r2.bbbb, (2, 1, 3, 4), (0, 2, 3, 4))
-    tmp21 = tmp19.copy()
+    tmp21 = np.copy(tmp19)
     del tmp19
     tmp21 += tmp20
     del tmp20
-    tmp16 = tmp14.copy()
+    tmp16 = np.copy(tmp14)
     del tmp14
     tmp16 += tmp15
     del tmp15
     tmp18 = einsum(r2.aaaa, (0, 1, 2, 3), f.aa.vv, (4, 3), (0, 1, 4, 2))
     tmp17 = einsum(r2.aaaa, (0, 1, 2, 3), f.aa.oo, (4, 1), (4, 0, 2, 3))
-    tmp13 = f.bb.oo.copy()
-    tmp13 += ints.tmp32.transpose((1, 0)) * 2
+    tmp13 = np.copy(f.bb.oo)
+    tmp13 += np.transpose(ints.tmp32, (1, 0)) * 2
     del ints.tmp32
-    tmp13 += ints.tmp34.transpose((1, 0))
+    tmp13 += np.transpose(ints.tmp34, (1, 0))
     del ints.tmp34
-    tmp7 = tmp4.copy()
+    tmp7 = np.copy(tmp4)
     tmp7 += tmp6 * -1
     del tmp6
-    tmp11 = v.bbbb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp11 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 1, 3)))
     tmp11 += v.bbbb.oovv * -1
-    tmp3 = tmp0.copy()
+    tmp3 = np.copy(tmp0)
     tmp3 += tmp2 * -1
     del tmp2
-    tmp12 = ints.tmp23.transpose((1, 0)).copy() * 2
+    tmp12 = np.copy(np.transpose(ints.tmp23, (1, 0))) * 2
     del ints.tmp23
-    tmp12 += ints.tmp25.transpose((1, 0))
+    tmp12 += np.transpose(ints.tmp25, (1, 0))
     del ints.tmp25
     tmp12 += f.bb.vv * -1
-    tmp9 = ints.tmp2.transpose((1, 0)).copy() * 2
+    tmp9 = np.copy(np.transpose(ints.tmp2, (1, 0))) * 2
     del ints.tmp2
-    tmp9 += ints.tmp4.transpose((1, 0))
+    tmp9 += np.transpose(ints.tmp4, (1, 0))
     del ints.tmp4
     tmp9 += f.aa.vv * -1
-    tmp10 = f.aa.oo.copy()
-    tmp10 += ints.tmp17.transpose((1, 0)) * 2
+    tmp10 = np.copy(f.aa.oo)
+    tmp10 += np.transpose(ints.tmp17, (1, 0)) * 2
     del ints.tmp17
-    tmp10 += ints.tmp19.transpose((1, 0))
+    tmp10 += np.transpose(ints.tmp19, (1, 0))
     del ints.tmp19
-    tmp8 = v.aaaa.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp8 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 1, 3)))
     tmp8 += v.aaaa.oovv * -1
-    r2new.bbbb = tmp21.copy() * -1
-    r2new.bbbb += tmp21.transpose((0, 1, 3, 2))
-    r2new.bbbb += tmp21.transpose((1, 0, 2, 3))
-    r2new.bbbb += tmp21.transpose((1, 0, 3, 2)) * -1
+    r2new.bbbb = np.copy(tmp21) * -1
+    r2new.bbbb += np.transpose(tmp21, (0, 1, 3, 2))
+    r2new.bbbb += np.transpose(tmp21, (1, 0, 2, 3))
+    r2new.bbbb += np.transpose(tmp21, (1, 0, 3, 2)) * -1
     del tmp21
-    r2new.bbbb += tmp22.transpose((0, 1, 3, 2)) * -2
-    r2new.bbbb += tmp22.transpose((1, 0, 3, 2)) * 2
+    r2new.bbbb += np.transpose(tmp22, (0, 1, 3, 2)) * -2
+    r2new.bbbb += np.transpose(tmp22, (1, 0, 3, 2)) * 2
     del tmp22
-    r2new.bbbb += tmp23.transpose((1, 0, 2, 3)) * 2
-    r2new.bbbb += tmp23.transpose((1, 0, 3, 2)) * -2
+    r2new.bbbb += np.transpose(tmp23, (1, 0, 2, 3)) * 2
+    r2new.bbbb += np.transpose(tmp23, (1, 0, 3, 2)) * -2
     del tmp23
     r2new.abab = einsum(r1.aa, (0, 1), v.aabb.vvov, (2, 1, 3, 4), (0, 3, 2, 4))
     r2new.abab += einsum(f.aa.vv, (0, 1), r2.abab, (2, 3, 1, 4), (2, 3, 0, 4))
@@ -533,16 +533,16 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     r2new.abab += einsum(v.aabb.ooov, (0, 1, 2, 3), r1.aa, (1, 4), (0, 2, 4, 3)) * -1
     r2new.abab += einsum(f.bb.oo, (0, 1), r2.abab, (2, 1, 3, 4), (2, 0, 3, 4)) * -1
     r2new.abab += einsum(v.aabb.ovoo, (0, 1, 2, 3), r1.bb, (3, 4), (0, 2, 1, 4)) * -1
-    r2new.aaaa = tmp16.copy() * -1
-    r2new.aaaa += tmp16.transpose((0, 1, 3, 2))
-    r2new.aaaa += tmp16.transpose((1, 0, 2, 3))
-    r2new.aaaa += tmp16.transpose((1, 0, 3, 2)) * -1
+    r2new.aaaa = np.copy(tmp16) * -1
+    r2new.aaaa += np.transpose(tmp16, (0, 1, 3, 2))
+    r2new.aaaa += np.transpose(tmp16, (1, 0, 2, 3))
+    r2new.aaaa += np.transpose(tmp16, (1, 0, 3, 2)) * -1
     del tmp16
-    r2new.aaaa += tmp17.transpose((0, 1, 3, 2)) * -2
-    r2new.aaaa += tmp17.transpose((1, 0, 3, 2)) * 2
+    r2new.aaaa += np.transpose(tmp17, (0, 1, 3, 2)) * -2
+    r2new.aaaa += np.transpose(tmp17, (1, 0, 3, 2)) * 2
     del tmp17
-    r2new.aaaa += tmp18.transpose((1, 0, 2, 3)) * 2
-    r2new.aaaa += tmp18.transpose((1, 0, 3, 2)) * -2
+    r2new.aaaa += np.transpose(tmp18, (1, 0, 2, 3)) * 2
+    r2new.aaaa += np.transpose(tmp18, (1, 0, 3, 2)) * -2
     del tmp18
     r1new.bb = einsum(r2.bbbb, (0, 1, 2, 3), v.bbbb.ovvv, (1, 3, 4, 2), (0, 4)) * 2
     r1new.bb += einsum(v.aabb.ovoo, (0, 1, 2, 3), r2.abab, (0, 3, 1, 4), (2, 4)) * -1
@@ -574,7 +574,7 @@ def hbar_matvec_ee(f=None, r1=None, r2=None, t2=None, v=None, **kwargs):
     del tmp9
     r1new.aa += einsum(r1.aa, (0, 1), tmp10, (0, 2), (2, 1)) * -1
     del tmp10
-    r2new.baba = r2new.abab.transpose(1, 0, 3, 2)
+    r2new.baba = np.transpose(r2new.abab, (1, 0, 3, 2))
 
     return {f"r1new": r1new, f"r2new": r2new}
 

--- a/ebcc/codegen/UMP2.py
+++ b/ebcc/codegen/UMP2.py
@@ -155,9 +155,9 @@ def make_rdm2_f(l2=None, t2=None, **kwargs):
     rdm2.abab = pack_2e(rdm2.abab.oooo, rdm2.abab.ooov, rdm2.abab.oovo, rdm2.abab.ovoo, rdm2.abab.vooo, rdm2.abab.oovv, rdm2.abab.ovov, rdm2.abab.ovvo, rdm2.abab.voov, rdm2.abab.vovo, rdm2.abab.vvoo, rdm2.abab.ovvv, rdm2.abab.vovv, rdm2.abab.vvov, rdm2.abab.vvvo, rdm2.abab.vvvv)
     rdm2.bbbb = pack_2e(rdm2.bbbb.oooo, rdm2.bbbb.ooov, rdm2.bbbb.oovo, rdm2.bbbb.ovoo, rdm2.bbbb.vooo, rdm2.bbbb.oovv, rdm2.bbbb.ovov, rdm2.bbbb.ovvo, rdm2.bbbb.voov, rdm2.bbbb.vovo, rdm2.bbbb.vvoo, rdm2.bbbb.ovvv, rdm2.bbbb.vovv, rdm2.bbbb.vvov, rdm2.bbbb.vvvo, rdm2.bbbb.vvvv)
     rdm2 = Namespace(
-        aaaa=rdm2.aaaa.swapaxes(1, 2),
-        aabb=rdm2.abab.swapaxes(1, 2),
-        bbbb=rdm2.bbbb.swapaxes(1, 2),
+        aaaa=rdm2.aaaa.transpose(0, 2, 1, 3),
+        aabb=rdm2.abab.transpose(0, 2, 1, 3),
+        bbbb=rdm2.bbbb.transpose(0, 2, 1, 3),
     )
     rdm1 = make_rdm1_f(t2=t2, l2=l2)
     delta = Namespace(

--- a/ebcc/codegen/UMP3.py
+++ b/ebcc/codegen/UMP3.py
@@ -32,32 +32,32 @@ def energy(t2=None, v=None, **kwargs):
     e_mp : array
     """
 
-    tmp5 = v.bbbb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp5 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 1, 3)))
     tmp5 += v.bbbb.oovv * -1
-    tmp3 = v.aaaa.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp3 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 1, 3)))
     tmp3 += v.aaaa.oovv * -1
-    tmp9 = v.aabb.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp9 = np.copy(np.transpose(v.aabb.ovov, (0, 2, 1, 3)))
     tmp9 += einsum(v.aabb.oovv, (0, 1, 2, 3), t2.abab, (1, 4, 5, 3), (0, 4, 5, 2)) * -1
     tmp9 += einsum(t2.abab, (0, 1, 2, 3), v.aabb.vvoo, (4, 2, 5, 1), (0, 5, 4, 3)) * -1
     tmp9 += einsum(v.aabb.vvvv, (0, 1, 2, 3), t2.abab, (4, 5, 1, 3), (4, 5, 0, 2))
     tmp9 += einsum(tmp5, (0, 1, 2, 3), t2.abab, (4, 0, 5, 2), (4, 1, 5, 3))
     e_mp = einsum(t2.abab, (0, 1, 2, 3), tmp9, (0, 1, 2, 3), ())
     del tmp9
-    tmp4 = v.aaaa.ovov.transpose((0, 2, 1, 3)).copy() * -0.25
+    tmp4 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 1, 3))) * -0.25
     tmp4 += einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (4, 2, 5, 3), (0, 4, 5, 1))
     tmp4 += einsum(v.aaaa.vvvv, (0, 1, 2, 3), t2.aaaa, (4, 5, 3, 1), (4, 5, 0, 2)) * 0.25
     tmp4 += einsum(t2.aaaa, (0, 1, 2, 3), tmp3, (1, 4, 3, 5), (4, 0, 2, 5))
     del tmp3
     e_mp += einsum(t2.aaaa, (0, 1, 2, 3), tmp4, (0, 1, 3, 2), ()) * 4
     del tmp4
-    tmp6 = v.bbbb.ovov.transpose((0, 2, 1, 3)).copy() * -1
+    tmp6 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 1, 3))) * -1
     tmp6 += einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (0, 4, 1, 5), (2, 4, 5, 3)) * 4
     tmp6 += einsum(v.bbbb.vvvv, (0, 1, 2, 3), t2.bbbb, (4, 5, 1, 3), (4, 5, 0, 2)) * -1
     tmp6 += einsum(t2.bbbb, (0, 1, 2, 3), tmp5, (1, 4, 3, 5), (4, 0, 2, 5)) * 4
     del tmp5
     e_mp += einsum(t2.bbbb, (0, 1, 2, 3), tmp6, (0, 1, 3, 2), ())
     del tmp6
-    tmp8 = v.aaaa.ovov.transpose((0, 2, 1, 3)).copy()
+    tmp8 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 1, 3)))
     tmp8 += v.aaaa.oovv * -1
     tmp0 = einsum(t2.aaaa, (0, 1, 2, 3), t2.aaaa, (4, 5, 2, 3), (0, 4, 5, 1))
     e_mp += einsum(v.aaaa.oooo, (0, 1, 2, 3), tmp0, (1, 0, 2, 3), ())

--- a/ebcc/codegen/UQCISD.py
+++ b/ebcc/codegen/UQCISD.py
@@ -64,26 +64,26 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
 
     t1new = Namespace()
     t2new = Namespace()
-    tmp57 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp57 += v.bbbb.ovov.transpose((0, 2, 1, 3)) * -1
-    tmp22 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy()
-    tmp22 += v.aaaa.ovov.transpose((0, 2, 1, 3)) * -1
+    tmp57 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1)))
+    tmp57 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3)) * -1
+    tmp22 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1)))
+    tmp22 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3)) * -1
     tmp16 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.bbbb, (4, 2, 3, 1), (4, 0)) * -1
     tmp15 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (0, 2, 4, 3), (1, 4))
     tmp58 = einsum(t2.bbbb, (0, 1, 2, 3), tmp57, (1, 4, 5, 3), (0, 4, 2, 5))
     del tmp57
-    tmp26 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp26 += v.bbbb.ovov.transpose((0, 2, 1, 3))
+    tmp26 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1))) * -1
+    tmp26 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
     tmp23 = einsum(t2.aaaa, (0, 1, 2, 3), tmp22, (1, 4, 5, 3), (0, 4, 2, 5))
     tmp11 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (4, 2, 1, 3), (4, 0))
     tmp10 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 2, 1, 3), (0, 4))
-    tmp5 = v.bbbb.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp5 += v.bbbb.ovov.transpose((0, 2, 1, 3))
-    tmp1 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp1 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp5 = np.copy(np.transpose(v.bbbb.ovov, (0, 2, 3, 1))) * -1
+    tmp5 += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
+    tmp1 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1))) * -1
+    tmp1 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp46 = einsum(t2.bbbb, (0, 1, 2, 3), v.aabb.ovov, (4, 5, 1, 3), (4, 0, 5, 2))
-    t2new.abab = tmp46.copy() * 2
-    tmp17 = tmp15.copy()
+    t2new.abab = np.copy(tmp46) * 2
+    tmp17 = np.copy(tmp15)
     tmp17 += tmp16 * 2
     t1new.bb = einsum(t1.bb, (0, 1), tmp17, (2, 0), (2, 1)) * -1
     tmp44 = einsum(t2.bbbb, (0, 1, 2, 3), v.bbbb.ovov, (0, 4, 1, 3), (2, 4))
@@ -91,27 +91,27 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp64 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.bbbb, (4, 5, 1, 3), (4, 5, 0, 2))
     tmp61 = einsum(tmp22, (0, 1, 2, 3), t2.abab, (0, 4, 3, 5), (1, 4, 2, 5))
     del tmp22
-    tmp59 = v.bbbb.oovv.copy()
+    tmp59 = np.copy(v.bbbb.oovv)
     tmp59 += tmp58 * -2
     del tmp58
-    tmp48 = v.aaaa.ovov.transpose((0, 2, 3, 1)).copy() * -1
-    tmp48 += v.aaaa.ovov.transpose((0, 2, 1, 3))
+    tmp48 = np.copy(np.transpose(v.aaaa.ovov, (0, 2, 3, 1))) * -1
+    tmp48 += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
     tmp20 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (4, 5, 1, 3), (0, 4, 2, 5))
-    t2new.aaaa = tmp20.copy()
-    t2new.aaaa += tmp20.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp20.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp20.transpose((1, 0, 3, 2))
+    t2new.aaaa = np.copy(tmp20)
+    t2new.aaaa += np.transpose(tmp20, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp20, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp20, (1, 0, 3, 2))
     tmp34 = einsum(v.aaaa.ovov, (0, 1, 2, 3), t2.aaaa, (0, 2, 4, 3), (4, 1))
     tmp35 = einsum(v.aabb.ovov, (0, 1, 2, 3), t2.abab, (0, 2, 4, 3), (4, 1))
     tmp27 = einsum(tmp26, (0, 1, 2, 3), t2.abab, (4, 0, 5, 3), (4, 1, 5, 2))
     del tmp26
     tmp50 = einsum(t2.aaaa, (0, 1, 2, 3), v.aabb.ovov, (1, 3, 4, 5), (0, 4, 2, 5))
     t2new.abab += tmp50 * 2
-    tmp24 = v.aaaa.oovv.copy()
+    tmp24 = np.copy(v.aaaa.oovv)
     tmp24 += tmp23 * -2
     del tmp23
     tmp30 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 3, 5, 2), (0, 1, 4, 5)) * -1
-    tmp39 = tmp10.copy() * 2
+    tmp39 = np.copy(tmp10) * 2
     tmp39 += tmp11
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp39, (4, 0), (4, 1, 2, 3)) * -1
     tmp6 = einsum(t1.bb, (0, 1), tmp5, (0, 2, 3, 1), (2, 3))
@@ -121,100 +121,100 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp2 = einsum(tmp1, (0, 1, 2, 3), t1.aa, (0, 3), (1, 2))
     del tmp1
     tmp0 = einsum(v.aabb.ovov, (0, 1, 2, 3), t1.bb, (2, 3), (0, 1))
-    t1new.aa = tmp0.copy()
+    t1new.aa = np.copy(tmp0)
     tmp66 = einsum(v.bbbb.oooo, (0, 1, 2, 3), t2.bbbb, (3, 1, 4, 5), (0, 2, 4, 5)) * -1
-    t2new.bbbb = tmp66.transpose((1, 0, 3, 2)).copy() * 0.5
-    t2new.bbbb += tmp66.transpose((1, 0, 3, 2)) * 0.5
-    t2new.bbbb += tmp66.transpose((1, 0, 3, 2)) * 0.5
-    t2new.bbbb += tmp66.transpose((1, 0, 3, 2)) * 0.5
+    t2new.bbbb = np.copy(np.transpose(tmp66, (1, 0, 3, 2))) * 0.5
+    t2new.bbbb += np.transpose(tmp66, (1, 0, 3, 2)) * 0.5
+    t2new.bbbb += np.transpose(tmp66, (1, 0, 3, 2)) * 0.5
+    t2new.bbbb += np.transpose(tmp66, (1, 0, 3, 2)) * 0.5
     del tmp66
     tmp56 = einsum(t2.abab, (0, 1, 2, 3), tmp46, (0, 4, 2, 5), (1, 4, 3, 5))
     del tmp46
-    t2new.bbbb += tmp56.transpose((1, 0, 2, 3)) * -2
-    t2new.bbbb += tmp56.transpose((0, 1, 3, 2)) * -2
-    t2new.bbbb += tmp56.transpose((1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp56, (1, 0, 2, 3)) * -2
+    t2new.bbbb += np.transpose(tmp56, (0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp56, (1, 0, 3, 2)) * 2
     t2new.bbbb += tmp56 * 2
     del tmp56
     tmp70 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (0, 2, 4, 5), (1, 4, 3, 5))
     t2new.bbbb += tmp70
-    t2new.bbbb += tmp70.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp70.transpose((1, 0, 2, 3)) * -1
-    t2new.bbbb += tmp70.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp70, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp70, (1, 0, 2, 3)) * -1
+    t2new.bbbb += np.transpose(tmp70, (1, 0, 3, 2))
     del tmp70
     tmp72 = einsum(t2.bbbb, (0, 1, 2, 3), tmp17, (4, 1), (0, 4, 2, 3)) * -1
     del tmp17
-    t2new.bbbb += tmp72.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp72.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp72.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp72.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp72, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp72, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp72, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp72, (0, 1, 3, 2)) * -1
     del tmp72
     tmp63 = einsum(v.bbbb.oovv, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (4, 0, 5, 2))
     t2new.bbbb += tmp63 * -2
-    t2new.bbbb += tmp63.transpose((1, 0, 2, 3)) * 2
+    t2new.bbbb += np.transpose(tmp63, (1, 0, 2, 3)) * 2
     del tmp63
-    tmp71 = f.bb.vv.copy() * -1
+    tmp71 = np.copy(f.bb.vv) * -1
     tmp71 += tmp43
     tmp71 += tmp44 * 2
     t2new.bbbb += einsum(tmp71, (0, 1), t2.bbbb, (2, 3, 4, 1), (2, 3, 0, 4)) * 2
     del tmp71
     tmp69 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.bbbb, (4, 2, 5, 3), (4, 0, 5, 1))
     t2new.bbbb += tmp69 * 2
-    t2new.bbbb += tmp69.transpose((0, 1, 3, 2)) * -2
-    t2new.bbbb += tmp69.transpose((1, 0, 2, 3)) * -2
-    t2new.bbbb += tmp69.transpose((1, 0, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp69, (0, 1, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp69, (1, 0, 2, 3)) * -2
+    t2new.bbbb += np.transpose(tmp69, (1, 0, 3, 2)) * 2
     del tmp69
-    tmp68 = tmp43.copy() * 0.5
+    tmp68 = np.copy(tmp43) * 0.5
     tmp68 += tmp44
     t2new.bbbb += einsum(tmp68, (0, 1), t2.bbbb, (2, 3, 4, 1), (2, 3, 4, 0)) * -4
     del tmp68
     tmp67 = einsum(t2.bbbb, (0, 1, 2, 3), f.bb.oo, (4, 1), (4, 0, 2, 3))
-    t2new.bbbb += tmp67.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp67.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp67.transpose((1, 0, 3, 2))
-    t2new.bbbb += tmp67.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp67, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp67, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp67, (1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp67, (1, 0, 3, 2))
     del tmp67
     tmp65 = einsum(tmp64, (0, 1, 2, 3), t2.bbbb, (3, 2, 4, 5), (1, 0, 4, 5))
     del tmp64
-    t2new.bbbb += tmp65.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp65.transpose((0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp65, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp65, (0, 1, 3, 2)) * -1
     del tmp65
     tmp55 = einsum(v.bbbb.ooov, (0, 1, 2, 3), t1.bb, (1, 4), (0, 2, 4, 3))
-    t2new.bbbb += tmp55.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp55, (1, 0, 2, 3))
     t2new.bbbb += tmp55 * -1
-    t2new.bbbb += tmp55.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp55.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp55, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp55, (0, 1, 3, 2))
     del tmp55
     tmp54 = einsum(v.bbbb.ovvv, (0, 1, 2, 3), t1.bb, (4, 3), (4, 0, 1, 2))
-    t2new.bbbb += tmp54.transpose((1, 0, 3, 2)) * -1
-    t2new.bbbb += tmp54.transpose((0, 1, 3, 2))
+    t2new.bbbb += np.transpose(tmp54, (1, 0, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp54, (0, 1, 3, 2))
     t2new.bbbb += tmp54 * -1
-    t2new.bbbb += tmp54.transpose((1, 0, 2, 3))
+    t2new.bbbb += np.transpose(tmp54, (1, 0, 2, 3))
     del tmp54
     tmp62 = einsum(t2.abab, (0, 1, 2, 3), tmp61, (0, 4, 2, 5), (1, 4, 3, 5))
     del tmp61
-    t2new.bbbb += tmp62.transpose((0, 1, 3, 2)) * -1
-    t2new.bbbb += tmp62.transpose((1, 0, 3, 2))
+    t2new.bbbb += np.transpose(tmp62, (0, 1, 3, 2)) * -1
+    t2new.bbbb += np.transpose(tmp62, (1, 0, 3, 2))
     del tmp62
     tmp60 = einsum(tmp59, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (4, 0, 5, 2))
     del tmp59
-    t2new.bbbb += tmp60.transpose((0, 1, 3, 2)) * 2
-    t2new.bbbb += tmp60.transpose((1, 0, 3, 2)) * -2
+    t2new.bbbb += np.transpose(tmp60, (0, 1, 3, 2)) * 2
+    t2new.bbbb += np.transpose(tmp60, (1, 0, 3, 2)) * -2
     del tmp60
-    tmp45 = tmp43.copy()
+    tmp45 = np.copy(tmp43)
     del tmp43
     tmp45 += tmp44 * 2
     del tmp44
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp45, (4, 3), (0, 1, 2, 4)) * -1
     del tmp45
-    tmp49 = v.aaaa.oovv.copy()
-    tmp49 += tmp20.transpose((1, 0, 3, 2)) * -1
+    tmp49 = np.copy(v.aaaa.oovv)
+    tmp49 += np.transpose(tmp20, (1, 0, 3, 2)) * -1
     tmp49 += einsum(t2.aaaa, (0, 1, 2, 3), tmp48, (1, 4, 5, 3), (4, 0, 5, 2)) * 2
     del tmp48
     t2new.abab += einsum(tmp49, (0, 1, 2, 3), t2.abab, (0, 4, 2, 5), (1, 4, 3, 5)) * -1
     del tmp49
-    tmp47 = f.aa.vv.copy() * -1
-    tmp47 += tmp34.transpose((1, 0)) * 2
-    tmp47 += tmp35.transpose((1, 0))
+    tmp47 = np.copy(f.aa.vv) * -1
+    tmp47 += np.transpose(tmp34, (1, 0)) * 2
+    tmp47 += np.transpose(tmp35, (1, 0))
     t2new.abab += einsum(tmp47, (0, 1), t2.abab, (2, 3, 0, 4), (2, 3, 1, 4)) * -1
     del tmp47
     tmp42 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.oooo, (4, 0, 5, 1), (4, 5, 2, 3))
@@ -224,16 +224,16 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp52 = einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (4, 2, 5, 3), (0, 4, 1, 5))
     t2new.abab += einsum(t2.abab, (0, 1, 2, 3), tmp52, (4, 0, 5, 1), (4, 5, 2, 3))
     del tmp52
-    tmp51 = tmp50.copy() * 2
+    tmp51 = np.copy(tmp50) * 2
     del tmp50
     tmp51 += tmp27 * -1
     t2new.abab += einsum(tmp51, (0, 1, 2, 3), t2.bbbb, (4, 1, 5, 3), (0, 4, 2, 5)) * 2
     del tmp51
-    tmp41 = v.aabb.vvoo.transpose((2, 3, 0, 1)).copy()
+    tmp41 = np.copy(np.transpose(v.aabb.vvoo, (2, 3, 0, 1)))
     tmp41 += einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovov, (0, 4, 5, 3), (5, 1, 4, 2)) * -1
     t2new.abab += einsum(tmp41, (0, 1, 2, 3), t2.abab, (4, 0, 2, 5), (4, 1, 3, 5)) * -1
     del tmp41
-    tmp53 = tmp15.copy() * 0.5
+    tmp53 = np.copy(tmp15) * 0.5
     del tmp15
     tmp53 += tmp16
     del tmp16
@@ -241,59 +241,59 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp53
     tmp28 = einsum(tmp27, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 5, 2)) * -1
     del tmp27
-    t2new.aaaa += tmp28.transpose((1, 0, 2, 3)) * -1
-    t2new.aaaa += tmp28.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp28, (1, 0, 2, 3)) * -1
+    t2new.aaaa += np.transpose(tmp28, (1, 0, 3, 2))
     del tmp28
     tmp19 = einsum(t1.aa, (0, 1), v.aaaa.ooov, (2, 0, 3, 4), (2, 3, 1, 4))
-    t2new.aaaa += tmp19.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp19, (1, 0, 2, 3))
     t2new.aaaa += tmp19 * -1
-    t2new.aaaa += tmp19.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp19.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp19, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp19, (0, 1, 3, 2))
     del tmp19
     tmp33 = einsum(t2.aaaa, (0, 1, 2, 3), f.aa.oo, (4, 1), (4, 0, 2, 3))
-    t2new.aaaa += tmp33.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp33.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp33.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp33.transpose((1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp33, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp33, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp33, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp33, (1, 0, 3, 2))
     del tmp33
     tmp25 = einsum(t2.aaaa, (0, 1, 2, 3), tmp24, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp24
-    t2new.aaaa += tmp25.transpose((0, 1, 3, 2)) * 2
-    t2new.aaaa += tmp25.transpose((1, 0, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp25, (0, 1, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp25, (1, 0, 3, 2)) * -2
     del tmp25
     tmp32 = einsum(v.aaaa.oooo, (0, 1, 2, 3), t2.aaaa, (1, 3, 4, 5), (0, 2, 4, 5))
-    t2new.aaaa += tmp32.transpose((1, 0, 3, 2)) * 0.5
-    t2new.aaaa += tmp32.transpose((1, 0, 3, 2)) * 0.5
-    t2new.aaaa += tmp32.transpose((1, 0, 3, 2)) * 0.5
-    t2new.aaaa += tmp32.transpose((1, 0, 3, 2)) * 0.5
+    t2new.aaaa += np.transpose(tmp32, (1, 0, 3, 2)) * 0.5
+    t2new.aaaa += np.transpose(tmp32, (1, 0, 3, 2)) * 0.5
+    t2new.aaaa += np.transpose(tmp32, (1, 0, 3, 2)) * 0.5
+    t2new.aaaa += np.transpose(tmp32, (1, 0, 3, 2)) * 0.5
     del tmp32
     tmp31 = einsum(tmp30, (0, 1, 2, 3), t2.aaaa, (3, 2, 4, 5), (1, 0, 4, 5))
     del tmp30
-    t2new.aaaa += tmp31.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp31.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp31, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp31, (0, 1, 3, 2)) * -1
     del tmp31
     tmp29 = einsum(v.aaaa.oovv, (0, 1, 2, 3), t2.aaaa, (4, 1, 5, 3), (4, 0, 5, 2))
     t2new.aaaa += tmp29 * -2
-    t2new.aaaa += tmp29.transpose((1, 0, 2, 3)) * 2
+    t2new.aaaa += np.transpose(tmp29, (1, 0, 2, 3)) * 2
     del tmp29
     tmp40 = einsum(t2.aaaa, (0, 1, 2, 3), tmp39, (4, 1), (0, 4, 2, 3)) * -1
     del tmp39
-    t2new.aaaa += tmp40.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp40.transpose((1, 0, 3, 2))
-    t2new.aaaa += tmp40.transpose((0, 1, 3, 2)) * -1
-    t2new.aaaa += tmp40.transpose((0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp40, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp40, (1, 0, 3, 2))
+    t2new.aaaa += np.transpose(tmp40, (0, 1, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp40, (0, 1, 3, 2)) * -1
     del tmp40
-    tmp36 = tmp34.copy()
+    tmp36 = np.copy(tmp34)
     tmp36 += tmp35 * 0.5
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), tmp36, (4, 3), (0, 1, 2, 4)) * -4
     del tmp36
     tmp37 = einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.ovov, (4, 5, 1, 3), (0, 4, 2, 5))
     t2new.aaaa += tmp37 * 2
-    t2new.aaaa += tmp37.transpose((0, 1, 3, 2)) * -2
-    t2new.aaaa += tmp37.transpose((1, 0, 2, 3)) * -2
-    t2new.aaaa += tmp37.transpose((1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp37, (0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp37, (1, 0, 2, 3)) * -2
+    t2new.aaaa += np.transpose(tmp37, (1, 0, 3, 2)) * 2
     del tmp37
-    tmp38 = f.aa.vv.copy() * -1
+    tmp38 = np.copy(f.aa.vv) * -1
     tmp38 += tmp34 * 2
     del tmp34
     tmp38 += tmp35
@@ -302,18 +302,18 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     del tmp38
     tmp21 = einsum(t2.aaaa, (0, 1, 2, 3), tmp20, (4, 1, 5, 3), (0, 4, 2, 5))
     del tmp20
-    t2new.aaaa += tmp21.transpose((1, 0, 2, 3)) * -2
-    t2new.aaaa += tmp21.transpose((0, 1, 3, 2)) * -2
-    t2new.aaaa += tmp21.transpose((1, 0, 3, 2)) * 2
+    t2new.aaaa += np.transpose(tmp21, (1, 0, 2, 3)) * -2
+    t2new.aaaa += np.transpose(tmp21, (0, 1, 3, 2)) * -2
+    t2new.aaaa += np.transpose(tmp21, (1, 0, 3, 2)) * 2
     t2new.aaaa += tmp21 * 2
     del tmp21
     tmp18 = einsum(t1.aa, (0, 1), v.aaaa.ovvv, (2, 3, 4, 1), (0, 2, 3, 4))
-    t2new.aaaa += tmp18.transpose((1, 0, 3, 2)) * -1
-    t2new.aaaa += tmp18.transpose((0, 1, 3, 2))
+    t2new.aaaa += np.transpose(tmp18, (1, 0, 3, 2)) * -1
+    t2new.aaaa += np.transpose(tmp18, (0, 1, 3, 2))
     t2new.aaaa += tmp18 * -1
-    t2new.aaaa += tmp18.transpose((1, 0, 2, 3))
+    t2new.aaaa += np.transpose(tmp18, (1, 0, 2, 3))
     del tmp18
-    tmp7 = f.bb.ov.copy()
+    tmp7 = np.copy(f.bb.ov)
     tmp7 += tmp4
     del tmp4
     tmp7 += tmp6 * -1
@@ -324,7 +324,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp13 = einsum(v.bbbb.ovov, (0, 1, 2, 3), t1.bb, (4, 3), (4, 0, 2, 1))
     t1new.bb += einsum(tmp13, (0, 1, 2, 3), t2.bbbb, (2, 1, 4, 3), (0, 4)) * -2
     del tmp13
-    tmp3 = f.aa.ov.copy()
+    tmp3 = np.copy(f.aa.ov)
     tmp3 += tmp0
     del tmp0
     tmp3 += tmp2 * -1
@@ -338,7 +338,7 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     tmp8 = einsum(v.aabb.ovov, (0, 1, 2, 3), t1.aa, (4, 1), (4, 0, 2, 3))
     t1new.aa += einsum(tmp8, (0, 1, 2, 3), t2.abab, (1, 2, 4, 3), (0, 4)) * -1
     del tmp8
-    tmp12 = tmp10.copy()
+    tmp12 = np.copy(tmp10)
     del tmp10
     tmp12 += tmp11 * 0.5
     del tmp11
@@ -363,12 +363,12 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t1new.bb += einsum(f.bb.vv, (0, 1), t1.bb, (2, 1), (2, 0))
     t1new.bb += einsum(t1.bb, (0, 1), v.bbbb.ovov, (2, 3, 0, 1), (2, 3))
     t1new.bb += einsum(t2.abab, (0, 1, 2, 3), v.aabb.ovvv, (0, 2, 4, 3), (1, 4))
-    t2new.aaaa += v.aaaa.ovov.transpose((0, 2, 1, 3))
-    t2new.aaaa += v.aaaa.ovov.transpose((0, 2, 3, 1)) * -1
+    t2new.aaaa += np.transpose(v.aaaa.ovov, (0, 2, 1, 3))
+    t2new.aaaa += np.transpose(v.aaaa.ovov, (0, 2, 3, 1)) * -1
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), v.aaaa.vvvv, (4, 3, 5, 2), (0, 1, 4, 5)) * -2
     t2new.aaaa += einsum(t2.aaaa, (0, 1, 2, 3), f.aa.vv, (4, 3), (0, 1, 2, 4)) * 2
     t2new.abab += einsum(v.aabb.ovvv, (0, 1, 2, 3), t1.bb, (4, 3), (0, 4, 1, 2))
-    t2new.abab += v.aabb.ovov.transpose((0, 2, 1, 3))
+    t2new.abab += np.transpose(v.aabb.ovov, (0, 2, 1, 3))
     t2new.abab += einsum(t1.bb, (0, 1), v.aabb.ovoo, (2, 3, 4, 0), (2, 4, 3, 1)) * -1
     t2new.abab += einsum(v.aabb.oovv, (0, 1, 2, 3), t2.abab, (1, 4, 5, 3), (0, 4, 5, 2)) * -1
     t2new.abab += einsum(v.aabb.ooov, (0, 1, 2, 3), t1.aa, (1, 4), (0, 2, 4, 3)) * -1
@@ -380,8 +380,8 @@ def update_amps(f=None, t1=None, t2=None, v=None, **kwargs):
     t2new.abab += einsum(v.bbbb.ovov, (0, 1, 2, 3), t2.abab, (4, 2, 5, 3), (4, 0, 5, 1))
     t2new.abab += einsum(v.bbbb.oovv, (0, 1, 2, 3), t2.abab, (4, 1, 5, 3), (4, 0, 5, 2)) * -1
     t2new.abab += einsum(v.aabb.vvvv, (0, 1, 2, 3), t2.abab, (4, 5, 1, 3), (4, 5, 0, 2))
-    t2new.bbbb += v.bbbb.ovov.transpose((0, 2, 1, 3))
-    t2new.bbbb += v.bbbb.ovov.transpose((0, 2, 3, 1)) * -1
+    t2new.bbbb += np.transpose(v.bbbb.ovov, (0, 2, 1, 3))
+    t2new.bbbb += np.transpose(v.bbbb.ovov, (0, 2, 3, 1)) * -1
     t2new.bbbb += einsum(v.bbbb.vvvv, (0, 1, 2, 3), t2.bbbb, (4, 5, 3, 1), (4, 5, 0, 2)) * -2
     t2new.bbbb += einsum(f.bb.vv, (0, 1), t2.bbbb, (2, 3, 4, 1), (2, 3, 4, 0)) * 2
 

--- a/ebcc/core/damping.py
+++ b/ebcc/core/damping.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pyscf.lib import diis
-
 from ebcc import numpy as np
 from ebcc import util
 
@@ -60,7 +58,7 @@ class DIIS:
             xerr: The error vector to push into the DIIS subspace.
         """
         if len(self._indices) >= self.space:
-            self._indices = self._indices[1 - self.space:]
+            self._indices = self._indices[1 - self.space :]
 
         if xerr is not None:
             if self._index >= self.space:

--- a/ebcc/core/damping.py
+++ b/ebcc/core/damping.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from ebcc import numpy as np
 from ebcc import util
-from ebcc.backend import ensure_scalar
+from ebcc.backend import _put, ensure_scalar
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -168,9 +168,9 @@ class DIIS:
         w, v = np.linalg.eigh(h)
         if np.any(np.abs(w) < 1e-14):
             # avoiding fancy indexing for compatibility
-            for i in range(nd):
+            for i in range(nd + 1):
                 if np.abs(w[i]) < 1e-14:
-                    v[:, i] = 0.0
+                    _put(v, np.ix_(np.arange(nd + 1), np.array([i])), np.zeros_like(v[:, i]))
         c = util.einsum("pi,qi,i,q->p", v, np.conj(v), w**-1.0, g)
 
         # Construct the new vector

--- a/ebcc/core/damping.py
+++ b/ebcc/core/damping.py
@@ -112,10 +112,13 @@ class DIIS:
         # this looks crazy, but it's just updating the `self._index`th row and
         # column with the new errors, it's just done this way to avoid using
         # calls to `__setitem__` in immutable backends
-        m_i = np.array([np.dot(np.conj(np.ravel(x1)), np.ravel(self._errors[i])) for i in range(nd)])
+        m_i = np.array([
+            np.ravel(np.dot(np.conj(np.ravel(x1)), np.ravel(self._errors[i])))[0]
+            for i in range(nd)
+        ])
         m_i = np.concatenate([np.array([1.0]), m_i, np.zeros(self.space - nd)])
         m_i = np.reshape(m_i, (-1, 1))
-        m_j = np.conj(m_i.T)
+        m_j = np.conj(np.transpose(m_i))
         pre = slice(0, self._index)
         pos = slice(self._index + 1, self.space + 1)
         self._matrix = np.block(
@@ -160,13 +163,15 @@ class DIIS:
 
         # Solve the linear problem
         w, v = np.linalg.eigh(h)
-        mask = np.abs(w) > 1e-14
-        c = util.einsum("pi,qi,i,q->p", v[:, mask], np.conj(v[:, mask]), 1 / w[mask], g)
+        if np.any(np.abs(w) < 1e-14):
+            mask = np.abs(w) > 1e-14
+            w, v = w[mask], v[:, mask]
+        c = util.einsum("pi,qi,i,q->p", v, np.conj(v), w ** -1, g)
 
         # Construct the new vector
         xnew: NDArray[T] = np.zeros_like(self._arrays[0])
-        for i, ci in enumerate(c[1:]):
+        for i in range(nd):
             xi = self._arrays[i]
-            xnew += xi * ci
+            xnew += xi * c[i + 1]
 
         return xnew

--- a/ebcc/core/damping.py
+++ b/ebcc/core/damping.py
@@ -103,10 +103,12 @@ class DIIS(diis.DIIS):
         # Build the error matrix
         x1 = self.get_err_vec(self._head - 1)
         if self._H is None:
-            self._H = np.block([
-                [np.zeros((1, 1)), np.ones((1, self.space))],
-                [np.ones((self.space, 1)), np.zeros((self.space, self.space))]
-            ])
+            self._H = np.block(
+                [
+                    [np.zeros((1, 1)), np.ones((1, self.space))],
+                    [np.ones((self.space, 1)), np.zeros((self.space, self.space))],
+                ]
+            )
         # this looks crazy, but it's just updating the `self._head`th row and
         # column with the new errors, it's just done this way to avoid using
         # calls to `__setitem__` in immutable backends
@@ -116,11 +118,13 @@ class DIIS(diis.DIIS):
         Hj = Hi.T.conj()
         pre = slice(0, self._head)
         pos = slice(self._head + 1, self.space + 1)
-        self._H = np.block([
-            [self._H[pre, pre], Hi[pre, :], self._H[pre, pos]],
-            [Hj[:, pre], Hi[[self._head]].reshape(1, 1), Hj[:, pos]],
-            [self._H[pos, pre], Hi[pos, :], self._H[pos, pos]],
-        ])
+        self._H = np.block(
+            [
+                [self._H[pre, pre], Hi[pre, :], self._H[pre, pos]],
+                [Hj[:, pre], Hi[[self._head]].reshape(1, 1), Hj[:, pos]],
+                [self._H[pos, pre], Hi[pos, :], self._H[pos, pos]],
+            ]
+        )
 
         if self._xprev is None:
             xnew = self.extrapolate(nd)

--- a/ebcc/core/damping.py
+++ b/ebcc/core/damping.py
@@ -6,6 +6,9 @@ from typing import TYPE_CHECKING
 
 from pyscf.lib import diis
 
+from ebcc import numpy as np
+from ebcc import util
+
 if TYPE_CHECKING:
     from typing import Optional
 
@@ -14,11 +17,19 @@ if TYPE_CHECKING:
 
     T = float64
 
-# TODO Custom version
-
 
 class DIIS(diis.DIIS):
-    """Direct inversion in the iterative subspace."""
+    """Direct inversion in the iterative subspace.
+
+    Adapted from PySCF.
+    """
+
+    _head: int
+    _buffer: dict[str, NDArray[T]]
+    _bookkeep: list[int]
+    _err_vec_touched: bool
+    _H: Optional[NDArray[T]]
+    _xprev: Optional[NDArray[T]]
 
     def __init__(self, space: int = 6, min_space: int = 1, damping: float = 0.0) -> None:
         """Initialize the DIIS object.
@@ -34,15 +45,111 @@ class DIIS(diis.DIIS):
         self.min_space = min_space
         self.damping = damping
 
+    def _store(self, key: str, value: NDArray[T]) -> None:
+        """Store the given values in the DIIS buffer."""
+        self._buffer[key] = value
+
+    def push_err_vec(self, xerr: NDArray[T]) -> None:
+        """Push the error vectors into the DIIS subspace."""
+        self._err_vec_touched = True
+        if self._head >= self.space:
+            self._head = 0
+        self._store(f"e{self._head}", xerr)
+
+    def push_vec(self, x: NDArray[T]) -> None:
+        """Push the vectors into the DIIS subspace."""
+        if len(self._bookkeep) >= self.space:
+            self._bookkeep = self._bookkeep[1 - self.space :]
+
+        if self._err_vec_touched:
+            self._bookkeep.append(self._head)
+            self._store(f"x{self._head}", x)
+            self._head += 1
+        elif self._xprev is None:
+            self._xprev = x
+            self._store("xprev", x)
+        else:
+            if self._head >= self.space:
+                self._head = 0
+            self._bookkeep.append(self._head)
+            self._store(f"x{self._head}", x)
+            self._store(f"e{self._head}", x - self._xprev)
+            self._head += 1
+
+    def get_err_vec(self, idx: int) -> NDArray[T]:
+        """Get the error vectors at the given index."""
+        return self._buffer[f"e{idx}"]
+
+    def get_vec(self, idx: int) -> NDArray[T]:
+        """Get the vectors at the given index."""
+        return self._buffer[f"x{idx}"]
+
+    def get_num_vec(self) -> int:
+        """Get the number of vector groups stored in the DIIS object."""
+        return len(self._bookkeep)
+
     def update(self, x: NDArray[T], xerr: Optional[NDArray[T]] = None) -> NDArray[T]:
         """Extrapolate a vector."""
-        x: NDArray[T] = super().update(x, xerr=xerr)
+        # Push the vector and error vector into the DIIS subspace
+        if xerr is not None:
+            self.push_err_vec(xerr)
+        self.push_vec(x)
+
+        # Check if the DIIS space is less than the minimum space
+        nd = self.get_num_vec()
+        if nd < self.min_space:
+            return x
+
+        # Build the error matrix
+        x1 = self.get_err_vec(self._head - 1)
+        if self._H is None:
+            self._H = np.zeros((self.space + 1, self.space + 1), x1[0].dtype)
+            self._H[0, 1:] = self._H[1:, 0] = 1
+        for i in range(nd):
+            x2 = self.get_err_vec(i)
+            tmp = np.dot(x1.conj(), x2)
+            self._H[self._head, i + 1] = tmp
+            self._H[i + 1, self._head] = tmp.conjugate()
+
+        if self._xprev is None:
+            xnew = self.extrapolate(nd)
+        else:
+            self._xprev = None  # release memory first
+            self._xprev = xnew = self.extrapolate(nd)
+            self._store("xprev", xnew)
 
         # Apply damping
         if self.damping:
             nd = self.get_num_vec()
             if nd > 1:
                 xprev = self.get_vec(self.get_num_vec() - 1)
-                x = (1.0 - self.damping) * x + self.damping * xprev
+                xnew = (1.0 - self.damping) * xnew + self.damping * xprev
 
-        return x
+        return xnew
+
+    def extrapolate(self, nd: Optional[int] = None) -> NDArray[T]:
+        """Extrapolate the next vector."""
+        if nd is None:
+            nd = self.get_num_vec()
+        if nd == 0:
+            raise RuntimeError("No vector found in DIIS object.")
+
+        # Get the linear problem to solve
+        if self._H is None:
+            raise RuntimeError("DIIS object not initialised.")
+        h = self._H[: nd + 1, : nd + 1]
+        g = np.zeros(nd + 1, h.dtype)
+        g[0] = 1
+
+        # Solve the linear problem
+        w, v = np.linalg.eigh(h)
+        mask = np.abs(w) > 1e-14
+        c = util.einsum("pi,qi,i,q->p", v[:, mask], v[:, mask].conj(), 1 / w[mask], g)
+
+        # Construct the new vector
+        xnew: NDArray[T] = np.zeros_like(self.get_vec(0))
+        for i, ci in enumerate(c[1:]):
+            xi = self.get_vec(i)
+            xnew += xi * ci
+
+        return xnew

--- a/ebcc/core/damping.py
+++ b/ebcc/core/damping.py
@@ -121,7 +121,7 @@ class DIIS(diis.DIIS):
         self._H = np.block(
             [
                 [self._H[pre, pre], Hi[pre, :], self._H[pre, pos]],
-                [Hj[:, pre], Hi[[self._head]].reshape(1, 1), Hj[:, pos]],
+                [Hj[:, pre], Hi[self._head, :].reshape(1, 1), Hj[:, pos]],
                 [self._H[pos, pre], Hi[pos, :], self._H[pos, pos]],
             ]
         )

--- a/ebcc/core/damping.py
+++ b/ebcc/core/damping.py
@@ -112,10 +112,12 @@ class DIIS:
         # this looks crazy, but it's just updating the `self._index`th row and
         # column with the new errors, it's just done this way to avoid using
         # calls to `__setitem__` in immutable backends
-        m_i = np.array([
-            np.ravel(np.dot(np.conj(np.ravel(x1)), np.ravel(self._errors[i])))[0]
-            for i in range(nd)
-        ])
+        m_i = np.array(
+            [
+                np.ravel(np.dot(np.conj(np.ravel(x1)), np.ravel(self._errors[i])))[0]
+                for i in range(nd)
+            ]
+        )
         m_i = np.concatenate([np.array([1.0]), m_i, np.zeros(self.space - nd)])
         m_i = np.reshape(m_i, (-1, 1))
         m_j = np.conj(np.transpose(m_i))
@@ -166,7 +168,7 @@ class DIIS:
         if np.any(np.abs(w) < 1e-14):
             mask = np.abs(w) > 1e-14
             w, v = w[mask], v[:, mask]
-        c = util.einsum("pi,qi,i,q->p", v, np.conj(v), w ** -1, g)
+        c = util.einsum("pi,qi,i,q->p", v, np.conj(v), w**-1.0, g)
 
         # Construct the new vector
         xnew: NDArray[T] = np.zeros_like(self._arrays[0])

--- a/ebcc/core/damping.py
+++ b/ebcc/core/damping.py
@@ -112,16 +112,16 @@ class DIIS:
         # this looks crazy, but it's just updating the `self._index`th row and
         # column with the new errors, it's just done this way to avoid using
         # calls to `__setitem__` in immutable backends
-        m_i = np.array([np.dot(x1.ravel().conj(), self._errors[i].ravel()) for i in range(nd)])
+        m_i = np.array([np.dot(np.conj(np.ravel(x1)), np.ravel(self._errors[i])) for i in range(nd)])
         m_i = np.concatenate([np.array([1.0]), m_i, np.zeros(self.space - nd)])
-        m_i = m_i.reshape(-1, 1)
-        m_j = m_i.T.conj()
+        m_i = np.reshape(m_i, (-1, 1))
+        m_j = np.conj(m_i.T)
         pre = slice(0, self._index)
         pos = slice(self._index + 1, self.space + 1)
         self._matrix = np.block(
             [
                 [self._matrix[pre, pre], m_i[pre, :], self._matrix[pre, pos]],
-                [m_j[:, pre], m_i[self._index, :].reshape(1, 1), m_j[:, pos]],
+                [m_j[:, pre], np.reshape(m_i[self._index, :], (1, 1)), m_j[:, pos]],
                 [self._matrix[pos, pre], m_i[pos, :], self._matrix[pos, pos]],
             ]
         )
@@ -161,7 +161,7 @@ class DIIS:
         # Solve the linear problem
         w, v = np.linalg.eigh(h)
         mask = np.abs(w) > 1e-14
-        c = util.einsum("pi,qi,i,q->p", v[:, mask], v[:, mask].conj(), 1 / w[mask], g)
+        c = util.einsum("pi,qi,i,q->p", v[:, mask], np.conj(v[:, mask]), 1 / w[mask], g)
 
         # Construct the new vector
         xnew: NDArray[T] = np.zeros_like(self._arrays[0])

--- a/ebcc/eom/base.py
+++ b/ebcc/eom/base.py
@@ -11,6 +11,7 @@ from pyscf import lib
 
 from ebcc import numpy as np
 from ebcc import util
+from ebcc.backend import to_numpy
 from ebcc.core.logging import ANSI
 from ebcc.core.precision import types
 
@@ -216,13 +217,13 @@ class BaseEOM(ABC):
                 w: NDArray[T], v: NDArray[T], nroots: int, env: dict[str, Any]
             ) -> tuple[NDArray[T], NDArray[T], int]:
                 """Pick the eigenvalues."""
-                x0 = numpy.asarray(lib.linalg_helper._gen_x0(env["v"], env["xs"]))
-                s = numpy.conj(numpy.asarray(guesses)) @ x0.T
-                s = numpy.einsum("pi,pi->i", numpy.conj(s), s)
+                x0 = to_numpy(lib.linalg_helper._gen_x0(env["v"], env["xs"]))
+                s = to_numpy(guesses).conj() @ x0.T
+                s = numpy.einsum("pi,pi->i", s.conj(), s)
                 arg = numpy.argsort(-s)[:nroots]
                 w, v, idx = lib.linalg_helper._eigs_cmplx2real(
-                    numpy.asarray(w),
-                    numpy.asarray(v),
+                    to_numpy(w),
+                    to_numpy(v),
                     arg,
                     real_system,
                 )
@@ -236,8 +237,8 @@ class BaseEOM(ABC):
                 """Pick the eigenvalues."""
                 real_idx = numpy.where(abs(numpy.imag(w)) < 1e-3)[0]
                 w, v, idx = lib.linalg_helper._eigs_cmplx2real(
-                    numpy.asarray(w),
-                    numpy.asarray(v),
+                    to_numpy(w),
+                    to_numpy(v),
                     real_idx,
                     real_system,
                 )
@@ -305,7 +306,7 @@ class BaseEOM(ABC):
         # Get the matrix-vector products and the diagonal:
         ints = self.matvec_intermediates(eris=eris, left=self.options.left)
         matvecs = lambda vs: [
-            numpy.asarray(self.matvec(np.asarray(v), eris=eris, ints=ints, left=self.options.left))
+            to_numpy(self.matvec(np.asarray(v), eris=eris, ints=ints, left=self.options.left))
             for v in vs
         ]
         diag = self.diag(eris=eris)
@@ -319,8 +320,8 @@ class BaseEOM(ABC):
         pick = self.get_pick(guesses=np.stack(guesses))
         converged, e, v = lib.davidson_nosym1(
             matvecs,
-            [numpy.asarray(g) for g in guesses],
-            numpy.asarray(diag),
+            [to_numpy(g) for g in guesses],
+            to_numpy(diag),
             tol=self.options.e_tol,
             nroots=nroots,
             pick=pick,

--- a/ebcc/eom/base.py
+++ b/ebcc/eom/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/ebcc/eom/base.py
+++ b/ebcc/eom/base.py
@@ -217,8 +217,8 @@ class BaseEOM(ABC):
             ) -> tuple[NDArray[T], NDArray[T], int]:
                 """Pick the eigenvalues."""
                 x0 = numpy.asarray(lib.linalg_helper._gen_x0(env["v"], env["xs"]))
-                s = numpy.asarray(guesses).conj() @ x0.T
-                s = numpy.einsum("pi,pi->i", s.conj(), s)
+                s = numpy.conj(numpy.asarray(guesses)) @ x0.T
+                s = numpy.einsum("pi,pi->i", numpy.conj(s), s)
                 arg = numpy.argsort(-s)[:nroots]
                 w, v, idx = lib.linalg_helper._eigs_cmplx2real(
                     numpy.asarray(w),
@@ -234,7 +234,7 @@ class BaseEOM(ABC):
                 w: NDArray[T], v: NDArray[T], nroots: int, env: dict[str, Any]
             ) -> tuple[NDArray[T], NDArray[T], int]:
                 """Pick the eigenvalues."""
-                real_idx = numpy.where(abs(w.imag) < 1e-3)[0]
+                real_idx = numpy.where(abs(numpy.imag(w)) < 1e-3)[0]
                 w, v, idx = lib.linalg_helper._eigs_cmplx2real(
                     numpy.asarray(w),
                     numpy.asarray(v),
@@ -344,8 +344,8 @@ class BaseEOM(ABC):
 
         # Update attributes:
         self.converged = converged
-        self.e = e.astype(types[float])
-        self.v = np.asarray(v).T.astype(types[float])
+        self.e = np.astype(e, types[float])
+        self.v = np.astype(np.asarray(v).T, types[float])
 
         self.log.debug("")
         self.log.output(
@@ -355,7 +355,7 @@ class BaseEOM(ABC):
             r1n = self.vector_to_amplitudes(vn)["r1"]
             qpwt = self._quasiparticle_weight(r1n)
             self.log.output(
-                f"{n:>4d} {en.item():>16.10f} {qpwt:>13.5g} "
+                f"{n:>4d} {np.ravel(en)[0]:>16.10f} {qpwt:>13.5g} "
                 f"{[ANSI.r, ANSI.g][bool(cn)]}{cn!r:>8s}{ANSI.R}"
             )
 

--- a/ebcc/eom/base.py
+++ b/ebcc/eom/base.py
@@ -246,7 +246,7 @@ class BaseEOM(ABC):
         return pick
 
     @abstractmethod
-    def _argsort_guesses(self, diag: NDArray[T]) -> NDArray[int64]:
+    def _argsort_guesses(self, diag: NDArray[T]) -> list[int]:
         """Sort the diagonal to inform the initial guesses."""
         pass
 
@@ -344,14 +344,14 @@ class BaseEOM(ABC):
 
         # Update attributes:
         self.converged = converged
-        self.e = np.astype(e, types[float])
-        self.v = np.astype(np.asarray(v).T, types[float])
+        self.e = np.asarray(e, dtype=types[float])
+        self.v = np.transpose(np.asarray(v, dtype=types[float]))
 
         self.log.debug("")
         self.log.output(
             f"{ANSI.B}{'Root':>4s} {'Energy':>16s} {'Weight':>13s} {'Conv.':>8s}{ANSI.R}"
         )
-        for n, (en, vn, cn) in enumerate(zip(self.e, self.v.T, converged)):
+        for n, (en, vn, cn) in enumerate(zip(self.e, np.transpose(self.v), converged)):
             r1n = self.vector_to_amplitudes(vn)["r1"]
             qpwt = self._quasiparticle_weight(r1n)
             self.log.output(

--- a/ebcc/eom/base.py
+++ b/ebcc/eom/base.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/ebcc/eom/base.py
+++ b/ebcc/eom/base.py
@@ -305,9 +305,7 @@ class BaseEOM(ABC):
         # Get the matrix-vector products and the diagonal:
         ints = self.matvec_intermediates(eris=eris, left=self.options.left)
         matvecs = lambda vs: [
-            numpy.asarray(
-                self.matvec(np.asarray(v), eris=eris, ints=ints, left=self.options.left)
-            )
+            numpy.asarray(self.matvec(np.asarray(v), eris=eris, ints=ints, left=self.options.left))
             for v in vs
         ]
         diag = self.diag(eris=eris)

--- a/ebcc/eom/base.py
+++ b/ebcc/eom/base.py
@@ -17,7 +17,7 @@ from ebcc.core.precision import types
 if TYPE_CHECKING:
     from typing import Any, Callable, Optional
 
-    from numpy import float64, int64
+    from numpy import float64
     from numpy.typing import NDArray
 
     from ebcc.cc.base import BaseEBCC, ERIsInputType, SpaceType, SpinArrayType

--- a/ebcc/eom/geom.py
+++ b/ebcc/eom/geom.py
@@ -11,7 +11,7 @@ from ebcc.eom.base import BaseEA_EOM, BaseEE_EOM, BaseEOM, BaseIP_EOM
 if TYPE_CHECKING:
     from typing import Optional
 
-    from numpy import float64, int64
+    from numpy import float64
     from numpy.typing import NDArray
 
     from ebcc.cc.gebcc import GEBCC, ERIsInputType, SpinArrayType
@@ -32,7 +32,7 @@ class GEOM(BaseEOM):
 class IP_GEOM(GEOM, BaseIP_EOM):
     """Generalised ionisation potential equation-of-motion coupled cluster."""
 
-    def _argsort_guesses(self, diag: NDArray[T]) -> NDArray[int64]:
+    def _argsort_guesses(self, diag: NDArray[T]) -> list[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]
@@ -128,7 +128,7 @@ class IP_GEOM(GEOM, BaseIP_EOM):
 class EA_GEOM(GEOM, BaseEA_EOM):
     """Generalised electron affinity equation-of-motion coupled cluster."""
 
-    def _argsort_guesses(self, diag: NDArray[T]) -> NDArray[int64]:
+    def _argsort_guesses(self, diag: NDArray[T]) -> list[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]
@@ -224,7 +224,7 @@ class EA_GEOM(GEOM, BaseEA_EOM):
 class EE_GEOM(GEOM, BaseEE_EOM):
     """Generalised electron-electron equation-of-motion coupled cluster."""
 
-    def _argsort_guesses(self, diag: NDArray[T]) -> NDArray[int64]:
+    def _argsort_guesses(self, diag: NDArray[T]) -> list[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]

--- a/ebcc/eom/geom.py
+++ b/ebcc/eom/geom.py
@@ -80,7 +80,7 @@ class IP_GEOM(GEOM, BaseIP_EOM):
         for name, key, n in self.ansatz.fermionic_cluster_ranks(
             spin_type=self.spin_type, which="ip"
         ):
-            vectors.append(util.compress_axes(key, amplitudes[name]).ravel())
+            vectors.append(np.ravel(util.compress_axes(key, amplitudes[name])))
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="ip"):
             raise util.ModelNotImplemented
@@ -176,7 +176,7 @@ class EA_GEOM(GEOM, BaseEA_EOM):
         for name, key, n in self.ansatz.fermionic_cluster_ranks(
             spin_type=self.spin_type, which="ea"
         ):
-            vectors.append(util.compress_axes(key, amplitudes[name]).ravel())
+            vectors.append(np.ravel(util.compress_axes(key, amplitudes[name])))
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="ea"):
             raise util.ModelNotImplemented
@@ -272,7 +272,7 @@ class EE_GEOM(GEOM, BaseEE_EOM):
         for name, key, n in self.ansatz.fermionic_cluster_ranks(
             spin_type=self.spin_type, which="ee"
         ):
-            vectors.append(util.compress_axes(key, amplitudes[name]).ravel())
+            vectors.append(np.ravel(util.compress_axes(key, amplitudes[name])))
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="ee"):
             raise util.ModelNotImplemented

--- a/ebcc/eom/geom.py
+++ b/ebcc/eom/geom.py
@@ -36,9 +36,9 @@ class IP_GEOM(GEOM, BaseIP_EOM):
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]
-            arg = np.argsort(np.abs(diag[: r1.size]))
+            arg = util.argsort(np.abs(diag[: r1.size]))
         else:
-            arg = np.argsort(np.abs(diag))
+            arg = util.argsort(np.abs(diag))
         return arg
 
     def _quasiparticle_weight(self, r1: SpinArrayType) -> T:
@@ -132,9 +132,9 @@ class EA_GEOM(GEOM, BaseEA_EOM):
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]
-            arg = np.argsort(np.abs(diag[: r1.size]))
+            arg = util.argsort(np.abs(diag[: r1.size]))
         else:
-            arg = np.argsort(np.abs(diag))
+            arg = util.argsort(np.abs(diag))
         return arg
 
     def _quasiparticle_weight(self, r1: SpinArrayType) -> T:
@@ -228,9 +228,9 @@ class EE_GEOM(GEOM, BaseEE_EOM):
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]
-            arg = np.argsort(diag[: r1.size])
+            arg = util.argsort(diag[: r1.size])
         else:
-            arg = np.argsort(diag)
+            arg = util.argsort(diag)
         return arg
 
     def _quasiparticle_weight(self, r1: SpinArrayType) -> T:

--- a/ebcc/eom/reom.py
+++ b/ebcc/eom/reom.py
@@ -32,13 +32,13 @@ class REOM(BaseEOM):
 class IP_REOM(REOM, BaseIP_EOM):
     """Restricted ionisation potential equation-of-motion coupled cluster."""
 
-    def _argsort_guesses(self, diag: NDArray[T]) -> NDArray[int64]:
+    def _argsort_guesses(self, diag: NDArray[T]) -> list[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]
-            arg = np.argsort(np.abs(diag[: r1.size]))
+            arg = util.argsort(np.abs(diag[: r1.size]))
         else:
-            arg = np.argsort(np.abs(diag))
+            arg = util.argsort(np.abs(diag))
         return arg
 
     def _quasiparticle_weight(self, r1: SpinArrayType) -> T:
@@ -126,13 +126,13 @@ class IP_REOM(REOM, BaseIP_EOM):
 class EA_REOM(REOM, BaseEA_EOM):
     """Restricted electron affinity equation-of-motion coupled cluster."""
 
-    def _argsort_guesses(self, diag: NDArray[T]) -> NDArray[int64]:
+    def _argsort_guesses(self, diag: NDArray[T]) -> list[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]
-            arg = np.argsort(np.abs(diag[: r1.size]))
+            arg = util.argsort(np.abs(diag[: r1.size]))
         else:
-            arg = np.argsort(np.abs(diag))
+            arg = util.argsort(np.abs(diag))
         return arg
 
     def _quasiparticle_weight(self, r1: SpinArrayType) -> T:
@@ -224,9 +224,9 @@ class EE_REOM(REOM, BaseEE_EOM):
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]
-            arg = np.argsort(diag[: r1.size])
+            arg = util.argsort(diag[: r1.size])
         else:
-            arg = np.argsort(diag)
+            arg = util.argsort(diag)
         return arg
 
     def _quasiparticle_weight(self, r1: SpinArrayType) -> T:

--- a/ebcc/eom/reom.py
+++ b/ebcc/eom/reom.py
@@ -11,7 +11,7 @@ from ebcc.eom.base import BaseEA_EOM, BaseEE_EOM, BaseEOM, BaseIP_EOM
 if TYPE_CHECKING:
     from typing import Optional
 
-    from numpy import float64, int64
+    from numpy import float64
     from numpy.typing import NDArray
 
     from ebcc.cc.rebcc import REBCC, ERIsInputType, SpinArrayType
@@ -220,7 +220,7 @@ class EA_REOM(REOM, BaseEA_EOM):
 class EE_REOM(REOM, BaseEE_EOM):
     """Restricted electron-electron equation-of-motion coupled cluster."""
 
-    def _argsort_guesses(self, diag: NDArray[T]) -> NDArray[int64]:
+    def _argsort_guesses(self, diag: NDArray[T]) -> list[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]

--- a/ebcc/eom/reom.py
+++ b/ebcc/eom/reom.py
@@ -80,7 +80,7 @@ class IP_REOM(REOM, BaseIP_EOM):
         for name, key, n in self.ansatz.fermionic_cluster_ranks(
             spin_type=self.spin_type, which="ip"
         ):
-            vectors.append(amplitudes[name].ravel())
+            vectors.append(np.ravel(amplitudes[name]))
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="ip"):
             raise util.ModelNotImplemented
@@ -109,7 +109,7 @@ class IP_REOM(REOM, BaseIP_EOM):
         ):
             shape = tuple(self.space.size(k) for k in key)
             size = util.prod(shape)
-            amplitudes[name] = vector[i0 : i0 + size].reshape(shape)
+            amplitudes[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="ip"):
@@ -174,7 +174,7 @@ class EA_REOM(REOM, BaseEA_EOM):
         for name, key, n in self.ansatz.fermionic_cluster_ranks(
             spin_type=self.spin_type, which="ea"
         ):
-            vectors.append(amplitudes[name].ravel())
+            vectors.append(np.ravel(amplitudes[name]))
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="ea"):
             raise util.ModelNotImplemented
@@ -203,7 +203,7 @@ class EA_REOM(REOM, BaseEA_EOM):
         ):
             shape = tuple(self.space.size(k) for k in key)
             size = util.prod(shape)
-            amplitudes[name] = vector[i0 : i0 + size].reshape(shape)
+            amplitudes[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="ea"):
@@ -268,7 +268,7 @@ class EE_REOM(REOM, BaseEE_EOM):
         for name, key, n in self.ansatz.fermionic_cluster_ranks(
             spin_type=self.spin_type, which="ee"
         ):
-            vectors.append(amplitudes[name].ravel())
+            vectors.append(np.ravel(amplitudes[name]))
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="ee"):
             raise util.ModelNotImplemented
@@ -297,7 +297,7 @@ class EE_REOM(REOM, BaseEE_EOM):
         ):
             shape = tuple(self.space.size(k) for k in key)
             size = util.prod(shape)
-            amplitudes[name] = vector[i0 : i0 + size].reshape(shape)
+            amplitudes[name] = np.reshape(vector[i0 : i0 + size], shape)
             i0 += size
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="ee"):

--- a/ebcc/eom/ueom.py
+++ b/ebcc/eom/ueom.py
@@ -86,7 +86,7 @@ class IP_UEOM(UEOM, BaseIP_EOM):
             for spin in util.generate_spin_combinations(n, excited=True, unique=True):
                 vn = amplitudes[name][spin]
                 subscript, _ = util.combine_subscripts(key, spin)
-                vectors.append(util.compress_axes(subscript, vn).ravel())
+                vectors.append(np.ravel(util.compress_axes(subscript, vn)))
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="ip"):
             raise util.ModelNotImplemented
@@ -201,7 +201,7 @@ class EA_UEOM(UEOM, BaseEA_EOM):
             for spin in util.generate_spin_combinations(n, excited=True, unique=True):
                 vn = amplitudes[name][spin]
                 subscript, _ = util.combine_subscripts(key, spin)
-                vectors.append(util.compress_axes(subscript, vn).ravel())
+                vectors.append(np.ravel(util.compress_axes(subscript, vn)))
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="ea"):
             raise util.ModelNotImplemented
@@ -316,7 +316,7 @@ class EE_UEOM(UEOM, BaseEE_EOM):
             for spin in util.generate_spin_combinations(n, unique=True):
                 vn = amplitudes[name][spin]
                 subscript, _ = util.combine_subscripts(key, spin)
-                vectors.append(util.compress_axes(subscript, vn).ravel())
+                vectors.append(np.ravel(util.compress_axes(subscript, vn)))
 
         for name, key, n in self.ansatz.bosonic_cluster_ranks(spin_type=self.spin_type, which="ee"):
             raise util.ModelNotImplemented

--- a/ebcc/eom/ueom.py
+++ b/ebcc/eom/ueom.py
@@ -11,7 +11,7 @@ from ebcc.eom.base import BaseEA_EOM, BaseEE_EOM, BaseEOM, BaseIP_EOM
 if TYPE_CHECKING:
     from typing import Optional
 
-    from numpy import float64, int64
+    from numpy import float64
     from numpy.typing import NDArray
 
     from ebcc.cc.uebcc import UEBCC, ERIsInputType, SpinArrayType
@@ -32,7 +32,7 @@ class UEOM(BaseEOM):
 class IP_UEOM(UEOM, BaseIP_EOM):
     """Unrestricted ionisation potential equation-of-motion coupled cluster."""
 
-    def _argsort_guesses(self, diag: NDArray[T]) -> NDArray[int64]:
+    def _argsort_guesses(self, diag: NDArray[T]) -> list[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]
@@ -147,7 +147,7 @@ class IP_UEOM(UEOM, BaseIP_EOM):
 class EA_UEOM(UEOM, BaseEA_EOM):
     """Unrestricted electron affinity equation-of-motion coupled cluster."""
 
-    def _argsort_guesses(self, diag: NDArray[T]) -> NDArray[int64]:
+    def _argsort_guesses(self, diag: NDArray[T]) -> list[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]
@@ -262,7 +262,7 @@ class EA_UEOM(UEOM, BaseEA_EOM):
 class EE_UEOM(UEOM, BaseEE_EOM):
     """Unrestricted electron-electron equation-of-motion coupled cluster."""
 
-    def _argsort_guesses(self, diag: NDArray[T]) -> NDArray[int64]:
+    def _argsort_guesses(self, diag: NDArray[T]) -> list[int]:
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]

--- a/ebcc/eom/ueom.py
+++ b/ebcc/eom/ueom.py
@@ -36,9 +36,9 @@ class IP_UEOM(UEOM, BaseIP_EOM):
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]
-            arg = np.argsort(np.abs(diag[: r1.a.size + r1.b.size]))
+            arg = util.argsort(np.abs(diag[: r1.a.size + r1.b.size]))
         else:
-            arg = np.argsort(np.abs(diag))
+            arg = util.argsort(np.abs(diag))
         return arg
 
     def _quasiparticle_weight(self, r1: SpinArrayType) -> T:
@@ -151,9 +151,9 @@ class EA_UEOM(UEOM, BaseEA_EOM):
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]
-            arg = np.argsort(np.abs(diag[: r1.a.size + r1.b.size]))
+            arg = util.argsort(np.abs(diag[: r1.a.size + r1.b.size]))
         else:
-            arg = np.argsort(np.abs(diag))
+            arg = util.argsort(np.abs(diag))
         return arg
 
     def _quasiparticle_weight(self, r1: SpinArrayType) -> T:
@@ -266,9 +266,9 @@ class EE_UEOM(UEOM, BaseEE_EOM):
         """Sort the diagonal to inform the initial guesses."""
         if self.options.koopmans:
             r1 = self.vector_to_amplitudes(diag)["r1"]
-            arg = np.argsort(diag[: r1.aa.size + r1.bb.size])
+            arg = util.argsort(diag[: r1.aa.size + r1.bb.size])
         else:
-            arg = np.argsort(diag)
+            arg = util.argsort(diag)
         return arg
 
     def _quasiparticle_weight(self, r1: SpinArrayType) -> T:

--- a/ebcc/ham/cderis.py
+++ b/ebcc/ham/cderis.py
@@ -9,6 +9,7 @@ from pyscf import ao2mo, lib
 
 from ebcc import numpy as np
 from ebcc import util
+from ebcc.backend import to_numpy
 from ebcc.core.precision import types
 from ebcc.ham.base import BaseERIs, BaseRHamiltonian, BaseUHamiltonian
 
@@ -57,9 +58,7 @@ class RCDERIs(BaseERIs, BaseRHamiltonian):
         if key_e2 not in self._members:
             s = 0 if not e2 else 2
             coeffs = [
-                numpy.asarray(
-                    self.mo_coeff[i + s][:, self.space[i + s].slice(k)], dtype=numpy.float64
-                )
+                to_numpy(self.mo_coeff[i + s][:, self.space[i + s].slice(k)], dtype=numpy.float64)
                 for i, k in enumerate(key)
             ]
             ijslice = (

--- a/ebcc/ham/cderis.py
+++ b/ebcc/ham/cderis.py
@@ -57,7 +57,9 @@ class RCDERIs(BaseERIs, BaseRHamiltonian):
         if key_e2 not in self._members:
             s = 0 if not e2 else 2
             coeffs = [
-                numpy.asarray(self.mo_coeff[i + s][:, self.space[i + s].slice(k)], dtype=numpy.float64)
+                numpy.asarray(
+                    self.mo_coeff[i + s][:, self.space[i + s].slice(k)], dtype=numpy.float64
+                )
                 for i, k in enumerate(key)
             ]
             ijslice = (

--- a/ebcc/ham/cderis.py
+++ b/ebcc/ham/cderis.py
@@ -71,7 +71,7 @@ class RCDERIs(BaseERIs, BaseRHamiltonian):
                 self.cc.mf.with_df._cderi, coeffs, ijslice, aosym="s2", mosym="s1"
             )
             block = block.reshape(-1, ijslice[1] - ijslice[0], ijslice[3] - ijslice[2])
-            self._members[key_e2] = block.astype(types[float])
+            self._members[key_e2] = np.asarray(block, dtype=types[float])
 
         return self._members[key_e2]
 

--- a/ebcc/ham/cderis.py
+++ b/ebcc/ham/cderis.py
@@ -57,7 +57,7 @@ class RCDERIs(BaseERIs, BaseRHamiltonian):
         if key_e2 not in self._members:
             s = 0 if not e2 else 2
             coeffs = [
-                numpy.asarray(self.mo_coeff[i + s][:, self.space[i + s].mask(k)], dtype=numpy.float64)
+                numpy.asarray(self.mo_coeff[i + s][:, self.space[i + s].slice(k)], dtype=numpy.float64)
                 for i, k in enumerate(key)
             ]
             ijslice = (

--- a/ebcc/ham/cderis.py
+++ b/ebcc/ham/cderis.py
@@ -57,7 +57,7 @@ class RCDERIs(BaseERIs, BaseRHamiltonian):
         if key_e2 not in self._members:
             s = 0 if not e2 else 2
             coeffs = [
-                self.mo_coeff[i + s][:, self.space[i + s].mask(k)].astype(numpy.float64)
+                numpy.asarray(self.mo_coeff[i + s][:, self.space[i + s].mask(k)], dtype=numpy.float64)
                 for i, k in enumerate(key)
             ]
             ijslice = (
@@ -70,7 +70,7 @@ class RCDERIs(BaseERIs, BaseRHamiltonian):
             block = ao2mo._ao2mo.nr_e2(
                 self.cc.mf.with_df._cderi, coeffs, ijslice, aosym="s2", mosym="s1"
             )
-            block = block.reshape(-1, ijslice[1] - ijslice[0], ijslice[3] - ijslice[2])
+            block = np.reshape(block, (-1, ijslice[1] - ijslice[0], ijslice[3] - ijslice[2]))
             self._members[key_e2] = np.asarray(block, dtype=types[float])
 
         return self._members[key_e2]

--- a/ebcc/ham/elbos.py
+++ b/ebcc/ham/elbos.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ebcc.ham.base import BaseElectronBoson, BaseGHamiltonian, BaseRHamiltonian, BaseUHamiltonian
+from ebcc import numpy as np
 
 if TYPE_CHECKING:
     from numpy import float64
@@ -31,7 +32,7 @@ class RElectronBoson(BaseElectronBoson, BaseRHamiltonian):
             assert key[0] == "b"
             i = self.space[0].mask(key[1])
             j = self.space[1].mask(key[2])
-            self._members[key] = self.array[:, i][:, :, j].copy()
+            self._members[key] = np.copy(self.array[:, i][:, :, j])
         return self._members[key]
 
     def _get_g(self) -> NDArray[T]:
@@ -89,7 +90,7 @@ class GElectronBoson(BaseElectronBoson, BaseGHamiltonian):
             assert key[0] == "b"
             i = self.space[0].mask(key[1])
             j = self.space[1].mask(key[2])
-            self._members[key] = self.array[:, i][:, :, j].copy()
+            self._members[key] = np.copy(self.array[:, i][:, :, j])
         return self._members[key]
 
     def _get_g(self) -> NDArray[T]:

--- a/ebcc/ham/elbos.py
+++ b/ebcc/ham/elbos.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ebcc.ham.base import BaseElectronBoson, BaseGHamiltonian, BaseRHamiltonian, BaseUHamiltonian
 from ebcc import numpy as np
+from ebcc.ham.base import BaseElectronBoson, BaseGHamiltonian, BaseRHamiltonian, BaseUHamiltonian
 
 if TYPE_CHECKING:
     from numpy import float64

--- a/ebcc/ham/elbos.py
+++ b/ebcc/ham/elbos.py
@@ -30,9 +30,9 @@ class RElectronBoson(BaseElectronBoson, BaseRHamiltonian):
         """
         if key not in self._members:
             assert key[0] == "b"
-            i = self.space[0].mask(key[1])
-            j = self.space[1].mask(key[2])
-            self._members[key] = np.copy(self.array[:, i][:, :, j])
+            i = self.space[0].slice(key[1])
+            j = self.space[1].slice(key[2])
+            self._members[key] = np.copy(self.array[:, i, j])
         return self._members[key]
 
     def _get_g(self) -> NDArray[T]:
@@ -88,9 +88,9 @@ class GElectronBoson(BaseElectronBoson, BaseGHamiltonian):
         """
         if key not in self._members:
             assert key[0] == "b"
-            i = self.space[0].mask(key[1])
-            j = self.space[1].mask(key[2])
-            self._members[key] = np.copy(self.array[:, i][:, :, j])
+            i = self.space[0].slice(key[1])
+            j = self.space[1].slice(key[2])
+            self._members[key] = np.copy(self.array[:, i, j])
         return self._members[key]
 
     def _get_g(self) -> NDArray[T]:

--- a/ebcc/ham/eris.py
+++ b/ebcc/ham/eris.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import numpy  # PySCF uses true numpy, no backend stuff here
 from pyscf import ao2mo
 
+from ebcc import numpy as np
 from ebcc.core.precision import types
 from ebcc.ham.base import BaseERIs, BaseGHamiltonian, BaseRHamiltonian, BaseUHamiltonian
 
@@ -37,7 +38,7 @@ class RERIs(BaseERIs, BaseRHamiltonian):
         if self.array is None:
             if key not in self._members.keys():
                 coeffs = [
-                    self.mo_coeff[i][:, self.space[i].mask(k)].astype(numpy.float64)
+                    numpy.asarray(self.mo_coeff[i][:, self.space[i].mask(k)], dtype=numpy.float64)
                     for i, k in enumerate(key)
                 ]
                 if getattr(self.cc.mf, "_eri", None) is not None:
@@ -45,7 +46,7 @@ class RERIs(BaseERIs, BaseRHamiltonian):
                 else:
                     block = ao2mo.kernel(self.cc.mf.mol, coeffs, compact=False)
                 block = block.reshape([c.shape[-1] for c in coeffs])
-                self._members[key] = block.astype(types[float])
+                self._members[key] = np.asarray(block.astype(types[float]))
             return self._members[key]
         else:
             i, j, k, l = [self.space[i].mask(k) for i, k in enumerate(key)]
@@ -81,7 +82,7 @@ class UERIs(BaseERIs, BaseUHamiltonian):
             elif isinstance(self.cc.mf._eri, tuple):
                 # Support spin-dependent integrals in the mean-field
                 coeffs = [
-                    self.mo_coeff[x][y].astype(numpy.float64)
+                    numpy.asarray(self.mo_coeff[x][y], dtype=numpy.float64)
                     for y, x in enumerate(sorted((i, i, j, j)))
                 ]
                 if getattr(self.cc.mf, "_eri", None) is not None:
@@ -90,7 +91,7 @@ class UERIs(BaseERIs, BaseUHamiltonian):
                     array = ao2mo.kernel(self.cc.mf.mol, coeffs, compact=False)
                 if key == "bbaa":
                     array = array.transpose(2, 3, 0, 1)
-                array = array.astype(types[float])
+                array = np.asarray(array, dtype=types[float])
             else:
                 array = None
 
@@ -118,8 +119,12 @@ class GERIs(BaseERIs, BaseGHamiltonian):
         """Initialise the class."""
         super().__init__(*args, **kwargs)
         if self.array is None:
-            mo_a = [mo[: self.cc.mf.mol.nao].astype(numpy.float64) for mo in self.mo_coeff]
-            mo_b = [mo[self.cc.mf.mol.nao :].astype(numpy.float64) for mo in self.mo_coeff]
+            mo_a = [
+                numpy.asarray(mo[: self.cc.mf.mol.nao], dtype=numpy.float64) for mo in self.mo_coeff
+            ]
+            mo_b = [
+                numpy.asarray(mo[self.cc.mf.mol.nao :], dtype=numpy.float64) for mo in self.mo_coeff
+            ]
             if getattr(self.cc.mf, "_eri", None) is not None:
                 array = ao2mo.incore.general(self.cc.mf._eri, mo_a)
                 array += ao2mo.incore.general(self.cc.mf._eri, mo_b)
@@ -131,7 +136,7 @@ class GERIs(BaseERIs, BaseGHamiltonian):
                 array += ao2mo.kernel(self.cc.mf.mol, mo_a[:2] + mo_b[2:])
                 array += ao2mo.kernel(self.cc.mf.mol, mo_b[:2] + mo_a[2:])
             array = ao2mo.addons.restore(1, array, self.cc.nmo).reshape((self.cc.nmo,) * 4)
-            array = array.astype(types[float])
+            array = np.asarray(array, dtype=types[float])
             array = array.transpose(0, 2, 1, 3) - array.transpose(0, 2, 3, 1)
             self.__dict__["array"] = array
 

--- a/ebcc/ham/eris.py
+++ b/ebcc/ham/eris.py
@@ -45,8 +45,8 @@ class RERIs(BaseERIs, BaseRHamiltonian):
                     block = ao2mo.incore.general(self.cc.mf._eri, coeffs, compact=False)
                 else:
                     block = ao2mo.kernel(self.cc.mf.mol, coeffs, compact=False)
-                block = block.reshape([c.shape[-1] for c in coeffs])
-                self._members[key] = np.asarray(block.astype(types[float]))
+                block = np.reshape(block, [c.shape[-1] for c in coeffs])
+                self._members[key] = np.asarray(np.astype(block, types[float]))
             return self._members[key]
         else:
             i, j, k, l = [self.space[i].mask(k) for i, k in enumerate(key)]
@@ -78,7 +78,7 @@ class UERIs(BaseERIs, BaseUHamiltonian):
             if self.array is not None:
                 array = self.array[ij]
                 if key == "bbaa":
-                    array = array.transpose(2, 3, 0, 1)
+                    array = np.transpose(array, (2, 3, 0, 1))
             elif isinstance(self.cc.mf._eri, tuple):
                 # Support spin-dependent integrals in the mean-field
                 coeffs = [
@@ -90,7 +90,7 @@ class UERIs(BaseERIs, BaseUHamiltonian):
                 else:
                     array = ao2mo.kernel(self.cc.mf.mol, coeffs, compact=False)
                 if key == "bbaa":
-                    array = array.transpose(2, 3, 0, 1)
+                    array = np.transpose(array, (2, 3, 0, 1))
                 array = np.asarray(array, dtype=types[float])
             else:
                 array = None
@@ -135,9 +135,9 @@ class GERIs(BaseERIs, BaseGHamiltonian):
                 array += ao2mo.kernel(self.cc.mf.mol, mo_b)
                 array += ao2mo.kernel(self.cc.mf.mol, mo_a[:2] + mo_b[2:])
                 array += ao2mo.kernel(self.cc.mf.mol, mo_b[:2] + mo_a[2:])
-            array = ao2mo.addons.restore(1, array, self.cc.nmo).reshape((self.cc.nmo,) * 4)
+            array = np.reshape(ao2mo.addons.restore(1, array, self.cc.nmo), (self.cc.nmo,) * 4)
             array = np.asarray(array, dtype=types[float])
-            array = array.transpose(0, 2, 1, 3) - array.transpose(0, 2, 3, 1)
+            array = np.transpose(array, (0, 2, 1, 3)) - np.transpose(array, (0, 2, 3, 1))
             self.__dict__["array"] = array
 
     def __getitem__(self, key: str) -> NDArray[T]:

--- a/ebcc/ham/eris.py
+++ b/ebcc/ham/eris.py
@@ -8,6 +8,7 @@ import numpy  # PySCF uses true numpy, no backend stuff here
 from pyscf import ao2mo
 
 from ebcc import numpy as np
+from ebcc.backend import to_numpy
 from ebcc.core.precision import types
 from ebcc.ham.base import BaseERIs, BaseGHamiltonian, BaseRHamiltonian, BaseUHamiltonian
 
@@ -38,7 +39,7 @@ class RERIs(BaseERIs, BaseRHamiltonian):
         if self.array is None:
             if key not in self._members.keys():
                 coeffs = [
-                    numpy.asarray(self.mo_coeff[i][:, self.space[i].slice(k)], dtype=numpy.float64)
+                    to_numpy(self.mo_coeff[i][:, self.space[i].slice(k)], dtype=numpy.float64)
                     for i, k in enumerate(key)
                 ]
                 if getattr(self.cc.mf, "_eri", None) is not None:
@@ -46,7 +47,7 @@ class RERIs(BaseERIs, BaseRHamiltonian):
                 else:
                     block = ao2mo.kernel(self.cc.mf.mol, coeffs, compact=False)
                 block = np.reshape(block, [c.shape[-1] for c in coeffs])
-                self._members[key] = np.asarray(np.astype(block, types[float]))
+                self._members[key] = np.asarray(block, dtype=types[float])
             return self._members[key]
         else:
             ijkl = tuple(self.space[i].slice(k) for i, k in enumerate(key))
@@ -82,7 +83,7 @@ class UERIs(BaseERIs, BaseUHamiltonian):
             elif isinstance(self.cc.mf._eri, tuple):
                 # Support spin-dependent integrals in the mean-field
                 coeffs = [
-                    numpy.asarray(self.mo_coeff[x][y], dtype=numpy.float64)
+                    to_numpy(self.mo_coeff[x][y], dtype=numpy.float64)
                     for y, x in enumerate(sorted((i, i, j, j)))
                 ]
                 if getattr(self.cc.mf, "_eri", None) is not None:
@@ -119,12 +120,8 @@ class GERIs(BaseERIs, BaseGHamiltonian):
         """Initialise the class."""
         super().__init__(*args, **kwargs)
         if self.array is None:
-            mo_a = [
-                numpy.asarray(mo[: self.cc.mf.mol.nao], dtype=numpy.float64) for mo in self.mo_coeff
-            ]
-            mo_b = [
-                numpy.asarray(mo[self.cc.mf.mol.nao :], dtype=numpy.float64) for mo in self.mo_coeff
-            ]
+            mo_a = [to_numpy(mo[: self.cc.mf.mol.nao], dtype=numpy.float64) for mo in self.mo_coeff]
+            mo_b = [to_numpy(mo[self.cc.mf.mol.nao :], dtype=numpy.float64) for mo in self.mo_coeff]
             if getattr(self.cc.mf, "_eri", None) is not None:
                 array = ao2mo.incore.general(self.cc.mf._eri, mo_a)
                 array += ao2mo.incore.general(self.cc.mf._eri, mo_b)

--- a/ebcc/ham/eris.py
+++ b/ebcc/ham/eris.py
@@ -38,7 +38,7 @@ class RERIs(BaseERIs, BaseRHamiltonian):
         if self.array is None:
             if key not in self._members.keys():
                 coeffs = [
-                    numpy.asarray(self.mo_coeff[i][:, self.space[i].mask(k)], dtype=numpy.float64)
+                    numpy.asarray(self.mo_coeff[i][:, self.space[i].slice(k)], dtype=numpy.float64)
                     for i, k in enumerate(key)
                 ]
                 if getattr(self.cc.mf, "_eri", None) is not None:
@@ -49,8 +49,8 @@ class RERIs(BaseERIs, BaseRHamiltonian):
                 self._members[key] = np.asarray(np.astype(block, types[float]))
             return self._members[key]
         else:
-            i, j, k, l = [self.space[i].mask(k) for i, k in enumerate(key)]
-            return self.array[i][:, j][:, :, k][:, :, :, l]  # type: ignore
+            ijkl = tuple(self.space[i].slice(k) for i, k in enumerate(key))
+            return self.array[ijkl]  # type: ignore
 
 
 class UERIs(BaseERIs, BaseUHamiltonian):
@@ -149,5 +149,5 @@ class GERIs(BaseERIs, BaseGHamiltonian):
         Returns:
             ERIs for the given spaces.
         """
-        i, j, k, l = [self.space[i].mask(k) for i, k in enumerate(key)]
-        return self.array[i][:, j][:, :, k][:, :, :, l]  # type: ignore
+        ijkl = tuple(self.space[i].slice(k) for i, k in enumerate(key))
+        return self.array[ijkl]  # type: ignore

--- a/ebcc/ham/fock.py
+++ b/ebcc/ham/fock.py
@@ -37,12 +37,12 @@ class RFock(BaseFock, BaseRHamiltonian):
         if key not in self._members:
             i = self.space[0].mask(key[0])
             j = self.space[1].mask(key[1])
-            self._members[key] = self.array[i][:, j].copy()
+            self._members[key] = np.copy(self.array[i][:, j])
 
             if self.shift:
                 xi = self.xi
-                g = self.g.__getattr__(f"b{key}").copy()
-                g += self.g.__getattr__(f"b{key[::-1]}").transpose(0, 2, 1)
+                g = np.copy(self.g.__getattr__(f"b{key}"))
+                g += np.transpose(self.g.__getattr__(f"b{key[::-1]}"), (0, 2, 1))
                 self._members[key] -= util.einsum("I,Ipq->pq", xi, g)
 
         return self._members[key]
@@ -104,12 +104,12 @@ class GFock(BaseFock, BaseGHamiltonian):
         if key not in self._members:
             i = self.space[0].mask(key[0])
             j = self.space[1].mask(key[1])
-            self._members[key] = self.array[i][:, j].copy()
+            self._members[key] = np.copy(self.array[i][:, j])
 
             if self.shift:
                 xi = self.xi
-                g = self.g.__getattr__(f"b{key}").copy()
-                g += self.g.__getattr__(f"b{key[::-1]}").transpose(0, 2, 1)
+                g = np.copy(self.g.__getattr__(f"b{key}"))
+                g += np.transpose(self.g.__getattr__(f"b{key[::-1]}"), (0, 2, 1))
                 self._members[key] -= util.einsum("I,Ipq->pq", xi, g)
 
         return self._members[key]

--- a/ebcc/ham/fock.py
+++ b/ebcc/ham/fock.py
@@ -35,9 +35,9 @@ class RFock(BaseFock, BaseRHamiltonian):
             Fock matrix for the given spaces.
         """
         if key not in self._members:
-            i = self.space[0].mask(key[0])
-            j = self.space[1].mask(key[1])
-            self._members[key] = np.copy(self.array[i][:, j])
+            i = self.space[0].slice(key[0])
+            j = self.space[1].slice(key[1])
+            self._members[key] = np.copy(self.array[i, j])
 
             if self.shift:
                 xi = self.xi
@@ -102,9 +102,9 @@ class GFock(BaseFock, BaseGHamiltonian):
             Fock matrix for the given spin.
         """
         if key not in self._members:
-            i = self.space[0].mask(key[0])
-            j = self.space[1].mask(key[1])
-            self._members[key] = np.copy(self.array[i][:, j])
+            i = self.space[0].slice(key[0])
+            j = self.space[1].slice(key[1])
+            self._members[key] = np.copy(self.array[i, j])
 
             if self.shift:
                 xi = self.xi

--- a/ebcc/ham/fock.py
+++ b/ebcc/ham/fock.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ebcc import numpy as np
 from ebcc import util
 from ebcc.core.precision import types
 from ebcc.ham.base import BaseFock, BaseGHamiltonian, BaseRHamiltonian, BaseUHamiltonian
@@ -21,7 +22,7 @@ class RFock(BaseFock, BaseRHamiltonian):
     _members: dict[str, NDArray[T]]
 
     def _get_fock(self) -> NDArray[T]:
-        fock_ao = self.cc.mf.get_fock().astype(types[float])
+        fock_ao: NDArray[T] = np.asarray(self.cc.mf.get_fock(), dtype=types[float])
         return util.einsum("pq,pi,qj->ij", fock_ao, self.mo_coeff[0], self.mo_coeff[1])
 
     def __getitem__(self, key: str) -> NDArray[T]:
@@ -53,7 +54,7 @@ class UFock(BaseFock, BaseUHamiltonian):
     _members: dict[str, RFock]
 
     def _get_fock(self) -> tuple[NDArray[T], NDArray[T]]:
-        fock_ao = self.cc.mf.get_fock().astype(types[float])
+        fock_ao: NDArray[T] = np.asarray(self.cc.mf.get_fock(), dtype=types[float])
         return (
             util.einsum("pq,pi,qj->ij", fock_ao[0], self.mo_coeff[0][0], self.mo_coeff[1][0]),
             util.einsum("pq,pi,qj->ij", fock_ao[1], self.mo_coeff[0][1], self.mo_coeff[1][1]),
@@ -88,7 +89,7 @@ class GFock(BaseFock, BaseGHamiltonian):
     _members: dict[str, NDArray[T]]
 
     def _get_fock(self) -> NDArray[T]:
-        fock_ao = self.cc.mf.get_fock().astype(types[float])
+        fock_ao: NDArray[T] = np.asarray(self.cc.mf.get_fock(), dtype=types[float])
         return util.einsum("pq,pi,qj->ij", fock_ao, self.mo_coeff[0], self.mo_coeff[1])
 
     def __getitem__(self, key: str) -> NDArray[T]:

--- a/ebcc/ham/space.py
+++ b/ebcc/ham/space.py
@@ -418,13 +418,13 @@ def construct_fno_space(
     dm1: NDArray[T]
     if not amplitudes:
         solver.kernel()
-        dm1 = np.astype(solver.make_rdm1(), types[float])
+        dm1 = np.asarray(solver.make_rdm1(), dtype=types[float])
     else:
         if isinstance(amplitudes.t2, util.Namespace):
             t2 = (amplitudes.t2.aaaa, amplitudes.t2.abab, amplitudes.t2.bbbb)
-            dm1 = np.astype(solver.make_rdm1(t2=t2), types[float])
+            dm1 = np.asarray(solver.make_rdm1(t2=t2), dtype=types[float])
         else:
-            dm1 = np.astype(solver.make_rdm1(t2=amplitudes.t2), types[float])
+            dm1 = np.asarray(solver.make_rdm1(t2=amplitudes.t2), dtype=types[float])
 
     # def _construct(dm1, mo_energy, mo_coeff, mo_occ):
     def _construct(
@@ -479,22 +479,22 @@ def construct_fno_space(
     # Construct the natural orbitals
     if mf.mo_occ.ndim == 2:
         coeff_a, occ_a, space_a = _construct(
-            np.astype(dm1[0], types[float]),
-            np.astype(mf.mo_energy[0], types[float]),
-            np.astype(mf.mo_coeff[0], types[float]),
-            np.astype(mf.mo_occ[0], types[float]),
+            np.asarray(dm1[0], dtype=types[float]),
+            np.asarray(mf.mo_energy[0], dtype=types[float]),
+            np.asarray(mf.mo_coeff[0], dtype=types[float]),
+            np.asarray(mf.mo_occ[0], dtype=types[float]),
         )
         coeff_b, occ_b, space_b = _construct(
-            np.astype(dm1[1], types[float]),
-            np.astype(mf.mo_energy[1], types[float]),
-            np.astype(mf.mo_coeff[1], types[float]),
-            np.astype(mf.mo_occ[1], types[float]),
+            np.asarray(dm1[1], dtype=types[float]),
+            np.asarray(mf.mo_energy[1], dtype=types[float]),
+            np.asarray(mf.mo_coeff[1], dtype=types[float]),
+            np.asarray(mf.mo_occ[1], dtype=types[float]),
         )
         return (coeff_a, coeff_b), (occ_a, occ_b), (space_a, space_b)
     else:
         return _construct(
-            np.astype(dm1, types[float]),
-            np.astype(mf.mo_energy, types[float]),
-            np.astype(mf.mo_coeff, types[float]),
-            np.astype(mf.mo_occ, types[float]),
+            np.asarray(dm1, dtype=types[float]),
+            np.asarray(mf.mo_energy, dtype=types[float]),
+            np.asarray(mf.mo_coeff, dtype=types[float]),
+            np.asarray(mf.mo_occ, dtype=types[float]),
         )

--- a/ebcc/ham/space.py
+++ b/ebcc/ham/space.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
     T = float64
     B = bool_
+    _slice = slice
 
 # Development note: multiplication of boolean arrays is used in place of logical or bitwise
 # AND functions. This is because backends are not guaranteed to support logical or bitwise
@@ -124,8 +125,8 @@ class Space:
             "a": self.inactive_virtual,
         }[char]
 
-    @functools.lru_cache(maxsize=128)
-    def slice(self, char: str) -> slice:
+    @functools.lru_cache(maxsize=128)  # noqa: B019
+    def slice(self, char: str) -> _slice:
         """Convert a character corresponding to a space to a slice of that space.
 
         Args:
@@ -169,7 +170,7 @@ class Space:
         """
         return self.mask(char)[self.virtual]
 
-    def oslice(self, char: str) -> slice:
+    def oslice(self, char: str) -> _slice:
         """Like `slice`, but returns only a slice into only the occupied sector.
 
         Args:
@@ -182,7 +183,7 @@ class Space:
         nocc = self.nocc
         return slice(s.start, min(s.stop, nocc))
 
-    def vslice(self, char: str) -> slice:
+    def vslice(self, char: str) -> _slice:
         """Like `slice`, but returns only a slice into only the virtual sector.
 
         Args:
@@ -414,6 +415,7 @@ def construct_fno_space(
     """
     # Get the MP2 1RDM
     solver = MP2(mf)
+    dm1: NDArray[T]
     if not amplitudes:
         solver.kernel()
         dm1 = np.astype(solver.make_rdm1(), types[float])

--- a/ebcc/ham/space.py
+++ b/ebcc/ham/space.py
@@ -58,9 +58,9 @@ class Space:
             frozen: Array containing boolean flags indicating whether or not each orbital is frozen.
             active: Array containing boolean flags indicating whether or not each orbital is active.
         """
-        self._occupied = np.asarray(occupied, dtype=bool)
-        self._frozen = np.asarray(frozen, dtype=bool)
-        self._active = np.asarray(active, dtype=bool)
+        self._occupied = np.asarray(occupied, dtype=np.bool_)
+        self._frozen = np.asarray(frozen, dtype=np.bool_)
+        self._active = np.asarray(active, dtype=np.bool_)
 
         # Checks:
         if not (self._occupied.size == self._frozen.size == self._active.size):
@@ -319,8 +319,8 @@ def construct_default_space(mf: SCF) -> Union[RConstructSpaceReturnType, UConstr
 
     def _construct(mo_occ: NDArray[T]) -> Space:
         """Build the default space."""
-        frozen = np.zeros(mo_occ.shape, dtype=bool)
-        active = np.zeros(mo_occ.shape, dtype=bool)
+        frozen = np.zeros(mo_occ.shape, dtype=np.bool_)
+        active = np.zeros(mo_occ.shape, dtype=np.bool_)
         space = Space(
             occupied=mo_occ > 0,
             frozen=frozen,
@@ -404,11 +404,11 @@ def construct_fno_space(
         no_coeff = np.concatenate((no_coeff_occ, no_coeff_avir, no_coeff_fvir), axis=1)
 
         # Build the natural orbital space
-        active = np.zeros(mo_occ.shape, dtype=bool)
+        active = np.zeros(mo_occ.shape, dtype=np.bool_)
         frozen = np.concatenate(
             (
-                np.zeros((nocc + num_active_vir,), dtype=bool),
-                np.ones((mo_occ.size - nocc - num_active_vir,), dtype=bool),
+                np.zeros((nocc + num_active_vir,), dtype=np.bool_),
+                np.ones((mo_occ.size - nocc - num_active_vir,), dtype=np.bool_),
             )
         )
         no_space = Space(

--- a/ebcc/ham/space.py
+++ b/ebcc/ham/space.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 from typing import TYPE_CHECKING, cast
 
 from pyscf.mp import MP2
@@ -70,7 +71,7 @@ class Space:
         # Checks:
         if not (self._occupied.size == self._frozen.size == self._active.size):
             raise ValueError("The sizes of the space arrays must match.")
-        if np.any(self._frozen * self._active):
+        if np.any(np.bitwise_and(self._frozen, self._active)):
             raise ValueError("Frozen and active orbitals must be mutually exclusive.")
 
     def __repr__(self) -> str:
@@ -123,6 +124,29 @@ class Space:
             "a": self.inactive_virtual,
         }[char]
 
+    @functools.lru_cache(maxsize=128)
+    def slice(self, char: str) -> slice:
+        """Convert a character corresponding to a space to a slice of that space.
+
+        Args:
+            char: Character to convert.
+
+        Returns:
+            Slice of the space.
+        """
+        # Check that the respective mask is contiguous
+        mask = self.mask(char)
+        first = np.argmax(mask)
+        size = self.size(char)
+        if not np.all(mask[first : first + size]):
+            raise ValueError(
+                f"Space '{char}' is not contiguous. In order to slice into this space, "
+                "the `mask` method must be used. If you see this error internally, it is "
+                "likely that you have constructed a disjoint space. Please reorder the "
+                "orbitals in the space."
+            )
+        return slice(first, first + size)
+
     def omask(self, char: str) -> NDArray[B]:
         """Like `mask`, but returns only a mask into only the occupied sector.
 
@@ -145,6 +169,32 @@ class Space:
         """
         return self.mask(char)[self.virtual]
 
+    def oslice(self, char: str) -> slice:
+        """Like `slice`, but returns only a slice into only the occupied sector.
+
+        Args:
+            char: Character to convert.
+
+        Returns:
+            Slice of the space.
+        """
+        s = self.slice(char)
+        nocc = self.nocc
+        return slice(s.start, min(s.stop, nocc))
+
+    def vslice(self, char: str) -> slice:
+        """Like `slice`, but returns only a slice into only the virtual sector.
+
+        Args:
+            char: Character to convert.
+
+        Returns:
+            Slice of the space.
+        """
+        s = self.slice(char)
+        nocc = self.nocc
+        return slice(max(s.start, nocc) - nocc, s.stop - nocc)
+
     # Full space:
 
     @property
@@ -152,86 +202,86 @@ class Space:
         """Get a boolean mask of occupied orbitals."""
         return self._occupied
 
-    @property
+    @functools.cached_property
     def virtual(self) -> NDArray[B]:
         """Get a boolean mask of virtual orbitals."""
-        return np.ones_like(self.occupied) - self.occupied
+        return np.bitwise_not(self.occupied)
 
     @property
     def nmo(self) -> int:
         """Get the number of orbitals."""
         return self.occupied.size
 
-    @property
+    @functools.cached_property
     def nocc(self) -> int:
         """Get the number of occupied orbitals."""
         return cast(int, np.sum(self.occupied))
 
-    @property
+    @functools.cached_property
     def nvir(self) -> int:
         """Get the number of virtual orbitals."""
         return cast(int, np.sum(self.virtual))
 
     # Correlated space:
 
-    @property
+    @functools.cached_property
     def correlated(self) -> NDArray[B]:
         """Get a boolean mask of correlated orbitals."""
-        return np.ones_like(self.frozen) - self.frozen
+        return np.bitwise_not(self.frozen)
 
-    @property
+    @functools.cached_property
     def correlated_occupied(self) -> NDArray[B]:
         """Get a boolean mask of occupied correlated orbitals."""
-        return self.correlated * self.occupied
+        return np.bitwise_and(self.correlated, self.occupied)
 
-    @property
+    @functools.cached_property
     def correlated_virtual(self) -> NDArray[B]:
         """Get a boolean mask of virtual correlated orbitals."""
-        return self.correlated * self.virtual
+        return np.bitwise_and(self.correlated, self.virtual)
 
-    @property
+    @functools.cached_property
     def ncorr(self) -> int:
         """Get the number of correlated orbitals."""
         return cast(int, np.sum(self.correlated))
 
-    @property
+    @functools.cached_property
     def ncocc(self) -> int:
         """Get the number of occupied correlated orbitals."""
         return cast(int, np.sum(self.correlated_occupied))
 
-    @property
+    @functools.cached_property
     def ncvir(self) -> int:
         """Get the number of virtual correlated orbitals."""
         return cast(int, np.sum(self.correlated_virtual))
 
     # Inactive space:
 
-    @property
+    @functools.cached_property
     def inactive(self) -> NDArray[B]:
         """Get a boolean mask of inactive orbitals."""
-        return np.ones_like(self.active) - self.active
+        return np.bitwise_not(self.active)
 
-    @property
+    @functools.cached_property
     def inactive_occupied(self) -> NDArray[B]:
         """Get a boolean mask of occupied inactive orbitals."""
-        return self.inactive * self.occupied
+        return np.bitwise_and(self.inactive, self.occupied)
 
-    @property
+    @functools.cached_property
     def inactive_virtual(self) -> NDArray[B]:
         """Get a boolean mask of virtual inactive orbitals."""
-        return self.inactive * self.virtual
+        return np.bitwise_and(self.inactive, self.virtual)
 
-    @property
+    @functools.cached_property
     def ninact(self) -> int:
         """Get the number of inactive orbitals."""
         return cast(int, np.sum(self.inactive))
 
-    @property
+    @functools.cached_property
     def niocc(self) -> int:
         """Get the number of occupied inactive orbitals."""
         return cast(int, np.sum(self.inactive_occupied))
 
-    @property
+    @functools.cached_property
     def nivir(self) -> int:
         """Get the number of virtual inactive orbitals."""
         return cast(int, np.sum(self.inactive_virtual))
@@ -243,27 +293,27 @@ class Space:
         """Get a boolean mask of frozen orbitals."""
         return self._frozen
 
-    @property
+    @functools.cached_property
     def frozen_occupied(self) -> NDArray[B]:
         """Get a boolean mask of occupied frozen orbitals."""
-        return self.frozen * self.occupied
+        return np.bitwise_and(self.frozen, self.occupied)
 
-    @property
+    @functools.cached_property
     def frozen_virtual(self) -> NDArray[B]:
         """Get a boolean mask of virtual frozen orbitals."""
-        return self.frozen * self.virtual
+        return np.bitwise_and(self.frozen, self.virtual)
 
-    @property
+    @functools.cached_property
     def nfroz(self) -> int:
         """Get the number of frozen orbitals."""
         return cast(int, np.sum(self.frozen))
 
-    @property
+    @functools.cached_property
     def nfocc(self) -> int:
         """Get the number of occupied frozen orbitals."""
         return cast(int, np.sum(self.frozen_occupied))
 
-    @property
+    @functools.cached_property
     def nfvir(self) -> int:
         """Get the number of virtual frozen orbitals."""
         return cast(int, np.sum(self.frozen_virtual))
@@ -275,27 +325,27 @@ class Space:
         """Get a boolean mask of active orbitals."""
         return self._active
 
-    @property
+    @functools.cached_property
     def active_occupied(self) -> NDArray[B]:
         """Get a boolean mask of occupied active orbitals."""
-        return self.active * self.occupied
+        return np.bitwise_and(self.active, self.occupied)
 
-    @property
+    @functools.cached_property
     def active_virtual(self) -> NDArray[B]:
         """Get a boolean mask of virtual active orbitals."""
-        return self.active * self.virtual
+        return np.bitwise_and(self.active, self.virtual)
 
-    @property
+    @functools.cached_property
     def nact(self) -> int:
         """Get the number of active orbitals."""
         return cast(int, np.sum(self.active))
 
-    @property
+    @functools.cached_property
     def naocc(self) -> int:
         """Get the number of occupied active orbitals."""
         return cast(int, np.sum(self.active_occupied))
 
-    @property
+    @functools.cached_property
     def navir(self) -> int:
         """Get the number of virtual active orbitals."""
         return cast(int, np.sum(self.active_virtual))

--- a/ebcc/ham/space.py
+++ b/ebcc/ham/space.py
@@ -65,7 +65,7 @@ class Space:
         # Checks:
         if not (self._occupied.size == self._frozen.size == self._active.size):
             raise ValueError("The sizes of the space arrays must match.")
-        if (self._frozen & self._active).any():
+        if np.any(self._frozen & self._active):
             raise ValueError("Frozen and active orbitals must be mutually exclusive.")
 
     def __repr__(self) -> str:
@@ -160,12 +160,12 @@ class Space:
     @property
     def nocc(self) -> int:
         """Get the number of occupied orbitals."""
-        return cast(int, self.occupied.sum())
+        return cast(int, np.sum(self.occupied))
 
     @property
     def nvir(self) -> int:
         """Get the number of virtual orbitals."""
-        return cast(int, self.virtual.sum())
+        return cast(int, np.sum(self.virtual))
 
     # Correlated space:
 
@@ -187,17 +187,17 @@ class Space:
     @property
     def ncorr(self) -> int:
         """Get the number of correlated orbitals."""
-        return cast(int, self.correlated.sum())
+        return cast(int, np.sum(self.correlated))
 
     @property
     def ncocc(self) -> int:
         """Get the number of occupied correlated orbitals."""
-        return cast(int, self.correlated_occupied.sum())
+        return cast(int, np.sum(self.correlated_occupied))
 
     @property
     def ncvir(self) -> int:
         """Get the number of virtual correlated orbitals."""
-        return cast(int, self.correlated_virtual.sum())
+        return cast(int, np.sum(self.correlated_virtual))
 
     # Inactive space:
 
@@ -219,17 +219,17 @@ class Space:
     @property
     def ninact(self) -> int:
         """Get the number of inactive orbitals."""
-        return cast(int, self.inactive.sum())
+        return cast(int, np.sum(self.inactive))
 
     @property
     def niocc(self) -> int:
         """Get the number of occupied inactive orbitals."""
-        return cast(int, self.inactive_occupied.sum())
+        return cast(int, np.sum(self.inactive_occupied))
 
     @property
     def nivir(self) -> int:
         """Get the number of virtual inactive orbitals."""
-        return cast(int, self.inactive_virtual.sum())
+        return cast(int, np.sum(self.inactive_virtual))
 
     # Frozen space:
 
@@ -251,12 +251,12 @@ class Space:
     @property
     def nfroz(self) -> int:
         """Get the number of frozen orbitals."""
-        return cast(int, self.frozen.sum())
+        return cast(int, np.sum(self.frozen))
 
     @property
     def nfocc(self) -> int:
         """Get the number of occupied frozen orbitals."""
-        return cast(int, self.frozen_occupied.sum())
+        return cast(int, np.sum(self.frozen_occupied))
 
     @property
     def nfvir(self) -> int:
@@ -283,17 +283,17 @@ class Space:
     @property
     def nact(self) -> int:
         """Get the number of active orbitals."""
-        return cast(int, self.active.sum())
+        return cast(int, np.sum(self.active))
 
     @property
     def naocc(self) -> int:
         """Get the number of occupied active orbitals."""
-        return cast(int, self.active_occupied.sum())
+        return cast(int, np.sum(self.active_occupied))
 
     @property
     def navir(self) -> int:
         """Get the number of virtual active orbitals."""
-        return cast(int, self.active_virtual.sum())
+        return cast(int, np.sum(self.active_virtual))
 
 
 if TYPE_CHECKING:
@@ -377,7 +377,7 @@ def construct_fno_space(
         mo_occ: NDArray[T],
     ) -> RConstructSpaceReturnType:
         # Get the number of occupied orbitals
-        nocc = (mo_occ > 0).astype(int).sum()
+        nocc = np.sum((mo_occ > 0).astype(int))
 
         # Calculate the natural orbitals
         n, c = np.linalg.eigh(dm1[nocc:, nocc:])
@@ -387,8 +387,8 @@ def construct_fno_space(
         if occ_frac is None:
             active_vir = n > occ_tol
         else:
-            active_vir = np.cumsum(n / n.sum()) <= occ_frac
-        num_active_vir = active_vir.astype(int).sum()
+            active_vir = np.cumsum(n / np.sum(n)) <= occ_frac
+        num_active_vir = np.sum(active_vir.astype(int))
 
         # Canonicalise the natural orbitals
         fock_vv = np.diag(mo_energy[nocc:])

--- a/ebcc/ham/space.py
+++ b/ebcc/ham/space.py
@@ -25,7 +25,8 @@ if TYPE_CHECKING:
 
 # Development note: multiplication of boolean arrays is used in place of logical or bitwise
 # AND functions. This is because backends are not guaranteed to support logical or bitwise
-# operations via overloaded operators.
+# operations via overloaded operators. Similarly, subtraction of boolean arrays is used in
+# place of logical or bitwise NOT functions.
 
 
 class Space:
@@ -154,7 +155,7 @@ class Space:
     @property
     def virtual(self) -> NDArray[B]:
         """Get a boolean mask of virtual orbitals."""
-        return ~self.occupied
+        return np.ones_like(self.occupied) - self.occupied
 
     @property
     def nmo(self) -> int:
@@ -176,7 +177,7 @@ class Space:
     @property
     def correlated(self) -> NDArray[B]:
         """Get a boolean mask of correlated orbitals."""
-        return ~self.frozen
+        return np.ones_like(self.frozen) - self.frozen
 
     @property
     def correlated_occupied(self) -> NDArray[B]:
@@ -208,7 +209,7 @@ class Space:
     @property
     def inactive(self) -> NDArray[B]:
         """Get a boolean mask of inactive orbitals."""
-        return ~self.active
+        return np.ones_like(self.active) - self.active
 
     @property
     def inactive_occupied(self) -> NDArray[B]:

--- a/ebcc/ham/space.py
+++ b/ebcc/ham/space.py
@@ -361,13 +361,13 @@ def construct_fno_space(
     solver = MP2(mf)
     if not amplitudes:
         solver.kernel()
-        dm1 = solver.make_rdm1().astype(types[float])
+        dm1 = np.astype(solver.make_rdm1(), types[float])
     else:
         if isinstance(amplitudes.t2, util.Namespace):
             t2 = (amplitudes.t2.aaaa, amplitudes.t2.abab, amplitudes.t2.bbbb)
-            dm1 = solver.make_rdm1(t2=t2).astype(types[float])
+            dm1 = np.astype(solver.make_rdm1(t2=t2), types[float])
         else:
-            dm1 = solver.make_rdm1(t2=amplitudes.t2).astype(types[float])
+            dm1 = np.astype(solver.make_rdm1(t2=amplitudes.t2), types[float])
 
     # def _construct(dm1, mo_energy, mo_coeff, mo_occ):
     def _construct(
@@ -422,22 +422,22 @@ def construct_fno_space(
     # Construct the natural orbitals
     if mf.mo_occ.ndim == 2:
         coeff_a, occ_a, space_a = _construct(
-            dm1[0].astype(types[float]),
-            mf.mo_energy[0].astype(types[float]),
-            mf.mo_coeff[0].astype(types[float]),
-            mf.mo_occ[0].astype(types[float]),
+            np.astype(dm1[0], types[float]),
+            np.astype(mf.mo_energy[0], types[float]),
+            np.astype(mf.mo_coeff[0], types[float]),
+            np.astype(mf.mo_occ[0], types[float]),
         )
         coeff_b, occ_b, space_b = _construct(
-            dm1[1].astype(types[float]),
-            mf.mo_energy[1].astype(types[float]),
-            mf.mo_coeff[1].astype(types[float]),
-            mf.mo_occ[1].astype(types[float]),
+            np.astype(dm1[1], types[float]),
+            np.astype(mf.mo_energy[1], types[float]),
+            np.astype(mf.mo_coeff[1], types[float]),
+            np.astype(mf.mo_occ[1], types[float]),
         )
         return (coeff_a, coeff_b), (occ_a, occ_b), (space_a, space_b)
     else:
         return _construct(
-            dm1.astype(types[float]),
-            mf.mo_energy.astype(types[float]),
-            mf.mo_coeff.astype(types[float]),
-            mf.mo_occ.astype(types[float]),
+            np.astype(dm1, types[float]),
+            np.astype(mf.mo_energy, types[float]),
+            np.astype(mf.mo_coeff, types[float]),
+            np.astype(mf.mo_occ, types[float]),
         )

--- a/ebcc/ham/space.py
+++ b/ebcc/ham/space.py
@@ -23,6 +23,10 @@ if TYPE_CHECKING:
     T = float64
     B = bool_
 
+# Development note: multiplication of boolean arrays is used in place of logical or bitwise
+# AND functions. This is because backends are not guaranteed to support logical or bitwise
+# operations via overloaded operators.
+
 
 class Space:
     """Space class.
@@ -65,7 +69,7 @@ class Space:
         # Checks:
         if not (self._occupied.size == self._frozen.size == self._active.size):
             raise ValueError("The sizes of the space arrays must match.")
-        if np.any(self._frozen & self._active):
+        if np.any(self._frozen * self._active):
             raise ValueError("Frozen and active orbitals must be mutually exclusive.")
 
     def __repr__(self) -> str:
@@ -177,12 +181,12 @@ class Space:
     @property
     def correlated_occupied(self) -> NDArray[B]:
         """Get a boolean mask of occupied correlated orbitals."""
-        return self.correlated & self.occupied
+        return self.correlated * self.occupied
 
     @property
     def correlated_virtual(self) -> NDArray[B]:
         """Get a boolean mask of virtual correlated orbitals."""
-        return self.correlated & self.virtual
+        return self.correlated * self.virtual
 
     @property
     def ncorr(self) -> int:
@@ -209,12 +213,12 @@ class Space:
     @property
     def inactive_occupied(self) -> NDArray[B]:
         """Get a boolean mask of occupied inactive orbitals."""
-        return self.inactive & self.occupied
+        return self.inactive * self.occupied
 
     @property
     def inactive_virtual(self) -> NDArray[B]:
         """Get a boolean mask of virtual inactive orbitals."""
-        return self.inactive & self.virtual
+        return self.inactive * self.virtual
 
     @property
     def ninact(self) -> int:
@@ -241,12 +245,12 @@ class Space:
     @property
     def frozen_occupied(self) -> NDArray[B]:
         """Get a boolean mask of occupied frozen orbitals."""
-        return self.frozen & self.occupied
+        return self.frozen * self.occupied
 
     @property
     def frozen_virtual(self) -> NDArray[B]:
         """Get a boolean mask of virtual frozen orbitals."""
-        return self.frozen & self.virtual
+        return self.frozen * self.virtual
 
     @property
     def nfroz(self) -> int:
@@ -273,12 +277,12 @@ class Space:
     @property
     def active_occupied(self) -> NDArray[B]:
         """Get a boolean mask of occupied active orbitals."""
-        return self.active & self.occupied
+        return self.active * self.occupied
 
     @property
     def active_virtual(self) -> NDArray[B]:
         """Get a boolean mask of virtual active orbitals."""
-        return self.active & self.virtual
+        return self.active * self.virtual
 
     @property
     def nact(self) -> int:

--- a/ebcc/opt/base.py
+++ b/ebcc/opt/base.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING
 import numpy
 from pyscf import lib
 
-from ebcc import util
 from ebcc import numpy as np
+from ebcc import util
 from ebcc.core.damping import DIIS
 from ebcc.core.logging import ANSI, NullLogger, init_logging
 from ebcc.core.precision import types

--- a/ebcc/opt/base.py
+++ b/ebcc/opt/base.py
@@ -126,8 +126,8 @@ class BaseBruecknerEBCC(ABC):
         diis.damping = self.options.damping
 
         # Initialise coefficients:
-        mo_coeff_new: NDArray[T] = np.copy(np.astype(self.cc.mo_coeff, types[float]))
-        mo_coeff_ref: NDArray[T] = np.copy(np.astype(self.cc.mo_coeff, types[float]))
+        mo_coeff_new: NDArray[T] = np.copy(np.asarray(self.cc.mo_coeff, dtype=types[float]))
+        mo_coeff_ref: NDArray[T] = np.copy(np.asarray(self.cc.mo_coeff, dtype=types[float]))
         mo_coeff_ref = self.mo_to_correlated(mo_coeff_ref)
         u_tot = None
 

--- a/ebcc/opt/base.py
+++ b/ebcc/opt/base.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import numpy
 from pyscf import lib
 
 from ebcc import util
@@ -23,6 +24,8 @@ if TYPE_CHECKING:
     from ebcc.util import Namespace
 
     T = float64
+
+# FIXME Custom versions of PySCF functions
 
 
 @dataclass
@@ -147,7 +150,7 @@ class BaseBruecknerEBCC(ABC):
             mo_coeff_new = self.update_coefficients(u_tot, mo_coeff_new, mo_coeff_ref)
 
             # Transform mean-field and amplitudes:
-            self.mf.mo_coeff = mo_coeff_new
+            self.mf.mo_coeff = numpy.asarray(mo_coeff_new)
             self.mf.e_tot = self.mf.energy_tot()
             amplitudes = self.transform_amplitudes(u)
 

--- a/ebcc/opt/base.py
+++ b/ebcc/opt/base.py
@@ -10,6 +10,7 @@ import numpy
 from pyscf import lib
 
 from ebcc import util
+from ebcc import numpy as np
 from ebcc.core.damping import DIIS
 from ebcc.core.logging import ANSI, NullLogger, init_logging
 from ebcc.core.precision import types
@@ -125,8 +126,8 @@ class BaseBruecknerEBCC(ABC):
         diis.damping = self.options.damping
 
         # Initialise coefficients:
-        mo_coeff_new: NDArray[T] = self.cc.mo_coeff.astype(types[float]).copy()
-        mo_coeff_ref: NDArray[T] = self.cc.mo_coeff.astype(types[float]).copy()
+        mo_coeff_new: NDArray[T] = np.copy(np.astype(self.cc.mo_coeff, types[float]))
+        mo_coeff_ref: NDArray[T] = np.copy(np.astype(self.cc.mo_coeff, types[float]))
         mo_coeff_ref = self.mo_to_correlated(mo_coeff_ref)
         u_tot = None
 

--- a/ebcc/opt/gbrueckner.py
+++ b/ebcc/opt/gbrueckner.py
@@ -8,6 +8,7 @@ import scipy.linalg
 
 from ebcc import numpy as np
 from ebcc import util
+from ebcc.backend import _put
 from ebcc.core.precision import types
 from ebcc.opt.base import BaseBruecknerEBCC
 
@@ -53,17 +54,15 @@ class BruecknerGEBCC(BaseBruecknerEBCC):
         if u_tot is None:
             u_tot = np.eye(self.cc.space.ncorr, dtype=types[float])
 
-        t1_block: NDArray[T] = np.zeros(
-            (self.cc.space.ncorr, self.cc.space.ncorr), dtype=types[float]
-        )
-        t1_block[: self.cc.space.ncocc, self.cc.space.ncocc :] = -t1
-        t1_block[self.cc.space.ncocc :, : self.cc.space.ncocc] = t1.T
+        zocc = np.zeros((self.cc.space.ncocc, self.cc.space.ncocc))
+        zvir = np.zeros((self.cc.space.ncvir, self.cc.space.ncvir))
+        t1_block: NDArray[T] = np.block([[zocc, -t1], [t1.T, zvir]])
 
         u = scipy.linalg.expm(t1_block)
 
         u_tot = u_tot @ u
         if np.linalg.det(u_tot) < 0:
-            u_tot[:, 0] *= -1
+            u_tot = _put(u_tot, np.ix(slice(None), [0]), -u_tot[:, 0])
 
         a = scipy.linalg.logm(u_tot)
         a = a.real.astype(types[float])
@@ -151,7 +150,7 @@ class BruecknerGEBCC(BaseBruecknerEBCC):
         Returns:
             Updated MO coefficients.
         """
-        mo_coeff[:, self.cc.space.correlated] = mo_coeff_corr
+        mo_coeff = _put(mo_coeff, np.ix_(np.arange(mo_coeff.shape[0]), self.cc.space.correlated), mo_coeff_corr)
         return mo_coeff
 
     def update_coefficients(

--- a/ebcc/opt/gbrueckner.py
+++ b/ebcc/opt/gbrueckner.py
@@ -64,7 +64,7 @@ class BruecknerGEBCC(BaseBruecknerEBCC):
         if np.linalg.det(u_tot) < 0:
             u_tot = _put(u_tot, np.ix_(np.arange(u_tot.shape[0]), np.array([0])), -u_tot[:, 0])
 
-        a: NDArray[T] = np.astype(np.real(scipy.linalg.logm(u_tot)), types[float])
+        a: NDArray[T] = np.asarray(np.real(scipy.linalg.logm(u_tot)), dtype=types[float])
         if diis is not None:
             a = diis.update(a, xerr=t1)
 

--- a/ebcc/opt/gbrueckner.py
+++ b/ebcc/opt/gbrueckner.py
@@ -64,8 +64,7 @@ class BruecknerGEBCC(BaseBruecknerEBCC):
         if np.linalg.det(u_tot) < 0:
             u_tot = _put(u_tot, np.ix_(np.arange(u_tot.shape[0]), np.array([0])), -u_tot[:, 0])
 
-        a = scipy.linalg.logm(u_tot)
-        a = np.astype(np.real(a), types[float])
+        a: NDArray[T] = np.astype(np.real(scipy.linalg.logm(u_tot)), types[float])
         if diis is not None:
             a = diis.update(a, xerr=t1)
 

--- a/ebcc/opt/gbrueckner.py
+++ b/ebcc/opt/gbrueckner.py
@@ -65,7 +65,7 @@ class BruecknerGEBCC(BaseBruecknerEBCC):
             u_tot = _put(u_tot, np.ix_(np.arange(u_tot.shape[0]), np.array([0])), -u_tot[:, 0])
 
         a = scipy.linalg.logm(u_tot)
-        a = a.real.astype(types[float])
+        a = np.astype(np.real(a), types[float])
         if diis is not None:
             a = diis.update(a, xerr=t1)
 

--- a/ebcc/opt/gbrueckner.py
+++ b/ebcc/opt/gbrueckner.py
@@ -56,7 +56,7 @@ class BruecknerGEBCC(BaseBruecknerEBCC):
 
         zocc = np.zeros((self.cc.space.ncocc, self.cc.space.ncocc))
         zvir = np.zeros((self.cc.space.ncvir, self.cc.space.ncvir))
-        t1_block: NDArray[T] = np.block([[zocc, -t1], [t1.T, zvir]])
+        t1_block: NDArray[T] = np.block([[zocc, -t1], [np.transpose(t1), zvir]])
 
         u = scipy.linalg.expm(t1_block)
 

--- a/ebcc/opt/gbrueckner.py
+++ b/ebcc/opt/gbrueckner.py
@@ -62,7 +62,7 @@ class BruecknerGEBCC(BaseBruecknerEBCC):
 
         u_tot = u_tot @ u
         if np.linalg.det(u_tot) < 0:
-            u_tot = _put(u_tot, np.ix(slice(None), [0]), -u_tot[:, 0])
+            u_tot = _put(u_tot, np.ix_(np.arange(u_tot.shape[0]), np.array([0])), -u_tot[:, 0])
 
         a = scipy.linalg.logm(u_tot)
         a = a.real.astype(types[float])
@@ -150,7 +150,11 @@ class BruecknerGEBCC(BaseBruecknerEBCC):
         Returns:
             Updated MO coefficients.
         """
-        mo_coeff = _put(mo_coeff, np.ix_(np.arange(mo_coeff.shape[0]), self.cc.space.correlated), mo_coeff_corr)
+        mo_coeff = _put(
+            mo_coeff,
+            np.ix_(np.arange(mo_coeff.shape[0]), self.cc.space.correlated),  # type: ignore
+            mo_coeff_corr,
+        )
         return mo_coeff
 
     def update_coefficients(

--- a/ebcc/opt/rbrueckner.py
+++ b/ebcc/opt/rbrueckner.py
@@ -65,7 +65,7 @@ class BruecknerREBCC(BaseBruecknerEBCC):
             u_tot = _put(u_tot, np.ix_(np.arange(u_tot.shape[0]), np.array([0])), -u_tot[:, 0])
 
         a = scipy.linalg.logm(u_tot)
-        a = a.real.astype(types[float])
+        a = np.astype(np.real(a), types[float])
         if diis is not None:
             a = diis.update(a, xerr=t1)
 

--- a/ebcc/opt/rbrueckner.py
+++ b/ebcc/opt/rbrueckner.py
@@ -64,7 +64,7 @@ class BruecknerREBCC(BaseBruecknerEBCC):
         if np.linalg.det(u_tot) < 0:
             u_tot = _put(u_tot, np.ix_(np.arange(u_tot.shape[0]), np.array([0])), -u_tot[:, 0])
 
-        a: NDArray[T] = np.astype(np.real(scipy.linalg.logm(u_tot)), types[float])
+        a: NDArray[T] = np.asarray(np.real(scipy.linalg.logm(u_tot)), dtype=types[float])
         if diis is not None:
             a = diis.update(a, xerr=t1)
 

--- a/ebcc/opt/rbrueckner.py
+++ b/ebcc/opt/rbrueckner.py
@@ -62,7 +62,7 @@ class BruecknerREBCC(BaseBruecknerEBCC):
 
         u_tot = u_tot @ u
         if np.linalg.det(u_tot) < 0:
-            u_tot = _put(u_tot, np.ix(slice(None), [0]), -u_tot[:, 0])
+            u_tot = _put(u_tot, np.ix_(np.arange(u_tot.shape[0]), np.array([0])), -u_tot[:, 0])
 
         a = scipy.linalg.logm(u_tot)
         a = a.real.astype(types[float])
@@ -150,7 +150,11 @@ class BruecknerREBCC(BaseBruecknerEBCC):
         Returns:
             Updated MO coefficients.
         """
-        mo_coeff = _put(mo_coeff, np.ix_(np.arange(mo_coeff.shape[0]), self.cc.space.correlated), mo_coeff_corr)
+        mo_coeff = _put(
+            mo_coeff,
+            np.ix_(np.arange(mo_coeff.shape[0]), self.cc.space.correlated),  # type: ignore
+            mo_coeff_corr,
+        )
         return mo_coeff
 
     def update_coefficients(

--- a/ebcc/opt/rbrueckner.py
+++ b/ebcc/opt/rbrueckner.py
@@ -56,7 +56,7 @@ class BruecknerREBCC(BaseBruecknerEBCC):
 
         zocc = np.zeros((self.cc.space.ncocc, self.cc.space.ncocc))
         zvir = np.zeros((self.cc.space.ncvir, self.cc.space.ncvir))
-        t1_block: NDArray[T] = np.block([[zocc, -t1], [t1.T, zvir]])
+        t1_block: NDArray[T] = np.block([[zocc, -t1], [np.transpose(t1), zvir]])
 
         u = scipy.linalg.expm(t1_block)
 

--- a/ebcc/opt/rbrueckner.py
+++ b/ebcc/opt/rbrueckner.py
@@ -8,6 +8,7 @@ import scipy.linalg
 
 from ebcc import numpy as np
 from ebcc import util
+from ebcc.backend import _put
 from ebcc.core.precision import types
 from ebcc.opt.base import BaseBruecknerEBCC
 
@@ -53,17 +54,15 @@ class BruecknerREBCC(BaseBruecknerEBCC):
         if u_tot is None:
             u_tot = np.eye(self.cc.space.ncorr, dtype=types[float])
 
-        t1_block: NDArray[T] = np.zeros(
-            (self.cc.space.ncorr, self.cc.space.ncorr), dtype=types[float]
-        )
-        t1_block[: self.cc.space.ncocc, self.cc.space.ncocc :] = -t1
-        t1_block[self.cc.space.ncocc :, : self.cc.space.ncocc] = t1.T
+        zocc = np.zeros((self.cc.space.ncocc, self.cc.space.ncocc))
+        zvir = np.zeros((self.cc.space.ncvir, self.cc.space.ncvir))
+        t1_block: NDArray[T] = np.block([[zocc, -t1], [t1.T, zvir]])
 
         u = scipy.linalg.expm(t1_block)
 
         u_tot = u_tot @ u
         if np.linalg.det(u_tot) < 0:
-            u_tot[:, 0] *= -1
+            u_tot = _put(u_tot, np.ix(slice(None), [0]), -u_tot[:, 0])
 
         a = scipy.linalg.logm(u_tot)
         a = a.real.astype(types[float])
@@ -151,7 +150,7 @@ class BruecknerREBCC(BaseBruecknerEBCC):
         Returns:
             Updated MO coefficients.
         """
-        mo_coeff[:, self.cc.space.correlated] = mo_coeff_corr
+        mo_coeff = _put(mo_coeff, np.ix_(np.arange(mo_coeff.shape[0]), self.cc.space.correlated), mo_coeff_corr)
         return mo_coeff
 
     def update_coefficients(

--- a/ebcc/opt/rbrueckner.py
+++ b/ebcc/opt/rbrueckner.py
@@ -64,8 +64,7 @@ class BruecknerREBCC(BaseBruecknerEBCC):
         if np.linalg.det(u_tot) < 0:
             u_tot = _put(u_tot, np.ix_(np.arange(u_tot.shape[0]), np.array([0])), -u_tot[:, 0])
 
-        a = scipy.linalg.logm(u_tot)
-        a = np.astype(np.real(a), types[float])
+        a: NDArray[T] = np.astype(np.real(scipy.linalg.logm(u_tot)), types[float])
         if diis is not None:
             a = diis.update(a, xerr=t1)
 

--- a/ebcc/opt/ubrueckner.py
+++ b/ebcc/opt/ubrueckner.py
@@ -70,9 +70,13 @@ class BruecknerUEBCC(BaseBruecknerEBCC):
         u_tot.aa = u_tot.aa @ u.aa
         u_tot.bb = u_tot.bb @ u.bb
         if np.linalg.det(u_tot.aa) < 0:
-            u_tot = _put(u_tot.aa, np.ix(slice(None), [0]), -u_tot[:, 0])
+            u_tot.aa = _put(
+                u_tot.aa, np.ix_(np.arange(u_tot.aa.shape[0]), np.array([0])), -u_tot.aa[:, 0]
+            )
         if np.linalg.det(u_tot.bb) < 0:
-            u_tot = _put(u_tot.bb, np.ix(slice(None), [0]), -u_tot[:, 0])
+            u_tot.bb = _put(
+                u_tot.bb, np.ix_(np.arange(u_tot.aa.shape[0]), np.array([0])), -u_tot.bb[:, 0]
+            )
 
         a = np.concatenate(
             [scipy.linalg.logm(u_tot.aa).ravel(), scipy.linalg.logm(u_tot.bb).ravel()], axis=0
@@ -173,8 +177,19 @@ class BruecknerUEBCC(BaseBruecknerEBCC):
         Returns:
             Updated MO coefficients.
         """
-        mo_coeff[0] = _put(mo_coeff[0], np.ix_(np.arange(mo_coeff[0].shape[0]), self.cc.space[0].correlated), mo_coeff_corr[0])
-        mo_coeff[1] = _put(mo_coeff[1], np.ix_(np.arange(mo_coeff[1].shape[0]), self.cc.space[1].correlated), mo_coeff_corr[1])
+        space = self.cc.space
+        mo_coeff = (
+            _put(
+                mo_coeff[0],
+                np.ix_(np.arange(mo_coeff[0].shape[0]), space[0].correlated),  # type: ignore
+                mo_coeff_corr[0],
+            ),
+            _put(
+                mo_coeff[1],
+                np.ix_(np.arange(mo_coeff[1].shape[0]), space[1].correlated),  # type: ignore
+                mo_coeff_corr[1],
+            ),
+        )
         return mo_coeff
 
     def update_coefficients(

--- a/ebcc/opt/ubrueckner.py
+++ b/ebcc/opt/ubrueckner.py
@@ -81,7 +81,7 @@ class BruecknerUEBCC(BaseBruecknerEBCC):
         a = np.concatenate(
             [np.ravel(scipy.linalg.logm(u_tot.aa)), np.ravel(scipy.linalg.logm(u_tot.bb))], axis=0
         )
-        a = np.astype(np.real(a), types[float])
+        a: NDArray[T] = np.astype(np.real(a), types[float])
         if diis is not None:
             xerr = np.concatenate([np.ravel(t1.aa), np.ravel(t1.bb)])
             a = diis.update(a, xerr=xerr)

--- a/ebcc/opt/ubrueckner.py
+++ b/ebcc/opt/ubrueckner.py
@@ -60,10 +60,10 @@ class BruecknerUEBCC(BaseBruecknerEBCC):
         t1_block: Namespace[NDArray[T]] = util.Namespace()
         zocc = np.zeros((self.cc.space[0].ncocc, self.cc.space[0].ncocc))
         zvir = np.zeros((self.cc.space[0].ncvir, self.cc.space[0].ncvir))
-        t1_block.aa = np.block([[zocc, -t1.aa], [t1.aa.T, zvir]])
+        t1_block.aa = np.block([[zocc, -t1.aa], [np.transpose(t1.aa), zvir]])
         zocc = np.zeros((self.cc.space[1].ncocc, self.cc.space[1].ncocc))
         zvir = np.zeros((self.cc.space[1].ncvir, self.cc.space[1].ncvir))
-        t1_block.bb = np.block([[zocc, -t1.bb], [t1.bb.T, zvir]])
+        t1_block.bb = np.block([[zocc, -t1.bb], [np.transpose(t1.bb), zvir]])
 
         u = util.Namespace(aa=scipy.linalg.expm(t1_block.aa), bb=scipy.linalg.expm(t1_block.bb))
 

--- a/ebcc/opt/ubrueckner.py
+++ b/ebcc/opt/ubrueckner.py
@@ -81,7 +81,7 @@ class BruecknerUEBCC(BaseBruecknerEBCC):
         a = np.concatenate(
             [np.ravel(scipy.linalg.logm(u_tot.aa)), np.ravel(scipy.linalg.logm(u_tot.bb))], axis=0
         )
-        a: NDArray[T] = np.astype(np.real(a), types[float])
+        a: NDArray[T] = np.asarray(np.real(a), dtype=types[float])
         if diis is not None:
             xerr = np.concatenate([np.ravel(t1.aa), np.ravel(t1.bb)])
             a = diis.update(a, xerr=xerr)

--- a/ebcc/opt/ubrueckner.py
+++ b/ebcc/opt/ubrueckner.py
@@ -79,15 +79,15 @@ class BruecknerUEBCC(BaseBruecknerEBCC):
             )
 
         a = np.concatenate(
-            [scipy.linalg.logm(u_tot.aa).ravel(), scipy.linalg.logm(u_tot.bb).ravel()], axis=0
+            [np.ravel(scipy.linalg.logm(u_tot.aa)), np.ravel(scipy.linalg.logm(u_tot.bb))], axis=0
         )
-        a = a.real.astype(types[float])
+        a = np.astype(np.real(a), types[float])
         if diis is not None:
-            xerr = np.concatenate([t1.aa.ravel(), t1.bb.ravel()])
+            xerr = np.concatenate([np.ravel(t1.aa), np.ravel(t1.bb)])
             a = diis.update(a, xerr=xerr)
 
-        u_tot.aa = scipy.linalg.expm(a[: u_tot.aa.size].reshape(u_tot.aa.shape))
-        u_tot.bb = scipy.linalg.expm(a[u_tot.aa.size :].reshape(u_tot.bb.shape))
+        u_tot.aa = scipy.linalg.expm(np.reshape(a[: u_tot.aa.size], u_tot.aa.shape))
+        u_tot.bb = scipy.linalg.expm(np.reshape(a[u_tot.aa.size :], u_tot.bb.shape))
 
         return u, u_tot
 

--- a/ebcc/util/__init__.py
+++ b/ebcc/util/__init__.py
@@ -1,6 +1,6 @@
 """Utilities."""
 
-from ebcc.util.misc import Inherited, ModelNotImplemented, Namespace, Timer, regularise_tuple, prod
+from ebcc.util.misc import Inherited, ModelNotImplemented, Namespace, Timer, regularise_tuple, prod, argsort
 from ebcc.util.einsumfunc import einsum, dirsum
 from ebcc.util.permutations import (
     antisymmetrise_array,

--- a/ebcc/util/__init__.py
+++ b/ebcc/util/__init__.py
@@ -1,6 +1,14 @@
 """Utilities."""
 
-from ebcc.util.misc import Inherited, ModelNotImplemented, Namespace, Timer, regularise_tuple, prod, argsort
+from ebcc.util.misc import (
+    Inherited,
+    ModelNotImplemented,
+    Namespace,
+    Timer,
+    regularise_tuple,
+    prod,
+    argsort,
+)
 from ebcc.util.einsumfunc import einsum, dirsum
 from ebcc.util.permutations import (
     antisymmetrise_array,

--- a/ebcc/util/einsumfunc.py
+++ b/ebcc/util/einsumfunc.py
@@ -330,10 +330,11 @@ def _contract_ttdt(
         out = out.reshape(shape_ct_flat)
 
     # Perform the contraction
+    ct: NDArray[T]
     if BACKEND == "numpy":
-        ct: NDArray[T] = dot(at, bt, alpha=alpha, beta=beta, c=out)
+        ct = dot(at, bt, alpha=alpha, beta=beta, c=out)
     else:
-        ct: NDArray[T] = np.dot(at, bt) * alpha
+        ct = np.dot(at, bt) * alpha
         if out is not None:
             ct += beta * out
 

--- a/ebcc/util/einsumfunc.py
+++ b/ebcc/util/einsumfunc.py
@@ -35,10 +35,10 @@ except ImportError:
 CONTRACTION_METHOD = "backend"
 
 """The size of the contraction to fall back on the backend."""
-BACKEND_EINSUM_SIZE = 2000
+BACKEND_EINSUM_SIZE = 1000
 
 """The size of the contraction to let the backend optimize."""
-BACKEND_OPTIMIZE_SIZE = 1000
+BACKEND_OPTIMIZE_SIZE = 100
 
 """Symbols used in einsum-like functions."""
 EINSUM_SYMBOLS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -226,7 +226,7 @@ def _contract_backend(
     return res
 
 
-def _contract_ttdt(
+def _contract_ttgt(
     subscript: str,
     a: NDArray[T],
     b: NDArray[T],
@@ -490,7 +490,7 @@ def einsum(
     if contract is None:
         contract = {
             "backend": _contract_backend,
-            "ttdt": _contract_ttdt,
+            "ttgt": _contract_ttgt,
             "tblis": _contract_tblis,
         }[CONTRACTION_METHOD.lower()]
 

--- a/ebcc/util/einsumfunc.py
+++ b/ebcc/util/einsumfunc.py
@@ -310,24 +310,24 @@ def _contract_ttgt(
     if a.size == 0 or b.size == 0:
         shape_c = [shape_ct[i] for i in order_ct]
         if out is not None:
-            return out.reshape(shape_c) * beta if beta != 1.0 else out.reshape(shape_c)
+            return np.reshape(out, shape_c) * beta if beta != 1.0 else np.reshape(out, shape_c)
         else:
             return np.zeros(shape_c, dtype=np.result_type(a, b))
 
     # Apply transposes
-    at = a.transpose(order_a)
-    bt = b.transpose(order_b)
+    at = np.transpose(a, order_a)
+    bt = np.transpose(b, order_b)
 
     # Reshape the inner dimensions
-    at = at.reshape(-1, inner_shape)
-    bt = bt.reshape(inner_shape, -1)
+    at = np.reshape(at, (-1, inner_shape))
+    bt = np.reshape(bt, (inner_shape, -1))
 
     # Get the output buffer
     if out is not None:
         shape_ct_flat = (at.shape[0], bt.shape[1])
         order_c = [outs.index(idx) for idx in inp_ct]
-        out = out.transpose(order_c)
-        out = out.reshape(shape_ct_flat)
+        out = np.transpose(out, order_c)
+        out = np.reshape(out, shape_ct_flat)
 
     # Perform the contraction
     ct: NDArray[T]
@@ -339,8 +339,8 @@ def _contract_ttgt(
             ct += beta * out
 
     # Reshape and transpose
-    ct = ct.reshape(shape_ct)
-    c = ct.transpose(order_ct)
+    ct = np.reshape(ct, shape_ct)
+    c = np.transpose(ct, order_ct)
 
     return c
 
@@ -412,7 +412,7 @@ def _contract_tblis(
     # If any dimension has size zero, return here
     if a.size == 0 or b.size == 0:
         if out is not None:
-            return out.reshape(shape_c) * beta
+            return np.reshape(out, shape_c) * beta
         else:
             return np.zeros(shape_c, dtype=dtype)
 
@@ -422,7 +422,7 @@ def _contract_tblis(
     else:
         assert out.dtype == dtype
         assert out.size == np.prod(shape_c)
-        c = out.reshape(shape_c)
+        c = np.reshape(out, shape_c)
 
     # Perform the contraction
     tblis_einsum.libtblis.as_einsum(
@@ -554,7 +554,7 @@ def dirsum(*operands: Union[str, tuple[int, ...], NDArray[T]]) -> NDArray[T]:
             res = array
         else:
             shape = res.shape + (1,) * array.ndim
-            res = res.reshape(shape) + array
+            res = np.reshape(res, shape) + array
 
     # Reshape the output
     res = einsum(f"{''.join(input_chars)}->{output_str}", res)

--- a/ebcc/util/einsumfunc.py
+++ b/ebcc/util/einsumfunc.py
@@ -64,8 +64,6 @@ def _parse_einsum_input(operands: list[OperandType]) -> tuple[str, str, list[NDA
         raise ValueError("No input operands")
 
     if isinstance(operands[0], str):
-        if not all(isinstance(op, np.ndarray) for op in operands[1:]):
-            raise EinsumOperandError("Invalid operands for einsum")
         subscripts = operands[0].replace(" ", "")
         operand_list: list[NDArray[T]] = operands[1:]  # type: ignore
 
@@ -90,10 +88,6 @@ def _parse_einsum_input(operands: list[OperandType]) -> tuple[str, str, list[NDA
                 raise ValueError(f"Character {s} is not a valid symbol.")
 
     else:
-        if not all(isinstance(op, np.ndarray) for op in operands[:-1:2]):
-            raise EinsumOperandError("Invalid operands for einsum")
-        if not all(isinstance(op, tuple) for op in operands[1::2]):
-            raise EinsumOperandError("Invalid subscripts for einsum")
         operand_list: list[NDArray[T]] = operands[:-1:2]  # type: ignore
         subscript_list: list[tuple[int, ...]] = operands[1::2]  # type: ignore
         output_list: Optional[tuple[int, ...]] = (

--- a/ebcc/util/misc.py
+++ b/ebcc/util/misc.py
@@ -7,7 +7,17 @@ from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 if TYPE_CHECKING:
-    from typing import Any, ItemsView, Iterator, KeysView, Union, ValuesView
+    from abc import abstractmethod
+    from typing import Any, ItemsView, Iterator, KeysView, Union, ValuesView, Protocol
+
+    class Comparable(Protocol):
+        """Protocol for comparable objects."""
+
+        @abstractmethod
+        def __lt__(self, other: C) -> bool:
+            pass
+
+    C = TypeVar("C", bound=Comparable)
 
 T = TypeVar("T")
 
@@ -162,6 +172,18 @@ def prod(values: Union[list[int], tuple[int, ...]]) -> int:
     for value in values:
         out *= value
     return out
+
+
+def argsort(values: list[C]) -> list[int]:
+    """Return the indices that would sort the values.
+
+    Args:
+        values: The values to sort.
+
+    Returns:
+        The indices that would sort the values.
+    """
+    return sorted(range(len(values)), key=values.__getitem__)
 
 
 def regularise_tuple(*_items: Union[Any, tuple[Any, ...], list[Any]]) -> tuple[Any, ...]:

--- a/ebcc/util/misc.py
+++ b/ebcc/util/misc.py
@@ -8,16 +8,21 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 
 if TYPE_CHECKING:
     from abc import abstractmethod
-    from typing import Any, ItemsView, Iterator, KeysView, Union, ValuesView, Protocol
+    from typing import Any, ItemsView, Iterator, KeysView, Protocol, Union, ValuesView
+
+    from numpy import generic
+    from numpy.typing import NDArray
 
     class Comparable(Protocol):
         """Protocol for comparable objects."""
 
         @abstractmethod
-        def __lt__(self, other: C) -> bool:
+        def __lt__(self, other: C) -> Any:
+            """Check if the object is less than another."""
             pass
 
     C = TypeVar("C", bound=Comparable)
+
 
 T = TypeVar("T")
 
@@ -174,7 +179,7 @@ def prod(values: Union[list[int], tuple[int, ...]]) -> int:
     return out
 
 
-def argsort(values: list[C]) -> list[int]:
+def argsort(values: Union[list[Union[float, str]], NDArray[generic]]) -> list[int]:
     """Return the indices that would sort the values.
 
     Args:

--- a/ebcc/util/permutations.py
+++ b/ebcc/util/permutations.py
@@ -324,7 +324,9 @@ def compress_axes(
             assert sizes[char] == n
         else:
             sizes[char] = n
-    array = np.reshape(array, [sizes[char] ** subscript.count(char) for char in sorted(set(subscript))])
+    array = np.reshape(
+        array, [sizes[char] ** subscript.count(char) for char in sorted(set(subscript))]
+    )
 
     # For each axis type, get the necessary lower-triangular indices:
     indices_ndim = [
@@ -409,7 +411,9 @@ def decompress_axes(
             assert sizes[char] == n
         else:
             sizes[char] = n
-    array = np.reshape(array, [sizes[char] ** subscript.count(char) for char in sorted(set(subscript))])
+    array = np.reshape(
+        array, [sizes[char] ** subscript.count(char) for char in sorted(set(subscript))]
+    )
 
     # Check the symmetry string, and compress it:
     n = 0
@@ -442,12 +446,13 @@ def decompress_axes(
         array = _put(array, indices_perm, array_flat * util.prod(signs))
 
     # Reshape array to non-flattened format
-    array = np.reshape(array, (
-        sum([(sizes[char],) * subscript.count(char) for char in sorted(set(subscript))], tuple())
-    ))
+    array = np.reshape(
+        array,
+        (sum([(sizes[char],) * subscript.count(char) for char in sorted(set(subscript))], tuple())),
+    )
 
     # Undo transpose:
-    arg = tuple(util.argsort(arg))
+    arg = tuple(util.argsort(list(arg)))
     array = np.transpose(array, arg)
 
     return array

--- a/ebcc/util/permutations.py
+++ b/ebcc/util/permutations.py
@@ -221,7 +221,7 @@ def antisymmetrise_array(v: NDArray[T], axes: Optional[tuple[int, ...]] = None) 
             if ax in axes:
                 j = axes.index(ax)
                 transpose[i] = perm[j]
-        v_as += sign * v.transpose(transpose).copy()
+        v_as += sign * np.copy(np.transpose(v, transpose))
 
     return v_as
 
@@ -314,7 +314,7 @@ def compress_axes(
 
     # Reshape array so that all axes of the same character are adjacent:
     arg = tuple(np.argsort(list(subscript)))
-    array = array.transpose(arg)
+    array = np.transpose(array, arg)
     subscript = permute_string(subscript, arg)
 
     # Reshape array so that all axes of the same character are flattened:
@@ -324,7 +324,7 @@ def compress_axes(
             assert sizes[char] == n
         else:
             sizes[char] = n
-    array = array.reshape([sizes[char] ** subscript.count(char) for char in sorted(set(subscript))])
+    array = np.reshape(array, [sizes[char] ** subscript.count(char) for char in sorted(set(subscript))])
 
     # For each axis type, get the necessary lower-triangular indices:
     indices_ndim = [
@@ -399,7 +399,7 @@ def decompress_axes(
 
     # Reshape array so that all axes of the same character are adjacent:
     arg = tuple(np.argsort(list(subscript)))
-    array = array.transpose(arg)
+    array = np.transpose(array, arg)
     subscript = permute_string(subscript, arg)
 
     # Reshape array so that all axes of the same character are flattened:
@@ -409,7 +409,7 @@ def decompress_axes(
             assert sizes[char] == n
         else:
             sizes[char] = n
-    array = array.reshape([sizes[char] ** subscript.count(char) for char in sorted(set(subscript))])
+    array = np.reshape(array, [sizes[char] ** subscript.count(char) for char in sorted(set(subscript))])
 
     # Check the symmetry string, and compress it:
     n = 0
@@ -442,13 +442,13 @@ def decompress_axes(
         array = _put(array, indices_perm, array_flat * util.prod(signs))
 
     # Reshape array to non-flattened format
-    array = array.reshape(
+    array = np.reshape(array, (
         sum([(sizes[char],) * subscript.count(char) for char in sorted(set(subscript))], tuple())
-    )
+    ))
 
     # Undo transpose:
     arg = tuple(np.argsort(arg))
-    array = array.transpose(arg)
+    array = np.transpose(array, arg)
 
     return array
 
@@ -522,7 +522,7 @@ def symmetrise(
             for i, p in zip(inds_part, perms_part):
                 perm[i] = p
         sign = util.prod(signs) if symmetry[perm[0]] == "-" else 1
-        array_as = array_as + sign * array.transpose(perm)
+        array_as = array_as + sign * np.transpose(array, perm)
 
     if apply_factor:
         # Apply factor

--- a/ebcc/util/permutations.py
+++ b/ebcc/util/permutations.py
@@ -221,7 +221,7 @@ def antisymmetrise_array(v: NDArray[T], axes: Optional[tuple[int, ...]] = None) 
             if ax in axes:
                 j = axes.index(ax)
                 transpose[i] = perm[j]
-        v_as += sign * np.copy(np.transpose(v, transpose))
+        v_as += np.copy(np.transpose(v, transpose)) * sign
 
     return v_as
 
@@ -313,7 +313,7 @@ def compress_axes(
     subscript = "".join([subs[s] for s in subscript])
 
     # Reshape array so that all axes of the same character are adjacent:
-    arg = tuple(np.argsort(list(subscript)))
+    arg = tuple(util.argsort(list(subscript)))
     array = np.transpose(array, arg)
     subscript = permute_string(subscript, arg)
 
@@ -398,7 +398,7 @@ def decompress_axes(
     subscript = "".join([subs[s] for s in subscript])
 
     # Reshape array so that all axes of the same character are adjacent:
-    arg = tuple(np.argsort(list(subscript)))
+    arg = tuple(util.argsort(list(subscript)))
     array = np.transpose(array, arg)
     subscript = permute_string(subscript, arg)
 
@@ -447,7 +447,7 @@ def decompress_axes(
     ))
 
     # Undo transpose:
-    arg = tuple(np.argsort(arg))
+    arg = tuple(util.argsort(arg))
     array = np.transpose(array, arg)
 
     return array
@@ -522,7 +522,7 @@ def symmetrise(
             for i, p in zip(inds_part, perms_part):
                 perm[i] = p
         sign = util.prod(signs) if symmetry[perm[0]] == "-" else 1
-        array_as = array_as + sign * np.transpose(array, perm)
+        array_as = array_as + np.transpose(array, perm) * sign
 
     if apply_factor:
         # Apply factor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,7 @@ exclude_lines = [
 directory = "cov_html"
 
 [tool.pytest.ini_options]
-addopts = "-m 'not slow'"
+addopts = "-m 'not slow' --durations=0"
 testpaths = [
     "tests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,7 @@ exclude_lines = [
 directory = "cov_html"
 
 [tool.pytest.ini_options]
-addopts = "-m 'not slow' --durations=0"
+addopts = "--durations=0"
 testpaths = [
     "tests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,10 @@ ignore_missing_imports = true
 module = "tensorflow.*"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "ctf.*"
+ignore_missing_imports = true
+
 [tool.coverage.run]
 branch = true
 source = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
+numpy = []
+tensorflow = [
+    "tensorflow>=2.0.0",
+    "opt_einsum>=3.3.0",
+]
 dev = [
     "black>=22.6.0",
     "isort>=5.10.1",
@@ -57,6 +62,8 @@ dev = [
     "mkdocs-include-markdown-plugin>=6.2.0",
     "mkdocstrings>=0.25.0",
     "mkdocstrings-python>=1.10.0",
+    "tensorflow>=2.0.0",
+    "opt_einsum>=3.3.0",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,6 @@ dev = [
     "mkdocs-include-markdown-plugin>=6.2.0",
     "mkdocstrings>=0.25.0",
     "mkdocstrings-python>=1.10.0",
-    "tensorflow>=2.0.0",
-    "opt_einsum>=3.3.0",
-    "jax>=0.2.0",
-    "cupy>=9.0.0",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,14 @@ tensorflow = [
     "tensorflow>=2.0.0",
     "opt_einsum>=3.3.0",
 ]
+jax = [
+    "jax>=0.2.0",
+    "opt_einsum>=3.3.0",
+]
+cupy = [
+    "cupy>=9.0.0",
+    "opt_einsum>=3.3.0",
+]
 dev = [
     "black>=22.6.0",
     "isort>=5.10.1",
@@ -64,6 +72,8 @@ dev = [
     "mkdocstrings-python>=1.10.0",
     "tensorflow>=2.0.0",
     "opt_einsum>=3.3.0",
+    "jax>=0.2.0",
+    "cupy>=9.0.0",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,18 @@ ignore_missing_imports = true
 module = "h5py.*"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "cupy.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "jax.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tensorflow.*"
+ignore_missing_imports = true
+
 [tool.coverage.run]
 branch = true
 source = [

--- a/tests/test_GCC2.py
+++ b/tests/test_GCC2.py
@@ -9,7 +9,7 @@ import numpy as np
 import scipy.linalg
 import pytest
 
-from ebcc import GEBCC, NullLogger, util
+from ebcc import GEBCC, NullLogger, util, BACKEND
 
 
 @pytest.mark.reference
@@ -135,14 +135,17 @@ class GCC2_Tests(unittest.TestCase):
         dm = util.einsum("ijkl,pi,qj,rk,sl->pqrs", dm, c, c, c, c)
         self.assertAlmostEqual(lib.fp(dm), 2.491733293012602, 6)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         e1 = self.ccsd.ip_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], 0.4334082808900563)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         e1 = self.ccsd.ea_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], 0.1663724198593271)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ee(self):
         e1 = self.ccsd.ee_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], 0.27385429984532744)

--- a/tests/test_GCC2.py
+++ b/tests/test_GCC2.py
@@ -74,7 +74,7 @@ class GCC2_PySCF_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = scipy.linalg.block_diag(self.ccsd_ref.t1, self.ccsd_ref.t1)[self.osort][:, self.vsort]
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     # This fails:
     #def test_rdm_energy(self):

--- a/tests/test_GCCD.py
+++ b/tests/test_GCCD.py
@@ -9,7 +9,7 @@ from pyscf import cc, gto, lib, scf
 from pyscf.cc import ccd as pyscf_ccd
 from pyscf.cc import ccsd_rdm
 
-from ebcc import GEBCC, NullLogger, Space, util
+from ebcc import GEBCC, NullLogger, Space, util, BACKEND
 
 
 @pytest.mark.reference
@@ -123,14 +123,17 @@ class GCCD_Tests(unittest.TestCase):
         rdm2 = util.einsum("ijkl,pi,qj,rk,sl->pqrs", self.ccd.make_rdm2_f(), c, c, c, c)
         self.assertAlmostEqual(lib.fp(rdm2), 0.21661134391721626)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         e1 = self.ccd.ip_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], 0.2979663212884527)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         e1 = self.ccd.ea_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], 0.0008756747431478695)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ee(self):
         e1 = self.ccd.ee_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], 0.12304746736972356)

--- a/tests/test_GCCSD.py
+++ b/tests/test_GCCSD.py
@@ -61,7 +61,7 @@ class GCCSD_Tests(unittest.TestCase):
         for tag in ("oo", "ov", "vo", "vv"):
             a = self.data[True]["f"+tag]
             b = getattr(self.ccsd.fock, tag)
-            np.testing.assert_almost_equal(a, b, 7)
+            self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_energy(self):
         a = self.data[True]["e_corr"]
@@ -71,32 +71,32 @@ class GCCSD_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.data[True]["t1"]
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_t2_amplitudes(self):
         a = self.data[True]["t2"]
         b = self.ccsd.t2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1_f(self):
         a = self.data[True]["rdm1_f"]
         b = self.ccsd.make_rdm1_f()
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm2_f(self):
         a = self.data[True]["rdm2_f"]
         b = self.ccsd.make_rdm2_f()
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l1_amplitudes(self):
         a = self.data[True]["l1"]
         b = self.ccsd.l1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l2_amplitudes(self):
         a = self.data[True]["l2"]
         b = self.ccsd.l2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     @pytest.mark.regression
     def test_from_rebcc(self):
@@ -124,12 +124,12 @@ class GCCSD_Tests(unittest.TestCase):
         gebcc2 = GEBCC.from_rebcc(rebcc)
 
         self.assertAlmostEqual(gebcc1.energy(), gebcc2.energy())
-        np.testing.assert_almost_equal(gebcc1.t1, gebcc2.t1, 6)
-        np.testing.assert_almost_equal(gebcc1.t2, gebcc2.t2, 6)
-        np.testing.assert_almost_equal(gebcc1.l1, gebcc2.l1, 5)
-        np.testing.assert_almost_equal(gebcc1.l2, gebcc2.l2, 5)
-        np.testing.assert_almost_equal(gebcc1.make_rdm1_f(), gebcc2.make_rdm1_f(), 6)
-        np.testing.assert_almost_equal(gebcc1.make_rdm2_f(), gebcc2.make_rdm2_f(), 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.t1 - gebcc2.t1)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.t2 - gebcc2.t2)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.l1 - gebcc2.l1)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.l2 - gebcc2.l2)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_rdm1_f() - gebcc2.make_rdm1_f())), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_rdm2_f() - gebcc2.make_rdm2_f())), 0.0, 6)
 
     @pytest.mark.regression
     def test_from_uebcc(self):
@@ -157,12 +157,12 @@ class GCCSD_Tests(unittest.TestCase):
         gebcc2 = GEBCC.from_uebcc(uebcc)
 
         self.assertAlmostEqual(gebcc1.energy(), gebcc2.energy())
-        np.testing.assert_almost_equal(gebcc1.t1, gebcc2.t1, 6)
-        np.testing.assert_almost_equal(gebcc1.t2, gebcc2.t2, 6)
-        np.testing.assert_almost_equal(gebcc1.l1, gebcc2.l1, 5)
-        np.testing.assert_almost_equal(gebcc1.l2, gebcc2.l2, 5)
-        np.testing.assert_almost_equal(gebcc1.make_rdm1_f(), gebcc2.make_rdm1_f(), 6)
-        np.testing.assert_almost_equal(gebcc1.make_rdm2_f(), gebcc2.make_rdm2_f(), 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.t1 - gebcc2.t1)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.t2 - gebcc2.t2)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.l1 - gebcc2.l1)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.l2 - gebcc2.l2)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_rdm1_f() - gebcc2.make_rdm1_f())), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_rdm2_f() - gebcc2.make_rdm2_f())), 0.0, 6)
 
     @pytest.mark.regression
     def test_from_rebcc_frozen(self):
@@ -205,12 +205,12 @@ class GCCSD_Tests(unittest.TestCase):
         gebcc2 = GEBCC.from_rebcc(rebcc)
 
         self.assertAlmostEqual(gebcc1.energy(), gebcc2.energy())
-        np.testing.assert_almost_equal(gebcc1.t1, gebcc2.t1, 6)
-        np.testing.assert_almost_equal(gebcc1.t2, gebcc2.t2, 6)
-        np.testing.assert_almost_equal(gebcc1.l1, gebcc2.l1, 5)
-        np.testing.assert_almost_equal(gebcc1.l2, gebcc2.l2, 5)
-        np.testing.assert_almost_equal(gebcc1.make_rdm1_f(), gebcc2.make_rdm1_f(), 6)
-        np.testing.assert_almost_equal(gebcc1.make_rdm2_f(), gebcc2.make_rdm2_f(), 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.t1 - gebcc2.t1)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.t2 - gebcc2.t2)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.l1 - gebcc2.l1)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.l2 - gebcc2.l2)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_rdm1_f() - gebcc2.make_rdm1_f())), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_rdm2_f() - gebcc2.make_rdm2_f())), 0.0, 6)
 
     @pytest.mark.regression
     def test_from_uebcc_frozen(self):
@@ -258,12 +258,12 @@ class GCCSD_Tests(unittest.TestCase):
         gebcc2 = GEBCC.from_uebcc(uebcc)
 
         self.assertAlmostEqual(gebcc1.energy(), gebcc2.energy())
-        np.testing.assert_almost_equal(gebcc1.t1, gebcc2.t1, 6)
-        np.testing.assert_almost_equal(gebcc1.t2, gebcc2.t2, 6)
-        np.testing.assert_almost_equal(gebcc1.l1, gebcc2.l1, 5)
-        np.testing.assert_almost_equal(gebcc1.l2, gebcc2.l2, 5)
-        np.testing.assert_almost_equal(gebcc1.make_rdm1_f(), gebcc2.make_rdm1_f(), 6)
-        np.testing.assert_almost_equal(gebcc1.make_rdm2_f(), gebcc2.make_rdm2_f(), 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.t1 - gebcc2.t1)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.t2 - gebcc2.t2)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.l1 - gebcc2.l1)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.l2 - gebcc2.l2)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_rdm1_f() - gebcc2.make_rdm1_f())), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_rdm2_f() - gebcc2.make_rdm2_f())), 0.0, 6)
 
 
 @pytest.mark.reference
@@ -316,32 +316,32 @@ class GCCSD_PySCF_Tests(unittest.TestCase):
     def test_ccsd_t1_amplitudes(self):
         a = self.ccsd_ref.t1
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_ccsd_t2_amplitudes(self):
         a = self.ccsd_ref.t2
         b = self.ccsd.t2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_ccsd_l1_amplitudes(self):
         a = self.ccsd_ref.l1
         b = self.ccsd.l1.T
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_ccsd_l2_amplitudes(self):
         a = self.ccsd_ref.l2
         b = self.ccsd.l2.transpose(2, 3, 0, 1)
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):
         a = self.ccsd_ref.make_rdm1()
         b = self.ccsd.make_rdm1_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm2(self):
         a = self.ccsd_ref.make_rdm2()
         b = self.ccsd.make_rdm2_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_eom_ip(self):
         e1 = np.asarray(self.ccsd.ip_eom(nroots=5).kernel())

--- a/tests/test_GCCSD.py
+++ b/tests/test_GCCSD.py
@@ -330,7 +330,7 @@ class GCCSD_PySCF_Tests(unittest.TestCase):
 
     def test_ccsd_l2_amplitudes(self):
         a = self.ccsd_ref.l2
-        b = self.ccsd.l2.transpose(2, 3, 0, 1)
+        b = np.transpose(self.ccsd.l2, (2, 3, 0, 1))
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):

--- a/tests/test_GCCSD.py
+++ b/tests/test_GCCSD.py
@@ -12,7 +12,7 @@ import scipy.linalg
 from types import SimpleNamespace
 from pyscf import cc, gto, lib, scf
 
-from ebcc import REBCC, UEBCC, GEBCC, Space, NullLogger, util
+from ebcc import REBCC, UEBCC, GEBCC, Space, NullLogger, util, BACKEND
 
 # TODO test more excitations in EOM
 
@@ -343,41 +343,49 @@ class GCCSD_PySCF_Tests(unittest.TestCase):
         b = self.ccsd.make_rdm2_f(eris=self.eris)
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         e1 = np.asarray(self.ccsd.ip_eom(nroots=5).kernel())
         e2, v2 = self.ccsd_ref.ipccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         e1 = np.asarray(self.ccsd.ea_eom(nroots=5).kernel())
         e2, v2 = self.ccsd_ref.eaccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ee(self):
         e1 = np.asarray(self.ccsd.ee_eom(nroots=5).kernel())
         e2, v2 = self.ccsd_ref.eeccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip_koopmans(self):
         e1 = np.asarray(self.ccsd.ip_eom(nroots=5, koopmans=True).kernel())
         e2, v2 = self.ccsd_ref.ipccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea_koopmans(self):
         e1 = np.asarray(self.ccsd.ea_eom(nroots=5, koopmans=True).kernel())
         e2, v2 = self.ccsd_ref.eaccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip_left(self):
         e1 = np.asarray(self.ccsd.ip_eom(nroots=5, left=True).kernel())
         e2, v2 = self.ccsd_ref.ipccsd(nroots=5, left=True)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea_left(self):
         e1 = np.asarray(self.ccsd.ea_eom(nroots=5, left=True).kernel())
         e2, v2 = self.ccsd_ref.eaccsd(nroots=5, left=True)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ee_left(self):
         e1 = np.asarray(self.ccsd.ee_eom(nroots=5, left=True).kernel())
         e2, v2 = self.ccsd_ref.eeccsd(nroots=5)  # No left EE-EOM in PySCF

--- a/tests/test_GCCSDTQ.py
+++ b/tests/test_GCCSDTQ.py
@@ -11,6 +11,7 @@ from ebcc import GEBCC, NullLogger
 
 
 @pytest.mark.regression
+@pytest.mark.slow
 class GCCSDTQ_Tests(unittest.TestCase):
     """Test GCCSDTQ against regression.
     """

--- a/tests/test_GCCSD_SD_1_1.py
+++ b/tests/test_GCCSD_SD_1_1.py
@@ -79,19 +79,19 @@ class GCCSD_SD_1_1_Tests(unittest.TestCase):
     def test_xi(self):
         a = self.data[self.shift]["xi"]
         b = self.ccsd.xi
-        np.testing.assert_almost_equal(a, b, 7)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_fock(self):
         for tag in ("oo", "ov", "vo", "vv"):
             a = self.data[self.shift]["f"+tag]
             b = getattr(self.ccsd.fock, tag)
-            np.testing.assert_almost_equal(a, b, 7)
+            self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_g(self):
         for tag in ("oo", "ov", "vo", "vv"):
             a = self.data[self.shift]["gb"+tag]
             b = getattr(self.ccsd.g, "b"+tag)
-            np.testing.assert_almost_equal(a, b, 7)
+            self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_energy(self):
         a = self.data[self.shift]["e_corr"]
@@ -101,27 +101,27 @@ class GCCSD_SD_1_1_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.data[self.shift]["t1"]
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_t2_amplitudes(self):
         a = self.data[self.shift]["t2"]
         b = self.ccsd.t2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_s1_amplitudes(self):
         a = self.data[self.shift]["s1"]
         b = self.ccsd.amplitudes["s1"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_s2_amplitudes(self):
         a = self.data[self.shift]["s2"]
         b = self.ccsd.amplitudes["s2"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_u11_amplitudes(self):
         a = self.data[self.shift]["u11"]
         b = self.ccsd.amplitudes["u11"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     @pytest.mark.regression
     def test_lambdas(self):

--- a/tests/test_GCCSD_SD_1_1.py
+++ b/tests/test_GCCSD_SD_1_1.py
@@ -44,7 +44,7 @@ class GCCSD_SD_1_1_Tests(unittest.TestCase):
         nbos = 5
         np.random.seed(12345)
         g_ = np.random.random((nbos, nmo, nmo)) * 0.02
-        g_ = 0.5 * (g_ + g_.transpose(0, 2, 1).conj())
+        g_ = 0.5 * (g_ + np.conj(np.transpose(g_, (0, 2, 1))))
         omega = np.random.random((nbos,)) * 5.0
 
         orbspin = scf.addons.get_ghf_orbspin(mf.mo_energy, mf.mo_occ, True)

--- a/tests/test_GCCSD_SD_1_2.py
+++ b/tests/test_GCCSD_SD_1_2.py
@@ -44,7 +44,7 @@ class GCCSD_SD_1_2_Tests(unittest.TestCase):
         nbos = 5
         np.random.seed(12345)
         g_ = np.random.random((nbos, nmo, nmo)) * 0.02
-        g_ = 0.5 * (g_ + g_.transpose(0, 2, 1).conj())
+        g_ = 0.5 * (g_ + np.conj(np.transpose(g_, (0, 2, 1))))
         omega = np.random.random((nbos,)) * 5.0
 
         orbspin = scf.addons.get_ghf_orbspin(mf.mo_energy, mf.mo_occ, True)
@@ -150,8 +150,8 @@ class GCCSD_SD_1_2_Tests(unittest.TestCase):
         orbspin = scf.addons.get_ghf_orbspin(uhf.mo_energy, uhf.mo_occ, False)
         nmo = self.mf.mo_occ.size
         g = np.zeros((self.omega.size, nmo*2, nmo*2))
-        g[np.ix_(range(self.omega.size), orbspin==0, orbspin==0)] = self.g_rhf.copy()
-        g[np.ix_(range(self.omega.size), orbspin==1, orbspin==1)] = self.g_rhf.copy()
+        g[np.ix_(range(self.omega.size), orbspin==0, orbspin==0)] = np.copy(self.g_rhf)
+        g[np.ix_(range(self.omega.size), orbspin==1, orbspin==1)] = np.copy(self.g_rhf)
 
         gebcc1 = GEBCC(
                 mf,
@@ -199,8 +199,8 @@ class GCCSD_SD_1_2_Tests(unittest.TestCase):
         orbspin = scf.addons.get_ghf_orbspin(mf.mo_energy, mf.mo_occ, False)
         nmo = self.mf.mo_occ.size
         g = np.zeros((self.omega.size, nmo*2, nmo*2))
-        g[np.ix_(range(self.omega.size), orbspin==0, orbspin==0)] = self.g_rhf.copy()
-        g[np.ix_(range(self.omega.size), orbspin==1, orbspin==1)] = self.g_rhf.copy()
+        g[np.ix_(range(self.omega.size), orbspin==0, orbspin==0)] = np.copy(self.g_rhf)
+        g[np.ix_(range(self.omega.size), orbspin==1, orbspin==1)] = np.copy(self.g_rhf)
 
         gebcc1 = GEBCC(
                 mf,

--- a/tests/test_GCCSD_SD_1_2.py
+++ b/tests/test_GCCSD_SD_1_2.py
@@ -81,19 +81,19 @@ class GCCSD_SD_1_2_Tests(unittest.TestCase):
     def test_xi(self):
         a = self.data[self.shift]["xi"]
         b = self.ccsd.xi
-        np.testing.assert_almost_equal(a, b, 7)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_fock(self):
         for tag in ("oo", "ov", "vo", "vv"):
             a = self.data[self.shift]["f"+tag]
             b = getattr(self.ccsd.fock, tag)
-            np.testing.assert_almost_equal(a, b, 7)
+            self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_g(self):
         for tag in ("oo", "ov", "vo", "vv"):
             a = self.data[self.shift]["gb"+tag]
             b = getattr(self.ccsd.g, "b"+tag)
-            np.testing.assert_almost_equal(a, b, 7)
+            self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_energy(self):
         a = self.data[self.shift]["e_corr"]
@@ -103,27 +103,27 @@ class GCCSD_SD_1_2_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.data[self.shift]["t1"]
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_t2_amplitudes(self):
         a = self.data[self.shift]["t2"]
         b = self.ccsd.t2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_s1_amplitudes(self):
         a = self.data[self.shift]["s1"]
         b = self.ccsd.amplitudes["s1"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_s2_amplitudes(self):
         a = self.data[self.shift]["s2"]
         b = self.ccsd.amplitudes["s2"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_u11_amplitudes(self):
         a = self.data[self.shift]["u11"]
         b = self.ccsd.amplitudes["u11"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     @pytest.mark.regression
     def test_lambdas(self):
@@ -182,14 +182,14 @@ class GCCSD_SD_1_2_Tests(unittest.TestCase):
 
         self.assertAlmostEqual(gebcc1.energy(), gebcc2.energy())
         for key in gebcc1.amplitudes.keys():
-            np.testing.assert_almost_equal(gebcc1.amplitudes[key], gebcc2.amplitudes[key], 6)
+            self.assertAlmostEqual(np.max(np.abs(gebcc1.amplitudes[key] - gebcc2.amplitudes[key])), 0.0, 6)
         for key in gebcc1.lambdas.keys():
-            np.testing.assert_almost_equal(gebcc1.lambdas[key], gebcc2.lambdas[key], 5)
-        np.testing.assert_almost_equal(gebcc1.make_rdm1_f(), gebcc2.make_rdm1_f(), 6)
-        np.testing.assert_almost_equal(gebcc1.make_rdm2_f(), gebcc2.make_rdm2_f(), 6)
-        np.testing.assert_almost_equal(gebcc1.make_rdm1_b(), gebcc2.make_rdm1_b(), 6)
-        np.testing.assert_almost_equal(gebcc1.make_sing_b_dm(), gebcc2.make_sing_b_dm(), 6)
-        np.testing.assert_almost_equal(gebcc1.make_eb_coup_rdm(), gebcc2.make_eb_coup_rdm(), 6)
+            self.assertAlmostEqual(np.max(np.abs(gebcc1.lambdas[key] - gebcc2.lambdas[key])), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_rdm1_f() - gebcc2.make_rdm1_f())), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_rdm2_f() - gebcc2.make_rdm2_f())), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_rdm1_b() - gebcc2.make_rdm1_b())), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_sing_b_dm() - gebcc2.make_sing_b_dm())), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_eb_coup_rdm() - gebcc2.make_eb_coup_rdm())), 0.0, 6)
 
     @pytest.mark.regression
     def test_from_uebcc(self):
@@ -234,14 +234,14 @@ class GCCSD_SD_1_2_Tests(unittest.TestCase):
 
         self.assertAlmostEqual(gebcc1.energy(), gebcc2.energy())
         for key in gebcc1.amplitudes.keys():
-            np.testing.assert_almost_equal(gebcc1.amplitudes[key], gebcc2.amplitudes[key], 6)
+            self.assertAlmostEqual(np.max(np.abs(gebcc1.amplitudes[key] - gebcc2.amplitudes[key])), 0.0, 6)
         for key in gebcc1.lambdas.keys():
-            np.testing.assert_almost_equal(gebcc1.lambdas[key], gebcc2.lambdas[key], 5)
-        np.testing.assert_almost_equal(gebcc1.make_rdm1_f(), gebcc2.make_rdm1_f(), 6)
-        np.testing.assert_almost_equal(gebcc1.make_rdm2_f(), gebcc2.make_rdm2_f(), 6)
-        np.testing.assert_almost_equal(gebcc1.make_rdm1_b(), gebcc2.make_rdm1_b(), 6)
-        np.testing.assert_almost_equal(gebcc1.make_sing_b_dm(), gebcc2.make_sing_b_dm(), 6)
-        np.testing.assert_almost_equal(gebcc1.make_eb_coup_rdm(), gebcc2.make_eb_coup_rdm(), 6)
+            self.assertAlmostEqual(np.max(np.abs(gebcc1.lambdas[key] - gebcc2.lambdas[key])), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_rdm1_f() - gebcc2.make_rdm1_f())), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_rdm2_f() - gebcc2.make_rdm2_f())), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_rdm1_b() - gebcc2.make_rdm1_b())), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_sing_b_dm() - gebcc2.make_sing_b_dm())), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(gebcc1.make_eb_coup_rdm() - gebcc2.make_eb_coup_rdm())), 0.0, 6)
 
 
 @pytest.mark.reference

--- a/tests/test_GCCSD_S_1_1.py
+++ b/tests/test_GCCSD_S_1_1.py
@@ -80,19 +80,19 @@ class GCCSD_S_1_1_Tests(unittest.TestCase):
     def test_xi(self):
         a = self.data[self.shift]["xi"]
         b = self.ccsd.xi
-        np.testing.assert_almost_equal(a, b, 7)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_fock(self):
         for tag in ("oo", "ov", "vo", "vv"):
             a = self.data[self.shift]["f"+tag]
             b = getattr(self.ccsd.fock, tag)
-            np.testing.assert_almost_equal(a, b, 7)
+            self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_g(self):
         for tag in ("oo", "ov", "vo", "vv"):
             a = self.data[self.shift]["gb"+tag]
             b = getattr(self.ccsd.g, "b"+tag)
-            np.testing.assert_almost_equal(a, b, 7)
+            self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_energy(self):
         a = self.data[self.shift]["e_corr"]
@@ -102,67 +102,67 @@ class GCCSD_S_1_1_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.data[self.shift]["t1"]
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_t2_amplitudes(self):
         a = self.data[self.shift]["t2"]
         b = self.ccsd.t2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_s1_amplitudes(self):
         a = self.data[self.shift]["s1"]
         b = self.ccsd.amplitudes["s1"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_u11_amplitudes(self):
         a = self.data[self.shift]["u11"]
         b = self.ccsd.amplitudes["u11"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l1_amplitudes(self):
         a = self.data[self.shift]["l1"]
         b = self.ccsd.l1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l2_amplitudes(self):
         a = self.data[self.shift]["l2"]
         b = self.ccsd.l2
-        np.testing.assert_almost_equal(a, b, 5)  # FIXME low tol
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 5)  # FIXME low tol
 
     def test_ls1_amplitudes(self):
         a = self.data[self.shift]["ls1"]
         b = self.ccsd.lambdas["ls1"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_lu11_amplitudes(self):
         a = self.data[self.shift]["lu11"]
         b = self.ccsd.lambdas["lu11"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1_f(self):
         a = self.data[self.shift]["rdm1_f"]
         b = self.ccsd.make_rdm1_f()
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm2_f(self):
         a = self.data[self.shift]["rdm2_f"]
         b = self.ccsd.make_rdm2_f()
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1_b(self):
         a = self.data[self.shift]["rdm1_b"]
         b = self.ccsd.make_rdm1_b()
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_dm_b(self):
         a = self.data[self.shift]["dm_b"]
         b = np.array(self.ccsd.make_sing_b_dm())
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm_eb(self):
         a = self.data[self.shift]["rdm_eb"]
         b = self.ccsd.make_eb_coup_rdm()
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 @pytest.mark.reference

--- a/tests/test_GCCSD_S_1_1.py
+++ b/tests/test_GCCSD_S_1_1.py
@@ -44,7 +44,7 @@ class GCCSD_S_1_1_Tests(unittest.TestCase):
         nbos = 5
         np.random.seed(12345)
         g_ = np.random.random((nbos, nmo, nmo)) * 0.02
-        g_ = 0.5 * (g_ + g_.transpose(0, 2, 1).conj())
+        g_ = 0.5 * (g_ + np.conj(np.transpose(g_, (0, 2, 1))))
         omega = np.random.random((nbos,)) * 5.0
 
         orbspin = scf.addons.get_ghf_orbspin(mf.mo_energy, mf.mo_occ, True)

--- a/tests/test_GCCSD_S_1_1.py
+++ b/tests/test_GCCSD_S_1_1.py
@@ -160,7 +160,7 @@ class GCCSD_S_1_1_Tests(unittest.TestCase):
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm_eb(self):
-        a = self.data[self.shift]["rdm_eb"]
+        a = np.asarray(self.data[self.shift]["rdm_eb"])
         b = self.ccsd.make_eb_coup_rdm()
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 

--- a/tests/test_GCCSDtp.py
+++ b/tests/test_GCCSDtp.py
@@ -8,10 +8,11 @@ import numpy as np
 import pytest
 from pyscf import gto, lib, scf, fci
 
-from ebcc import GEBCC, REBCC, Space, NullLogger, util
+from ebcc import GEBCC, REBCC, Space, NullLogger, util, BACKEND
 
 
 @pytest.mark.regression
+@pytest.mark.skipif(BACKEND != "numpy", reason="Currently requires mutable backend.")
 class GCCSDtp_Tests(unittest.TestCase):
     """Test GCCSDt' against regression.
     """

--- a/tests/test_RCC2.py
+++ b/tests/test_RCC2.py
@@ -11,7 +11,7 @@ import pytest
 import scipy.linalg
 from pyscf import cc, gto, lib, scf
 
-from ebcc import REBCC, NullLogger, util
+from ebcc import REBCC, NullLogger, util, BACKEND
 
 
 @pytest.mark.reference
@@ -122,10 +122,12 @@ class RCC2_Tests(unittest.TestCase):
         dm = util.einsum("ijkl,pi,qj,rk,sl->pqrs", dm, c, c, c, c)
         self.assertAlmostEqual(lib.fp(dm), 6.475456720894991, 6)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         e1 = self.ccsd.ip_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], 0.433406912467204)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         e1 = self.ccsd.ea_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], 0.16637220504347422)

--- a/tests/test_RCC2.py
+++ b/tests/test_RCC2.py
@@ -69,12 +69,12 @@ class RCC2_PySCF_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.ccsd_ref.t1
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_t2_amplitudes(self):
         a = self.ccsd_ref.t2
         b = self.ccsd.t2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 @pytest.mark.regression

--- a/tests/test_RCC3.py
+++ b/tests/test_RCC3.py
@@ -67,7 +67,7 @@ class RCC3_Tests(unittest.TestCase):
     def test_t1(self):
         a = scipy.linalg.block_diag(self.rcc3.t1, self.rcc3.t1)[self.osort][:, self.vsort]
         b = self.gcc3.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     # TODO reference test, too slow
     #def test_h2o_ccpvdz(self):

--- a/tests/test_RCCD.py
+++ b/tests/test_RCCD.py
@@ -71,22 +71,22 @@ class RCCD_PySCF_Tests(unittest.TestCase):
     def test_t2_amplitudes(self):
         a = self.ccd_ref.t2
         b = self.ccd.t2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l2_amplitudes(self):
         a = self.ccd_ref.l2
         b = self.ccd.l2.transpose(2, 3, 0, 1)
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):
         a = self.ccd_ref.make_rdm1()
         b = self.ccd.make_rdm1_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm2(self):
         a = self.ccd_ref.make_rdm2()
         b = self.ccd.make_rdm2_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 @pytest.mark.reference
@@ -156,12 +156,12 @@ class RCCD_PySCF_Frozen_Tests(unittest.TestCase):
     def test_t2_amplitudes(self):
         a = self.ccd_ref.t2
         b = self.ccd.t2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l2_amplitudes(self):
         a = self.ccd_ref.l2
         b = self.ccd.l2.transpose(2, 3, 0, 1)
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):
         nocc = self.ccd_ref.nocc
@@ -170,7 +170,7 @@ class RCCD_PySCF_Frozen_Tests(unittest.TestCase):
         l2, t2 = self.ccd_ref.l2, self.ccd_ref.t2
         a = ccsd_rdm.make_rdm1(self.ccd_ref, t1, t2, l1, l2, with_frozen=False)
         b = self.ccd.make_rdm1_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm2(self):
         nocc = self.ccd_ref.nocc
@@ -179,7 +179,7 @@ class RCCD_PySCF_Frozen_Tests(unittest.TestCase):
         l2, t2 = self.ccd_ref.l2, self.ccd_ref.t2
         a = ccsd_rdm.make_rdm2(self.ccd_ref, t1, t2, l1, l2, with_frozen=False)
         b = self.ccd.make_rdm2_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 @pytest.mark.reference

--- a/tests/test_RCCD.py
+++ b/tests/test_RCCD.py
@@ -75,7 +75,7 @@ class RCCD_PySCF_Tests(unittest.TestCase):
 
     def test_l2_amplitudes(self):
         a = self.ccd_ref.l2
-        b = self.ccd.l2.transpose(2, 3, 0, 1)
+        b = np.transpose(self.ccd.l2, (2, 3, 0, 1))
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):
@@ -160,7 +160,7 @@ class RCCD_PySCF_Frozen_Tests(unittest.TestCase):
 
     def test_l2_amplitudes(self):
         a = self.ccd_ref.l2
-        b = self.ccd.l2.transpose(2, 3, 0, 1)
+        b = np.transpose(self.ccd.l2, (2, 3, 0, 1))
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):

--- a/tests/test_RCCD.py
+++ b/tests/test_RCCD.py
@@ -13,7 +13,7 @@ from pyscf import cc, gto, lib, scf
 from pyscf.cc import ccd as pyscf_ccd
 from pyscf.cc import ccsd_rdm
 
-from ebcc import REBCC, NullLogger, Space
+from ebcc import REBCC, NullLogger, Space, BACKEND
 
 
 @pytest.mark.reference
@@ -222,10 +222,12 @@ class RCCD_PySCF_Tests(unittest.TestCase):
     def tearDownClass(cls):
         del cls.mf, cls.ccd_ref, cls.ccd
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         e1 = self.ccd.ip_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], 0.2979663212884527)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         e1 = self.ccd.ea_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], 0.0008750978075545658)

--- a/tests/test_RCCSD.py
+++ b/tests/test_RCCSD.py
@@ -86,7 +86,7 @@ class RCCSD_Tests(unittest.TestCase):
     # def test_ip_moments(self):
     #    eom = self.ccsd.ip_eom()
     #    ip_moms = eom.moments(4)
-    #    a = self.data[True]["ip_moms"].transpose(2, 0, 1)
+    #    a = np.transpose(self.data[True]["ip_moms"], (2, 0, 1))
     #    b = np.array([scipy.linalg.block_diag(x, x) for x in ip_moms])
     #    b = b[:, self.fsort][:, :, self.fsort]
     #    for x, y in zip(a, b):
@@ -112,7 +112,7 @@ class RCCSD_Tests(unittest.TestCase):
     # def test_ea_moments(self):
     #    eom = self.ccsd.ea_eom()
     #    ea_moms = eom.moments(4)
-    #    a = self.data[True]["ea_moms"].transpose(2, 0, 1)
+    #    a = np.transpose(self.data[True]["ea_moms"], (2, 0, 1))
     #    b = np.array([scipy.linalg.block_diag(x, x) for x in ea_moms])
     #    b = b[:, self.fsort][:, :, self.fsort]
     #    for x, y in zip(a, b):
@@ -207,7 +207,7 @@ class RCCSD_PySCF_Tests(unittest.TestCase):
 
     def test_l2_amplitudes(self):
         a = self.ccsd_ref.l2
-        b = self.ccsd.l2.transpose(2, 3, 0, 1)
+        b = np.transpose(self.ccsd.l2, (2, 3, 0, 1))
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):
@@ -383,7 +383,7 @@ class RCCSD_PySCF_Frozen_Tests(unittest.TestCase):
 
     def test_l2_amplitudes(self):
         a = self.ccsd_ref.l2
-        b = self.ccsd.l2.transpose(2, 3, 0, 1)
+        b = np.transpose(self.ccsd.l2, (2, 3, 0, 1))
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):

--- a/tests/test_RCCSD.py
+++ b/tests/test_RCCSD.py
@@ -12,7 +12,7 @@ import pytest
 import scipy.linalg
 from pyscf import cc, dft, gto, lib, scf
 
-from ebcc import REBCC, NullLogger, Space
+from ebcc import REBCC, NullLogger, Space, BACKEND
 from ebcc.ham.space import construct_fno_space
 
 
@@ -220,24 +220,28 @@ class RCCSD_PySCF_Tests(unittest.TestCase):
         b = self.ccsd.make_rdm2_f(eris=self.eris)
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         eom = self.ccsd.ip_eom(nroots=5)
         e1 = np.asarray(eom.kernel())
         e2, v2 = self.ccsd_ref.ipccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         eom = self.ccsd.ea_eom(nroots=5)
         e1 = np.asarray(eom.kernel())
         e2, v2 = self.ccsd_ref.eaccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip_left(self):
         eom = self.ccsd.ip_eom(nroots=5, left=True)
         e1 = np.asarray(eom.kernel())
         e2, v2 = self.ccsd_ref.ipccsd(nroots=5, left=True)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea_left(self):
         eom = self.ccsd.ea_eom(nroots=5, left=True)
         e1 = np.asarray(eom.kernel())
@@ -392,24 +396,28 @@ class RCCSD_PySCF_Frozen_Tests(unittest.TestCase):
         b = self.ccsd.make_rdm2_f(eris=self.eris)
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         eom = self.ccsd.ip_eom(nroots=5)
         e1 = np.asarray(eom.kernel())
         e2, v2 = self.ccsd_ref.ipccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         eom = self.ccsd.ea_eom(nroots=5)
         e1 = np.asarray(eom.kernel())
         e2, v2 = self.ccsd_ref.eaccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip_left(self):
         eom = self.ccsd.ip_eom(nroots=5, left=True)
         e1 = np.asarray(eom.kernel())
         e2, v2 = self.ccsd_ref.ipccsd(nroots=5, left=True)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea_left(self):
         eom = self.ccsd.ea_eom(nroots=5, left=True)
         e1 = np.asarray(eom.kernel())

--- a/tests/test_RCCSD.py
+++ b/tests/test_RCCSD.py
@@ -69,19 +69,19 @@ class RCCSD_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.data[True]["t1"]
         b = scipy.linalg.block_diag(self.ccsd.t1, self.ccsd.t1)[self.osort][:, self.vsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1_f(self):
         rdm1_f = self.ccsd.make_rdm1_f()
         a = self.data[True]["rdm1_f"]
         b = scipy.linalg.block_diag(rdm1_f, rdm1_f) / 2
         b = b[self.fsort][:, self.fsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l1_amplitudes(self):
         a = self.data[True]["l1"]
         b = scipy.linalg.block_diag(self.ccsd.l1, self.ccsd.l1)[self.vsort][:, self.osort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     # def test_ip_moments(self):
     #    eom = self.ccsd.ip_eom()
@@ -107,7 +107,7 @@ class RCCSD_Tests(unittest.TestCase):
     #        print(y[:self.ccsd.nocc*2, :self.ccsd.nocc*2])
     #        x /= np.max(np.abs(x))
     #        y /= np.max(np.abs(y))
-    #        np.testing.assert_almost_equal(x, y, 6)
+    #        self.assertAlmostEqual(np.max(np.abs(x - y)), 0.0, 6)
 
     # def test_ea_moments(self):
     #    eom = self.ccsd.ea_eom()
@@ -124,19 +124,19 @@ class RCCSD_Tests(unittest.TestCase):
     #        )
     #        x /= np.max(np.abs(x))
     #        y /= np.max(np.abs(y))
-    #        np.testing.assert_almost_equal(x, y, 6)
+    #        self.assertAlmostEqual(np.max(np.abs(x - y)), 0.0, 6)
 
     # def test_ip_1mom(self):
     #    ip_1mom = self.ccsd.make_ip_1mom()
     #    a = self.data[True]["ip_1mom"]
     #    b = scipy.linalg.block_diag(ip_1mom, ip_1mom)
-    #    np.testing.assert_almost_equal(a, b, 6)
+    #    self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     # def test_ea_1mom(self):
     #    ea_1mom = self.ccsd.make_ea_1mom()
     #    a = self.data[True]["ea_1mom"]
     #    b = sceay.linalg.block_diag(ea_1mom, ea_1mom)
-    #    np.testing.assert_almost_equal(a, b, 6)
+    #    self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 @pytest.mark.reference
@@ -193,32 +193,32 @@ class RCCSD_PySCF_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.ccsd_ref.t1
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_t2_amplitudes(self):
         a = self.ccsd_ref.t2
         b = self.ccsd.t2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l1_amplitudes(self):
         a = self.ccsd_ref.l1
         b = self.ccsd.l1.T
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l2_amplitudes(self):
         a = self.ccsd_ref.l2
         b = self.ccsd.l2.transpose(2, 3, 0, 1)
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):
         a = self.ccsd_ref.make_rdm1()
         b = self.ccsd.make_rdm1_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm2(self):
         a = self.ccsd_ref.make_rdm2()
         b = self.ccsd.make_rdm2_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_eom_ip(self):
         eom = self.ccsd.ip_eom(nroots=5)
@@ -291,12 +291,12 @@ class FNORCCSD_PySCF_Tests(RCCSD_PySCF_Tests):
     def test_rdm1(self):
         a = self.ccsd_ref.make_rdm1(with_frozen=False)
         b = self.ccsd.make_rdm1_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm2(self):
         a = self.ccsd_ref.make_rdm2(with_frozen=False)
         b = self.ccsd.make_rdm2_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 @pytest.mark.reference
@@ -365,32 +365,32 @@ class RCCSD_PySCF_Frozen_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.ccsd_ref.t1
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_t2_amplitudes(self):
         a = self.ccsd_ref.t2
         b = self.ccsd.t2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l1_amplitudes(self):
         a = self.ccsd_ref.l1
         b = self.ccsd.l1.T
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l2_amplitudes(self):
         a = self.ccsd_ref.l2
         b = self.ccsd.l2.transpose(2, 3, 0, 1)
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):
         a = self.ccsd_ref.make_rdm1(with_frozen=False)
         b = self.ccsd.make_rdm1_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm2(self):
         a = self.ccsd_ref.make_rdm2(with_frozen=False)
         b = self.ccsd.make_rdm2_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_eom_ip(self):
         eom = self.ccsd.ip_eom(nroots=5)
@@ -514,7 +514,7 @@ class RCCSD_PySCF_DFT_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.ccsd_ref.t1
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 if __name__ == "__main__":

--- a/tests/test_RCCSDT.py
+++ b/tests/test_RCCSDT.py
@@ -70,7 +70,7 @@ class RCCSDT_Tests(unittest.TestCase):
     def test_t1(self):
         a = scipy.linalg.block_diag(self.rccsdt.t1, self.rccsdt.t1)[self.osort][:, self.vsort]
         b = self.gccsdt.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm_energy(self):
         dm1 = self.rccsdt.make_rdm1_f()

--- a/tests/test_RCCSD_SD_1_1.py
+++ b/tests/test_RCCSD_SD_1_1.py
@@ -45,7 +45,7 @@ class RCCSD_SD_1_1_Tests(unittest.TestCase):
         nbos = 5
         np.random.seed(12345)
         g = np.random.random((nbos, nmo, nmo)) * 0.02
-        g = 0.5 * (g + g.transpose(0, 2, 1).conj())
+        g = 0.5 * (g + np.conj(np.transpose(g, (0, 2, 1))))
         omega = np.random.random((nbos,)) * 5.0
 
         ccsd = REBCC(

--- a/tests/test_RCCSD_SD_1_1.py
+++ b/tests/test_RCCSD_SD_1_1.py
@@ -81,7 +81,7 @@ class RCCSD_SD_1_1_Tests(unittest.TestCase):
     def test_xi(self):
         a = self.data[self.shift]["xi"]
         b = self.ccsd.xi
-        np.testing.assert_almost_equal(a, b, 7)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_energy(self):
         a = self.data[self.shift]["e_corr"]
@@ -91,18 +91,18 @@ class RCCSD_SD_1_1_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.data[self.shift]["t1"]
         b = scipy.linalg.block_diag(self.ccsd.t1, self.ccsd.t1)[self.osort][:, self.vsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_s1_amplitudes(self):
         a = self.data[self.shift]["s1"]
         b = self.ccsd.amplitudes["s1"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_u11_amplitudes(self):
         a = self.data[self.shift]["u11"]
         b = np.array([scipy.linalg.block_diag(x, x) for x in self.ccsd.amplitudes["u11"]])
         b = b[:, self.osort][:, :, self.vsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     @pytest.mark.regression
     def test_lambdas(self):

--- a/tests/test_RCCSD_SD_1_2.py
+++ b/tests/test_RCCSD_SD_1_2.py
@@ -82,7 +82,7 @@ class RCCSD_SD_1_2_Tests(unittest.TestCase):
     def test_xi(self):
         a = self.data[self.shift]["xi"]
         b = self.ccsd.xi
-        np.testing.assert_almost_equal(a, b, 7)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_energy(self):
         a = self.data[self.shift]["e_corr"]
@@ -92,18 +92,18 @@ class RCCSD_SD_1_2_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.data[self.shift]["t1"]
         b = scipy.linalg.block_diag(self.ccsd.t1, self.ccsd.t1)[self.osort][:, self.vsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_s1_amplitudes(self):
         a = self.data[self.shift]["s1"]
         b = self.ccsd.amplitudes["s1"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_u11_amplitudes(self):
         a = self.data[self.shift]["u11"]
         b = np.array([scipy.linalg.block_diag(x, x) for x in self.ccsd.amplitudes["u11"]])
         b = b[:, self.osort][:, :, self.vsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     @pytest.mark.regression
     def test_lambdas(self):

--- a/tests/test_RCCSD_SD_1_2.py
+++ b/tests/test_RCCSD_SD_1_2.py
@@ -46,7 +46,7 @@ class RCCSD_SD_1_2_Tests(unittest.TestCase):
         nbos = 5
         np.random.seed(12345)
         g = np.random.random((nbos, nmo, nmo)) * 0.02
-        g = 0.5 * (g + g.transpose(0, 2, 1).conj())
+        g = 0.5 * (g + np.conj(np.transpose(g, (0, 2, 1))))
         omega = np.random.random((nbos,)) * 5.0
 
         ccsd = REBCC(
@@ -177,7 +177,7 @@ class RCCSD_SD_1_2_Dump_Tests(RCCSD_SD_1_2_Tests):
         nbos = 5
         np.random.seed(12345)
         g = np.random.random((nbos, nmo, nmo)) * 0.02
-        g = 0.5 * (g + g.transpose(0, 2, 1).conj())
+        g = 0.5 * (g + np.conj(np.transpose(g, (0, 2, 1))))
         omega = np.random.random((nbos,)) * 5.0
 
         ccsd = REBCC(

--- a/tests/test_RCCSD_S_1_1.py
+++ b/tests/test_RCCSD_S_1_1.py
@@ -45,7 +45,7 @@ class RCCSD_S_1_1_Tests(unittest.TestCase):
         nbos = 5
         np.random.seed(12345)
         g = np.random.random((nbos, nmo, nmo)) * 0.02
-        g = 0.5 * (g + g.transpose(0, 2, 1).conj())
+        g = 0.5 * (g + np.conj(np.transpose(g, (0, 2, 1))))
         omega = np.random.random((nbos,)) * 5.0
 
         ccsd = REBCC(

--- a/tests/test_RCCSD_S_1_1.py
+++ b/tests/test_RCCSD_S_1_1.py
@@ -81,7 +81,7 @@ class RCCSD_S_1_1_Tests(unittest.TestCase):
     def test_xi(self):
         a = self.data[self.shift]["xi"]
         b = self.ccsd.xi
-        np.testing.assert_almost_equal(a, b, 7)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_energy(self):
         a = self.data[self.shift]["e_corr"]
@@ -91,41 +91,41 @@ class RCCSD_S_1_1_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.data[self.shift]["t1"]
         b = scipy.linalg.block_diag(self.ccsd.t1, self.ccsd.t1)[self.osort][:, self.vsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_s1_amplitudes(self):
         a = self.data[self.shift]["s1"]
         b = self.ccsd.amplitudes["s1"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_u11_amplitudes(self):
         a = self.data[self.shift]["u11"]
         b = np.array([scipy.linalg.block_diag(x, x) for x in self.ccsd.amplitudes["u11"]])
         b = b[:, self.osort][:, :, self.vsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l1_amplitudes(self):
         a = self.data[self.shift]["l1"]
         b = scipy.linalg.block_diag(self.ccsd.l1, self.ccsd.l1)[self.vsort][:, self.osort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_ls1_amplitudes(self):
         a = self.data[self.shift]["ls1"]
         b = self.ccsd.lambdas["ls1"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_lu11_amplitudes(self):
         a = self.data[self.shift]["lu11"]
         b = np.array([scipy.linalg.block_diag(x, x) for x in self.ccsd.lambdas["lu11"]])
         b = b[:, self.vsort][:, :, self.osort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1_f(self):
         rdm1_f = self.ccsd.make_rdm1_f()
         a = self.data[self.shift]["rdm1_f"]
         b = scipy.linalg.block_diag(rdm1_f, rdm1_f) / 2
         b = b[self.fsort][:, self.fsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     @pytest.mark.regression
     def test_rdm2_f(self):
@@ -134,18 +134,18 @@ class RCCSD_S_1_1_Tests(unittest.TestCase):
     def test_rdm1_b(self):
         a = self.data[self.shift]["rdm1_b"]
         b = self.ccsd.make_rdm1_b()
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_dm_b(self):
         a = self.data[self.shift]["dm_b"]
         b = np.array(self.ccsd.make_sing_b_dm())
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm_eb(self):
         a = np.array(self.data[self.shift]["rdm_eb"])
         b = np.array([[scipy.linalg.block_diag(x, x) for x in y] for y in self.ccsd.make_eb_coup_rdm()]) / 2
         b = b[:, :, self.fsort][:, :, :, self.fsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 @pytest.mark.reference

--- a/tests/test_RCCSDtp.py
+++ b/tests/test_RCCSDtp.py
@@ -89,7 +89,7 @@ class RCCSDtp_Tests(unittest.TestCase):
     def test_t1(self):
         a = scipy.linalg.block_diag(self.rccsdt.t1, self.rccsdt.t1)[self.osort][:, self.vsort]
         b = self.gccsdt.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 @pytest.mark.regression

--- a/tests/test_RCCSDtp.py
+++ b/tests/test_RCCSDtp.py
@@ -14,6 +14,7 @@ from ebcc import GEBCC, REBCC, Space, NullLogger, util
 
 
 @pytest.mark.regression
+@pytest.mark.skipif(BACKEND != "numpy", reason="Currently requires mutable backend.")
 class RCCSDtp_Tests(unittest.TestCase):
     """Test RCCSDt' against GCCSDt'.
     """
@@ -93,6 +94,7 @@ class RCCSDtp_Tests(unittest.TestCase):
 
 
 @pytest.mark.regression
+@pytest.mark.skipif(BACKEND != "numpy", reason="Currently requires mutable backend.")
 class RCCSDtp_Frozen_Tests(unittest.TestCase):
     """Test RCCSDt' against GCCSDt' with a frozen core approximation.
     """

--- a/tests/test_RCCSDtp.py
+++ b/tests/test_RCCSDtp.py
@@ -10,6 +10,7 @@ import pytest
 import scipy
 from pyscf import gto, lib, scf, fci
 
+from ebcc import BACKEND
 from ebcc import GEBCC, REBCC, Space, NullLogger, util
 
 

--- a/tests/test_RDFCC2.py
+++ b/tests/test_RDFCC2.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from pyscf import gto, scf, lib
 
-from ebcc import REBCC, NullLogger, Space
+from ebcc import REBCC, NullLogger, Space, BACKEND
 
 
 @pytest.mark.regression
@@ -96,11 +96,13 @@ class RDFCC2_Tests(unittest.TestCase):
         b = self.cc2.make_rdm2_f()
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         e1 = self.cc2.ip_eom(nroots=5).kernel()
         e2 = self.cc2_ref.ip_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         e1 = self.cc2.ea_eom(nroots=5).kernel()
         e2 = self.cc2_ref.ea_eom(nroots=5).kernel()

--- a/tests/test_RDFCC2.py
+++ b/tests/test_RDFCC2.py
@@ -69,32 +69,32 @@ class RDFCC2_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.cc2_ref.t1
         b = self.cc2.t1
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_t2_amplitudes(self):
         a = self.cc2_ref.t2
         b = self.cc2.t2
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_l1_amplitudes(self):
         a = self.cc2_ref.l1
         b = self.cc2.l1
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_l2_amplitudes(self):
         a = self.cc2_ref.l2
         b = self.cc2.l2
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_rdm1(self):
         a = self.cc2_ref.make_rdm1_f()
         b = self.cc2.make_rdm1_f()
-        np.testing.assert_almost_equal(a, b, 4, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_rdm2(self):
         a = self.cc2_ref.make_rdm2_f()
         b = self.cc2.make_rdm2_f()
-        np.testing.assert_almost_equal(a, b, 4, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_eom_ip(self):
         e1 = self.cc2.ip_eom(nroots=5).kernel()

--- a/tests/test_RDFCCD.py
+++ b/tests/test_RDFCCD.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from pyscf import gto, scf, lib
 
-from ebcc import REBCC, NullLogger, Space
+from ebcc import REBCC, NullLogger, Space, BACKEND
 
 
 @pytest.mark.regression
@@ -76,11 +76,13 @@ class RDFCCD_Tests(unittest.TestCase):
         b = self.ccd.l2
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         e1 = self.ccd.ip_eom(nroots=5).kernel()
         e2 = self.ccd_ref.ip_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         e1 = self.ccd.ea_eom(nroots=5).kernel()
         e2 = self.ccd_ref.ea_eom(nroots=5).kernel()

--- a/tests/test_RDFCCD.py
+++ b/tests/test_RDFCCD.py
@@ -69,12 +69,12 @@ class RDFCCD_Tests(unittest.TestCase):
     def test_t2_amplitudes(self):
         a = self.ccd_ref.t2
         b = self.ccd.t2
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_l2_amplitudes(self):
         a = self.ccd_ref.l2
         b = self.ccd.l2
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_eom_ip(self):
         e1 = self.ccd.ip_eom(nroots=5).kernel()

--- a/tests/test_RDFCCSD.py
+++ b/tests/test_RDFCCSD.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from pyscf import gto, scf, cc, lib
 
-from ebcc import REBCC, NullLogger, Space
+from ebcc import REBCC, NullLogger, Space, BACKEND
 
 
 @pytest.mark.reference
@@ -92,12 +92,14 @@ class RDFCCSD_PySCF_Tests(unittest.TestCase):
         b = self.ccsd.make_rdm2_f(eris=self.eris)
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         eom = self.ccsd.ip_eom(nroots=5)
         e1 = eom.kernel()
         e2, v2 = self.ccsd_ref.ipccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         eom = self.ccsd.ea_eom(nroots=5)
         e1 = eom.kernel()

--- a/tests/test_RDFCCSD.py
+++ b/tests/test_RDFCCSD.py
@@ -79,7 +79,7 @@ class RDFCCSD_PySCF_Tests(unittest.TestCase):
 
     def test_l2_amplitudes(self):
         a = self.ccsd_ref.l2
-        b = self.ccsd.l2.transpose(2, 3, 0, 1)
+        b = np.transpose(self.ccsd.l2, (2, 3, 0, 1))
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):
@@ -189,7 +189,7 @@ class RDFCCSD_PySCF_Frozen_Tests(unittest.TestCase):
 
     def test_l2_amplitudes(self):
         a = self.ccsd_ref.l2
-        b = self.ccsd.l2.transpose(2, 3, 0, 1)
+        b = np.transpose(self.ccsd.l2, (2, 3, 0, 1))
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):

--- a/tests/test_RDFCCSD.py
+++ b/tests/test_RDFCCSD.py
@@ -65,32 +65,32 @@ class RDFCCSD_PySCF_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.ccsd_ref.t1
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_t2_amplitudes(self):
         a = self.ccsd_ref.t2
         b = self.ccsd.t2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l1_amplitudes(self):
         a = self.ccsd_ref.l1
         b = self.ccsd.l1.T
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l2_amplitudes(self):
         a = self.ccsd_ref.l2
         b = self.ccsd.l2.transpose(2, 3, 0, 1)
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):
         a = self.ccsd_ref.make_rdm1()
         b = self.ccsd.make_rdm1_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm2(self):
         a = self.ccsd_ref.make_rdm2()
         b = self.ccsd.make_rdm2_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_eom_ip(self):
         eom = self.ccsd.ip_eom(nroots=5)
@@ -173,32 +173,32 @@ class RDFCCSD_PySCF_Frozen_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.ccsd_ref.t1
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_t2_amplitudes(self):
         a = self.ccsd_ref.t2
         b = self.ccsd.t2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l1_amplitudes(self):
         a = self.ccsd_ref.l1
         b = self.ccsd.l1.T
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l2_amplitudes(self):
         a = self.ccsd_ref.l2
         b = self.ccsd.l2.transpose(2, 3, 0, 1)
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):
         a = self.ccsd_ref.make_rdm1(with_frozen=False)
         b = self.ccsd.make_rdm1_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm2(self):
         a = self.ccsd_ref.make_rdm2(with_frozen=False)
         b = self.ccsd.make_rdm2_f(eris=self.eris)
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 if __name__ == "__main__":

--- a/tests/test_RDFDCD.py
+++ b/tests/test_RDFDCD.py
@@ -65,7 +65,7 @@ class RDFDCD_Tests(unittest.TestCase):
     def test_t2_amplitudes(self):
         a = self.ccd_ref.t2
         b = self.ccd.t2
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
 
 if __name__ == "__main__":

--- a/tests/test_RDFDCSD.py
+++ b/tests/test_RDFDCSD.py
@@ -65,12 +65,12 @@ class RDFDCSD_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.ccsd_ref.t1
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_t2_amplitudes(self):
         a = self.ccsd_ref.t2
         b = self.ccsd.t2
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
 
 if __name__ == "__main__":

--- a/tests/test_RDFQCISD.py
+++ b/tests/test_RDFQCISD.py
@@ -65,12 +65,12 @@ class RDFQCISD_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.qcisd_ref.t1
         b = self.qcisd.t1
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_t2_amplitudes(self):
         a = self.qcisd_ref.t2
         b = self.qcisd.t2
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
 
 if __name__ == "__main__":

--- a/tests/test_RMP2.py
+++ b/tests/test_RMP2.py
@@ -11,7 +11,7 @@ import pytest
 import scipy.linalg
 from pyscf import mp, gto, lib, scf, adc
 
-from ebcc import REBCC, NullLogger, Space
+from ebcc import REBCC, NullLogger, Space, BACKEND
 
 
 @pytest.mark.reference
@@ -52,6 +52,7 @@ class RMP2_PySCF_Tests(unittest.TestCase):
         b = self.mp2.e_tot
         self.assertAlmostEqual(a, b, 7)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         eom = self.mp2.ip_eom(nroots=5, e_tol=1e-10)
         e1 = eom.kernel()
@@ -60,6 +61,7 @@ class RMP2_PySCF_Tests(unittest.TestCase):
         e2, v2 = adc2.ip_adc(nroots=5)[:2]
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         eom = self.mp2.ea_eom(nroots=5, e_tol=1e-10)
         e1 = eom.kernel()

--- a/tests/test_RQCISD.py
+++ b/tests/test_RQCISD.py
@@ -66,12 +66,12 @@ class RQCISD_PySCF_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.qcisd_ref.t1
         b = self.qcisd.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_t2_amplitudes(self):
         a = self.qcisd_ref.t2
         b = self.qcisd.t2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 @pytest.mark.reference
@@ -137,12 +137,12 @@ class RQCISD_PySCF_Frozen_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.qcisd_ref.t1
         b = self.qcisd.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_t2_amplitudes(self):
         a = self.qcisd_ref.t2
         b = self.qcisd.t2
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 if __name__ == "__main__":

--- a/tests/test_UCC2.py
+++ b/tests/test_UCC2.py
@@ -8,7 +8,7 @@ import numpy as np
 import scipy.linalg
 import pytest
 
-from ebcc import UEBCC, NullLogger, util
+from ebcc import UEBCC, NullLogger, util, BACKEND
 
 
 @pytest.mark.reference
@@ -127,10 +127,12 @@ class UCC2_Tests(unittest.TestCase):
         self.assertAlmostEqual(lib.fp(dmaabb), 1.617909309590978, 6)
         self.assertAlmostEqual(lib.fp(dmbbbb), 2.231837825282723, 6)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         e1 = self.ccsd.ip_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], 0.1596528431761164)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         e1 = self.ccsd.ea_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], -0.11586919638803718)

--- a/tests/test_UCC2.py
+++ b/tests/test_UCC2.py
@@ -66,13 +66,13 @@ class UCC2_PySCF_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.ccsd_ref.t1
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a, b.aa, 6)
-        np.testing.assert_almost_equal(a, b.bb, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b.aa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b.bb)), 0.0, 6)
 
     def test_t2_amplitudes(self):
         a = self.ccsd_ref.t2
         b = self.ccsd.t2
-        np.testing.assert_almost_equal(a, b.abab, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b.abab)), 0.0, 6)
 
 
 @pytest.mark.regression

--- a/tests/test_UCC3.py
+++ b/tests/test_UCC3.py
@@ -66,7 +66,7 @@ class UCC3_Tests(unittest.TestCase):
     def test_t1(self):
         a = scipy.linalg.block_diag(self.ucc3.t1.aa, self.ucc3.t1.bb)[self.osort][:, self.vsort]
         b = self.gcc3.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 if __name__ == "__main__":

--- a/tests/test_UCCD.py
+++ b/tests/test_UCCD.py
@@ -66,24 +66,24 @@ class UCCD_PySCF_Tests(unittest.TestCase):
     def test_t2_amplitudes(self):
         a = self.ccd_ref.t2
         b = self.ccd.t2.abab
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l2_amplitudes(self):
         a = self.ccd_ref.l2
         b = self.ccd.l2.abab.transpose(2, 3, 0, 1)
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):
         a = self.ccd_ref.make_rdm1()
         b = self.ccd.make_rdm1_f(eris=self.eris)
         b = b.aa + b.bb
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm2(self):
         a = self.ccd_ref.make_rdm2()
         b = self.ccd.make_rdm2_f(eris=self.eris)
         b = 2 * b.aabb + b.aaaa + b.bbbb
-        np.testing.assert_almost_equal(a, b, 6, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 @pytest.mark.regression

--- a/tests/test_UCCD.py
+++ b/tests/test_UCCD.py
@@ -9,7 +9,7 @@ from pyscf import cc, gto, lib, scf
 from pyscf.cc import ccd as pyscf_ccd
 from pyscf.cc import ccsd_rdm
 
-from ebcc import REBCC, UEBCC, NullLogger, Space
+from ebcc import REBCC, UEBCC, NullLogger, Space, BACKEND
 
 
 @pytest.mark.reference
@@ -120,10 +120,12 @@ class UCCD_Tests(unittest.TestCase):
     def tearDownClass(cls):
         del cls.mf, cls.ccd, cls.eris
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         e1 = self.ccd.ip_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], 0.3054216876546247)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         e1 = self.ccd.ea_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], 0.002154489320978545)

--- a/tests/test_UCCD.py
+++ b/tests/test_UCCD.py
@@ -70,7 +70,7 @@ class UCCD_PySCF_Tests(unittest.TestCase):
 
     def test_l2_amplitudes(self):
         a = self.ccd_ref.l2
-        b = self.ccd.l2.abab.transpose(2, 3, 0, 1)
+        b = np.transpose(self.ccd.l2.abab, (2, 3, 0, 1))
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1(self):

--- a/tests/test_UCCSD.py
+++ b/tests/test_UCCSD.py
@@ -12,7 +12,7 @@ import pytest
 import scipy.linalg
 from pyscf import cc, gto, scf
 
-from ebcc import REBCC, UEBCC, GEBCC, NullLogger, Space
+from ebcc import REBCC, UEBCC, GEBCC, NullLogger, Space, BACKEND
 
 
 @pytest.mark.reference
@@ -240,21 +240,25 @@ class UCCSD_PySCF_Tests(unittest.TestCase):
         self.assertAlmostEqual(np.max(np.abs(a[1] - b.aabb)), 0.0, 6)
         self.assertAlmostEqual(np.max(np.abs(a[2] - b.bbbb)), 0.0, 6)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         e1 = np.asarray(self.ccsd.ip_eom(nroot=5).kernel())
         e2, v2 = self.ccsd_ref.ipccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         e1 = np.asarray(self.ccsd.ea_eom(nroots=5).kernel())
         e2, v2 = self.ccsd_ref.eaccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip_left(self):
         e1 = np.asarray(self.ccsd.ip_eom(nroot=5, left=True).kernel())
         e2, v2 = self.ccsd_ref.ipccsd(nroots=5)  # No left EE-EOM in PySCF
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea_left(self):
         e1 = np.asarray(self.ccsd.ea_eom(nroots=5, left=True).kernel())
         e2, v2 = self.ccsd_ref.eaccsd(nroots=5)  # No left EE-EOM in PySCF
@@ -412,21 +416,25 @@ class UCCSD_PySCF_Frozen_Tests(unittest.TestCase):
         self.assertAlmostEqual(np.max(np.abs(a[1] - b.aabb)), 0.0, 6)
         self.assertAlmostEqual(np.max(np.abs(a[2] - b.bbbb)), 0.0, 6)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         e1 = np.asarray(self.ccsd.ip_eom(nroot=5).kernel())
         e2, v2 = self.ccsd_ref.ipccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         e1 = np.asarray(self.ccsd.ea_eom(nroots=5).kernel())
         e2, v2 = self.ccsd_ref.eaccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip_left(self):
         e1 = np.asarray(self.ccsd.ip_eom(nroot=5, left=True).kernel())
         e2, v2 = self.ccsd_ref.ipccsd(nroots=5)  # No left EE-EOM in PySCF
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea_left(self):
         e1 = np.asarray(self.ccsd.ea_eom(nroots=5, left=True).kernel())
         e2, v2 = self.ccsd_ref.eaccsd(nroots=5)  # No left EE-EOM in PySCF

--- a/tests/test_UCCSD.py
+++ b/tests/test_UCCSD.py
@@ -79,19 +79,19 @@ class UCCSD_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.data[True]["t1"]
         b = scipy.linalg.block_diag(self.ccsd.t1.aa, self.ccsd.t1.bb)[self.osort][:, self.vsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1_f(self):
         rdm1_f = self.ccsd.make_rdm1_f()
         a = self.data[True]["rdm1_f"]
         b = scipy.linalg.block_diag(rdm1_f.aa, rdm1_f.bb)
         b = b[self.fsort][:, self.fsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l1_amplitudes(self):
         a = self.data[True]["l1"]
         b = scipy.linalg.block_diag(self.ccsd.l1.aa, self.ccsd.l1.bb)[self.vsort][:, self.osort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_from_rebcc(self):
         rebcc = REBCC(
@@ -104,16 +104,16 @@ class UCCSD_Tests(unittest.TestCase):
         rebcc.solve_lambda()
         uebcc = UEBCC.from_rebcc(rebcc)
         self.assertAlmostEqual(self.ccsd.energy(), uebcc.energy(), 8)
-        np.testing.assert_almost_equal(self.ccsd.t1.aa, uebcc.t1.aa, 6)
-        np.testing.assert_almost_equal(self.ccsd.t1.bb, uebcc.t1.bb, 6)
-        np.testing.assert_almost_equal(self.ccsd.t2.aaaa, uebcc.t2.aaaa, 6)
-        np.testing.assert_almost_equal(self.ccsd.t2.abab, uebcc.t2.abab, 6)
-        np.testing.assert_almost_equal(self.ccsd.t2.bbbb, uebcc.t2.bbbb, 6)
-        np.testing.assert_almost_equal(self.ccsd.l1.aa, uebcc.l1.aa, 5)
-        np.testing.assert_almost_equal(self.ccsd.l1.bb, uebcc.l1.bb, 5)
-        np.testing.assert_almost_equal(self.ccsd.l2.aaaa, uebcc.l2.aaaa, 5)
-        np.testing.assert_almost_equal(self.ccsd.l2.abab, uebcc.l2.abab, 5)
-        np.testing.assert_almost_equal(self.ccsd.l2.bbbb, uebcc.l2.bbbb, 5)
+        self.assertAlmostEqual(np.max(np.abs(self.ccsd.t1.aa - uebcc.t1.aa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(self.ccsd.t1.bb - uebcc.t1.bb)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(self.ccsd.t2.aaaa - uebcc.t2.aaaa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(self.ccsd.t2.abab - uebcc.t2.abab)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(self.ccsd.t2.bbbb - uebcc.t2.bbbb)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(self.ccsd.l1.aa - uebcc.l1.aa)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(self.ccsd.l1.bb - uebcc.l1.bb)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(self.ccsd.l2.aaaa - uebcc.l2.aaaa)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(self.ccsd.l2.abab - uebcc.l2.abab)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(self.ccsd.l2.bbbb - uebcc.l2.bbbb)), 0.0, 5)
 
     def test_from_rebcc_frozen(self):
         mf = self.mf.to_rhf()
@@ -158,16 +158,16 @@ class UCCSD_Tests(unittest.TestCase):
         uebcc_2.solve_lambda()
 
         self.assertAlmostEqual(uebcc_2.energy(), uebcc_1.energy(), 8)
-        np.testing.assert_almost_equal(uebcc_2.t1.aa, uebcc_1.t1.aa, 6)
-        np.testing.assert_almost_equal(uebcc_2.t1.bb, uebcc_1.t1.bb, 6)
-        np.testing.assert_almost_equal(uebcc_2.t2.aaaa, uebcc_1.t2.aaaa, 6)
-        np.testing.assert_almost_equal(uebcc_2.t2.abab, uebcc_1.t2.abab, 6)
-        np.testing.assert_almost_equal(uebcc_2.t2.bbbb, uebcc_1.t2.bbbb, 6)
-        np.testing.assert_almost_equal(uebcc_2.l1.aa, uebcc_1.l1.aa, 5)
-        np.testing.assert_almost_equal(uebcc_2.l1.bb, uebcc_1.l1.bb, 5)
-        np.testing.assert_almost_equal(uebcc_2.l2.aaaa, uebcc_1.l2.aaaa, 5)
-        np.testing.assert_almost_equal(uebcc_2.l2.abab, uebcc_1.l2.abab, 5)
-        np.testing.assert_almost_equal(uebcc_2.l2.bbbb, uebcc_1.l2.bbbb, 5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc_2.t1.aa - uebcc_1.t1.aa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(uebcc_2.t1.bb - uebcc_1.t1.bb)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(uebcc_2.t2.aaaa - uebcc_1.t2.aaaa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(uebcc_2.t2.abab - uebcc_1.t2.abab)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(uebcc_2.t2.bbbb - uebcc_1.t2.bbbb)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(uebcc_2.l1.aa - uebcc_1.l1.aa)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc_2.l1.bb - uebcc_1.l1.bb)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc_2.l2.aaaa - uebcc_1.l2.aaaa)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc_2.l2.abab - uebcc_1.l2.abab)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc_2.l2.bbbb - uebcc_1.l2.bbbb)), 0.0, 5)
 
 
 @pytest.mark.reference
@@ -218,27 +218,27 @@ class UCCSD_PySCF_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.ccsd_ref.t1
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a[0], b.aa, 6)
-        np.testing.assert_almost_equal(a[1], b.bb, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.bb)), 0.0, 6)
 
     def test_l1_amplitudes(self):
         a = self.ccsd_ref.l1
         b = self.ccsd.l1
-        np.testing.assert_almost_equal(a[0], b.aa.T, 6)
-        np.testing.assert_almost_equal(a[1], b.bb.T, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aa.T)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.bb.T)), 0.0, 6)
 
     def test_rdm1(self):
         a = self.ccsd_ref.make_rdm1()
         b = self.ccsd.make_rdm1_f(eris=self.eris)
-        np.testing.assert_almost_equal(a[0], b.aa, 6)
-        np.testing.assert_almost_equal(a[1], b.bb, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.bb)), 0.0, 6)
 
     def test_rdm2(self):
         a = self.ccsd_ref.make_rdm2()
         b = self.ccsd.make_rdm2_f(eris=self.eris)
-        np.testing.assert_almost_equal(a[0], b.aaaa, 6)
-        np.testing.assert_almost_equal(a[1], b.aabb, 6)
-        np.testing.assert_almost_equal(a[2], b.bbbb, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aaaa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.aabb)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[2] - b.bbbb)), 0.0, 6)
 
     def test_eom_ip(self):
         e1 = np.asarray(self.ccsd.ip_eom(nroot=5).kernel())
@@ -307,15 +307,15 @@ class UCCSD_PySCF_Tests(unittest.TestCase):
 #    def test_rdm1(self):
 #        a = self.ccsd_ref.make_rdm1(with_frozen=False)
 #        b = self.ccsd.make_rdm1_f(eris=self.eris)
-#        np.testing.assert_almost_equal(a[0], b.aa, 6)
-#        np.testing.assert_almost_equal(a[1], b.bb, 6)
+#        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aa)), 0.0, 6)
+#        self.assertAlmostEqual(np.max(np.abs(a[1] - b.bb)), 0.0, 6)
 #
 #    def test_rdm2(self):
 #        a = self.ccsd_ref.make_rdm2(with_frozen=False)
 #        b = self.ccsd.make_rdm2_f(eris=self.eris)
-#        np.testing.assert_almost_equal(a[0], b.aaaa, 6)
-#        np.testing.assert_almost_equal(a[1], b.aabb, 6)
-#        np.testing.assert_almost_equal(a[2], b.bbbb, 6)
+#        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aaaa)), 0.0, 6)
+#        self.assertAlmostEqual(np.max(np.abs(a[1] - b.aabb)), 0.0, 6)
+#        self.assertAlmostEqual(np.max(np.abs(a[2] - b.bbbb)), 0.0, 6)
 
 
 @pytest.mark.reference
@@ -390,27 +390,27 @@ class UCCSD_PySCF_Frozen_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.ccsd_ref.t1
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a[0], b.aa, 6)
-        np.testing.assert_almost_equal(a[1], b.bb, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.bb)), 0.0, 6)
 
     def test_l1_amplitudes(self):
         a = self.ccsd_ref.l1
         b = self.ccsd.l1
-        np.testing.assert_almost_equal(a[0], b.aa.T, 6)
-        np.testing.assert_almost_equal(a[1], b.bb.T, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aa.T)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.bb.T)), 0.0, 6)
 
     def test_rdm1(self):
         a = self.ccsd_ref.make_rdm1(with_frozen=False)
         b = self.ccsd.make_rdm1_f(eris=self.eris)
-        np.testing.assert_almost_equal(a[0], b.aa, 6)
-        np.testing.assert_almost_equal(a[1], b.bb, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.bb)), 0.0, 6)
 
     def test_rdm2(self):
         a = self.ccsd_ref.make_rdm2(with_frozen=False)
         b = self.ccsd.make_rdm2_f(eris=self.eris)
-        np.testing.assert_almost_equal(a[0], b.aaaa, 6)
-        np.testing.assert_almost_equal(a[1], b.aabb, 6)
-        np.testing.assert_almost_equal(a[2], b.bbbb, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aaaa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.aabb)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[2] - b.bbbb)), 0.0, 6)
 
     def test_eom_ip(self):
         e1 = np.asarray(self.ccsd.ip_eom(nroot=5).kernel())

--- a/tests/test_UCCSDT.py
+++ b/tests/test_UCCSDT.py
@@ -96,7 +96,7 @@ class UCCSDT_Tests(unittest.TestCase):
     def test_t1(self):
         a = scipy.linalg.block_diag(self.uccsdt.t1.aa, self.uccsdt.t1.bb)[self.osort][:, self.vsort]
         b = self.gccsdt.t1
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm_energy(self):
         dm1 = self.uccsdt.make_rdm1_f()

--- a/tests/test_UCCSD_SD_1_1.py
+++ b/tests/test_UCCSD_SD_1_1.py
@@ -82,7 +82,7 @@ class UCCSD_SD_1_1_Tests(unittest.TestCase):
     def test_xi(self):
         a = self.data[self.shift]["xi"]
         b = self.ccsd.xi
-        np.testing.assert_almost_equal(a, b, 7)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_energy(self):
         a = self.data[self.shift]["e_corr"]
@@ -92,24 +92,24 @@ class UCCSD_SD_1_1_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.data[self.shift]["t1"]
         b = scipy.linalg.block_diag(self.ccsd.t1.aa, self.ccsd.t1.bb)[self.osort][:, self.vsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_s1_amplitudes(self):
         a = self.data[self.shift]["s1"]
         b = self.ccsd.amplitudes["s1"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_s1_amplitudes(self):
         a = self.data[self.shift]["s2"]
         b = self.ccsd.amplitudes["s2"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_u11_amplitudes(self):
         a = self.data[self.shift]["u11"]
         b = self.ccsd.amplitudes["u11"]
         b = np.array([scipy.linalg.block_diag(x, y) for x, y in zip(b.aa, b.bb)])
         b = b[:, self.osort][:, :, self.vsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     @pytest.mark.regression
     def test_lambdas(self):

--- a/tests/test_UCCSD_SD_1_1.py
+++ b/tests/test_UCCSD_SD_1_1.py
@@ -46,7 +46,7 @@ class UCCSD_SD_1_1_Tests(unittest.TestCase):
         nbos = 5
         np.random.seed(12345)
         g = np.random.random((nbos, nmo, nmo)) * 0.02
-        g = 0.5 * (g + g.transpose(0, 2, 1).conj())
+        g = 0.5 * (g + np.conj(np.transpose(g, (0, 2, 1))))
         omega = np.random.random((nbos,)) * 5.0
 
         ccsd = UEBCC(

--- a/tests/test_UCCSD_SD_1_2.py
+++ b/tests/test_UCCSD_SD_1_2.py
@@ -85,7 +85,7 @@ class UCCSD_SD_1_2_Tests(unittest.TestCase):
     def test_xi(self):
         a = self.data[self.shift]["xi"]
         b = self.ccsd.xi
-        np.testing.assert_almost_equal(a, b, 7)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_energy(self):
         a = self.data[self.shift]["e_corr"]
@@ -95,24 +95,24 @@ class UCCSD_SD_1_2_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.data[self.shift]["t1"]
         b = scipy.linalg.block_diag(self.ccsd.t1.aa, self.ccsd.t1.bb)[self.osort][:, self.vsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_s1_amplitudes(self):
         a = self.data[self.shift]["s1"]
         b = self.ccsd.amplitudes["s1"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_s1_amplitudes(self):
         a = self.data[self.shift]["s2"]
         b = self.ccsd.amplitudes["s2"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_u11_amplitudes(self):
         a = self.data[self.shift]["u11"]
         b = self.ccsd.amplitudes["u11"]
         b = np.array([scipy.linalg.block_diag(x, y) for x, y in zip(b.aa, b.bb)])
         b = b[:, self.osort][:, :, self.vsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     @pytest.mark.regression
     def test_lambdas(self):
@@ -173,29 +173,29 @@ class UCCSD_SD_1_2_Tests(unittest.TestCase):
         rebcc.solve_lambda(eris=eris)
         uebcc2 = UEBCC.from_rebcc(rebcc)
 
-        np.testing.assert_almost_equal(uebcc1.amplitudes["t1"].aa,   uebcc2.amplitudes["t1"].aa,   5)
-        np.testing.assert_almost_equal(uebcc1.amplitudes["t1"].bb,   uebcc2.amplitudes["t1"].bb,   5)
-        np.testing.assert_almost_equal(uebcc1.amplitudes["t2"].aaaa, uebcc2.amplitudes["t2"].aaaa, 5)
-        np.testing.assert_almost_equal(uebcc1.amplitudes["t2"].abab, uebcc2.amplitudes["t2"].abab, 5)
-        np.testing.assert_almost_equal(uebcc1.amplitudes["t2"].bbbb, uebcc2.amplitudes["t2"].bbbb, 5)
-        np.testing.assert_almost_equal(uebcc1.amplitudes["s1"],      uebcc2.amplitudes["s1"],      5)
-        np.testing.assert_almost_equal(uebcc1.amplitudes["s1"],      uebcc2.amplitudes["s1"],      5)
-        np.testing.assert_almost_equal(uebcc1.amplitudes["s2"],      uebcc2.amplitudes["s2"],      5)
-        np.testing.assert_almost_equal(uebcc1.amplitudes["s2"],      uebcc2.amplitudes["s2"],      5)
-        np.testing.assert_almost_equal(uebcc1.amplitudes["u11"].aa,  uebcc2.amplitudes["u11"].aa,  5)
-        np.testing.assert_almost_equal(uebcc1.amplitudes["u11"].bb,  uebcc2.amplitudes["u11"].bb,  5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.amplitudes["t1"].aa -   uebcc2.amplitudes["t1"].aa)), 0.0,   5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.amplitudes["t1"].bb -   uebcc2.amplitudes["t1"].bb)), 0.0,   5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.amplitudes["t2"].aaaa - uebcc2.amplitudes["t2"].aaaa)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.amplitudes["t2"].abab - uebcc2.amplitudes["t2"].abab)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.amplitudes["t2"].bbbb - uebcc2.amplitudes["t2"].bbbb)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.amplitudes["s1"] -      uebcc2.amplitudes["s1"])), 0.0,      5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.amplitudes["s1"] -      uebcc2.amplitudes["s1"])), 0.0,      5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.amplitudes["s2"] -      uebcc2.amplitudes["s2"])), 0.0,      5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.amplitudes["s2"] -      uebcc2.amplitudes["s2"])), 0.0,      5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.amplitudes["u11"].aa -  uebcc2.amplitudes["u11"].aa)), 0.0,  5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.amplitudes["u11"].bb -  uebcc2.amplitudes["u11"].bb)), 0.0,  5)
 
-        np.testing.assert_almost_equal(uebcc1.lambdas["l1"].aa,   uebcc2.lambdas["l1"].aa,   5)
-        np.testing.assert_almost_equal(uebcc1.lambdas["l1"].bb,   uebcc2.lambdas["l1"].bb,   5)
-        np.testing.assert_almost_equal(uebcc1.lambdas["l2"].aaaa, uebcc2.lambdas["l2"].aaaa, 5)
-        np.testing.assert_almost_equal(uebcc1.lambdas["l2"].abab, uebcc2.lambdas["l2"].abab, 5)
-        np.testing.assert_almost_equal(uebcc1.lambdas["l2"].bbbb, uebcc2.lambdas["l2"].bbbb, 5)
-        np.testing.assert_almost_equal(uebcc1.lambdas["ls1"],     uebcc2.lambdas["ls1"],     5)
-        np.testing.assert_almost_equal(uebcc1.lambdas["ls1"],     uebcc2.lambdas["ls1"],     5)
-        np.testing.assert_almost_equal(uebcc1.lambdas["ls2"],     uebcc2.lambdas["ls2"],     5)
-        np.testing.assert_almost_equal(uebcc1.lambdas["ls2"],     uebcc2.lambdas["ls2"],     5)
-        np.testing.assert_almost_equal(uebcc1.lambdas["lu11"].aa, uebcc2.lambdas["lu11"].aa, 5)
-        np.testing.assert_almost_equal(uebcc1.lambdas["lu11"].bb, uebcc2.lambdas["lu11"].bb, 5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.lambdas["l1"].aa -   uebcc2.lambdas["l1"].aa)), 0.0,   5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.lambdas["l1"].bb -   uebcc2.lambdas["l1"].bb)), 0.0,   5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.lambdas["l2"].aaaa - uebcc2.lambdas["l2"].aaaa)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.lambdas["l2"].abab - uebcc2.lambdas["l2"].abab)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.lambdas["l2"].bbbb - uebcc2.lambdas["l2"].bbbb)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.lambdas["ls1"] -     uebcc2.lambdas["ls1"])), 0.0,     5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.lambdas["ls1"] -     uebcc2.lambdas["ls1"])), 0.0,     5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.lambdas["ls2"] -     uebcc2.lambdas["ls2"])), 0.0,     5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.lambdas["ls2"] -     uebcc2.lambdas["ls2"])), 0.0,     5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.lambdas["lu11"].aa - uebcc2.lambdas["lu11"].aa)), 0.0, 5)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1.lambdas["lu11"].bb - uebcc2.lambdas["lu11"].bb)), 0.0, 5)
 
         uebcc1_rdm1_f = uebcc1.make_rdm1_f()
         uebcc1_rdm2_f = uebcc1.make_rdm2_f()
@@ -208,15 +208,15 @@ class UCCSD_SD_1_2_Tests(unittest.TestCase):
         uebcc2_dm_b = uebcc2.make_sing_b_dm()
         uebcc2_dm_eb = uebcc2.make_eb_coup_rdm()
 
-        np.testing.assert_almost_equal(uebcc1_rdm1_f.aa,   uebcc2_rdm1_f.aa,   6)
-        np.testing.assert_almost_equal(uebcc1_rdm1_f.bb,   uebcc2_rdm1_f.bb,   6)
-        np.testing.assert_almost_equal(uebcc1_rdm2_f.aaaa, uebcc2_rdm2_f.aaaa, 6)
-        np.testing.assert_almost_equal(uebcc1_rdm2_f.aabb, uebcc2_rdm2_f.aabb, 6)
-        np.testing.assert_almost_equal(uebcc1_rdm2_f.bbbb, uebcc2_rdm2_f.bbbb, 6)
-        np.testing.assert_almost_equal(uebcc1_rdm1_b,      uebcc2_rdm1_b,      6)
-        np.testing.assert_almost_equal(uebcc1_dm_b,        uebcc2_dm_b,        6)
-        np.testing.assert_almost_equal(uebcc1_dm_eb.aa,    uebcc2_dm_eb.aa,    6)
-        np.testing.assert_almost_equal(uebcc1_dm_eb.bb,    uebcc2_dm_eb.bb,    6)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1_rdm1_f.aa -   uebcc2_rdm1_f.aa)), 0.0,   6)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1_rdm1_f.bb -   uebcc2_rdm1_f.bb)), 0.0,   6)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1_rdm2_f.aaaa - uebcc2_rdm2_f.aaaa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1_rdm2_f.aabb - uebcc2_rdm2_f.aabb)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1_rdm2_f.bbbb - uebcc2_rdm2_f.bbbb)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1_rdm1_b -      uebcc2_rdm1_b)), 0.0,      6)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1_dm_b -        uebcc2_dm_b)), 0.0,        6)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1_dm_eb.aa -    uebcc2_dm_eb.aa)), 0.0,    6)
+        self.assertAlmostEqual(np.max(np.abs(uebcc1_dm_eb.bb -    uebcc2_dm_eb.bb)), 0.0,    6)
 
 
 @pytest.mark.reference

--- a/tests/test_UCCSD_SD_1_2.py
+++ b/tests/test_UCCSD_SD_1_2.py
@@ -47,7 +47,7 @@ class UCCSD_SD_1_2_Tests(unittest.TestCase):
         nbos = 5
         np.random.seed(12345)
         g = np.random.random((nbos, nmo, nmo)) * 0.02
-        g = 0.5 * (g + g.transpose(0, 2, 1).conj())
+        g = 0.5 * (g + np.conj(np.transpose(g, (0, 2, 1))))
         omega = np.random.random((nbos,)) * 5.0
 
         ccsd = UEBCC(
@@ -289,7 +289,7 @@ class UCCSD_SD_1_2_Dump_Tests(UCCSD_SD_1_2_Tests):
         nbos = 5
         np.random.seed(12345)
         g = np.random.random((nbos, nmo, nmo)) * 0.02
-        g = 0.5 * (g + g.transpose(0, 2, 1).conj())
+        g = 0.5 * (g + np.conj(np.transpose(g, (0, 2, 1))))
         omega = np.random.random((nbos,)) * 5.0
 
         ccsd = UEBCC(

--- a/tests/test_UCCSD_S_1_1.py
+++ b/tests/test_UCCSD_S_1_1.py
@@ -46,7 +46,7 @@ class UCCSD_S_1_1_Tests(unittest.TestCase):
         nbos = 5
         np.random.seed(12345)
         g = np.random.random((nbos, nmo, nmo)) * 0.02
-        g = 0.5 * (g + g.transpose(0, 2, 1).conj())
+        g = 0.5 * (g + np.conj(np.transpose(g, (0, 2, 1))))
         omega = np.random.random((nbos,)) * 5.0
 
         ccsd = UEBCC(

--- a/tests/test_UCCSD_S_1_1.py
+++ b/tests/test_UCCSD_S_1_1.py
@@ -82,7 +82,7 @@ class UCCSD_S_1_1_Tests(unittest.TestCase):
     def test_xi(self):
         a = self.data[self.shift]["xi"]
         b = self.ccsd.xi
-        np.testing.assert_almost_equal(a, b, 7)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
     def test_energy(self):
         a = self.data[self.shift]["e_corr"]
@@ -92,43 +92,43 @@ class UCCSD_S_1_1_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.data[self.shift]["t1"]
         b = scipy.linalg.block_diag(self.ccsd.t1.aa, self.ccsd.t1.bb)[self.osort][:, self.vsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_s1_amplitudes(self):
         a = self.data[self.shift]["s1"]
         b = self.ccsd.amplitudes["s1"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_u11_amplitudes(self):
         a = self.data[self.shift]["u11"]
         b = self.ccsd.amplitudes["u11"]
         b = np.array([scipy.linalg.block_diag(x, y) for x, y in zip(b.aa, b.bb)])
         b = b[:, self.osort][:, :, self.vsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_l1_amplitudes(self):
         a = self.data[self.shift]["l1"]
         b = scipy.linalg.block_diag(self.ccsd.l1.aa, self.ccsd.l1.bb)[self.vsort][:, self.osort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_ls1_amplitudes(self):
         a = self.data[self.shift]["ls1"]
         b = self.ccsd.lambdas["ls1"]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_lu11_amplitudes(self):
         a = self.data[self.shift]["lu11"]
         b = self.ccsd.lambdas["lu11"]
         b = np.array([scipy.linalg.block_diag(x, y) for x, y in zip(b.aa, b.bb)])
         b = b[:, self.vsort][:, :, self.osort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm1_f(self):
         rdm1_f = self.ccsd.make_rdm1_f()
         a = self.data[self.shift]["rdm1_f"]
         b = scipy.linalg.block_diag(rdm1_f.aa, rdm1_f.bb)
         b = b[self.fsort][:, self.fsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     @pytest.mark.regression
     def test_rdm2_f(self):
@@ -140,12 +140,12 @@ class UCCSD_S_1_1_Tests(unittest.TestCase):
     def test_rdm1_b(self):
         a = self.data[self.shift]["rdm1_b"]
         b = self.ccsd.make_rdm1_b()
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_dm_b(self):
         a = self.data[self.shift]["dm_b"]
         b = np.array(self.ccsd.make_sing_b_dm())
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_rdm_eb(self):
         a = np.array(self.data[self.shift]["rdm_eb"])
@@ -155,7 +155,7 @@ class UCCSD_S_1_1_Tests(unittest.TestCase):
             [scipy.linalg.block_diag(x, y) for x, y in zip(b.aa[1], b.bb[1])],
         ])
         b = b[:, :, self.fsort][:, :, :, self.fsort]
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 @pytest.mark.reference

--- a/tests/test_UCCSDtp.py
+++ b/tests/test_UCCSDtp.py
@@ -15,6 +15,7 @@ from ebcc import UEBCC, GEBCC, Space, NullLogger, util
 
 
 @pytest.mark.regression
+@pytest.mark.skipif(BACKEND != "numpy", reason="Currently requires mutable backend.")
 class UCCSDtp_Tests(unittest.TestCase):
     """Test UCCSDt' against GCCSDt'.
     """

--- a/tests/test_UCCSDtp.py
+++ b/tests/test_UCCSDtp.py
@@ -9,6 +9,7 @@ import pytest
 from pyscf import gto, lib, scf, fci
 import scipy.linalg
 
+from ebcc import BACKEND
 from ebcc import UEBCC, GEBCC, Space, NullLogger, util
 
 # TODO from http://dx.doi.org/10.1021/acs.jpca.7b10892

--- a/tests/test_UDFCC2.py
+++ b/tests/test_UDFCC2.py
@@ -69,32 +69,32 @@ class UDFCC2_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.cc2_ref.t1.aa
         b = self.cc2.t1.aa
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_t2_amplitudes(self):
         a = self.cc2_ref.t2.aaaa
         b = self.cc2.t2.aaaa
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_l1_amplitudes(self):
         a = self.cc2_ref.l1.aa
         b = self.cc2.l1.aa
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_l2_amplitudes(self):
         a = self.cc2_ref.l2.aaaa
         b = self.cc2.l2.aaaa
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_rdm1(self):
         a = self.cc2_ref.make_rdm1_f().aa
         b = self.cc2.make_rdm1_f().aa
-        np.testing.assert_almost_equal(a, b, 4, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_rdm2(self):
         a = self.cc2_ref.make_rdm2_f().aaaa
         b = self.cc2.make_rdm2_f().aaaa
-        np.testing.assert_almost_equal(a, b, 4, verbose=True)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_eom_ip(self):
         e1 = self.cc2.ip_eom(nroots=5).kernel()

--- a/tests/test_UDFCC2.py
+++ b/tests/test_UDFCC2.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from pyscf import gto, scf, lib
 
-from ebcc import UEBCC, NullLogger, Space
+from ebcc import UEBCC, NullLogger, Space, BACKEND
 
 
 @pytest.mark.regression
@@ -96,11 +96,13 @@ class UDFCC2_Tests(unittest.TestCase):
         b = self.cc2.make_rdm2_f().aaaa
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         e1 = self.cc2.ip_eom(nroots=5).kernel()
         e2 = self.cc2_ref.ip_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         e1 = self.cc2.ea_eom(nroots=5).kernel()
         e2 = self.cc2_ref.ea_eom(nroots=5).kernel()

--- a/tests/test_UDFCCD.py
+++ b/tests/test_UDFCCD.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from pyscf import gto, scf, lib
 
-from ebcc import UEBCC, NullLogger, Space
+from ebcc import UEBCC, NullLogger, Space, BACKEND
 
 
 @pytest.mark.regression
@@ -76,11 +76,13 @@ class UDFCCD_Tests(unittest.TestCase):
         b = self.ccd.l2.aaaa
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         e1 = self.ccd.ip_eom(nroots=5).kernel()
         e2 = self.ccd_ref.ip_eom(nroots=5).kernel()
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         e1 = self.ccd.ea_eom(nroots=5).kernel()
         e2 = self.ccd_ref.ea_eom(nroots=5).kernel()

--- a/tests/test_UDFCCD.py
+++ b/tests/test_UDFCCD.py
@@ -69,12 +69,12 @@ class UDFCCD_Tests(unittest.TestCase):
     def test_t2_amplitudes(self):
         a = self.ccd_ref.t2.aaaa
         b = self.ccd.t2.aaaa
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_l2_amplitudes(self):
         a = self.ccd_ref.l2.aaaa
         b = self.ccd.l2.aaaa
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_eom_ip(self):
         e1 = self.ccd.ip_eom(nroots=5).kernel()

--- a/tests/test_UDFCCSD.py
+++ b/tests/test_UDFCCSD.py
@@ -60,27 +60,27 @@ class UDFCCSD_PySCF_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.ccsd_ref.t1
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a[0], b.aa, 6)
-        np.testing.assert_almost_equal(a[1], b.bb, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.bb)), 0.0, 6)
 
     def test_l1_amplitudes(self):
         a = self.ccsd_ref.l1
         b = self.ccsd.l1
-        np.testing.assert_almost_equal(a[0], b.aa.T, 6)
-        np.testing.assert_almost_equal(a[1], b.bb.T, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aa.T)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.bb.T)), 0.0, 6)
 
     def test_rdm1(self):
         a = self.ccsd_ref.make_rdm1()
         b = self.ccsd.make_rdm1_f(eris=self.eris)
-        np.testing.assert_almost_equal(a[0], b.aa, 6)
-        np.testing.assert_almost_equal(a[1], b.bb, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.bb)), 0.0, 6)
 
     def test_rdm2(self):
         a = self.ccsd_ref.make_rdm2()
         b = self.ccsd.make_rdm2_f(eris=self.eris)
-        np.testing.assert_almost_equal(a[0], b.aaaa, 6)
-        np.testing.assert_almost_equal(a[1], b.aabb, 6)
-        np.testing.assert_almost_equal(a[2], b.bbbb, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aaaa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.aabb)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[2] - b.bbbb)), 0.0, 6)
 
     def test_eom_ip(self):
         e1 = self.ccsd.ip_eom(nroot=5).kernel()
@@ -167,27 +167,27 @@ class UDFCCSD_PySCF_Frozen_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.ccsd_ref.t1
         b = self.ccsd.t1
-        np.testing.assert_almost_equal(a[0], b.aa, 6)
-        np.testing.assert_almost_equal(a[1], b.bb, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.bb)), 0.0, 6)
 
     def test_l1_amplitudes(self):
         a = self.ccsd_ref.l1
         b = self.ccsd.l1
-        np.testing.assert_almost_equal(a[0], b.aa.T, 6)
-        np.testing.assert_almost_equal(a[1], b.bb.T, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aa.T)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.bb.T)), 0.0, 6)
 
     def test_rdm1(self):
         a = self.ccsd_ref.make_rdm1(with_frozen=False)
         b = self.ccsd.make_rdm1_f(eris=self.eris)
-        np.testing.assert_almost_equal(a[0], b.aa, 6)
-        np.testing.assert_almost_equal(a[1], b.bb, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.bb)), 0.0, 6)
 
     def test_rdm2(self):
         a = self.ccsd_ref.make_rdm2(with_frozen=False)
         b = self.ccsd.make_rdm2_f(eris=self.eris)
-        np.testing.assert_almost_equal(a[0], b.aaaa, 6)
-        np.testing.assert_almost_equal(a[1], b.aabb, 6)
-        np.testing.assert_almost_equal(a[2], b.bbbb, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[0] - b.aaaa)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[1] - b.aabb)), 0.0, 6)
+        self.assertAlmostEqual(np.max(np.abs(a[2] - b.bbbb)), 0.0, 6)
 
 
 if __name__ == "__main__":

--- a/tests/test_UDFCCSD.py
+++ b/tests/test_UDFCCSD.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from pyscf import cc, gto, lib, scf
 
-from ebcc import UEBCC, NullLogger, Space
+from ebcc import UEBCC, NullLogger, Space, BACKEND
 
 
 @pytest.mark.reference
@@ -82,11 +82,13 @@ class UDFCCSD_PySCF_Tests(unittest.TestCase):
         self.assertAlmostEqual(np.max(np.abs(a[1] - b.aabb)), 0.0, 6)
         self.assertAlmostEqual(np.max(np.abs(a[2] - b.bbbb)), 0.0, 6)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         e1 = self.ccsd.ip_eom(nroot=5).kernel()
         e2, v2 = self.ccsd_ref.ipccsd(nroots=5)
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         e1 = self.ccsd.ea_eom(nroots=5).kernel()
         e2, v2 = self.ccsd_ref.eaccsd(nroots=5)

--- a/tests/test_UDFDCD.py
+++ b/tests/test_UDFDCD.py
@@ -65,7 +65,7 @@ class UDFDCD_Tests(unittest.TestCase):
     def test_t2_amplitudes(self):
         a = self.ccd_ref.t2.aaaa
         b = self.ccd.t2.aaaa
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
 
 if __name__ == "__main__":

--- a/tests/test_UDFDCSD.py
+++ b/tests/test_UDFDCSD.py
@@ -65,12 +65,12 @@ class UDFCC2_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.cc2_ref.t1.aa
         b = self.cc2.t1.aa
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_t2_amplitudes(self):
         a = self.cc2_ref.t2.aaaa
         b = self.cc2.t2.aaaa
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
 
 if __name__ == "__main__":

--- a/tests/test_UDFQCISD.py
+++ b/tests/test_UDFQCISD.py
@@ -65,12 +65,12 @@ class UDFQCISD_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.qcisd_ref.t1.aa
         b = self.qcisd.t1.aa
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
     def test_t2_amplitudes(self):
         a = self.qcisd_ref.t2.aaaa
         b = self.qcisd.t2.aaaa
-        np.testing.assert_almost_equal(a, b, 4)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 4)
 
 
 if __name__ == "__main__":

--- a/tests/test_UMP2.py
+++ b/tests/test_UMP2.py
@@ -11,7 +11,7 @@ import pytest
 import scipy.linalg
 from pyscf import mp, gto, lib, scf, adc
 
-from ebcc import UEBCC, NullLogger, Space
+from ebcc import UEBCC, NullLogger, Space, BACKEND
 
 
 @pytest.mark.reference
@@ -53,6 +53,7 @@ class UMP2_PySCF_Tests(unittest.TestCase):
         b = self.mp2.e_tot
         self.assertAlmostEqual(a, b, 7)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ip(self):
         eom = self.mp2.ip_eom(nroots=5, e_tol=1e-10)
         e1 = eom.kernel()
@@ -61,6 +62,7 @@ class UMP2_PySCF_Tests(unittest.TestCase):
         e2, v2 = adc2.ip_adc(nroots=5)[:2]
         self.assertAlmostEqual(e1[0], e2[0], 5)
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="EOM is currently too slow with non-NumPy backends")
     def test_eom_ea(self):
         eom = self.mp2.ea_eom(nroots=5, e_tol=1e-12)
         e1 = eom.kernel()

--- a/tests/test_UQCISD.py
+++ b/tests/test_UQCISD.py
@@ -61,12 +61,12 @@ class UQCISD_PySCF_Tests(unittest.TestCase):
     def test_t1_amplitudes(self):
         a = self.qcisd_ref.t1
         b = self.qcisd.t1.aa
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
     def test_t2_amplitudes(self):
         a = self.qcisd_ref.t2
         b = self.qcisd.t2.abab
-        np.testing.assert_almost_equal(a, b, 6)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 if __name__ == "__main__":

--- a/tests/test_brueckner.py
+++ b/tests/test_brueckner.py
@@ -69,7 +69,7 @@ class RBCCD_PySCF_Tests(unittest.TestCase):
     #def test_t2_amplitudes(self):
     #    a = self.ccsd_ref.t2
     #    b = self.ccsd.t2
-    #    np.testing.assert_almost_equal(a, b, 6)
+    #    self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 6)
 
 
 @pytest.mark.reference

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -1,0 +1,238 @@
+"""Minimal tests for the module.
+
+These tests simply check the energies for small systems.
+"""
+
+import unittest
+import pytest
+
+from pyscf import gto, scf
+
+from ebcc import REBCC, UEBCC, GEBCC, util, NullLogger
+from ebcc import numpy as np
+
+
+class _Minimal_Tests:
+    """Base class for minimal tests."""
+
+    ENERGY_REBCC: float
+    ENERGY_UEBCC: float
+    ENERGY_GEBCC: float
+    ANSATZ: str
+    SOLVE_LAMBDA: bool = True
+    CHECK_DMS: bool = True
+
+    def test_rebcc(self):
+        rebcc = REBCC(self.mf, ansatz=self.ANSATZ, log=NullLogger())
+        rebcc.kernel()
+        self.assertTrue(rebcc.converged)
+        self.assertAlmostEqual(rebcc.e_tot, self.ENERGY_REBCC, places=7)
+
+        if self.CHECK_DMS:
+            if self.SOLVE_LAMBDA:
+                rebcc.solve_lambda()
+            dm1 = rebcc.make_rdm1_f()
+            dm2 = rebcc.make_rdm2_f()
+            c = rebcc.mf.mo_coeff
+            h = rebcc.mf.get_hcore()
+            h = c.T @ h @ c
+            v = rebcc.get_eris().xxxx
+            e_rdm = util.einsum("pq,pq->", h, dm1)
+            e_rdm += util.einsum("pqrs,pqrs->", v, dm2) * 0.5
+            e_rdm += rebcc.mf.mol.energy_nuc()
+            self.assertAlmostEqual(e_rdm, rebcc.e_tot)
+
+        if callable(self.test_uebcc):
+            uebcc = UEBCC.from_rebcc(rebcc)
+            uebcc.kernel()
+            self.assertAlmostEqual(uebcc.e_tot, self.ENERGY_UEBCC, places=7)
+
+    def test_uebcc(self):
+        uebcc = UEBCC(self.mf, ansatz=self.ANSATZ, log=NullLogger())
+        uebcc.kernel()
+        self.assertTrue(uebcc.converged)
+        self.assertAlmostEqual(uebcc.e_tot, self.ENERGY_UEBCC, places=7)
+
+        if callable(self.test_gebcc):
+            gebcc = GEBCC.from_uebcc(uebcc)
+            gebcc.kernel()
+            self.assertAlmostEqual(gebcc.e_tot, self.ENERGY_GEBCC, places=7)
+
+    def test_gebcc(self):
+        gebcc = GEBCC(self.mf, ansatz=self.ANSATZ, log=NullLogger())
+        gebcc.kernel()
+        self.assertTrue(gebcc.converged)
+        self.assertAlmostEqual(gebcc.e_tot, self.ENERGY_GEBCC, places=7)
+
+        if self.CHECK_DMS:
+            if self.SOLVE_LAMBDA:
+                gebcc.solve_lambda()
+            dm1 = gebcc.make_rdm1_f()
+            dm2 = gebcc.make_rdm2_f()
+            c = gebcc.mf.mo_coeff
+            h = gebcc.mf.get_hcore()
+            h = c.T @ h @ c
+            v = gebcc.get_eris().xxxx
+            e_rdm = util.einsum("pq,pq->", h, dm1)
+            e_rdm += util.einsum("pqrs,pqrs->", v, dm2) * 0.5
+            e_rdm += gebcc.mf.mol.energy_nuc()
+            self.assertAlmostEqual(e_rdm, gebcc.e_tot)
+
+
+@pytest.mark.reference
+class Minimal_LiH_CCSD_Tests(unittest.TestCase, _Minimal_Tests):
+    ENERGY_REBCC = -7.881447660132
+    ENERGY_UEBCC = -7.881447660219
+    ENERGY_GEBCC = -7.881447660088
+    ANSATZ = "CCSD"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mol = gto.Mole()
+        cls.mol.atom = "Li 0 0 0; H 0 0 1.64"
+        cls.mol.basis = "sto3g"
+        cls.mol.verbose = 0
+        cls.mol.build()
+
+        cls.mf = scf.RHF(cls.mol)
+        cls.mf.conv_tol = 1e-12
+        cls.mf.kernel()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.mol, cls.mf
+
+
+@pytest.mark.reference
+class Minimal_LiH_CC2_Tests(unittest.TestCase, _Minimal_Tests):
+    ENERGY_REBCC = -7.873708239966
+    ENERGY_UEBCC = -7.873708239926
+    ENERGY_GEBCC = -7.873708239943
+    ANSATZ = "CC2"
+    CHECK_DMS = False
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mol = gto.Mole()
+        cls.mol.atom = "Li 0 0 0; H 0 0 1.64"
+        cls.mol.basis = "sto3g"
+        cls.mol.verbose = 0
+        cls.mol.build()
+
+        cls.mf = scf.RHF(cls.mol)
+        cls.mf.conv_tol = 1e-12
+        cls.mf.kernel()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.mol, cls.mf
+
+
+@pytest.mark.reference
+class Minimal_H2O_DFDCD_Tests(unittest.TestCase, _Minimal_Tests):
+    ENERGY_REBCC = -76.121571466693
+    ENERGY_UEBCC = -76.121571463778
+    ANSATZ = "DCD"
+    CHECK_DMS = False
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mol = gto.Mole()
+        cls.mol.atom = "O 0 0 -0.11779; H 0 -0.755453 0.471161; H 0 0.755453 0.471161"
+        cls.mol.basis = "6-31g"
+        cls.mol.verbose = 0
+        cls.mol.build()
+
+        cls.mf = scf.RHF(cls.mol)
+        cls.mf = cls.mf.density_fit()
+        cls.mf.conv_tol = 1e-12
+        cls.mf.kernel()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.mol, cls.mf
+
+    test_gebcc = None
+
+
+@pytest.mark.reference
+class Minimal_HeH_CC3_Tests(unittest.TestCase, _Minimal_Tests):
+    ENERGY_UEBCC = -2.824682673746
+    ANSATZ = "CC3"
+    CHECK_DMS = False
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mol = gto.Mole()
+        cls.mol.atom = "He 0 0 0; H 0 0 1.5"
+        cls.mol.basis = "sto3g"
+        cls.mol.charge = 1
+        cls.mol.verbose = 0
+        cls.mol.build()
+
+        cls.mf = scf.UHF(cls.mol)
+        cls.mf.conv_tol = 1e-12
+        cls.mf.kernel()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.mol, cls.mf
+
+    test_rebcc = None
+    test_gebcc = None
+
+
+@pytest.mark.reference
+class Minimal_O2_MP2_Tests(unittest.TestCase, _Minimal_Tests):
+    ENERGY_REBCC = -147.675973450322
+    ENERGY_UEBCC = -147.675973450322
+    ANSATZ = "MP2"
+    SOLVE_LAMBDA = False
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mol = gto.Mole()
+        cls.mol.atom = "O 0 0 0; O 0 0 1.207"
+        cls.mol.basis = "sto3g"
+        cls.mol.verbose = 0
+        cls.mol.build()
+
+        cls.mf = scf.RHF(cls.mol)
+        cls.mf.conv_tol = 1e-12
+        cls.mf.kernel()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.mol, cls.mf
+
+    test_gebcc = None
+
+
+@pytest.mark.reference
+class Minimal_LiH_CCSDT_Tests(unittest.TestCase, _Minimal_Tests):
+    ENERGY_REBCC = -7.8814585781527
+    ENERGY_UEBCC = -7.8814585767463
+    ANSATZ = "CCSDT"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mol = gto.Mole()
+        cls.mol.atom = "Li 0 0 0; H 0 0 1.64"
+        cls.mol.basis = "sto3g"
+        cls.mol.verbose = 0
+        cls.mol.build()
+
+        cls.mf = scf.RHF(cls.mol)
+        cls.mf.conv_tol = 1e-12
+        cls.mf.kernel()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.mol, cls.mf
+
+    test_gebcc = None
+
+
+if __name__ == "__main__":
+    print("Minimal tests.")
+    unittest.main()

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -156,33 +156,6 @@ class Minimal_H2O_DFDCD_Tests(unittest.TestCase, _Minimal_Tests):
 
 
 @pytest.mark.reference
-class Minimal_HeH_CC3_Tests(unittest.TestCase, _Minimal_Tests):
-    ENERGY_UEBCC = -2.824682673746
-    ANSATZ = "CC3"
-    CHECK_DMS = False
-
-    @classmethod
-    def setUpClass(cls):
-        cls.mol = gto.Mole()
-        cls.mol.atom = "He 0 0 0; H 0 0 1.5"
-        cls.mol.basis = "sto3g"
-        cls.mol.charge = 1
-        cls.mol.verbose = 0
-        cls.mol.build()
-
-        cls.mf = scf.UHF(cls.mol)
-        cls.mf.conv_tol = 1e-12
-        cls.mf.kernel()
-
-    @classmethod
-    def tearDownClass(cls):
-        del cls.mol, cls.mf
-
-    test_rebcc = None
-    test_gebcc = None
-
-
-@pytest.mark.reference
 class Minimal_O2_MP2_Tests(unittest.TestCase, _Minimal_Tests):
     ENERGY_REBCC = -147.675973450322
     ENERGY_UEBCC = -147.675973450322

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -9,7 +9,7 @@ import pytest
 from pyscf import gto, scf
 
 import ebcc
-from ebcc import util
+from ebcc import util, BACKEND
 
 
 @pytest.mark.regression
@@ -36,6 +36,7 @@ class Util_Tests(unittest.TestCase):
         self.assertEqual(util.permute_string("god", (2, 1, 0)), "dog")
         self.assertEqual(util.permute_string("ebcc", (2, 0, 3, 1)), "cecb")
 
+    @pytest.mark.skipif(BACKEND != "numpy", reason="Requires mutable array backend")
     def test_tril_indices_ndim(self):
         for n in (1, 2, 3, 4):
             for ndim in (1, 2, 3, 4):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -113,7 +113,7 @@ class Util_Tests(unittest.TestCase):
                 array = np.cos(np.arange(1, n**ndim + 1).reshape((n,) * ndim))
                 array = util.antisymmetrise_array(array, axes=range(ndim))
                 for perm, sign in util.permutations_with_signs(range(ndim)):
-                    np.testing.assert_almost_equal(array, sign * array.transpose(perm))
+                    self.assertAlmostEqual(np.max(np.abs(array - sign * array.transpose(perm))), 0.0, 7)
 
     def test_is_mixed(self):
         self.assertEqual(util.is_mixed_spin("aa"), False)
@@ -142,7 +142,7 @@ class Util_Tests(unittest.TestCase):
                     for p2, s2 in util.permutations_with_signs(range(ndim // 2, ndim)):
                         perm = tuple(p1) + tuple(p2)
                         sign = s1 * s2
-                        np.testing.assert_almost_equal(array, sign * array.transpose(perm))
+                        self.assertAlmostEqual(np.max(np.abs(array - sign * array.transpose(perm))), 0.0, 7)
 
     def test_constructors(self):
         # Tests the constructors in the main __init__.py
@@ -169,8 +169,8 @@ class Util_Tests(unittest.TestCase):
 
     def test_einsum(self):
         # Tests the einsum implementation
-        _size = util.einsumfunc.NUMPY_EINSUM_SIZE
-        util.einsumfunc.NUMPY_EINSUM_SIZE = 0
+        _size = util.einsumfunc.BACKEND_EINSUM_SIZE
+        util.einsumfunc.BACKEND_EINSUM_SIZE = 0
 
         x = np.random.random((10, 11, 12, 13))
         y = np.random.random((13, 12, 5, 6))
@@ -178,21 +178,21 @@ class Util_Tests(unittest.TestCase):
 
         a = np.einsum("ijkl,lkab->ijab", x, y)
         b = util.einsum("ijkl,lkab->ijab", x, y)
-        np.testing.assert_almost_equal(a, b)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
         b[:] = 0
         b = util.einsum("ijkl,lkab->ijab", x, y, out=b, alpha=1.0, beta=0.0)
-        np.testing.assert_almost_equal(a, b)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
         b = util.einsum("ijkl,lkab->ijab", x, y, out=b, alpha=1.0, beta=1.0)
-        np.testing.assert_almost_equal(a * 2, b)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
         b = util.einsum("ijkl,lkab->ijab", x, y, out=b, alpha=2.0, beta=0.0)
-        np.testing.assert_almost_equal(a * 2, b)
+        self.assertAlmostEqual(np.max(np.abs(a * 2 - b)), 0.0, 7)
 
         a = np.einsum("ijkl,lkab,bacd->ijcd", x, y, z)
         b = util.einsum("ijkl,lkab,bacd->ijcd", x, y, z)
-        np.testing.assert_almost_equal(a, b)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
         x = np.asfortranarray(np.random.random((5, 5, 5)))
         y = np.asfortranarray(np.random.random((5, 5, 5)))
@@ -200,7 +200,7 @@ class Util_Tests(unittest.TestCase):
 
         a = np.einsum("ijk,jki,kji->ik", x, y, z)
         b = util.einsum("ijk,jki,kji->ik", x, y, z)
-        np.testing.assert_almost_equal(a, b)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
         with pytest.raises(NotImplementedError):
             b = util.einsum("ijk,jki,kji->ik", x, y, z, alpha=0.5)
@@ -209,29 +209,29 @@ class Util_Tests(unittest.TestCase):
 
         a = np.einsum("iik,kjj->ij", x, y)
         b = util.einsum("iik,kjj->ij", x, y)
-        np.testing.assert_almost_equal(a, b)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
         a = np.einsum("ijk,ijk->", x, y)
         b = util.einsum("ijk,ijk->", x, y)
-        np.testing.assert_almost_equal(a, b)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
         z = np.random.random((5, 5))
 
         a = np.einsum("ijk,jk->", x, z)
         b = util.einsum("ijk,jk->", x, z)
-        np.testing.assert_almost_equal(a, b)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
         a = np.einsum("ijk,kl->il", x, z)
         b = util.einsum("ijk,kl->il", x, z)
-        np.testing.assert_almost_equal(a, b)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
         x = np.random.random((5, 5, 0))
 
         a = np.einsum("ikl,jkl->ij", x, x)
         b = util.einsum("ikl,jkl->ij", x, x)
-        np.testing.assert_almost_equal(a, b)
+        self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
-        util.einsumfunc.NUMPY_EINSUM_SIZE = _size
+        util.einsumfunc.BACKEND_EINSUM_SIZE = _size
 
 
 if __name__ == "__main__":

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -237,8 +237,8 @@ class Util_Tests(unittest.TestCase):
     def test_einsum_backend(self):
         self._test_einsum("backend")
 
-    def test_einsum_ttdt(self):
-        self._test_einsum("ttdt")
+    def test_einsum_ttgt(self):
+        self._test_einsum("ttgt")
 
     @pytest.mark.skipif(util.einsumfunc.FOUND_TBLIS is False, reason="TBLIS not found")
     def test_einsum_tblis(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -111,10 +111,10 @@ class Util_Tests(unittest.TestCase):
     def test_antisymmetrise_array(self):
         for n in (1, 2, 3, 4):
             for ndim in (1, 2, 3, 4, 5, 6):
-                array = np.cos(np.arange(1, n**ndim + 1).reshape((n,) * ndim))
+                array = np.cos(np.reshape(np.arange(1, n**ndim + 1), (n,) * ndim))
                 array = util.antisymmetrise_array(array, axes=range(ndim))
                 for perm, sign in util.permutations_with_signs(range(ndim)):
-                    self.assertAlmostEqual(np.max(np.abs(array - sign * array.transpose(perm))), 0.0, 7)
+                    self.assertAlmostEqual(np.max(np.abs(array - sign * np.transpose(array, perm))), 0.0, 7)
 
     def test_is_mixed(self):
         self.assertEqual(util.is_mixed_spin("aa"), False)
@@ -137,13 +137,13 @@ class Util_Tests(unittest.TestCase):
         for n in (1, 2, 3, 4):
             for ndim in (2, 4, 6):
                 subscript = "i" * (ndim // 2) + "a" * (ndim // 2)
-                array = np.cos(np.arange(n**ndim).reshape((n,) * ndim))
+                array = np.cos(np.reshape(np.arange(n**ndim), (n,) * ndim))
                 array = util.symmetrise(subscript, array)
                 for p1, s1 in util.permutations_with_signs(range(ndim // 2)):
                     for p2, s2 in util.permutations_with_signs(range(ndim // 2, ndim)):
                         perm = tuple(p1) + tuple(p2)
                         sign = s1 * s2
-                        self.assertAlmostEqual(np.max(np.abs(array - sign * array.transpose(perm))), 0.0, 7)
+                        self.assertAlmostEqual(np.max(np.abs(array - sign * np.transpose(array, perm))), 0.0, 7)
 
     def test_constructors(self):
         # Tests the constructors in the main __init__.py

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -180,7 +180,7 @@ class Util_Tests(unittest.TestCase):
         b = util.einsum("ijkl,lkab->ijab", x, y)
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 
-        b[:] = 0
+        b = np.zeros_like(b)
         b = util.einsum("ijkl,lkab->ijab", x, y, out=b, alpha=1.0, beta=0.0)
         self.assertAlmostEqual(np.max(np.abs(a - b)), 0.0, 7)
 


### PR DESCRIPTION
Adds a `ebcc.backends` module which allows the `numpy` module to be switched. This is specified by the `BACKEND` variable, reading the `EBCC_BACKEND` environment variable at import time.

Currently available backends:
- `numpy`
- `tensorflow`
- `cupy`
- `jax`
- `ctf`

Unless you're using a `numpy` backend, not all features are guaranteed to be functional. I've ensured that at the very least CC calculations on simple ansatzes are supported. `jax` and `tensorflow` have simple unit tests. `ctf` may currently only support RCC. I am fine with this as these are experimental features.

Other changes:
- DIIS object is now a custom implementation
- Lots of changes to the way the array API is interacted with to make sure functionality can be delegated to a backend with needing to do hacky patching
- The `einsum` contraction functions are now handled better and there are some flags to customised them. Could do with some benchmarking.
- Space masking is mostly done by slices now, with warnings for disjoint spaces. This is no loss of functionality since orbital spaces can be reordered to make the spaces contiguous.