### PR TITLE
Compatibility with `pyscfad`

### DIFF
--- a/ebcc/__init__.py
+++ b/ebcc/__init__.py
@@ -56,6 +56,14 @@ if TYPE_CHECKING:
 else:
     numpy = importlib.import_module(f"ebcc.backend._{BACKEND}")
 
+if BACKEND == "jax" and not TYPE_CHECKING:
+    try:
+        import pyscfad as pyscf
+    except:
+        import pyscf
+else:
+    import pyscf
+
 from ebcc.core.logging import NullLogger, default_log, init_logging
 from ebcc.cc import GEBCC, REBCC, UEBCC
 from ebcc.core import precision

--- a/ebcc/__init__.py
+++ b/ebcc/__init__.py
@@ -60,6 +60,17 @@ if BACKEND == "jax" and not TYPE_CHECKING:
     # Try to import pyscfad if JAX is used so we can use automatic differentiation
     try:
         import pyscfad as pyscf
+
+        # See https://github.com/fishjojo/pyscfad/issues/60
+        from pyscfad import scf, ao2mo, mp
+        from pyscfad.ao2mo import _ao2mo, addons
+
+        pyscf.scf = scf
+        pyscf.ao2mo = ao2mo
+        pyscf.ao2mo._ao2mo = _ao2mo
+        pyscf.ao2mo.addons = addons
+        pyscf.mp = mp
+
     except ImportError:
         import pyscf
 else:

--- a/ebcc/__init__.py
+++ b/ebcc/__init__.py
@@ -60,7 +60,7 @@ if BACKEND == "jax" and not TYPE_CHECKING:
     # Try to import pyscfad if JAX is used so we can use automatic differentiation
     try:
         import pyscfad as pyscf
-    except:
+    except ImportError:
         import pyscf
 else:
     import pyscf

--- a/ebcc/__init__.py
+++ b/ebcc/__init__.py
@@ -57,6 +57,7 @@ else:
     numpy = importlib.import_module(f"ebcc.backend._{BACKEND}")
 
 if BACKEND == "jax" and not TYPE_CHECKING:
+    # Try to import pyscfad if JAX is used so we can use automatic differentiation
     try:
         import pyscfad as pyscf
     except:

--- a/ebcc/backend/__init__.py
+++ b/ebcc/backend/__init__.py
@@ -58,8 +58,11 @@ def ensure_scalar(obj: Union[T, NDArray[T]]) -> T:
     Returns:
         Scalar object.
     """
-    if BACKEND in ("numpy", "cupy", "jax"):
+    if BACKEND in ("numpy", "cupy"):
         return np.asarray(obj).item()  # type: ignore
+    elif BACKEND == "jax":
+        # Returning the `item` seems to be problematic for traced objects
+        return obj  # type: ignore
     elif BACKEND == "tensorflow":
         if isinstance(obj, tf.Tensor):
             return obj.numpy().item()  # type: ignore

--- a/ebcc/backend/__init__.py
+++ b/ebcc/backend/__init__.py
@@ -61,8 +61,7 @@ def ensure_scalar(obj: Union[T, NDArray[T]]) -> T:
     if BACKEND in ("numpy", "cupy"):
         return np.asarray(obj).item()  # type: ignore
     elif BACKEND == "jax":
-        # Can't return an item for traced objects, so make this function a no-op for JAX
-        return obj  # type: ignore
+        return np.ravel(obj)[0]  # type: ignore
     elif BACKEND == "tensorflow":
         if isinstance(obj, tf.Tensor):
             return obj.numpy().item()  # type: ignore

--- a/ebcc/backend/__init__.py
+++ b/ebcc/backend/__init__.py
@@ -61,7 +61,7 @@ def ensure_scalar(obj: Union[T, NDArray[T]]) -> T:
     if BACKEND in ("numpy", "cupy"):
         return np.asarray(obj).item()  # type: ignore
     elif BACKEND == "jax":
-        # Returning the `item` seems to be problematic for traced objects
+        # Can't return an item for traced objects, so make this function a no-op for JAX
         return obj  # type: ignore
     elif BACKEND == "tensorflow":
         if isinstance(obj, tf.Tensor):

--- a/ebcc/cc/base.py
+++ b/ebcc/cc/base.py
@@ -241,13 +241,21 @@ class BaseEBCC(ABC):
         # Get the initial energy:
         e_cc = self.energy(amplitudes=amplitudes, eris=eris)
 
+        def _format(value, fmt="{:.10f}"):
+            try:
+                out = fmt.format(value)
+            except:
+                out = str(value)
+                if len(out) > len(fmt.format(0.0)):
+                    out = out[: len(fmt.format(0.0)) - 3] + "..."
+            return out
         self.log.output("Solving for excitation amplitudes.")
         self.log.debug("")
         self.log.info(
             f"{ANSI.B}{'Iter':>4s} {'Energy (corr.)':>16s} {'Energy (tot.)':>18s} "
             f"{'Δ(Energy)':>13s} {'Δ(Ampl.)':>13s}{ANSI.R}"
         )
-        self.log.info(f"{0:4d} {e_cc:16.10f} {e_cc + self.mf.e_tot:18.10f}")
+        self.log.info(f"{0:4d} {_format(e_cc, '{:16.10f}')} {_format(e_cc + self.mf.e_tot, '{:18.10f}')}")
 
         if not self.ansatz.is_one_shot:
             # Set up damping:
@@ -273,10 +281,15 @@ class BaseEBCC(ABC):
                 # Log the iteration:
                 converged_e = bool(de < self.options.e_tol)
                 converged_t = bool(dt < self.options.t_tol)
+                #self.log.info(
+                #    f"{niter:4d} {e_cc:16.10f} {e_cc + self.mf.e_tot:18.10f}"
+                #    f" {[ANSI.r, ANSI.g][bool(converged_e)]}{de:13.3e}{ANSI.R}"
+                #    f" {[ANSI.r, ANSI.g][bool(converged_t)]}{dt:13.3e}{ANSI.R}"
+                #)
                 self.log.info(
-                    f"{niter:4d} {e_cc:16.10f} {e_cc + self.mf.e_tot:18.10f}"
-                    f" {[ANSI.r, ANSI.g][bool(converged_e)]}{de:13.3e}{ANSI.R}"
-                    f" {[ANSI.r, ANSI.g][bool(converged_t)]}{dt:13.3e}{ANSI.R}"
+                    f"{niter:4d} {_format(e_cc, '{:16.10f}')} {_format(e_cc + self.mf.e_tot, '{:18.10f}')}"
+                    f" {[ANSI.r, ANSI.g][bool(converged_e)]}{_format(de, '{:13.3e}')}{ANSI.R}"
+                    f" {[ANSI.r, ANSI.g][bool(converged_t)]}{_format(dt, '{:13.3e}')}{ANSI.R}"
                 )
 
                 # Check for convergence:
@@ -306,8 +319,10 @@ class BaseEBCC(ABC):
         self.converged = converged
 
         self.log.debug("")
-        self.log.output(f"E(corr) = {self.e_corr:.10f}")
-        self.log.output(f"E(tot)  = {self.e_tot:.10f}")
+        #self.log.output(f"E(corr) = {self.e_corr:.10f}")
+        #self.log.output(f"E(tot)  = {self.e_tot:.10f}")
+        self.log.output(f"E(corr) = {_format(self.e_corr, '{:.10f}')}")
+        self.log.output(f"E(tot)  = {_format(self.e_corr + self.mf.e_tot, '{:.10f}')}")
         self.log.debug("")
         self.log.debug("Time elapsed: %s", timer.format_time(timer()))
         self.log.debug("")

--- a/ebcc/cc/base.py
+++ b/ebcc/cc/base.py
@@ -274,8 +274,8 @@ class BaseEBCC(ABC):
                 converged_e = bool(de < self.options.e_tol)
                 converged_t = bool(dt < self.options.t_tol)
                 self.log.info(
-                    f"%4d %16.10f %18.10f {[ANSI.r, ANSI.g][converged_e]}%13.3e{ANSI.R}"
-                    f" {[ANSI.r, ANSI.g][converged_t]}%13.3e{ANSI.R}",
+                    f"%4d %16.10f %18.10f {[ANSI.r, ANSI.g][int(converged_e)]}%13.3e{ANSI.R}"
+                    f" {[ANSI.r, ANSI.g][int(converged_t)]}%13.3e{ANSI.R}",
                     niter,
                     e_cc,
                     e_cc + self.mf.e_tot,
@@ -373,7 +373,7 @@ class BaseEBCC(ABC):
 
             # Log the iteration:
             converged = bool(dl < self.options.t_tol)
-            self.log.info(f"%4d {[ANSI.r, ANSI.g][converged]}%13.3e{ANSI.R}", niter, dl)
+            self.log.info(f"%4d {[ANSI.r, ANSI.g][int(converged)]}%13.3e{ANSI.R}", niter, dl)
 
             # Check for convergence:
             if converged:

--- a/ebcc/cc/base.py
+++ b/ebcc/cc/base.py
@@ -241,21 +241,13 @@ class BaseEBCC(ABC):
         # Get the initial energy:
         e_cc = self.energy(amplitudes=amplitudes, eris=eris)
 
-        def _format(value, fmt="{:.10f}"):
-            try:
-                out = fmt.format(value)
-            except:
-                out = str(value)
-                if len(out) > len(fmt.format(0.0)):
-                    out = out[: len(fmt.format(0.0)) - 3] + "..."
-            return out
         self.log.output("Solving for excitation amplitudes.")
         self.log.debug("")
         self.log.info(
             f"{ANSI.B}{'Iter':>4s} {'Energy (corr.)':>16s} {'Energy (tot.)':>18s} "
             f"{'Δ(Energy)':>13s} {'Δ(Ampl.)':>13s}{ANSI.R}"
         )
-        self.log.info(f"{0:4d} {_format(e_cc, '{:16.10f}')} {_format(e_cc + self.mf.e_tot, '{:18.10f}')}")
+        self.log.info("%4d %16.10f %18.10f", 0, e_cc, e_cc + self.mf.e_tot)
 
         if not self.ansatz.is_one_shot:
             # Set up damping:
@@ -281,15 +273,14 @@ class BaseEBCC(ABC):
                 # Log the iteration:
                 converged_e = bool(de < self.options.e_tol)
                 converged_t = bool(dt < self.options.t_tol)
-                #self.log.info(
-                #    f"{niter:4d} {e_cc:16.10f} {e_cc + self.mf.e_tot:18.10f}"
-                #    f" {[ANSI.r, ANSI.g][bool(converged_e)]}{de:13.3e}{ANSI.R}"
-                #    f" {[ANSI.r, ANSI.g][bool(converged_t)]}{dt:13.3e}{ANSI.R}"
-                #)
                 self.log.info(
-                    f"{niter:4d} {_format(e_cc, '{:16.10f}')} {_format(e_cc + self.mf.e_tot, '{:18.10f}')}"
-                    f" {[ANSI.r, ANSI.g][bool(converged_e)]}{_format(de, '{:13.3e}')}{ANSI.R}"
-                    f" {[ANSI.r, ANSI.g][bool(converged_t)]}{_format(dt, '{:13.3e}')}{ANSI.R}"
+                    f"%4d %16.10f %18.10f {[ANSI.r, ANSI.g][converged_e]}%13.3e{ANSI.R}"
+                    f" {[ANSI.r, ANSI.g][converged_t]}%13.3e{ANSI.R}",
+                    niter,
+                    e_cc,
+                    e_cc + self.mf.e_tot,
+                    de,
+                    dt,
                 )
 
                 # Check for convergence:
@@ -308,7 +299,7 @@ class BaseEBCC(ABC):
                 self.log.info("Computing perturbative energy correction.")
                 e_pert = self.energy_perturbative(amplitudes=amplitudes, eris=eris)
                 e_cc += e_pert
-                self.log.info(f"E(pert) = {e_pert:.10f}")
+                self.log.info("E(pert) = %.10f", e_pert)
 
         else:
             converged = True
@@ -319,10 +310,8 @@ class BaseEBCC(ABC):
         self.converged = converged
 
         self.log.debug("")
-        #self.log.output(f"E(corr) = {self.e_corr:.10f}")
-        #self.log.output(f"E(tot)  = {self.e_tot:.10f}")
-        self.log.output(f"E(corr) = {_format(self.e_corr, '{:.10f}')}")
-        self.log.output(f"E(tot)  = {_format(self.e_corr + self.mf.e_tot, '{:.10f}')}")
+        self.log.output("E(corr) = %.10f", self.e_corr)
+        self.log.output("E(tot)  = %.10f", self.e_corr + self.mf.e_tot)
         self.log.debug("")
         self.log.debug("Time elapsed: %s", timer.format_time(timer()))
         self.log.debug("")
@@ -384,7 +373,7 @@ class BaseEBCC(ABC):
 
             # Log the iteration:
             converged = bool(dl < self.options.t_tol)
-            self.log.info(f"{niter:4d} {[ANSI.r, ANSI.g][converged]}{dl:13.3e}{ANSI.R}")
+            self.log.info(f"%4d {[ANSI.r, ANSI.g][converged]}%13.3e{ANSI.R}", niter, dl)
 
             # Check for convergence:
             if converged:

--- a/ebcc/core/precision.py
+++ b/ebcc/core/precision.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from ebcc import BACKEND
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from typing import Type, TypeVar
@@ -37,12 +39,12 @@ def astype(value: T, dtype: Type[T]) -> T:
     Returns:
         The value cast to the current floating point type.
     """
-    try:
+    if BACKEND == "jax":
+        # Value may be traced, can't cast directly to the type
+        return value.astype(types[dtype])
+    else:
         out: T = types[dtype](value)
-    except:
-        # Might be traced by JAX
-        out = value
-    return out
+        return out
 
 
 def set_precision(**kwargs: type) -> None:

--- a/ebcc/core/precision.py
+++ b/ebcc/core/precision.py
@@ -39,9 +39,9 @@ def astype(value: T, dtype: Type[T]) -> T:
     Returns:
         The value cast to the current floating point type.
     """
-    if BACKEND == "jax":
+    if BACKEND == "jax" and not TYPE_CHECKING:
         # Value may be traced, can't cast directly to the type
-        return value.astype(types[dtype])
+        return value.astype(types[dtype])  # type: ignore
     else:
         out: T = types[dtype](value)
         return out

--- a/ebcc/core/precision.py
+++ b/ebcc/core/precision.py
@@ -37,7 +37,11 @@ def astype(value: T, dtype: Type[T]) -> T:
     Returns:
         The value cast to the current floating point type.
     """
-    out: T = types[dtype](value)
+    try:
+        out: T = types[dtype](value)
+    except:
+        # Might be traced by JAX
+        out = value
     return out
 
 

--- a/ebcc/eom/base.py
+++ b/ebcc/eom/base.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import numpy
-from pyscf import lib
 
+from ebcc import pyscf
 from ebcc import numpy as np
 from ebcc import util
 from ebcc.backend import to_numpy
@@ -217,11 +217,11 @@ class BaseEOM(ABC):
                 w: NDArray[T], v: NDArray[T], nroots: int, env: dict[str, Any]
             ) -> tuple[NDArray[T], NDArray[T], int]:
                 """Pick the eigenvalues."""
-                x0 = to_numpy(lib.linalg_helper._gen_x0(env["v"], env["xs"]))
+                x0 = to_numpy(pyscf.lib.linalg_helper._gen_x0(env["v"], env["xs"]))
                 s = to_numpy(guesses).conj() @ x0.T
                 s = numpy.einsum("pi,pi->i", s.conj(), s)
                 arg = numpy.argsort(-s)[:nroots]
-                w, v, idx = lib.linalg_helper._eigs_cmplx2real(
+                w, v, idx = pyscf.lib.linalg_helper._eigs_cmplx2real(
                     to_numpy(w),
                     to_numpy(v),
                     arg,
@@ -236,7 +236,7 @@ class BaseEOM(ABC):
             ) -> tuple[NDArray[T], NDArray[T], int]:
                 """Pick the eigenvalues."""
                 real_idx = numpy.where(abs(numpy.imag(w)) < 1e-3)[0]
-                w, v, idx = lib.linalg_helper._eigs_cmplx2real(
+                w, v, idx = pyscf.lib.linalg_helper._eigs_cmplx2real(
                     to_numpy(w),
                     to_numpy(v),
                     real_idx,
@@ -318,7 +318,7 @@ class BaseEOM(ABC):
         # Solve the EOM Hamiltonian:
         nroots = min(len(guesses), self.options.nroots)
         pick = self.get_pick(guesses=np.stack(guesses))
-        converged, e, v = lib.davidson_nosym1(
+        converged, e, v = pyscf.lib.davidson_nosym1(
             matvecs,
             [to_numpy(g) for g in guesses],
             to_numpy(diag),

--- a/ebcc/eom/base.py
+++ b/ebcc/eom/base.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import numpy
+from pyscf import lib
 
-from ebcc import pyscf
 from ebcc import numpy as np
 from ebcc import util
 from ebcc.backend import to_numpy
@@ -217,11 +217,11 @@ class BaseEOM(ABC):
                 w: NDArray[T], v: NDArray[T], nroots: int, env: dict[str, Any]
             ) -> tuple[NDArray[T], NDArray[T], int]:
                 """Pick the eigenvalues."""
-                x0 = to_numpy(pyscf.lib.linalg_helper._gen_x0(env["v"], env["xs"]))
+                x0 = to_numpy(lib.linalg_helper._gen_x0(env["v"], env["xs"]))
                 s = to_numpy(guesses).conj() @ x0.T
                 s = numpy.einsum("pi,pi->i", s.conj(), s)
                 arg = numpy.argsort(-s)[:nroots]
-                w, v, idx = pyscf.lib.linalg_helper._eigs_cmplx2real(
+                w, v, idx = lib.linalg_helper._eigs_cmplx2real(
                     to_numpy(w),
                     to_numpy(v),
                     arg,
@@ -236,7 +236,7 @@ class BaseEOM(ABC):
             ) -> tuple[NDArray[T], NDArray[T], int]:
                 """Pick the eigenvalues."""
                 real_idx = numpy.where(abs(numpy.imag(w)) < 1e-3)[0]
-                w, v, idx = pyscf.lib.linalg_helper._eigs_cmplx2real(
+                w, v, idx = lib.linalg_helper._eigs_cmplx2real(
                     to_numpy(w),
                     to_numpy(v),
                     real_idx,
@@ -318,7 +318,7 @@ class BaseEOM(ABC):
         # Solve the EOM Hamiltonian:
         nroots = min(len(guesses), self.options.nroots)
         pick = self.get_pick(guesses=np.stack(guesses))
-        converged, e, v = pyscf.lib.davidson_nosym1(
+        converged, e, v = lib.davidson_nosym1(
             matvecs,
             [to_numpy(g) for g in guesses],
             to_numpy(diag),

--- a/ebcc/eom/base.py
+++ b/ebcc/eom/base.py
@@ -356,8 +356,11 @@ class BaseEOM(ABC):
             r1n = self.vector_to_amplitudes(vn)["r1"]
             qpwt = self._quasiparticle_weight(r1n)
             self.log.output(
-                f"{n:>4d} {np.ravel(en)[0]:>16.10f} {qpwt:>13.5g} "
-                f"{[ANSI.r, ANSI.g][bool(cn)]}{cn!r:>8s}{ANSI.R}"
+                f"%4d %16.10f %13.5g {[ANSI.r, ANSI.g][bool(cn)]}%8s{ANSI.R}",
+                n,
+                np.ravel(en)[0],
+                qpwt,
+                bool(cn),
             )
 
         self.log.debug("")

--- a/ebcc/ham/cderis.py
+++ b/ebcc/ham/cderis.py
@@ -7,9 +7,8 @@ from typing import TYPE_CHECKING
 import numpy  # PySCF uses true numpy, no backend stuff here
 from pyscf import lib
 
-from ebcc import pyscf
 from ebcc import numpy as np
-from ebcc import util
+from ebcc import pyscf, util
 from ebcc.backend import to_numpy
 from ebcc.core.precision import types
 from ebcc.ham.base import BaseERIs, BaseRHamiltonian, BaseUHamiltonian

--- a/ebcc/ham/cderis.py
+++ b/ebcc/ham/cderis.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy  # PySCF uses true numpy, no backend stuff here
-from pyscf import ao2mo, lib
+from pyscf import lib
 
+from ebcc import pyscf
 from ebcc import numpy as np
 from ebcc import util
 from ebcc.backend import to_numpy
@@ -68,7 +69,7 @@ class RCDERIs(BaseERIs, BaseRHamiltonian):
                 coeffs[0].shape[-1] + coeffs[1].shape[-1],
             )
             coeffs = numpy.concatenate(coeffs, axis=1)
-            block = ao2mo._ao2mo.nr_e2(
+            block = pyscf.ao2mo._ao2mo.nr_e2(
                 self.cc.mf.with_df._cderi, coeffs, ijslice, aosym="s2", mosym="s1"
             )
             block = np.reshape(block, (-1, ijslice[1] - ijslice[0], ijslice[3] - ijslice[2]))

--- a/ebcc/ham/eris.py
+++ b/ebcc/ham/eris.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy  # PySCF uses true numpy, no backend stuff here
-from pyscf import ao2mo
 
+from ebcc import pyscf
 from ebcc import numpy as np
 from ebcc.backend import to_numpy
 from ebcc.core.precision import types
@@ -43,9 +43,9 @@ class RERIs(BaseERIs, BaseRHamiltonian):
                     for i, k in enumerate(key)
                 ]
                 if getattr(self.cc.mf, "_eri", None) is not None:
-                    block = ao2mo.incore.general(self.cc.mf._eri, coeffs, compact=False)
+                    block = pyscf.ao2mo.incore.general(self.cc.mf._eri, coeffs, compact=False)
                 else:
-                    block = ao2mo.kernel(self.cc.mf.mol, coeffs, compact=False)
+                    block = pyscf.ao2mo.kernel(self.cc.mf.mol, coeffs, compact=False)
                 block = np.reshape(block, [c.shape[-1] for c in coeffs])
                 self._members[key] = np.asarray(block, dtype=types[float])
             return self._members[key]
@@ -87,9 +87,9 @@ class UERIs(BaseERIs, BaseUHamiltonian):
                     for y, x in enumerate(sorted((i, i, j, j)))
                 ]
                 if getattr(self.cc.mf, "_eri", None) is not None:
-                    array = ao2mo.incore.general(self.cc.mf.mol, coeffs, compact=False)
+                    array = pyscf.ao2mo.incore.general(self.cc.mf.mol, coeffs, compact=False)
                 else:
-                    array = ao2mo.kernel(self.cc.mf.mol, coeffs, compact=False)
+                    array = pyscf.ao2mo.kernel(self.cc.mf.mol, coeffs, compact=False)
                 if key == "bbaa":
                     array = np.transpose(array, (2, 3, 0, 1))
                 array = np.asarray(array, dtype=types[float])
@@ -123,16 +123,16 @@ class GERIs(BaseERIs, BaseGHamiltonian):
             mo_a = [to_numpy(mo[: self.cc.mf.mol.nao], dtype=numpy.float64) for mo in self.mo_coeff]
             mo_b = [to_numpy(mo[self.cc.mf.mol.nao :], dtype=numpy.float64) for mo in self.mo_coeff]
             if getattr(self.cc.mf, "_eri", None) is not None:
-                array = ao2mo.incore.general(self.cc.mf._eri, mo_a)
-                array += ao2mo.incore.general(self.cc.mf._eri, mo_b)
-                array += ao2mo.incore.general(self.cc.mf._eri, mo_a[:2] + mo_b[2:])
-                array += ao2mo.incore.general(self.cc.mf._eri, mo_b[:2] + mo_a[2:])
+                array = pyscf.ao2mo.incore.general(self.cc.mf._eri, mo_a)
+                array += pyscf.ao2mo.incore.general(self.cc.mf._eri, mo_b)
+                array += pyscf.ao2mo.incore.general(self.cc.mf._eri, mo_a[:2] + mo_b[2:])
+                array += pyscf.ao2mo.incore.general(self.cc.mf._eri, mo_b[:2] + mo_a[2:])
             else:
-                array = ao2mo.kernel(self.cc.mf.mol, mo_a)
-                array += ao2mo.kernel(self.cc.mf.mol, mo_b)
-                array += ao2mo.kernel(self.cc.mf.mol, mo_a[:2] + mo_b[2:])
-                array += ao2mo.kernel(self.cc.mf.mol, mo_b[:2] + mo_a[2:])
-            array = np.reshape(ao2mo.addons.restore(1, array, self.cc.nmo), (self.cc.nmo,) * 4)
+                array = pyscf.ao2mo.kernel(self.cc.mf.mol, mo_a)
+                array += pyscf.ao2mo.kernel(self.cc.mf.mol, mo_b)
+                array += pyscf.ao2mo.kernel(self.cc.mf.mol, mo_a[:2] + mo_b[2:])
+                array += pyscf.ao2mo.kernel(self.cc.mf.mol, mo_b[:2] + mo_a[2:])
+            array = np.reshape(pyscf.ao2mo.addons.restore(1, array, self.cc.nmo), (self.cc.nmo,) * 4)
             array = np.asarray(array, dtype=types[float])
             array = np.transpose(array, (0, 2, 1, 3)) - np.transpose(array, (0, 2, 3, 1))
             self.__dict__["array"] = array

--- a/ebcc/ham/eris.py
+++ b/ebcc/ham/eris.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING
 
 import numpy  # PySCF uses true numpy, no backend stuff here
 
-from ebcc import pyscf
 from ebcc import numpy as np
+from ebcc import pyscf
 from ebcc.backend import to_numpy
 from ebcc.core.precision import types
 from ebcc.ham.base import BaseERIs, BaseGHamiltonian, BaseRHamiltonian, BaseUHamiltonian
@@ -132,7 +132,9 @@ class GERIs(BaseERIs, BaseGHamiltonian):
                 array += pyscf.ao2mo.kernel(self.cc.mf.mol, mo_b)
                 array += pyscf.ao2mo.kernel(self.cc.mf.mol, mo_a[:2] + mo_b[2:])
                 array += pyscf.ao2mo.kernel(self.cc.mf.mol, mo_b[:2] + mo_a[2:])
-            array = np.reshape(pyscf.ao2mo.addons.restore(1, array, self.cc.nmo), (self.cc.nmo,) * 4)
+            array = np.reshape(
+                pyscf.ao2mo.addons.restore(1, array, self.cc.nmo), (self.cc.nmo,) * 4
+            )
             array = np.asarray(array, dtype=types[float])
             array = np.transpose(array, (0, 2, 1, 3)) - np.transpose(array, (0, 2, 3, 1))
             self.__dict__["array"] = array

--- a/ebcc/ham/space.py
+++ b/ebcc/ham/space.py
@@ -412,7 +412,7 @@ def construct_fno_space(
         natural orbital space.
     """
     # Get the MP2 1RDM
-    solver = pyscf.mp2.MP2(mf)
+    solver = pyscf.mp.mp2.MP2(mf)
     dm1: NDArray[T]
     if not amplitudes:
         solver.kernel()

--- a/ebcc/ham/space.py
+++ b/ebcc/ham/space.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import functools
 from typing import TYPE_CHECKING, cast
 
-from ebcc import pyscf
 from ebcc import numpy as np
-from ebcc import util
+from ebcc import pyscf, util
 from ebcc.core.precision import types
 
 if TYPE_CHECKING:

--- a/ebcc/ham/space.py
+++ b/ebcc/ham/space.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import functools
 from typing import TYPE_CHECKING, cast
 
-from pyscf.mp import MP2
-
+from ebcc import pyscf
 from ebcc import numpy as np
 from ebcc import util
 from ebcc.core.precision import types
@@ -414,7 +413,7 @@ def construct_fno_space(
         natural orbital space.
     """
     # Get the MP2 1RDM
-    solver = MP2(mf)
+    solver = pyscf.mp2.MP2(mf)
     dm1: NDArray[T]
     if not amplitudes:
         solver.kernel()

--- a/ebcc/opt/base.py
+++ b/ebcc/opt/base.py
@@ -142,8 +142,11 @@ class BaseBruecknerEBCC(ABC):
             f"{'Conv.':>8s} {'Δ(Energy)':>13s} {'|T1|':>13s}{ANSI.R}"
         )
         self.log.info(
-            f"{0:4d} {self.cc.e_corr:16.10f} {self.cc.e_tot:18.10f} "
-            f"{[ANSI.r, ANSI.g][self.cc.converged]}{self.cc.converged!r:>8}{ANSI.R}"
+            f"%4d %16.10f %18.10f {[ANSI.r, ANSI.g][self.cc.converged]}%8r{ANSI.R}",
+            0,
+            self.cc.e_corr,
+            self.cc.e_tot,
+            self.cc.converged,
         )
 
         converged = False
@@ -182,10 +185,15 @@ class BaseBruecknerEBCC(ABC):
             converged_e = bool(de < self.options.e_tol)
             converged_t = bool(dt < self.options.t_tol)
             self.log.info(
-                f"{niter:4d} {self.cc.e_corr:16.10f} {self.cc.e_tot:18.10f}"
-                f" {[ANSI.r, ANSI.g][int(self.cc.converged)]}{self.cc.converged!r:>8}{ANSI.R}"
-                f" {[ANSI.r, ANSI.g][int(converged_e)]}{de:13.3e}{ANSI.R}"
-                f" {[ANSI.r, ANSI.g][int(converged_t)]}{dt:13.3e}{ANSI.R}"
+                f"%4s %16.10f %18.10f {[ANSI.r, ANSI.g][int(converged)]}%8r{ANSI.R}"
+                f" {[ANSI.r, ANSI.g][int(converged_e)]}%13.3e{ANSI.R}"
+                f" {[ANSI.r, ANSI.g][int(converged_t)]}%13.3e{ANSI.R}",
+                niter,
+                self.cc.e_corr,
+                self.cc.e_tot,
+                self.cc.converged,
+                de,
+                dt,
             )
 
             # Check for convergence:

--- a/ebcc/util/einsumfunc.py
+++ b/ebcc/util/einsumfunc.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import ctypes
-import scipy.linalg
 from typing import TYPE_CHECKING
+
+import scipy.linalg
 
 from ebcc import BACKEND
 from ebcc import numpy as np

--- a/ebcc/util/einsumfunc.py
+++ b/ebcc/util/einsumfunc.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import ctypes
 from typing import TYPE_CHECKING
 
-from pyscf.lib import dot  # noqa: F401
-
 from ebcc import BACKEND
 from ebcc import numpy as np
 from ebcc.core.precision import types
@@ -331,12 +329,13 @@ def _contract_ttgt(
 
     # Perform the contraction
     ct: NDArray[T]
-    if BACKEND == "numpy":
-        ct = dot(at, bt, alpha=alpha, beta=beta, c=out)
-    else:
-        ct = np.dot(at, bt) * alpha
-        if out is not None:
-            ct += beta * out
+    #if BACKEND == "numpy":
+    #    ct = dot(at, bt, alpha=alpha, beta=beta, c=out)
+    #else:
+    # FIXME use scipy.linalg.blas.dgemm instead of pyscf.lib.dot
+    ct = np.dot(at, bt) * alpha
+    if out is not None:
+        ct += beta * out
 
     # Reshape and transpose
     ct = np.reshape(ct, shape_ct)

--- a/ebcc/util/einsumfunc.py
+++ b/ebcc/util/einsumfunc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ctypes
+import scipy.linalg
 from typing import TYPE_CHECKING
 
 from ebcc import BACKEND
@@ -329,13 +330,12 @@ def _contract_ttgt(
 
     # Perform the contraction
     ct: NDArray[T]
-    #if BACKEND == "numpy":
-    #    ct = dot(at, bt, alpha=alpha, beta=beta, c=out)
-    #else:
-    # FIXME use scipy.linalg.blas.dgemm instead of pyscf.lib.dot
-    ct = np.dot(at, bt) * alpha
-    if out is not None:
-        ct += beta * out
+    if BACKEND == "numpy":
+        ct = scipy.linalg.blas.dgemm(alpha, at, bt, beta=beta, c=out)
+    else:
+        ct = np.dot(at, bt) * alpha
+        if out is not None:
+            ct += beta * out
 
     # Reshape and transpose
     ct = np.reshape(ct, shape_ct)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,11 @@ numpy = []
 tensorflow = [
     "tensorflow>=2.0.0",
     "opt_einsum>=3.3.0",
-    "pyscfad>=0.1.7",
 ]
 jax = [
     "jax>=0.2.0",
     "opt_einsum>=3.3.0",
+    "pyscfad>=0.1.8",
 ]
 cupy = [
     "cupy>=9.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,10 @@ ignore_missing_imports = true
 module = "ctf.*"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "pyscfad.*"
+ignore_missing_imports = true
+
 [tool.coverage.run]
 branch = true
 source = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ numpy = []
 tensorflow = [
     "tensorflow>=2.0.0",
     "opt_einsum>=3.3.0",
+    "pyscfad>=0.1.7",
 ]
 jax = [
     "jax>=0.2.0",


### PR DESCRIPTION
Currently incredibly hacky support for `pyscfad` with `jax` backends. Will take a lot of refactoring to properly support.